### PR TITLE
Author stats banner, public recipe stats, and full delete cleanup

### DIFF
--- a/design-explorations/single-recipe/author-stats.html
+++ b/design-explorations/single-recipe/author-stats.html
@@ -1,0 +1,408 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Author Stats &amp; Controls · Single Recipe Explorations</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --primary:#ff5722; --secondary:#00adb5;
+    --primary-text:#303841; --secondary-text:#595f66; --tertiary-text:#979ba0;
+    --white:#fff; --gray-50:#fafafa; --gray-200:#eeeeee; --gray-300:#e6e6e6;
+    --gray-400:#d6d6d6; --gray-500:#bebebe; --gray-600:#a6a6a6;
+    --success-green:#28a745; --error-red:#dc3545; --error-red-hover:#b02a37;
+    --radius:10px; --shadow:rgba(0,0,0,0.24) 0px 3px 8px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0;}
+  body{font-family:'Montserrat',sans-serif;background:var(--gray-200);color:var(--primary-text);-webkit-font-smoothing:antialiased;}
+
+  /* ---------- switcher ---------- */
+  .switcher{position:sticky;top:0;z-index:50;background:var(--primary-text);color:#fff;
+    display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;padding:.85rem 1.25rem;box-shadow:0 2px 10px rgba(0,0,0,.25);}
+  .switcher .brand{font-weight:800;letter-spacing:-.01em;margin-right:.5rem;}
+  .switcher .brand span{color:var(--primary);}
+  .switcher button{font-family:inherit;font-weight:700;font-size:.85rem;color:#fff;background:rgba(255,255,255,.08);
+    border:1px solid rgba(255,255,255,.18);border-radius:999px;padding:.4rem .9rem;cursor:pointer;transition:.12s;}
+  .switcher button:hover{background:rgba(255,255,255,.18);}
+  .switcher button.active{background:var(--primary);border-color:var(--primary);}
+  .switcher .hint{margin-left:auto;font-size:.75rem;color:var(--gray-500);font-weight:600;}
+
+  .desc-strip{background:var(--gray-50);border-bottom:1px solid var(--gray-400);padding:.85rem 1.25rem;}
+  .desc-strip .v-name{font-weight:800;font-size:1rem;}
+  .desc-strip .v-name b{color:var(--primary);}
+  .desc-strip p{font-size:.85rem;color:var(--secondary-text);font-weight:500;margin-top:.2rem;max-width:90ch;}
+
+  /* ---------- mock page chrome (shared) ---------- */
+  .stage{padding:2.5rem 1.25rem 6rem;}
+  .page{max-width:1000px;margin:0 auto;background:var(--gray-200);}
+  .recipe-header{display:flex;gap:3rem;padding-bottom:2rem;margin-bottom:2rem;border-bottom:1px solid var(--gray-400);}
+  .recipe-header .img{flex:0 0 320px;height:320px;border-radius:6px;
+    background:linear-gradient(135deg,#f6b59c,#ff5722 70%);position:relative;overflow:hidden;}
+  .recipe-header .img::after{content:'recipe photo';position:absolute;inset:auto 0 12px 0;text-align:center;
+    color:rgba(255,255,255,.85);font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:2px;}
+  .desc{display:flex;flex-direction:column;gap:.9rem;flex:1;}
+  .price{font-size:.75rem;font-weight:700;color:var(--primary);text-transform:uppercase;letter-spacing:1.2px;}
+  .title{font-size:2rem;font-weight:600;line-height:1.1;}
+  .description{font-size:1rem;font-weight:500;color:var(--primary-text);max-width:560px;flex:1;}
+  .recipe-data{display:flex;gap:2.5rem;}
+  .recipe-data .rd{display:flex;flex-direction:column;align-items:center;gap:.4rem;}
+  .recipe-data .rd .icon{height:26px;width:26px;color:var(--primary-text);}
+  .recipe-data .rd h4{font-size:.95rem;font-weight:700;}
+  .recipe-data .rd .d{font-size:.9rem;color:var(--secondary-text);}
+  .body-spacer{text-align:center;color:var(--gray-600);font-weight:700;font-size:.8rem;letter-spacing:2px;
+    text-transform:uppercase;padding:3rem 0;border-bottom:1px dashed var(--gray-500);margin-bottom:2.5rem;}
+
+  /* shared building blocks */
+  .section-label{font-size:.8rem;color:var(--primary);font-weight:700;text-transform:uppercase;letter-spacing:1.2px;}
+  .icon{display:inline-block;vertical-align:middle;}
+  .btn{display:inline-flex;align-items:center;gap:.45rem;font-family:inherit;font-weight:600;font-size:.9rem;
+    border-radius:var(--radius);cursor:pointer;transition:all .12s linear;}
+  .btn .icon{height:17px;width:17px;}
+
+  .variation{display:none;}
+  .variation.active{display:block;}
+
+  /* ========================================================= */
+  /* V1 — Owner banner (top) + clean icon stat row (bottom)    */
+  /* ========================================================= */
+  #v1 .owner-banner{display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap;
+    background:var(--gray-50);border:1px solid var(--gray-400);border-radius:var(--radius);
+    padding:.7rem 1.25rem;margin-bottom:2rem;}
+  #v1 .owner-banner .who{display:flex;align-items:center;gap:.6rem;font-weight:600;color:var(--secondary-text);font-size:.9rem;}
+  #v1 .owner-banner .who .icon{height:20px;width:20px;color:var(--secondary);}
+  #v1 .owner-banner .who b{color:var(--primary-text);}
+  #v1 .owner-banner .acts{display:flex;gap:.6rem;}
+  #v1 .owner-banner .btn{border:1px solid var(--gray-500);background:transparent;padding:.4rem .8rem;color:var(--primary-text);}
+  #v1 .owner-banner .btn.delete:hover{background:var(--error-red);border-color:var(--error-red);color:#fff;}
+  #v1 .owner-banner .btn.edit:disabled{opacity:.5;cursor:not-allowed;}
+  #v1 .stats{margin-top:1rem;}
+  #v1 .stats .section-label{display:block;margin-bottom:1.5rem;}
+  #v1 .stat-row{display:flex;justify-content:space-around;flex-wrap:wrap;gap:1.5rem;}
+  #v1 .stat{display:flex;flex-direction:column;align-items:center;gap:.4rem;}
+  #v1 .stat .icon{height:28px;width:28px;color:var(--secondary-text);}
+  #v1 .stat .num{font-size:1.6rem;font-weight:700;color:var(--primary-text);}
+  #v1 .stat .lbl{font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:1px;color:var(--secondary-text);}
+
+  /* ========================================================= */
+  /* V2 — Title pill badge (top) + refined stat cards (bottom) */
+  /* ========================================================= */
+  #v2 .owner-pill{display:inline-flex;align-items:center;gap:.4rem;align-self:flex-start;
+    border:1.5px solid var(--primary);color:var(--primary);border-radius:999px;
+    padding:.28rem .8rem;font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.6px;}
+  #v2 .owner-pill .icon{height:14px;width:14px;}
+  #v2 .stats .section-label{display:block;margin-bottom:1.25rem;}
+  #v2 .stat-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1rem;}
+  #v2 .stat{background:var(--white);border-radius:var(--radius);box-shadow:var(--shadow);
+    padding:1.25rem 1rem;display:flex;flex-direction:column;align-items:center;gap:.35rem;}
+  #v2 .stat .icon{height:24px;width:24px;color:var(--primary);}
+  #v2 .stat .num{font-size:1.5rem;font-weight:700;}
+  #v2 .stat .lbl{font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--secondary-text);}
+  #v2 .controls{display:flex;justify-content:flex-end;gap:.75rem;margin-top:1.25rem;}
+  #v2 .controls .btn{padding:.5rem 1rem;border:1px solid var(--primary-text);background:transparent;color:var(--primary-text);}
+  #v2 .controls .btn.edit:disabled{opacity:.45;cursor:not-allowed;}
+  #v2 .controls .btn.delete{border-color:var(--error-red);color:var(--error-red);}
+  #v2 .controls .btn.delete:hover{background:var(--error-red);color:#fff;}
+
+  /* ========================================================= */
+  /* V3 — Accent label (top) + divided inline bar w/ controls  */
+  /* ========================================================= */
+  #v3 .owner-tag{font-size:.75rem;font-weight:700;color:var(--primary);text-transform:uppercase;letter-spacing:1.5px;
+    display:flex;align-items:center;gap:.4rem;}
+  #v3 .owner-tag .icon{height:14px;width:14px;}
+  #v3 .stats-bar{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:1.5rem;
+    border:1px solid var(--gray-400);border-radius:var(--radius);background:var(--gray-50);padding:1.1rem 1.75rem;}
+  #v3 .stats-inline{display:flex;}
+  #v3 .stats-inline .stat{display:flex;flex-direction:column;align-items:center;gap:.2rem;padding:0 1.75rem;
+    border-right:1px solid var(--gray-400);}
+  #v3 .stats-inline .stat:last-child{border-right:none;}
+  #v3 .stats-inline .stat:first-child{padding-left:0;}
+  #v3 .stat .num{font-size:1.4rem;font-weight:700;}
+  #v3 .stat .lbl{font-size:.68rem;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--secondary-text);}
+  #v3 .stat .num .star{color:var(--primary);}
+  #v3 .controls{display:flex;gap:.6rem;}
+  #v3 .controls .btn{padding:.45rem .85rem;border:1px solid var(--gray-500);background:var(--white);color:var(--primary-text);}
+  #v3 .controls .btn.edit:disabled{opacity:.45;cursor:not-allowed;}
+  #v3 .controls .btn.delete:hover{background:var(--error-red);border-color:var(--error-red);color:#fff;}
+
+  /* ========================================================= */
+  /* V4 — Image corner chip (top) + combined owner card        */
+  /* ========================================================= */
+  #v4 .recipe-header .img .chip{position:absolute;top:12px;left:12px;z-index:2;
+    display:flex;align-items:center;gap:.35rem;background:rgba(48,56,65,.92);color:#fff;
+    padding:.3rem .7rem;border-radius:999px;font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.6px;}
+  #v4 .recipe-header .img .chip .icon{height:13px;width:13px;}
+  #v4 .owner-card{background:var(--white);border-left:4px solid var(--primary);border-radius:var(--radius);
+    box-shadow:var(--shadow);padding:1.5rem 1.75rem;}
+  #v4 .owner-card .head{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:1rem;
+    padding-bottom:1.25rem;margin-bottom:1.25rem;border-bottom:1px solid var(--gray-300);}
+  #v4 .owner-card .head .ttl{font-size:1.1rem;font-weight:700;}
+  #v4 .owner-card .head .sub{font-size:.8rem;color:var(--secondary-text);font-weight:500;margin-top:.15rem;}
+  #v4 .owner-card .head .acts{display:flex;gap:.6rem;}
+  #v4 .owner-card .btn{padding:.5rem 1rem;border:1px solid var(--primary-text);background:transparent;color:var(--primary-text);}
+  #v4 .owner-card .btn.edit:disabled{opacity:.45;cursor:not-allowed;}
+  #v4 .owner-card .btn.delete{border-color:var(--error-red);color:var(--error-red);}
+  #v4 .owner-card .btn.delete:hover{background:var(--error-red);color:#fff;}
+  #v4 .owner-card .stat-row{display:flex;gap:3rem;flex-wrap:wrap;}
+  #v4 .stat{display:flex;align-items:center;gap:.7rem;}
+  #v4 .stat .icon{height:26px;width:26px;color:var(--primary);}
+  #v4 .stat .num{font-size:1.35rem;font-weight:700;line-height:1;}
+  #v4 .stat .lbl{font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--secondary-text);}
+
+  /* ========================================================= */
+  /* V5 — Minimal editorial line (top) + light inline stats    */
+  /* ========================================================= */
+  #v5 .owner-line{font-size:.85rem;color:var(--secondary-text);font-weight:600;display:flex;align-items:center;gap:.5rem;}
+  #v5 .owner-line .dot{color:var(--gray-500);}
+  #v5 .owner-line a{color:var(--primary);text-decoration:none;font-weight:700;}
+  #v5 .owner-line a:hover{text-decoration:underline;}
+  #v5 .stats-foot{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:1.25rem;
+    padding-top:1.5rem;border-top:1px solid var(--gray-400);}
+  #v5 .stats-minimal{display:flex;align-items:center;gap:1.1rem;color:var(--secondary-text);font-weight:600;font-size:.95rem;}
+  #v5 .stats-minimal .stat{display:flex;align-items:center;gap:.45rem;}
+  #v5 .stats-minimal .stat .icon{height:18px;width:18px;color:var(--tertiary-text);}
+  #v5 .stats-minimal .stat b{color:var(--primary-text);font-weight:700;}
+  #v5 .stats-minimal .star{color:var(--primary);}
+  #v5 .stats-minimal .sep{color:var(--gray-500);}
+  #v5 .controls{display:flex;gap:1.25rem;}
+  #v5 .controls .btn{background:none;border:none;padding:0;font-weight:700;font-size:.9rem;color:var(--secondary-text);}
+  #v5 .controls .btn:hover{text-decoration:underline;}
+  #v5 .controls .btn.delete{color:var(--error-red);}
+  #v5 .controls .btn.edit:disabled{opacity:.5;cursor:not-allowed;text-decoration:none;}
+
+  @media(max-width:760px){
+    .recipe-header{flex-direction:column;gap:1.5rem;}
+    .recipe-header .img{flex-basis:auto;width:100%;height:240px;}
+    #v2 .stat-grid{grid-template-columns:repeat(2,1fr);}
+  }
+</style>
+</head>
+<body>
+  <!-- icon symbols -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+    <symbol id="i-eye" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></symbol>
+    <symbol id="i-bookmark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></symbol>
+    <symbol id="i-star" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></symbol>
+    <symbol id="i-edit" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></symbol>
+    <symbol id="i-trash" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></symbol>
+    <symbol id="i-user" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></symbol>
+    <symbol id="i-clock" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></symbol>
+  </svg>
+
+  <div class="switcher">
+    <span class="brand">Prep<span>ify</span> · Author stats</span>
+    <button data-v="1" class="active">V1 · Banner</button>
+    <button data-v="2">V2 · Pill + cards</button>
+    <button data-v="3">V3 · Inline bar</button>
+    <button data-v="4">V4 · Owner card</button>
+    <button data-v="5">V5 · Minimal</button>
+    <span class="hint">press 1–5 to switch</span>
+  </div>
+
+  <div class="desc-strip" id="desc"></div>
+
+  <div class="stage">
+
+    <!-- ============ V1 ============ -->
+    <section class="variation active" id="v1">
+      <div class="page">
+        <div class="owner-banner">
+          <div class="who"><svg class="icon"><use href="#i-user"/></svg><span><b>You</b> created this recipe</span></div>
+          <div class="acts">
+            <button class="btn edit" disabled title="Editing coming soon"><svg class="icon"><use href="#i-edit"/></svg>Edit</button>
+            <button class="btn delete"><svg class="icon"><use href="#i-trash"/></svg>Delete</button>
+          </div>
+        </div>
+        <div class="recipe-header">
+          <div class="img"></div>
+          <div class="desc">
+            <p class="price">$2.00 / serving</p>
+            <h1 class="title">Chicken Tacos</h1>
+            <p class="description">Tender spiced chicken, crisp slaw, and a quick lime crema folded into warm corn tortillas — a 30-minute weeknight favorite.</p>
+            <div class="recipe-data">
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Prep</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Cook</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-user"/></svg><h4>Serves</h4><span class="d">4</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="body-spacer">ingredients · instructions · tags</div>
+        <div class="stats">
+          <span class="section-label">Recipe Stats</span>
+          <div class="stat-row">
+            <div class="stat"><svg class="icon"><use href="#i-eye"/></svg><span class="num">1,234</span><span class="lbl">Views</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-bookmark"/></svg><span class="num">1</span><span class="lbl">Save</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-check"/></svg><span class="num">5</span><span class="lbl">Made</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-star"/></svg><span class="num">4.2</span><span class="lbl">8 Ratings</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ V2 ============ -->
+    <section class="variation" id="v2">
+      <div class="page">
+        <div class="recipe-header">
+          <div class="img"></div>
+          <div class="desc">
+            <span class="owner-pill"><svg class="icon"><use href="#i-user"/></svg>Your recipe</span>
+            <p class="price">$2.00 / serving</p>
+            <h1 class="title">Chicken Tacos</h1>
+            <p class="description">Tender spiced chicken, crisp slaw, and a quick lime crema folded into warm corn tortillas — a 30-minute weeknight favorite.</p>
+            <div class="recipe-data">
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Prep</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Cook</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-user"/></svg><h4>Serves</h4><span class="d">4</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="body-spacer">ingredients · instructions · tags</div>
+        <div class="stats">
+          <span class="section-label">Recipe Stats</span>
+          <div class="stat-grid">
+            <div class="stat"><svg class="icon"><use href="#i-eye"/></svg><span class="num">1,234</span><span class="lbl">Views</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-bookmark"/></svg><span class="num">1</span><span class="lbl">Save</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-check"/></svg><span class="num">5</span><span class="lbl">Made</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-star"/></svg><span class="num">4.2</span><span class="lbl">8 Ratings</span></div>
+          </div>
+          <div class="controls">
+            <button class="btn edit" disabled title="Editing coming soon"><svg class="icon"><use href="#i-edit"/></svg>Edit</button>
+            <button class="btn delete"><svg class="icon"><use href="#i-trash"/></svg>Delete</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ V3 ============ -->
+    <section class="variation" id="v3">
+      <div class="page">
+        <div class="recipe-header">
+          <div class="img"></div>
+          <div class="desc">
+            <span class="owner-tag"><svg class="icon"><use href="#i-user"/></svg>Your recipe</span>
+            <p class="price">$2.00 / serving</p>
+            <h1 class="title">Chicken Tacos</h1>
+            <p class="description">Tender spiced chicken, crisp slaw, and a quick lime crema folded into warm corn tortillas — a 30-minute weeknight favorite.</p>
+            <div class="recipe-data">
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Prep</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Cook</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-user"/></svg><h4>Serves</h4><span class="d">4</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="body-spacer">ingredients · instructions · tags</div>
+        <div class="stats-bar">
+          <div class="stats-inline">
+            <div class="stat"><span class="num">1,234</span><span class="lbl">Views</span></div>
+            <div class="stat"><span class="num">1</span><span class="lbl">Save</span></div>
+            <div class="stat"><span class="num">5</span><span class="lbl">Made</span></div>
+            <div class="stat"><span class="num"><span class="star">★</span> 4.2</span><span class="lbl">8 Ratings</span></div>
+          </div>
+          <div class="controls">
+            <button class="btn edit" disabled title="Editing coming soon"><svg class="icon"><use href="#i-edit"/></svg>Edit</button>
+            <button class="btn delete"><svg class="icon"><use href="#i-trash"/></svg>Delete</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ V4 ============ -->
+    <section class="variation" id="v4">
+      <div class="page">
+        <div class="recipe-header">
+          <div class="img"><span class="chip"><svg class="icon"><use href="#i-user"/></svg>Your recipe</span></div>
+          <div class="desc">
+            <p class="price">$2.00 / serving</p>
+            <h1 class="title">Chicken Tacos</h1>
+            <p class="description">Tender spiced chicken, crisp slaw, and a quick lime crema folded into warm corn tortillas — a 30-minute weeknight favorite.</p>
+            <div class="recipe-data">
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Prep</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Cook</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-user"/></svg><h4>Serves</h4><span class="d">4</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="body-spacer">ingredients · instructions · tags</div>
+        <div class="owner-card">
+          <div class="head">
+            <div>
+              <div class="ttl">Your Recipe</div>
+              <div class="sub">Only you can see these controls and stats.</div>
+            </div>
+            <div class="acts">
+              <button class="btn edit" disabled title="Editing coming soon"><svg class="icon"><use href="#i-edit"/></svg>Edit</button>
+              <button class="btn delete"><svg class="icon"><use href="#i-trash"/></svg>Delete</button>
+            </div>
+          </div>
+          <div class="stat-row">
+            <div class="stat"><svg class="icon"><use href="#i-eye"/></svg><div><div class="num">1,234</div><div class="lbl">Views</div></div></div>
+            <div class="stat"><svg class="icon"><use href="#i-bookmark"/></svg><div><div class="num">1</div><div class="lbl">Save</div></div></div>
+            <div class="stat"><svg class="icon"><use href="#i-check"/></svg><div><div class="num">5</div><div class="lbl">Made</div></div></div>
+            <div class="stat"><svg class="icon"><use href="#i-star"/></svg><div><div class="num">4.2</div><div class="lbl">8 Ratings</div></div></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ V5 ============ -->
+    <section class="variation" id="v5">
+      <div class="page">
+        <div class="recipe-header">
+          <div class="img"></div>
+          <div class="desc">
+            <p class="price">$2.00 / serving</p>
+            <h1 class="title">Chicken Tacos</h1>
+            <div class="owner-line"><svg class="icon" style="height:16px;width:16px;color:var(--secondary)"><use href="#i-user"/></svg>By you <span class="dot">·</span> <a href="#">Manage recipe</a></div>
+            <p class="description">Tender spiced chicken, crisp slaw, and a quick lime crema folded into warm corn tortillas — a 30-minute weeknight favorite.</p>
+            <div class="recipe-data">
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Prep</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Cook</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-user"/></svg><h4>Serves</h4><span class="d">4</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="body-spacer">ingredients · instructions · tags</div>
+        <div class="stats-foot">
+          <div class="stats-minimal">
+            <span class="stat"><svg class="icon"><use href="#i-eye"/></svg><b>1,234</b> views</span>
+            <span class="sep">·</span>
+            <span class="stat"><svg class="icon"><use href="#i-bookmark"/></svg><b>1</b> save</span>
+            <span class="sep">·</span>
+            <span class="stat"><svg class="icon"><use href="#i-check"/></svg><b>5</b> made</span>
+            <span class="sep">·</span>
+            <span class="stat"><span class="star">★</span> <b>4.2</b> (8)</span>
+          </div>
+          <div class="controls">
+            <button class="btn edit" disabled title="Editing coming soon">Edit</button>
+            <button class="btn delete">Delete</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </div>
+
+  <script>
+    const descriptions = {
+      1: ['<span class="v-name">V1 · <b>Owner banner</b></span>','A slim ownership bar sits above the recipe with the Edit/Delete actions on the right; stats live at the bottom as a clean centered icon row (mirrors the existing prep/cook/serves data row). Controls are up top where you notice them first.'],
+      2: ['<span class="v-name">V2 · <b>Pill badge + cards</b></span>','A small orange-outline "Your recipe" pill tucks in beside the title. Stats become elevated white cards with the page\'s card shadow; Edit/Delete sit as a tidy button group beneath them.'],
+      3: ['<span class="v-name">V3 · <b>Inline divided bar</b></span>','An orange uppercase "Your recipe" tag (same treatment as the price label) marks ownership near the title. Stats + controls share one bordered bar at the bottom, stats divided by thin rules, actions on the right.'],
+      4: ['<span class="v-name">V4 · <b>Owner card</b></span>','A subtle dark chip on the photo flags ownership. Everything author-only is consolidated into one shadowed card with an orange accent edge: a titled header with Edit/Delete, and the stats laid out as labeled rows below.'],
+      5: ['<span class="v-name">V5 · <b>Minimal editorial</b></span>','The lightest touch — a "By you · Manage recipe" line under the title, and a single understated stats line with text buttons at the bottom. Closest to a content-first, low-chrome feel.'],
+    };
+    const buttons = [...document.querySelectorAll('.switcher button')];
+    const desc = document.getElementById('desc');
+    function show(v){
+      document.querySelectorAll('.variation').forEach(s=>s.classList.toggle('active', s.id==='v'+v));
+      buttons.forEach(b=>b.classList.toggle('active', b.dataset.v===String(v)));
+      desc.innerHTML = '<div>'+descriptions[v][0]+'</div><p>'+descriptions[v][1]+'</p>';
+      window.scrollTo({top:0,behavior:'smooth'});
+    }
+    buttons.forEach(b=>b.addEventListener('click',()=>show(b.dataset.v)));
+    window.addEventListener('keydown',e=>{ if(e.key>='1'&&e.key<='5') show(e.key); });
+    show(1);
+  </script>
+</body>
+</html>

--- a/server/__mocks__/firebase-admin.js
+++ b/server/__mocks__/firebase-admin.js
@@ -1,4 +1,6 @@
 // apps is non-empty so the initializeApp guard in middleware/auth.js is skipped
+const deleteFile = jest.fn().mockResolvedValue([{}])
+
 const admin = {
   apps: [{}],
   initializeApp: jest.fn(),
@@ -6,6 +8,14 @@ const admin = {
   auth: jest.fn(() => ({
     verifyIdToken: jest.fn().mockResolvedValue({ uid: 'test-uid' }),
   })),
+  // Storage chain used by util/firebaseStorage.deleteRecipeImage. deleteFile is
+  // exported so tests can assert (or override) image-deletion behavior.
+  storage: jest.fn(() => ({
+    bucket: jest.fn(() => ({
+      file: jest.fn(() => ({ delete: deleteFile })),
+    })),
+  })),
+  __deleteFile: deleteFile,
 }
 
 module.exports = admin

--- a/server/__tests__/firebaseStorage.test.js
+++ b/server/__tests__/firebaseStorage.test.js
@@ -1,0 +1,43 @@
+const admin = require('firebase-admin') // auto-mocked
+const { parseStorageUrl, deleteRecipeImage } = require('../util/firebaseStorage')
+
+describe('parseStorageUrl', () => {
+  it('extracts bucket and decoded path from a Firebase download URL', () => {
+    const url =
+      'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ftuscan.jpg?alt=media&token=abc'
+    expect(parseStorageUrl(url)).toEqual({
+      bucket: 'test-bucket',
+      path: 'recipeImages/tuscan.jpg',
+    })
+  })
+
+  it('returns null for empty, non-string, or non-Firebase values', () => {
+    expect(parseStorageUrl('')).toBeNull()
+    expect(parseStorageUrl(null)).toBeNull()
+    expect(parseStorageUrl(undefined)).toBeNull()
+    expect(parseStorageUrl('https://example.com/image.jpg')).toBeNull()
+  })
+})
+
+describe('deleteRecipeImage', () => {
+  beforeEach(() => admin.__deleteFile.mockClear())
+
+  it('deletes the parsed file and returns true', async () => {
+    const url =
+      'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ftuscan.jpg?alt=media&token=abc'
+    await expect(deleteRecipeImage(url)).resolves.toBe(true)
+    expect(admin.__deleteFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns false without calling storage for an unparseable url', async () => {
+    await expect(deleteRecipeImage('')).resolves.toBe(false)
+    expect(admin.__deleteFile).not.toHaveBeenCalled()
+  })
+
+  it('swallows storage errors and returns false', async () => {
+    admin.__deleteFile.mockRejectedValueOnce(new Error('boom'))
+    const url =
+      'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ftuscan.jpg?alt=media&token=abc'
+    await expect(deleteRecipeImage(url)).resolves.toBe(false)
+  })
+})

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -11,9 +11,15 @@
  */
 
 const request = require('supertest')
+const admin = require('firebase-admin') // auto-mocked (server/__mocks__/firebase-admin.js)
 const app = require('../app')
 const { getDB } = require('../db')
-const { seedRecipe, seedRecipes, seedUserRecipeData } = require('./helpers/seed')
+const {
+  seedRecipe,
+  seedRecipes,
+  seedUserRecipeData,
+  seedRating,
+} = require('./helpers/seed')
 
 const TEST_UID = 'test-uid'
 const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
@@ -33,6 +39,8 @@ const BASE_RECIPE = {
   description: 'A great dish',
   ingredients: [{ id: 'i1', name: 'chicken' }],
   instructions: [{ step: 'Cook the chicken' }],
+  recipeImage:
+    'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ftuscan.jpg?alt=media&token=abc',
 }
 
 afterEach(async () => {
@@ -41,6 +49,7 @@ afterEach(async () => {
     db.collection('recipes').deleteMany({}),
     db.collection('userRecipeData').deleteMany({}),
     db.collection('stats').deleteMany({}),
+    db.collection('ratings').deleteMany({}),
   ])
 })
 
@@ -349,9 +358,32 @@ describe('GET /getRecipe', () => {
 // ─── DELETE /deleteRecipe ─────────────────────────────────────────────────────
 
 describe('DELETE /deleteRecipe', () => {
+  const OTHER_UID = 'other-user'
+  const KEEP_ID = 'recipe-keep'
+
   beforeEach(async () => {
+    admin.__deleteFile.mockClear()
     await seedRecipe({ ...BASE_RECIPE, userId: TEST_UID })
-    await seedUserRecipeData(TEST_UID, { userRecipes: [{ recipeId: RECIPE_ID }] })
+
+    // Owner's created/saved/made lists all reference the recipe.
+    await seedUserRecipeData(TEST_UID, {
+      userRecipes: [{ recipeId: RECIPE_ID }],
+      savedRecipes: [{ recipeId: RECIPE_ID, dateSaved: '1000' }],
+      madeRecipes: [{ recipeId: RECIPE_ID }],
+    })
+    // A different user who saved and made it — plus an unrelated recipe that
+    // must survive the delete.
+    await seedUserRecipeData(OTHER_UID, {
+      savedRecipes: [
+        { recipeId: RECIPE_ID, dateSaved: '2000' },
+        { recipeId: KEEP_ID, dateSaved: '3000' },
+      ],
+      madeRecipes: [{ recipeId: RECIPE_ID }],
+    })
+    // Ratings/reviews for the recipe, and one for an unrelated recipe.
+    await seedRating({ username: 'someone', recipeId: RECIPE_ID, rating: 5, reviewText: 'Great' })
+    await seedRating({ username: 'another', recipeId: RECIPE_ID, rating: 4 })
+    await seedRating({ username: 'someone', recipeId: KEEP_ID, rating: 3 })
   })
 
   it('rejects request with no auth token (401)', async () => {
@@ -377,11 +409,13 @@ describe('DELETE /deleteRecipe', () => {
       .set(AUTH_HEADER)
 
     expect(res.status).toBe(403)
-    // Recipe must still exist
+    // Recipe must still exist, and nothing should have been cleaned up.
     expect(await db.collection('recipes').findOne({ _id: RECIPE_ID })).not.toBeNull()
+    expect(await db.collection('ratings').countDocuments({ recipeId: RECIPE_ID })).toBe(2)
+    expect(admin.__deleteFile).not.toHaveBeenCalled()
   })
 
-  it('deletes the recipe and removes it from userRecipes', async () => {
+  it('deletes the recipe and removes it from the owner\'s created/saved/made lists', async () => {
     const res = await request(app)
       .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
@@ -394,6 +428,62 @@ describe('DELETE /deleteRecipe', () => {
 
     const userData = await db.collection('userRecipeData').findOne({ _id: TEST_UID })
     expect(userData.userRecipes).toHaveLength(0)
+    expect(userData.savedRecipes).toHaveLength(0)
+    expect(userData.madeRecipes).toHaveLength(0)
+  })
+
+  it('removes the recipe\'s ratings/reviews but leaves other recipes\' ratings', async () => {
+    await request(app)
+      .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+
+    const db = getDB()
+    expect(await db.collection('ratings').countDocuments({ recipeId: RECIPE_ID })).toBe(0)
+    expect(await db.collection('ratings').countDocuments({ recipeId: KEEP_ID })).toBe(1)
+  })
+
+  it('removes the recipeId from other users\' saved/made lists without touching unrelated entries', async () => {
+    await request(app)
+      .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+
+    const db = getDB()
+    const other = await db.collection('userRecipeData').findOne({ _id: OTHER_UID })
+    expect(other.savedRecipes).toEqual([{ recipeId: KEEP_ID, dateSaved: '3000' }])
+    expect(other.madeRecipes).toHaveLength(0)
+  })
+
+  it('deletes the recipe image from storage', async () => {
+    await request(app)
+      .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+
+    expect(admin.__deleteFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('succeeds (200) and still deletes the recipe when there is no stored image', async () => {
+    const db = getDB()
+    await db.collection('recipes').updateOne({ _id: RECIPE_ID }, { $set: { recipeImage: '' } })
+
+    const res = await request(app)
+      .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    expect(admin.__deleteFile).not.toHaveBeenCalled()
+    expect(await db.collection('recipes').findOne({ _id: RECIPE_ID })).toBeNull()
+  })
+
+  it('succeeds (200) even if storage image deletion fails', async () => {
+    admin.__deleteFile.mockRejectedValueOnce(new Error('storage down'))
+
+    const res = await request(app)
+      .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    const db = getDB()
+    expect(await db.collection('recipes').findOne({ _id: RECIPE_ID })).toBeNull()
   })
 })
 

--- a/server/__tests__/setup.js
+++ b/server/__tests__/setup.js
@@ -1,12 +1,15 @@
-const { MongoMemoryServer } = require('mongodb-memory-server')
+const { MongoMemoryReplSet } = require('mongodb-memory-server')
 const { connectDB, closeDB } = require('../db')
 
 let mongod
 
+// A single-node replica set (rather than a standalone) so multi-document
+// transactions — used by DELETE /deleteRecipe — work in tests, matching the
+// replica-set topology of the production Atlas deployment.
 beforeAll(async () => {
-  mongod = await MongoMemoryServer.create()
+  mongod = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
   await connectDB(mongod.getUri())
-}, 30000)
+}, 60000)
 
 afterAll(async () => {
   await closeDB()

--- a/server/db.js
+++ b/server/db.js
@@ -51,4 +51,9 @@ function getDB() {
   return db
 }
 
-module.exports = { connectDB, closeDB, getDB }
+function getClient() {
+  if (!client) throw new Error('DB not initialized. Call connectDB() first.')
+  return client
+}
+
+module.exports = { connectDB, closeDB, getDB, getClient }

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -1,9 +1,10 @@
 const { Router } = require('express')
 const { ObjectId } = require('mongodb')
-const { getDB } = require('../db')
+const { getDB, getClient } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { validateRecipeBounds } = require('../util/recipeLimits')
+const { deleteRecipeImage } = require('../util/firebaseStorage')
 
 const router = Router()
 
@@ -180,11 +181,36 @@ router.delete('/deleteRecipe', verifyToken, async (req, res) => {
     if (recipe.userId !== uid) {
       return res.status(403).json({ error: 'Forbidden' })
     }
-    await db.collection('recipes').deleteOne(recipeIdQuery(recipeId))
-    await db.collection('userRecipeData').updateOne(
-      { _id: uid },
-      { $pull: { userRecipes: { recipeId } } }
-    )
+
+    // Remove the recipe and every reference to it atomically: its ratings/
+    // reviews, and the recipeId entry from any user's saved/made/created lists.
+    // userRecipes only ever lives on the owner's doc, but pulling it across all
+    // docs in the same updateMany is harmless and keeps this to one write.
+    const session = getClient().startSession()
+    try {
+      await session.withTransaction(async () => {
+        await db.collection('recipes').deleteOne(recipeIdQuery(recipeId), { session })
+        await db.collection('ratings').deleteMany({ recipeId }, { session })
+        await db.collection('userRecipeData').updateMany(
+          {},
+          {
+            $pull: {
+              savedRecipes: { recipeId },
+              madeRecipes: { recipeId },
+              userRecipes: { recipeId },
+            },
+          },
+          { session }
+        )
+      })
+    } finally {
+      await session.endSession()
+    }
+
+    // External side effect — runs after the transaction commits and never
+    // fails the request (an orphaned image is preferable to a 500 here).
+    await deleteRecipeImage(recipe.recipeImage)
+
     res.json({ deleted: true })
   } catch (err) {
     res.status(500).json({ error: err.message })

--- a/server/scripts/check-username-dupes.js
+++ b/server/scripts/check-username-dupes.js
@@ -1,0 +1,81 @@
+/**
+ * READ-ONLY precheck for the unique index on usernames.username_lower.
+ *
+ * The migration in db.js (ensureIndexes) builds a UNIQUE index on the
+ * lowercased username. If the collection already contains two usernames that
+ * differ only by case (e.g. "John" and "john"), that index will fail to build.
+ * This script finds those collisions BEFORE you deploy, without writing
+ * anything — it opens its own connection and never calls ensureIndexes().
+ *
+ * Usage (from the repo root or the server dir):
+ *   node server/scripts/check-username-dupes.js
+ *
+ * Exit code 0 = clean (index will build), 1 = collisions found, 2 = error.
+ */
+const path = require('path')
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') })
+const { MongoClient } = require('mongodb')
+
+async function main() {
+  const uri = process.env.MONGO_URI
+  if (!uri) {
+    console.error('MONGO_URI is not set (looked in server/.env).')
+    process.exit(2)
+  }
+
+  const client = new MongoClient(uri, { serverSelectionTimeoutMS: 10000 })
+
+  try {
+    await client.connect()
+    const usernames = client.db('prepify').collection('usernames')
+
+    const total = await usernames.countDocuments()
+    const missingLower = await usernames.countDocuments({
+      username_lower: { $exists: false },
+      username: { $type: 'string' },
+    })
+
+    // Group by the lowercased username and keep only groups with >1 doc.
+    const collisions = await usernames
+      .aggregate([
+        { $match: { username: { $type: 'string' } } },
+        {
+          $group: {
+            _id: { $toLower: '$username' },
+            count: { $sum: 1 },
+            ids: { $push: '$_id' },
+            originals: { $push: '$username' },
+          },
+        },
+        { $match: { count: { $gt: 1 } } },
+        { $sort: { count: -1 } },
+      ])
+      .toArray()
+
+    console.log(`\nusernames documents:        ${total}`)
+    console.log(`missing username_lower:     ${missingLower} (will be backfilled on deploy)`)
+    console.log(`case-insensitive collisions: ${collisions.length}\n`)
+
+    if (collisions.length === 0) {
+      console.log('✅ No case-variant duplicates. The unique index will build cleanly.')
+      process.exit(0)
+    }
+
+    console.log('❌ Found usernames that collide once lowercased. Resolve these before deploying:\n')
+    for (const c of collisions) {
+      console.log(`  "${c._id}" x${c.count}`)
+      c.originals.forEach((name, i) => {
+        console.log(`      - ${JSON.stringify(name)}  (uid: ${c.ids[i]})`)
+      })
+    }
+    console.log('')
+    process.exit(1)
+  } catch (err) {
+    console.error('Precheck failed:', err.message)
+    process.exit(2)
+  } finally {
+    await client.close()
+  }
+}
+
+main()

--- a/server/util/firebaseStorage.js
+++ b/server/util/firebaseStorage.js
@@ -1,0 +1,30 @@
+const admin = require('firebase-admin')
+
+// Firebase Storage download URLs look like:
+//   https://firebasestorage.googleapis.com/v0/b/<bucket>/o/<url-encoded-path>?alt=media&token=...
+// Pull out the bucket and the decoded object path so the file can be deleted
+// server-side. Returns null for anything that isn't a recognizable URL (e.g.
+// empty string, an already-relative path, or a non-Firebase URL).
+function parseStorageUrl(url) {
+  if (typeof url !== 'string') return null
+  const match = url.match(/\/b\/([^/]+)\/o\/([^?]+)/)
+  if (!match) return null
+  return { bucket: match[1], path: decodeURIComponent(match[2]) }
+}
+
+// Best-effort deletion of a recipe's image from Firebase Storage. Never throws:
+// an orphaned image is undesirable but must not fail (or roll back) the recipe
+// deletion it accompanies. Returns true only when a file was actually deleted.
+async function deleteRecipeImage(url) {
+  const parsed = parseStorageUrl(url)
+  if (!parsed) return false
+  try {
+    await admin.storage().bucket(parsed.bucket).file(parsed.path).delete()
+    return true
+  } catch (err) {
+    console.error('Failed to delete recipe image from storage:', err.message)
+    return false
+  }
+}
+
+module.exports = { parseStorageUrl, deleteRecipeImage }

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
@@ -2,21 +2,53 @@
 
 .recipe-controls-container {
   display: flex;
-  justify-content: flex-end;
-  padding-bottom: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  padding: 0.7rem 1.25rem;
   width: 100%;
+  background: s.$gray-50;
+  border: 1px solid s.$gray-400;
+  border-radius: s.$border-radius;
+  .who {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: s.$secondary-text;
+    .icon {
+      height: 20px;
+      width: 20px;
+      color: s.$secondary;
+    }
+    strong {
+      color: s.$primary-text;
+      font-weight: 700;
+    }
+  }
   .btns-container {
     display: flex;
-    gap: 1rem;
+    gap: 0.6rem;
   }
   button {
-    border: 1px solid s.$secondary-text;
-    padding: 0.5rem 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    border: 1px solid s.$gray-500;
+    padding: 0.4rem 0.8rem;
     border-radius: s.$border-radius;
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 600;
     color: s.$primary-text;
+    background: transparent;
+    .icon {
+      height: 17px;
+      width: 17px;
+    }
     &:focus {
       @include s.outline();
     }
@@ -28,10 +60,16 @@
       color: s.$primary-background;
       background: s.$primary-text;
     }
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      &:hover {
+        color: s.$primary-text;
+        background: none;
+      }
+    }
   }
   button.delete-btn {
-    // background: s.$primary-text;
-    // color: s.$primary-background;
     background: none;
     transition: all 0.1s linear;
     &:hover {

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -9,6 +9,7 @@ import { TailSpin } from 'react-loader-spinner'
 import Modal from 'react-modal'
 import { useNavigate } from 'react-router-dom'
 import { isAxiosError } from 'axios'
+import toast from 'react-hot-toast'
 import AuthAPI from 'src/api/auth'
 import RecipeAPI from 'src/api/recipes'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -78,6 +79,8 @@ const RecipeControls: FC<RecipeControlsType> = ({
       queryClient.removeQueries({ queryKey: ['recipe', recipeId] })
       queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
       closeDeleteModal()
+      // Toaster is mounted at the app root, so the toast survives the redirect.
+      toast.success('Recipe deleted.')
       navigate('/')
     } catch (err: unknown) {
       const message = isAxiosError(err)

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -80,7 +80,7 @@ const RecipeControls: FC<RecipeControlsType> = ({
       queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
       closeDeleteModal()
       // Toaster is mounted at the app root, so the toast survives the redirect.
-      toast.success('Recipe deleted.')
+      toast.success(`"${recipeTitle}" deleted.`)
       navigate('/')
     } catch (err: unknown) {
       const message = isAxiosError(err)

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -1,11 +1,17 @@
 import React, { FC, useState } from 'react'
-import { AiOutlineClose } from 'react-icons/ai'
+import {
+  AiOutlineClose,
+  AiOutlineEdit,
+  AiOutlineDelete,
+  AiOutlineUser,
+} from 'react-icons/ai'
 import { TailSpin } from 'react-loader-spinner'
 import Modal from 'react-modal'
 import { useNavigate } from 'react-router-dom'
+import { isAxiosError } from 'axios'
 import AuthAPI from 'src/api/auth'
 import RecipeAPI from 'src/api/recipes'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import './RecipeControls.scss'
 
 type RecipeControlsType = {
@@ -45,6 +51,7 @@ const RecipeControls: FC<RecipeControlsType> = ({
   }
 
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const [deleteLoading, setDeleteLoading] = useState(false)
   const [deleteError, setDeleteError] = useState('')
@@ -61,30 +68,50 @@ const RecipeControls: FC<RecipeControlsType> = ({
 
   if (!isUsersRecipe) return null
 
-  const handleDeleteRecipe = () => {
-    if (currUID) {
-      setDeleteLoading(true)
-      RecipeAPI.deleteRecipe(recipeId).then(res => {
-        const response = res as { error?: string }
-        if (response.error) {
-          setDeleteError(response.error)
-        } else {
-          closeDeleteModal()
-          navigate('/')
-        }
-        setDeleteLoading(false)
-      })
+  const handleDeleteRecipe = async () => {
+    if (!currUID) return
+    setDeleteLoading(true)
+    setDeleteError('')
+    try {
+      await RecipeAPI.deleteRecipe(recipeId)
+      // Drop cached copies so lists/pages don't show the deleted recipe.
+      queryClient.removeQueries({ queryKey: ['recipe', recipeId] })
+      queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
+      closeDeleteModal()
+      navigate('/')
+    } catch (err: unknown) {
+      const message = isAxiosError(err)
+        ? err.response?.data?.error ?? err.message
+        : 'Failed to delete recipe. Please try again.'
+      setDeleteError(message)
+    } finally {
+      setDeleteLoading(false)
     }
   }
 
   return (
     <div className='recipe-controls-container'>
+      <span className='who'>
+        <AiOutlineUser className='icon' aria-hidden='true' />
+        <span>
+          <strong>You</strong> created this recipe
+        </span>
+      </span>
       <div className='btns-container'>
-        {/* <button className='edit-btn'>Edit</button> */}
+        <button
+          className='edit-btn'
+          disabled
+          title='Editing is coming soon'
+          aria-label='Edit recipe (coming soon)'
+        >
+          <AiOutlineEdit className='icon' aria-hidden='true' />
+          Edit
+        </button>
         <button
           className='delete-btn'
           onClick={() => setIsDeleteModalOpen(true)}
         >
+          <AiOutlineDelete className='icon' aria-hidden='true' />
           Delete
         </button>
       </div>

--- a/src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats.scss
@@ -1,0 +1,50 @@
+@use '../../../../helpers.scss' as s;
+
+.recipe-stats-foot {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid s.$gray-400;
+
+  .stats-minimal {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1.1rem;
+    color: s.$secondary-text;
+    font-weight: 600;
+    font-size: 0.95rem;
+
+    .stat {
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+
+      .icon {
+        height: 18px;
+        width: 18px;
+        color: s.$tertiary-text;
+      }
+      .icon.star {
+        color: s.$primary;
+      }
+      b {
+        color: s.$primary-text;
+        font-weight: 700;
+      }
+    }
+
+    .sep {
+      color: s.$gray-500;
+    }
+  }
+
+  @media screen and (max-width: 500px) {
+    .stats-minimal {
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      .sep {
+        display: none;
+      }
+    }
+  }
+}

--- a/src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats.tsx
@@ -1,0 +1,66 @@
+import React, { FC } from 'react'
+import { AiOutlineEye } from 'react-icons/ai'
+import { BsBookmark, BsCheck2Circle, BsStarFill } from 'react-icons/bs'
+import { RecipeType } from 'types'
+import './RecipeStats.scss'
+
+type RecipeStatsProps = {
+  currRecipe: RecipeType | null
+  loading: boolean
+}
+
+const formatCount = (n: number | null | undefined): string =>
+  (n ?? 0).toLocaleString()
+
+const RecipeStats: FC<RecipeStatsProps> = ({ currRecipe, loading }) => {
+  if (loading || !currRecipe) return null
+
+  const views = currRecipe.views ?? 0
+  const numTimesSaved = currRecipe.numTimesSaved ?? 0
+  const numTimesMade = currRecipe.numTimesMade ?? 0
+  const rateValue = currRecipe.rating?.rateValue ?? 0
+  const rateCount = currRecipe.rating?.rateCount ?? 0
+
+  return (
+    <div className='recipe-stats-foot'>
+      <div className='stats-minimal' aria-label='Recipe statistics'>
+        <span className='stat'>
+          <AiOutlineEye className='icon' aria-hidden='true' />
+          <b>{formatCount(views)}</b> {views === 1 ? 'view' : 'views'}
+        </span>
+        <span className='sep' aria-hidden='true'>
+          ·
+        </span>
+        <span className='stat'>
+          <BsBookmark className='icon' aria-hidden='true' />
+          <b>{formatCount(numTimesSaved)}</b>{' '}
+          {numTimesSaved === 1 ? 'save' : 'saves'}
+        </span>
+        <span className='sep' aria-hidden='true'>
+          ·
+        </span>
+        <span className='stat'>
+          <BsCheck2Circle className='icon' aria-hidden='true' />
+          <b>{formatCount(numTimesMade)}</b> made
+        </span>
+        <span className='sep' aria-hidden='true'>
+          ·
+        </span>
+        <span className='stat'>
+          <BsStarFill className='icon star' aria-hidden='true' />
+          {rateCount > 0 ? (
+            <>
+              <b>{rateValue.toFixed(1)}</b> ({formatCount(rateCount)})
+            </>
+          ) : (
+            <>
+              <b>—</b> no ratings
+            </>
+          )}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export default RecipeStats

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -9,6 +9,7 @@ import Ingredients from 'src/pages/SingleRecipe/DataSections/Ingredients/Ingredi
 import Instructions from 'src/pages/SingleRecipe/DataSections/Instructions/Instructions'
 import Tags from 'src/pages/SingleRecipe/DataSections/Tags'
 import RecipeControls from 'src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls'
+import RecipeStats from 'src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats'
 import MadeRecipeBtn from 'src/pages/SingleRecipe/Buttons/MadeRecipeBtn'
 
 import { updateIngredients } from 'src/util/updateIngredients'
@@ -145,7 +146,9 @@ const SingleRecipe: FC<Props> = ({ recipe }) => {
                 />
                 <Tags loading={loading} currRecipe={currRecipe} />
                 {recipeId && <MadeRecipeBtn recipeId={recipeId} />}
-                <div className='recipe-stats'></div>
+                <div className='recipe-stats'>
+                  <RecipeStats currRecipe={currRecipe} loading={loading} />
+                </div>
               </div>
               {!loading && currRecipe && (
                 <RatingsAndReviews

--- a/src/test/RecipeStats.test.tsx
+++ b/src/test/RecipeStats.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import RecipeStats from 'src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats'
+import { RecipeType } from 'types'
+
+const baseRecipe = {
+  _id: 'recipe-1',
+  title: 'Chicken Tacos',
+  views: 1234,
+  numTimesSaved: 1,
+  numTimesMade: 5,
+  rating: { rateValue: 4.2, rateCount: 8 },
+} as unknown as RecipeType
+
+describe('RecipeStats', () => {
+  it('renders nothing while loading', () => {
+    const { container } = render(
+      <RecipeStats currRecipe={baseRecipe} loading={true} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when there is no recipe', () => {
+    const { container } = render(
+      <RecipeStats currRecipe={null} loading={false} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('displays formatted views, saves, made and rating', () => {
+    render(<RecipeStats currRecipe={baseRecipe} loading={false} />)
+
+    expect(screen.getByText('1,234')).toBeInTheDocument()
+    expect(screen.getByText('views')).toBeInTheDocument()
+    // numTimesSaved of 1 should be singular
+    expect(screen.getByText('save')).toBeInTheDocument()
+    expect(screen.getByText('made')).toBeInTheDocument()
+    expect(screen.getByText('4.2')).toBeInTheDocument()
+    expect(screen.getByText(/\(8\)/)).toBeInTheDocument()
+  })
+
+  it('pluralizes saves when there is more than one', () => {
+    const manySaves = { ...baseRecipe, numTimesSaved: 3 } as unknown as RecipeType
+    render(<RecipeStats currRecipe={manySaves} loading={false} />)
+    expect(screen.getByText('saves')).toBeInTheDocument()
+  })
+
+  it('shows "no ratings" with an em dash when there are no ratings', () => {
+    const noRatings = {
+      ...baseRecipe,
+      rating: { rateValue: 0, rateCount: 0 },
+    } as unknown as RecipeType
+    render(<RecipeStats currRecipe={noRatings} loading={false} />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.getByText('no ratings')).toBeInTheDocument()
+  })
+
+  it('defaults missing counts to zero', () => {
+    const sparse = { _id: 'r2', title: 'x' } as unknown as RecipeType
+    render(<RecipeStats currRecipe={sparse} loading={false} />)
+    // views, saves, made all default to 0
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(3)
+  })
+})


### PR DESCRIPTION
## Summary

Adds an author-only ownership banner and a public stats line to the single recipe page, and hardens recipe deletion so it cleans up everything that references a recipe.

### Single recipe page
- **Author banner (top):** a "You created this recipe" bar with a disabled **Edit** placeholder (for the upcoming edit feature) and **Delete**. Author-only.
- **Public stats line (bottom):** a minimal inline `views · saves · made · rating` line, visible to everyone.
- **Delete handler fix:** the old handler had no `.catch`, so a failed delete (server returns non-2xx → axios throws) left the spinner stuck and the error branch was dead code. Now surfaces the server error, invalidates the `created-recipes` cache, and shows a success toast (`"<title>" deleted.`) that survives the redirect home — mirroring the create-recipe toast.

### Delete cleanup (server)
`DELETE /deleteRecipe` previously removed only the recipe doc and the owner's `userRecipes` entry, orphaning everything else. It now removes all references **atomically in one transaction**:
- ratings/reviews for the recipe (`ratings` collection)
- the `recipeId` from every user's `savedRecipes`, `madeRecipes`, and `userRecipes`

and, after commit, **best-effort** deletes the recipe image from Firebase Storage (parsed from the stored download URL; never fails the request).

## Testing
- Frontend: new `RecipeStats` unit tests; existing `SingleRecipe` tests pass. Typecheck clean.
- Server: Jest harness switched to a single-node `MongoMemoryReplSet` so the transaction is exercised (matches production Atlas). New coverage for ratings/saved/made cleanup, image deletion, and best-effort failure. **All 132 server tests pass.**

## Notes
- Test harness now requires a replica set for transactions; production Atlas is one. A dev `MONGO_URI` pointed at a standalone mongod would error on delete.
- `totalRecipeViews` global stat is intentionally not decremented on delete (lifetime accounting).
- Includes a design-exploration mockup at `design-explorations/single-recipe/author-stats.html`.