### PR TITLE
fix(auth): harden the username flow (uniqueness, validation, page guard)

### DIFF
--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -63,6 +63,12 @@ describe('GET /checkUsernameAvailability', () => {
     expect(res.status).toBe(200)
     expect(res.body).toBe(false)
   })
+
+  it('treats availability case-insensitively', async () => {
+    const res = await request(app).get('/api/checkUsernameAvailability?username=TAKEN')
+    expect(res.status).toBe(200)
+    expect(res.body).toBe(false)
+  })
 })
 
 // ─── POST /setUsername ────────────────────────────────────────────────────────
@@ -94,6 +100,53 @@ describe('POST /setUsername', () => {
 
     const doc = await getDB().collection('usernames').findOne({ _id: TEST_UID })
     expect(doc.username).toBe('newuser')
+    expect(doc.username_lower).toBe('newuser')
+  })
+
+  it('stores a lowercased username_lower while preserving original casing', async () => {
+    const res = await request(app)
+      .post(`/api/setUsername?username=NewUser`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+
+    const doc = await getDB().collection('usernames').findOne({ _id: TEST_UID })
+    expect(doc.username).toBe('NewUser')
+    expect(doc.username_lower).toBe('newuser')
+  })
+
+  it('returns 409 for a case-variant of a name taken by another user', async () => {
+    await seedUser('other-uid', 'taken')
+
+    const res = await request(app)
+      .post(`/api/setUsername?username=TAKEN`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(409)
+  })
+
+  it('rejects a username with whitespace (400)', async () => {
+    const res = await request(app)
+      .post(`/api/setUsername?username=${encodeURIComponent('has space')}`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a username shorter than 3 characters (400)', async () => {
+    const res = await request(app)
+      .post(`/api/setUsername?username=ab`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a username longer than 30 characters (400)', async () => {
+    const res = await request(app)
+      .post(`/api/setUsername?username=${'a'.repeat(31)}`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(400)
   })
 
   it('updates an existing username entry', async () => {

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -13,28 +13,32 @@ afterEach(async () => {
 // ─── GET /getUsername ─────────────────────────────────────────────────────────
 
 describe('GET /getUsername', () => {
-  beforeEach(async () => {
-    await seedUser(TEST_UID, 'testuser')
-  })
-
-  it('returns 400 if userId is missing', async () => {
+  it('rejects request with no auth token (401)', async () => {
     const res = await request(app).get('/api/getUsername')
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(401)
   })
 
-  it('returns 400 if userId is the string "null"', async () => {
-    const res = await request(app).get('/api/getUsername?userId=null')
-    expect(res.status).toBe(400)
+  it("returns the authenticated user's own username", async () => {
+    await seedUser(TEST_UID, 'testuser')
+    const res = await request(app).get('/api/getUsername').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('testuser')
   })
 
-  it('returns 200 with null body if userId is not found', async () => {
-    const res = await request(app).get('/api/getUsername?userId=unknown')
+  it('returns null when the authenticated user has no username yet', async () => {
+    const res = await request(app).get('/api/getUsername').set(AUTH_HEADER)
     expect(res.status).toBe(200)
     expect(res.body).toBeNull()
   })
 
-  it('returns the username for a valid userId', async () => {
-    const res = await request(app).get(`/api/getUsername?userId=${TEST_UID}`)
+  it('ignores a userId query param and only returns the caller\'s own username', async () => {
+    await seedUser(TEST_UID, 'testuser')
+    await seedUser('other-uid', 'otheruser')
+
+    const res = await request(app)
+      .get('/api/getUsername?userId=other-uid')
+      .set(AUTH_HEADER)
+
     expect(res.status).toBe(200)
     expect(res.body).toBe('testuser')
   })

--- a/server/__tests__/helpers/seed.js
+++ b/server/__tests__/helpers/seed.js
@@ -9,7 +9,9 @@ async function seedRecipes(recipes) {
 }
 
 async function seedUser(uid, username) {
-  await getDB().collection('usernames').insertOne({ _id: uid, username })
+  await getDB()
+    .collection('usernames')
+    .insertOne({ _id: uid, username, username_lower: username.toLowerCase() })
 }
 
 async function seedUserRecipeData(uid, data) {

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -41,8 +41,8 @@ const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
 beforeEach(async () => {
   const db = getDB()
   await db.collection('usernames').insertMany([
-    { _id: TEST_UID, username: TEST_USERNAME },
-    { _id: OTHER_UID, username: OTHER_USERNAME },
+    { _id: TEST_UID, username: TEST_USERNAME, username_lower: TEST_USERNAME.toLowerCase() },
+    { _id: OTHER_UID, username: OTHER_USERNAME, username_lower: OTHER_USERNAME.toLowerCase() },
   ])
   await db.collection('recipes').insertOne({
     _id: RECIPE_ID,

--- a/server/db.js
+++ b/server/db.js
@@ -13,6 +13,29 @@ async function connectDB(uri) {
   await client.connect()
   db = client.db('prepify')
   console.log('Connected to MongoDB')
+  await ensureIndexes()
+}
+
+// Enforces case-insensitive username uniqueness at the database level. Legacy
+// docs created before `username_lower` existed are backfilled first so the
+// unique index can be built over the whole collection.
+async function ensureIndexes() {
+  const usernames = db.collection('usernames')
+  await usernames.updateMany(
+    { username_lower: { $exists: false }, username: { $type: 'string' } },
+    [{ $set: { username_lower: { $toLower: '$username' } } }]
+  )
+  try {
+    await usernames.createIndex({ username_lower: 1 }, { unique: true })
+  } catch (err) {
+    // Pre-existing case-variant duplicates would make the unique index fail to
+    // build. Log it rather than crashing startup; the duplicates need manual
+    // cleanup, but the rest of the server should still come up.
+    console.error(
+      'Failed to create unique index on usernames.username_lower:',
+      err.message
+    )
+  }
 }
 
 async function closeDB() {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -25,16 +25,14 @@ function validateUsername(username) {
   return null
 }
 
-// GET /getUsername?userId=...
-// Returns the username for a given uid
-router.get('/getUsername', async (req, res) => {
+// GET /getUsername
+// Returns the authenticated user's own username, or null if not set yet.
+// Scoped to req.uid so a user can't enumerate other users' usernames by id;
+// other users' usernames are surfaced through the reviews endpoints instead.
+router.get('/getUsername', verifyToken, async (req, res) => {
   try {
-    const { userId } = req.query
-    if (!userId || userId === 'null') {
-      return res.status(400).json({ error: 'userId is required' })
-    }
     const db = getDB()
-    const doc = await db.collection('usernames').findOne({ _id: userId })
+    const doc = await db.collection('usernames').findOne({ _id: req.uid })
     if (!doc) return res.json(null)
     res.json(doc.username)
   } catch (err) {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -3,6 +3,28 @@ const router = express.Router()
 const { getDB } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 
+const USERNAME_MIN_LENGTH = 3
+const USERNAME_MAX_LENGTH = 30
+
+// Mirrors the client-side rules in src/Components/Form/UsernameInput.tsx so the
+// API can't be bypassed by calling it directly. Returns an error string, or
+// null when the username is valid.
+function validateUsername(username) {
+  if (typeof username !== 'string' || !username) {
+    return 'username is required'
+  }
+  if (/\s/.test(username)) {
+    return 'Username cannot contain whitespace'
+  }
+  if (username.length < USERNAME_MIN_LENGTH) {
+    return `Username must be at least ${USERNAME_MIN_LENGTH} characters`
+  }
+  if (username.length > USERNAME_MAX_LENGTH) {
+    return `Username must be at most ${USERNAME_MAX_LENGTH} characters`
+  }
+  return null
+}
+
 // GET /getUsername?userId=...
 // Returns the username for a given uid
 router.get('/getUsername', async (req, res) => {
@@ -27,7 +49,9 @@ router.get('/checkUsernameAvailability', async (req, res) => {
     const { username } = req.query
     if (!username) return res.status(400).json({ error: 'username is required' })
     const db = getDB()
-    const existing = await db.collection('usernames').findOne({ username })
+    const existing = await db
+      .collection('usernames')
+      .findOne({ username_lower: username.toLowerCase() })
     res.json(existing === null)
   } catch (err) {
     res.status(500).json({ error: err.message })
@@ -39,23 +63,37 @@ router.get('/checkUsernameAvailability', async (req, res) => {
 router.post('/setUsername', verifyToken, async (req, res) => {
   try {
     const { username } = req.query
-    if (!username) {
-      return res.status(400).json({ error: 'username is required' })
+    const validationError = validateUsername(username)
+    if (validationError) {
+      return res.status(400).json({ error: validationError })
     }
+    const usernameLower = username.toLowerCase()
     const uid = req.uid
     const db = getDB()
 
-    // Check username is not already taken by someone else
-    const existing = await db.collection('usernames').findOne({ username })
+    // Check the name isn't already taken by someone else (case-insensitive).
+    const existing = await db
+      .collection('usernames')
+      .findOne({ username_lower: usernameLower })
     if (existing && existing._id !== uid) {
       return res.status(409).json({ error: 'Username already taken' })
     }
 
-    await db.collection('usernames').updateOne(
-      { _id: uid },
-      { $set: { username } },
-      { upsert: true }
-    )
+    try {
+      await db.collection('usernames').updateOne(
+        { _id: uid },
+        { $set: { username, username_lower: usernameLower } },
+        { upsert: true }
+      )
+    } catch (err) {
+      // The unique index on username_lower is the source of truth: it closes
+      // the race between the check above and this write, where two concurrent
+      // requests could both pass the findOne.
+      if (err.code === 11000) {
+        return res.status(409).json({ error: 'Username already taken' })
+      }
+      throw err
+    }
     res.json({ success: true })
   } catch (err) {
     res.status(500).json({ error: err.message })

--- a/src/Components/Form/UsernameInput.tsx
+++ b/src/Components/Form/UsernameInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, FC, useState } from 'react'
+import React, { useEffect, FC } from 'react'
 import FormInput from 'src/Components/Form/FormInput'
 import { MdAlternateEmail } from 'react-icons/md'
 import AuthAPI from 'src/api/auth'
@@ -20,9 +20,7 @@ const UsernameInput: FC<UsernameInputProps> = ({
   isUsernameAvailable,
   setIsUsernameAvailable,
 }) => {
-  const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout | null>(null)
-
-  // on username change, check username availability against firestore 'usernames' collection
+  // on username change, check availability against the 'usernames' collection
   useEffect(() => {
     setError('')
     setSuccess('')
@@ -31,21 +29,25 @@ const UsernameInput: FC<UsernameInputProps> = ({
       return setError('Cannot have white space in username')
     if (!username || username.length < 3) return setIsUsernameAvailable(null)
 
-    if (timeoutId) clearTimeout(timeoutId)
+    // `cancelled` guards against a slow in-flight request resolving after a
+    // newer keystroke's request and clobbering the result with stale data.
+    let cancelled = false
 
-    const newTimeoutId = setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       AuthAPI.checkUsernameAvailability(username)
         .then(val => {
-          setIsUsernameAvailable(val)
+          if (!cancelled) setIsUsernameAvailable(val)
         })
-        .catch(err => setError(err.code))
+        .catch(err => {
+          if (!cancelled) setError(err.code)
+        })
     }, 500) // 500 milliseconds debounce time
 
-    setTimeoutId(newTimeoutId)
-
-    // cleanup function to clear timeout on unmount or username change
+    // Clears the pending debounce and ignores any in-flight response on the
+    // next keystroke or unmount.
     return () => {
-      if (timeoutId) clearTimeout(timeoutId)
+      cancelled = true
+      clearTimeout(timeoutId)
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Components/Navbar/Navbar.tsx
+++ b/src/Components/Navbar/Navbar.tsx
@@ -37,7 +37,7 @@ const Navbar: FC<NavbarProps> = ({
 
   const { data } = useQuery({
     queryKey: ['username', uid],
-    queryFn: () => AuthAPI.getUsername(uid!),
+    queryFn: () => AuthAPI.getUsername(),
     enabled: !!uid && !!authRes?.user,
   })
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -11,17 +11,19 @@ class AuthAPIClass {
       uid = this.getUID()
     }
     if (!uid) return null
-    const result = await http.get(`api/getUsername?userId=${uid}`)
+    const result = await http.get(
+      `api/getUsername?userId=${encodeURIComponent(uid)}`
+    )
     return result.data
   }
   async checkUsernameAvailability(username: string): Promise<boolean> {
     const result = await http.get(
-      `api/checkUsernameAvailability?username=${username}`
+      `api/checkUsernameAvailability?username=${encodeURIComponent(username)}`
     )
     return result.data
   }
   async setUsername(username: string) {
-    await http.post(`api/setUsername?username=${username}`)
+    await http.post(`api/setUsername?username=${encodeURIComponent(username)}`)
   }
 }
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -5,15 +5,12 @@ class AuthAPIClass {
   getUID(): string | null {
     return auth?.currentUser?.uid ?? null
   }
-  async getUsername(userId?: string): Promise<string | null> {
-    let uid: string | null = userId ?? null
-    if (!userId) {
-      uid = this.getUID()
-    }
-    if (!uid) return null
-    const result = await http.get(
-      `api/getUsername?userId=${encodeURIComponent(uid)}`
-    )
+  // The server resolves the username from the auth token, so this always
+  // returns the current user's own username. Skip the request when nobody is
+  // signed in (it would just 401).
+  async getUsername(): Promise<string | null> {
+    if (!this.getUID()) return null
+    const result = await http.get('api/getUsername')
     return result.data
   }
   async checkUsernameAvailability(username: string): Promise<boolean> {

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -262,7 +262,6 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
     if (loading || !user || !user.uid) return
 
     let cancelled = false
-    const uid = user.uid
     const MAX_ATTEMPTS = 3
     const BASE_DELAY_MS = 500
     const delay = (ms: number) =>
@@ -271,7 +270,7 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
     const verifyUsername = async () => {
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         try {
-          const username = await AuthAPI.getUsername(uid)
+          const username = await AuthAPI.getUsername()
           if (cancelled) return
           if (!username) navigate('/create-username')
           return

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -254,21 +254,44 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
     return () => unsubscribe()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-  // Check if user has username after auth is loaded and user exists
+  // Check if user has username after auth is loaded and user exists. A failed
+  // lookup leaves a username-less user (e.g. a fresh Google sign-in) stranded
+  // without the redirect, so retry transient failures with backoff before
+  // giving up rather than surfacing a non-actionable error to the user.
   useEffect(() => {
-    if (!loading && user && user.uid) {
-      AuthAPI.getUsername(user.uid)
-        .then(username => {
-          if (!username) {
-            navigate('/create-username')
+    if (loading || !user || !user.uid) return
+
+    let cancelled = false
+    const uid = user.uid
+    const MAX_ATTEMPTS = 3
+    const BASE_DELAY_MS = 500
+    const delay = (ms: number) =>
+      new Promise(resolve => setTimeout(resolve, ms))
+
+    const verifyUsername = async () => {
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+          const username = await AuthAPI.getUsername(uid)
+          if (cancelled) return
+          if (!username) navigate('/create-username')
+          return
+        } catch (err) {
+          if (cancelled) return
+          if (attempt === MAX_ATTEMPTS) {
+            console.error('Failed to verify username on auth load:', err)
+            return
           }
-        })
-        .catch(err => {
-          // Don't silently swallow the failure: if we can't confirm the user
-          // has a username we surface it rather than letting them proceed in a
-          // half-onboarded state that breaks username-dependent features.
-          console.error('Failed to verify username on auth load:', err)
-        })
+          // Exponential backoff: 500ms, then 1000ms.
+          await delay(BASE_DELAY_MS * 2 ** (attempt - 1))
+          if (cancelled) return
+        }
+      }
+    }
+
+    verifyUsername()
+
+    return () => {
+      cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, user])

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -257,11 +257,18 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
   // Check if user has username after auth is loaded and user exists
   useEffect(() => {
     if (!loading && user && user.uid) {
-      AuthAPI.getUsername(user.uid).then(username => {
-        if (!username) {
-          navigate('/create-username')
-        }
-      })
+      AuthAPI.getUsername(user.uid)
+        .then(username => {
+          if (!username) {
+            navigate('/create-username')
+          }
+        })
+        .catch(err => {
+          // Don't silently swallow the failure: if we can't confirm the user
+          // has a username we surface it rather than letting them proceed in a
+          // half-onboarded state that breaks username-dependent features.
+          console.error('Failed to verify username on auth load:', err)
+        })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, user])

--- a/src/pages/Account/Account.tsx
+++ b/src/pages/Account/Account.tsx
@@ -18,7 +18,7 @@ const Account: FC = () => {
 
   const { data } = useQuery({
     queryKey: ['username', uid],
-    queryFn: () => AuthAPI.getUsername(uid!),
+    queryFn: () => AuthAPI.getUsername(),
     enabled: !!uid && !authRes?.user?.displayName,
   })
 

--- a/src/pages/CreateUsername/CreateUsername.scss
+++ b/src/pages/CreateUsername/CreateUsername.scss
@@ -1,0 +1,23 @@
+@use '../../helpers.scss' as s;
+
+.create-username-page {
+  .loading-state {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 200px;
+  }
+
+  .logout-prompt {
+    margin-top: 1rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-decoration: underline;
+    font-weight: 500;
+    font-size: 0.875rem;
+    color: s.$secondary-text;
+    width: fit-content;
+    align-self: center;
+  }
+}

--- a/src/pages/CreateUsername/CreateUsername.tsx
+++ b/src/pages/CreateUsername/CreateUsername.tsx
@@ -36,7 +36,7 @@ const CreateUsername: FC = () => {
       return
     }
     let cancelled = false
-    AuthAPI.getUsername(user.uid)
+    AuthAPI.getUsername()
       .then(username => {
         if (cancelled) return
         if (username) navigate('/')

--- a/src/pages/CreateUsername/CreateUsername.tsx
+++ b/src/pages/CreateUsername/CreateUsername.tsx
@@ -3,6 +3,7 @@ import '../../Components/Form/FormStyles.scss'
 import './CreateUsername.scss'
 import { TailSpin } from 'react-loader-spinner'
 import { useNavigate } from 'react-router-dom'
+import toast from 'react-hot-toast'
 import UsernameInput from 'src/Components/Form/UsernameInput'
 import AuthAPI from 'src/api/auth'
 import { useAuth } from 'src/context/AuthContext'
@@ -19,7 +20,6 @@ const CreateUsername: FC = () => {
   const [checkingExisting, setCheckingExisting] = useState(true)
 
   const [error, setError] = useState('')
-  const [success, setSuccess] = useState('')
 
   const navigate = useNavigate()
 
@@ -64,12 +64,13 @@ const CreateUsername: FC = () => {
 
     setLoadingCreateUsername(true)
     setError('')
-    setSuccess('')
 
     AuthAPI.setUsername(currUsername)
       .then(() => {
         setLoadingCreateUsername(false)
-        setSuccess('Username Created Successfully!')
+        // A toast (rendered at the app root) survives the redirect, unlike an
+        // inline message on a page we immediately navigate away from.
+        toast.success('Username created successfully!')
         navigate('/')
       })
       .catch((error: unknown) => {
@@ -96,13 +97,12 @@ const CreateUsername: FC = () => {
           <p className='prompt'>
             Create a unique username to identify yourself with.
           </p>
-          {success ? <div className='success'>{success}</div> : null}
           {error ? <div className='error'>{error}</div> : null}
           <div className='input-fields'>
             <UsernameInput
               username={currUsername}
               setUsername={setCurrUsername}
-              setSuccess={setSuccess}
+              setSuccess={() => {}}
               setError={setError}
               isUsernameAvailable={isUsernameAvailable}
               setIsUsernameAvailable={setIsUsernameAvailable}

--- a/src/pages/CreateUsername/CreateUsername.tsx
+++ b/src/pages/CreateUsername/CreateUsername.tsx
@@ -1,10 +1,11 @@
-import React, { ChangeEvent, FC, useState } from 'react'
+import React, { ChangeEvent, FC, useEffect, useState } from 'react'
 import '../../Components/Form/FormStyles.scss'
 import './CreateUsername.scss'
 import { TailSpin } from 'react-loader-spinner'
 import { useNavigate } from 'react-router-dom'
 import UsernameInput from 'src/Components/Form/UsernameInput'
 import AuthAPI from 'src/api/auth'
+import { useAuth } from 'src/context/AuthContext'
 
 const CreateUsername: FC = () => {
   const [currUsername, setCurrUsername] = useState('')
@@ -13,33 +14,78 @@ const CreateUsername: FC = () => {
   >(null)
 
   const [loadingCreateUsername, setLoadingCreateUsername] = useState(false)
+  // Block rendering the form until we've confirmed the user actually needs it,
+  // so a user who already has a username never sees a flash of the form.
+  const [checkingExisting, setCheckingExisting] = useState(true)
 
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
 
   const navigate = useNavigate()
 
-  const uid = AuthAPI.getUID()
+  const auth = useAuth()
+  const user = auth?.user ?? null
+  const authLoading = auth?.authLoading ?? false
+
+  // Guard the page: only username-less, signed-in users belong here. Send
+  // everyone else away rather than letting them set/overwrite a username.
+  useEffect(() => {
+    if (authLoading) return
+    if (!user) {
+      navigate('/login')
+      return
+    }
+    let cancelled = false
+    AuthAPI.getUsername(user.uid)
+      .then(username => {
+        if (cancelled) return
+        if (username) navigate('/')
+        else setCheckingExisting(false)
+      })
+      .catch(() => {
+        // If we can't confirm, let them proceed — setting a username is
+        // idempotent and the server still enforces uniqueness.
+        if (!cancelled) setCheckingExisting(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [authLoading, user, navigate])
 
   const handleCreateUsernameForm = (e: ChangeEvent<HTMLFormElement>) => {
-    if (uid && isUsernameAvailable) {
-      e.preventDefault()
-      setLoadingCreateUsername(true)
+    e.preventDefault()
 
-      setError('')
-      setSuccess('')
-
-      AuthAPI.setUsername(currUsername)
-        .then(() => {
-          setLoadingCreateUsername(false)
-          setSuccess('Username Created Successfully!')
-          navigate('/')
-        })
-        .catch((error: unknown) => {
-          setLoadingCreateUsername(false)
-          setError(error instanceof Error ? error.message : String(error))
-        })
+    const uid = user?.uid
+    if (!uid) {
+      setError('You must be signed in to create a username.')
+      return
     }
+    if (!isUsernameAvailable) return
+
+    setLoadingCreateUsername(true)
+    setError('')
+    setSuccess('')
+
+    AuthAPI.setUsername(currUsername)
+      .then(() => {
+        setLoadingCreateUsername(false)
+        setSuccess('Username Created Successfully!')
+        navigate('/')
+      })
+      .catch((error: unknown) => {
+        setLoadingCreateUsername(false)
+        setError(error instanceof Error ? error.message : String(error))
+      })
+  }
+
+  if (authLoading || checkingExisting) {
+    return (
+      <div className='create-username-page form-format'>
+        <div className='login-form-container loading-state'>
+          <TailSpin height='50' width='50' color='gray' ariaLabel='loading' />
+        </div>
+      </div>
+    )
   }
 
   return (
@@ -76,6 +122,13 @@ const CreateUsername: FC = () => {
             ) : (
               'Create Username'
             )}
+          </button>
+          <button
+            type='button'
+            className='logout-prompt'
+            onClick={() => auth?.logout()}
+          >
+            Cancel and log out
           </button>
         </form>
       </div>

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewOptions.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewOptions.tsx
@@ -26,7 +26,7 @@ const ReviewOptions: FC<ReviewOptionsProps> = ({
 
   const { data: currUsername } = useQuery({
     queryKey: ['username', uid],
-    queryFn: () => AuthAPI.getUsername(uid!),
+    queryFn: () => AuthAPI.getUsername(),
     enabled: !!uid,
   })
 

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -53,7 +53,7 @@ const RecipeControls: FC<RecipeControlsType> = ({
 
   const { data: currUsername } = useQuery({
     queryKey: ['username', currUID],
-    queryFn: () => AuthAPI.getUsername(currUID!),
+    queryFn: () => AuthAPI.getUsername(),
     enabled: !!currUID,
   })
 

--- a/src/test/Account.test.tsx
+++ b/src/test/Account.test.tsx
@@ -124,7 +124,7 @@ describe('Account page', () => {
       })
       mockGetUsername.mockResolvedValue('johndoe')
       renderAccount()
-      await waitFor(() => expect(mockGetUsername).toHaveBeenCalledWith('u1'))
+      await waitFor(() => expect(mockGetUsername).toHaveBeenCalled())
     })
 
     it('displays the resolved username in the h1.username element', async () => {


### PR DESCRIPTION
Hardens the username creation flow end to end. Each fix is its own commit.

## Backend
- **Case-insensitive uniqueness enforced at the DB level** — new unique index on `usernames.username_lower`, with a backfill of legacy docs on connect. Closes the check-then-write race by treating duplicate-key errors as 409.
- **Server-side validation** of usernames (non-empty, no whitespace, length 3–30), mirroring the client so the API can't be bypassed directly.
- **`GET /getUsername` is now auth-scoped** — requires a verified token and returns only the caller's own username, instead of letting anyone enumerate `uid → username` via a query param.

## Frontend
- **URL-encode** username/userId query params so names with `&`, `+`, `#`, etc. don't corrupt the request.
- **Retry** the auth-load username check (3 attempts, exponential backoff) so a transient failure no longer strands a username-less user without the create-username redirect.
- **Guard the `/create-username` page** — users who already have a username are redirected away; signed-out visitors go to `/login`; a loader prevents a form flash.
- **"Cancel and log out" escape** so a username-less user isn't trapped on the page.
- **Fix silent submit** — submitting before Firebase rehydrates now shows an error instead of triggering a native page reload.
- **Ignore stale availability responses** in the debounced username field (per-effect cancellation), removing the buggy timeout-in-state pattern.
- **Success toast** on username creation (survives the redirect) replacing a dead inline message.
- **Cleanup**: dropped the now-vestigial `userId` arg from `AuthAPI.getUsername` and its call sites.

## Testing
- Server: full Jest suite green (122), incl. new tests for case-insensitive uniqueness, validation rejections, and the auth-scoped getUsername (asserts a supplied userId can't read another user's name).
- Frontend: full Vitest suite green (130 passed / 2 skipped), `tsc --noEmit` clean.

## Not smoke-tested
Per discussion, this was not manually smoke-tested against a running stack. Note the index build runs over the live `usernames` collection on first boot/deploy — if production contains case-variant duplicate usernames, the unique index will fail to build (logged, non-fatal) and those dupes need manual cleanup.