### PR TITLE
feat(recipes): allow authors to edit their recipes

### DIFF
--- a/cypress/fixtures/single-recipe.json
+++ b/cypress/fixtures/single-recipe.json
@@ -444,8 +444,8 @@
   },
   "totalTime": 40,
   "rating": {
-    "rateCount": "3",
-    "rateValue": "13"
+    "rateCount": 3,
+    "rateValue": 4.3
   },
   "createdAt": "1678299721258",
   "editedAt": null,

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -233,6 +233,148 @@ describe('POST /addRecipe', () => {
   })
 })
 
+// ─── PUT /editRecipe ──────────────────────────────────────────────────────────
+
+describe('PUT /editRecipe', () => {
+  const OWNED_RECIPE = {
+    ...BASE_RECIPE,
+    userId: TEST_UID,
+    rating: { rateCount: 12, rateValue: 4.5 },
+    numTimesSaved: 7,
+    numTimesMade: 3,
+    views: 99,
+    editedAt: null,
+  }
+
+  const validEdit = () => ({
+    title: 'Updated Title',
+    description: 'An updated description',
+    ingredients: [{ id: 'i1', name: 'chicken' }],
+    instructions: [{ content: 'Cook it well', index: 1, id: 's1' }],
+    mealTypes: ['dinner'],
+  })
+
+  beforeEach(async () => {
+    await seedRecipe({ ...OWNED_RECIPE })
+  })
+
+  it('rejects request with no auth token (401)', async () => {
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .send(validEdit())
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when recipeId is missing', async () => {
+    const res = await request(app)
+      .put('/api/editRecipe')
+      .set(AUTH_HEADER)
+      .send(validEdit())
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 if the recipe does not exist', async () => {
+    const res = await request(app)
+      .put('/api/editRecipe?recipeId=nonexistent')
+      .set(AUTH_HEADER)
+      .send(validEdit())
+    expect(res.status).toBe(404)
+  })
+
+  it('rejects an edit by a non-owner (403) and leaves the recipe unchanged', async () => {
+    const db = getDB()
+    await db.collection('recipes').deleteOne({ _id: RECIPE_ID })
+    await seedRecipe({ ...OWNED_RECIPE, userId: 'someone-else' })
+
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send(validEdit())
+
+    expect(res.status).toBe(403)
+    const stored = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(stored.title).toBe(OWNED_RECIPE.title)
+    expect(stored.editedAt).toBeNull()
+  })
+
+  it('rejects missing required fields (400)', async () => {
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send({ description: 'no title/ingredients/etc' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Missing required fields/)
+  })
+
+  it('enforces input bounds (400)', async () => {
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send({ ...validEdit(), title: 'A'.repeat(51) })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Title cannot exceed/)
+  })
+
+  it('updates editable fields and stamps editedAt', async () => {
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send(validEdit())
+
+    expect(res.status).toBe(200)
+
+    const db = getDB()
+    const stored = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(stored.title).toBe('Updated Title')
+    expect(stored.description).toBe('An updated description')
+    expect(typeof stored.editedAt).toBe('string')
+    expect(stored.editedAt).not.toBeNull()
+  })
+
+  it('never resets ratings, saves, made-count, views, or createdAt on edit', async () => {
+    await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send(validEdit())
+
+    const db = getDB()
+    const stored = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(stored.rating).toEqual({ rateCount: 12, rateValue: 4.5 })
+    expect(stored.numTimesSaved).toBe(7)
+    expect(stored.numTimesMade).toBe(3)
+    expect(stored.views).toBe(99)
+    expect(stored.createdAt).toBe(OWNED_RECIPE.createdAt)
+  })
+
+  it('ignores attempts to overwrite protected fields via the payload', async () => {
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send({
+        ...validEdit(),
+        // Malicious / stray fields the whitelist must drop:
+        rating: { rateCount: 9999, rateValue: 1 },
+        numTimesSaved: 0,
+        numTimesMade: 0,
+        views: 0,
+        userId: 'someone-else',
+        _id: 'hijacked-id',
+        createdAt: '1',
+      })
+
+    expect(res.status).toBe(200)
+    const db = getDB()
+    const stored = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(stored.rating).toEqual({ rateCount: 12, rateValue: 4.5 })
+    expect(stored.numTimesSaved).toBe(7)
+    expect(stored.numTimesMade).toBe(3)
+    expect(stored.views).toBe(99)
+    expect(stored.userId).toBe(TEST_UID)
+    expect(stored._id).toBe(RECIPE_ID)
+    expect(stored.createdAt).toBe(OWNED_RECIPE.createdAt)
+  })
+})
+
 // ─── POST /recipes/:id/save ───────────────────────────────────────────────────
 
 describe('POST /recipes/:id/save', () => {

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -165,6 +165,79 @@ router.post('/addRecipe', verifyToken, async (req, res) => {
   }
 })
 
+// PUT /editRecipe — owner-only edit. Social/derived counters and immutable
+// metadata are never writable here (see EDITABLE_FIELDS), so an edit can never
+// reset a recipe's ratings, saves, or made-count. editedAt is stamped so the UI
+// can surface that the recipe changed after people saved it.
+const EDITABLE_FIELDS = [
+  'title',
+  'prepTime',
+  'cookTime',
+  'servings',
+  'fridgeLife',
+  'freezerLife',
+  'description',
+  'ingredients',
+  'instructions',
+  'recipeImage',
+  'cuisine',
+  'mealTypes',
+  'nutritionData',
+  'nutritionLabels',
+  'servingPrice',
+  'totalTime',
+]
+
+router.put('/editRecipe', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    const { recipeId } = req.query
+    if (!recipeId) {
+      return res.status(400).json({ error: 'recipeId is required' })
+    }
+    const uid = req.uid
+    const recipe = await db.collection('recipes').findOne(recipeIdQuery(recipeId))
+    if (!recipe) {
+      return res.status(404).json({ error: 'Recipe not found' })
+    }
+    if (recipe.userId !== uid) {
+      return res.status(403).json({ error: 'Forbidden' })
+    }
+
+    const body = req.body
+    const requiredFields = ['title', 'ingredients', 'instructions', 'mealTypes']
+    const missing = requiredFields.filter(f => {
+      const val = body[f]
+      return val == null || val === '' || (Array.isArray(val) && val.length === 0)
+    })
+    if (missing.length > 0) {
+      return res.status(400).json({ error: `Missing required fields: ${missing.join(', ')}` })
+    }
+    const boundsError = validateRecipeBounds(body)
+    if (boundsError) {
+      return res.status(400).json({ error: boundsError })
+    }
+
+    // Whitelist: copy only editable fields from the client payload. Anything
+    // else the client sends (rating, numTimesSaved, views, userId, _id, …) is
+    // ignored.
+    const update = {}
+    for (const field of EDITABLE_FIELDS) {
+      if (field in body) update[field] = body[field]
+    }
+    update.editedAt = Date.now().toString()
+
+    const updated = await db.collection('recipes').findOneAndUpdate(
+      recipeIdQuery(recipeId),
+      { $set: update },
+      { returnDocument: 'after' }
+    )
+    res.json(updated)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
 // DELETE /deleteRecipe
 router.delete('/deleteRecipe', verifyToken, async (req, res) => {
   try {

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -3,7 +3,7 @@ const { ObjectId } = require('mongodb')
 const { getDB, getClient } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
-const { validateRecipeBounds } = require('../util/recipeLimits')
+const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 
 const router = Router()
@@ -138,13 +138,9 @@ router.post('/addRecipe', verifyToken, async (req, res) => {
     const db = getDB()
     const body = req.body
     const uid = req.uid
-    const requiredFields = ['title', 'ingredients', 'instructions', 'mealTypes']
-    const missing = requiredFields.filter(f => {
-      const val = body[f]
-      return val == null || val === '' || (Array.isArray(val) && val.length === 0)
-    })
-    if (missing.length > 0) {
-      return res.status(400).json({ error: `Missing required fields: ${missing.join(', ')}` })
+    const requiredError = validateRequiredRecipeFields(body)
+    if (requiredError) {
+      return res.status(400).json({ error: requiredError })
     }
     const boundsError = validateRecipeBounds(body)
     if (boundsError) {
@@ -205,13 +201,9 @@ router.put('/editRecipe', verifyToken, async (req, res) => {
     }
 
     const body = req.body
-    const requiredFields = ['title', 'ingredients', 'instructions', 'mealTypes']
-    const missing = requiredFields.filter(f => {
-      const val = body[f]
-      return val == null || val === '' || (Array.isArray(val) && val.length === 0)
-    })
-    if (missing.length > 0) {
-      return res.status(400).json({ error: `Missing required fields: ${missing.join(', ')}` })
+    const requiredError = validateRequiredRecipeFields(body)
+    if (requiredError) {
+      return res.status(400).json({ error: requiredError })
     }
     const boundsError = validateRecipeBounds(body)
     if (boundsError) {

--- a/server/util/recipeLimits.js
+++ b/server/util/recipeLimits.js
@@ -7,6 +7,22 @@ const INSTRUCTION_MAX_LENGTH = 1000
 const MAX_INGREDIENTS = 50
 const MAX_INSTRUCTIONS = 50
 
+// Fields a recipe must carry to be created or edited. Shared by both routes so
+// the requirement can't drift between create and edit.
+const REQUIRED_RECIPE_FIELDS = ['title', 'ingredients', 'instructions', 'mealTypes']
+
+// Returns an error string when a required field is missing/empty, or null when
+// all are present. An array field counts as missing when empty.
+function validateRequiredRecipeFields(body) {
+  const missing = REQUIRED_RECIPE_FIELDS.filter(f => {
+    const val = body[f]
+    return val == null || val === '' || (Array.isArray(val) && val.length === 0)
+  })
+  return missing.length > 0
+    ? `Missing required fields: ${missing.join(', ')}`
+    : null
+}
+
 // Returns an error string when `body` violates a bound, or null when it's within
 // limits. Only checks fields that are present — required-field presence is
 // validated separately by the route.
@@ -46,5 +62,7 @@ module.exports = {
   INSTRUCTION_MAX_LENGTH,
   MAX_INGREDIENTS,
   MAX_INSTRUCTIONS,
+  REQUIRED_RECIPE_FIELDS,
+  validateRequiredRecipeFields,
   validateRecipeBounds,
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import UserRatings from 'src/pages/Account/UserRatings/UserRatings'
 import UserRecipes from 'src/pages/Account/UserRecipes/UserRecipes'
 
 import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
+import EditRecipe from 'src/pages/EditRecipe/EditRecipe'
 import Layout from 'src/Components/Layout/Layout'
 import Help from 'src/pages/Help/Help'
 import NotFound from 'src/pages/404/404'
@@ -113,6 +114,14 @@ const App: FC = () => {
                 element={
                   <Layout darkNavLinks={true}>
                     <AddRecipe />
+                  </Layout>
+                }
+              />
+              <Route
+                path='/recipes/:recipeId/edit'
+                element={
+                  <Layout darkNavLinks={true}>
+                    <EditRecipe />
                   </Layout>
                 }
               />

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -119,6 +119,40 @@ class RecipeAPIClass {
     }
   }
 
+  // The editable subset of a recipe document, assembled from the form data plus
+  // the values computed at submit time. addRecipe layers creation-only fields
+  // (authorUsername, rating, counters…) on top; editRecipe sends it as-is. Single
+  // source for the field list so the two paths can't drift.
+  private buildEditableRecipeFields(
+    data: RecipeFormType | RecipeEditFormType,
+    computed: {
+      recipeImage: string
+      nutritionData: NutritionDataType | null
+      nutritionLabels: string[] | null
+      servingPrice: number
+      totalTime: number
+    }
+  ) {
+    return {
+      title: data.title,
+      prepTime: data.prepTime,
+      cookTime: data.cookTime,
+      servings: data.servings,
+      fridgeLife: data.fridgeLife,
+      freezerLife: data.freezerLife,
+      description: data.description,
+      ingredients: data.ingredients,
+      instructions: data.instructions,
+      cuisine: data.cuisine,
+      mealTypes: data.mealTypes,
+      recipeImage: computed.recipeImage,
+      nutritionData: computed.nutritionData,
+      nutritionLabels: computed.nutritionLabels,
+      servingPrice: computed.servingPrice,
+      totalTime: computed.totalTime,
+    }
+  }
+
   async addRecipe(
     recipeData: RecipeFormType,
     setProgress: (val: number) => void
@@ -143,18 +177,13 @@ class RecipeAPIClass {
       const nutritionData = nutritionDataRes.nutritionData
       const nutritionLabels = nutritionDataRes.dietLabels
       const returnRecipeData: Omit<RecipeType, '_id'> = {
-        title: recipeData.title,
-        prepTime: recipeData.prepTime,
-        cookTime: recipeData.cookTime,
-        servings: recipeData.servings,
-        fridgeLife: recipeData.fridgeLife,
-        freezerLife: recipeData.freezerLife,
-        description: recipeData.description,
-        ingredients: recipeData.ingredients,
-        instructions: recipeData.instructions,
-        recipeImage,
-        nutritionData,
-        totalTime,
+        ...this.buildEditableRecipeFields(recipeData, {
+          recipeImage,
+          nutritionData,
+          nutritionLabels,
+          servingPrice,
+          totalTime,
+        }),
         authorUsername,
         rating: {
           rateCount: 0,
@@ -162,10 +191,6 @@ class RecipeAPIClass {
         },
         createdAt: new Date().getTime().toString(),
         editedAt: null,
-        servingPrice,
-        cuisine: recipeData.cuisine,
-        mealTypes: recipeData.mealTypes,
-        nutritionLabels,
         views: 0,
         numTimesSaved: 0,
         numTimesMade: 0,
@@ -210,10 +235,13 @@ class RecipeAPIClass {
 
       // Nutrition is a paid Edamam call, so only re-run it when the ingredient set
       // actually changed; minor edits (title, instructions, times) reuse the
-      // stored nutrition data and labels.
+      // stored nutrition data and labels. Compare the exact strings the lookup
+      // would send, element-wise.
+      const newIngredients = this.buildNutritionIngredients(recipeData.ingredients)
+      const oldIngredients = this.buildNutritionIngredients(originalRecipe.ingredients)
       const ingredientsChanged =
-        JSON.stringify(this.buildNutritionIngredients(recipeData.ingredients)) !==
-        JSON.stringify(this.buildNutritionIngredients(originalRecipe.ingredients))
+        newIngredients.length !== oldIngredients.length ||
+        newIngredients.some((ingr, i) => ingr !== oldIngredients[i])
 
       let nutritionData = originalRecipe.nutritionData
       let nutritionLabels = originalRecipe.nutritionLabels
@@ -233,24 +261,13 @@ class RecipeAPIClass {
       setProgress(90)
       // Only the editable fields are sent; the server whitelists these and never
       // lets ratings/saves/counters be overwritten.
-      const payload = {
-        title: recipeData.title,
-        prepTime: recipeData.prepTime,
-        cookTime: recipeData.cookTime,
-        servings: recipeData.servings,
-        fridgeLife: recipeData.fridgeLife,
-        freezerLife: recipeData.freezerLife,
-        description: recipeData.description,
-        ingredients: recipeData.ingredients,
-        instructions: recipeData.instructions,
+      const payload = this.buildEditableRecipeFields(recipeData, {
         recipeImage,
-        cuisine: recipeData.cuisine,
-        mealTypes: recipeData.mealTypes,
         nutritionData,
         nutritionLabels,
         servingPrice,
         totalTime,
-      }
+      })
       const res = await http.put<RecipeType>(
         `api/editRecipe?recipeId=${recipeId}`,
         payload

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -9,6 +9,7 @@ import {
   NutritionDataType,
   OptionalReviewType,
   RecipeDBResponseType,
+  RecipeEditFormType,
   RecipeFormType,
   RecipeSearchResponseType,
   RecipeType,
@@ -175,23 +176,101 @@ class RecipeAPIClass {
       return null
     }
   }
+
+  async editRecipe(
+    recipeId: string,
+    recipeData: RecipeEditFormType,
+    originalRecipe: RecipeType,
+    setProgress: (val: number) => void
+  ): Promise<boolean | typeof ADD_RECIPE_AUTH_ERROR> {
+    try {
+      setProgress(10)
+      // Image: only upload when the user picked a new file. Otherwise the recipe
+      // keeps its existing stored image URL.
+      let recipeImage = originalRecipe.recipeImage
+      if (recipeData.recipeImage) {
+        recipeImage = await this.uploadRecipeImage(
+          recipeData.recipeImage,
+          setProgress
+        )
+      }
+      setProgress(80)
+      // Serving price is a local calculation (no API cost), so always recompute —
+      // it depends on both ingredients and servings.
+      const servingPrice: number = calculateServingPrice(
+        recipeData.ingredients,
+        recipeData.servings
+      )
+      const totalTime: number = recipeData.prepTime + (recipeData.cookTime ?? 0)
+
+      // Nutrition is a paid Edamam call, so only re-run it when the ingredient set
+      // actually changed; minor edits (title, instructions, times) reuse the
+      // stored nutrition data and labels.
+      const ingredientsChanged =
+        JSON.stringify(this.buildNutritionIngredients(recipeData.ingredients)) !==
+        JSON.stringify(this.buildNutritionIngredients(originalRecipe.ingredients))
+
+      let nutritionData = originalRecipe.nutritionData
+      let nutritionLabels = originalRecipe.nutritionLabels
+      if (ingredientsChanged) {
+        const nutritionDataRes = await this.getRecipeNutrition(
+          recipeData.ingredients
+        )
+        nutritionData = nutritionDataRes.nutritionData
+        nutritionLabels = nutritionDataRes.dietLabels
+      }
+      setProgress(90)
+      // Only the editable fields are sent; the server whitelists these and never
+      // lets ratings/saves/counters be overwritten.
+      const payload = {
+        title: recipeData.title,
+        prepTime: recipeData.prepTime,
+        cookTime: recipeData.cookTime,
+        servings: recipeData.servings,
+        fridgeLife: recipeData.fridgeLife,
+        freezerLife: recipeData.freezerLife,
+        description: recipeData.description,
+        ingredients: recipeData.ingredients,
+        instructions: recipeData.instructions,
+        recipeImage,
+        cuisine: recipeData.cuisine,
+        mealTypes: recipeData.mealTypes,
+        nutritionData,
+        nutritionLabels,
+        servingPrice,
+        totalTime,
+      }
+      await http.put(`api/editRecipe?recipeId=${recipeId}`, payload)
+      return true
+    } catch (error: unknown) {
+      console.error('editRecipe failed:', error)
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        return ADD_RECIPE_AUTH_ERROR
+      }
+      return false
+    }
+  }
+  // The exact ingredient strings sent to Edamam for nutrition lookup. Shared by
+  // getRecipeNutrition and editRecipe so the "did the ingredients change?" check
+  // compares the same representation that actually drives the nutrition result.
+  buildNutritionIngredients(ingrArr: IngredientsType[]): string[] {
+    const ingr: string[] = []
+    ingrArr.forEach(ing => {
+      if ('parsedIngredient' in ing) {
+        const { quantity, unit, ingredient } = ing.parsedIngredient
+        if (quantity) {
+          ingr.push(`${quantity} ${unit || ''} ${ingredient}`)
+        }
+      }
+    })
+    return ingr
+  }
   async getRecipeNutrition(ingrArr: IngredientsType[]): Promise<{ nutritionData: NutritionDataType | null; dietLabels: string[] | null }> {
     try {
       const ingrData: { title: string; ingr: string[] } = {
         title: 'recipe 1',
-        ingr: [],
+        ingr: this.buildNutritionIngredients(ingrArr),
       }
-
-      ingrArr.forEach(ingr => {
-        if ('parsedIngredient' in ingr) {
-          const { quantity, unit, ingredient } = ingr.parsedIngredient
-
-          if (quantity) {
-            const str = `${quantity} ${unit || ''} ${ingredient}`
-            ingrData.ingr.push(str)
-          }
-        }
-      })
       const nutritionResultRes = await nutrition.post(
         `nutrition-details?app_id=${import.meta.env.VITE_EDAMAM_APP_ID}&app_key=${import.meta.env.VITE_EDAMAM_APP_KEY}`,
         ingrData

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -22,6 +22,11 @@ import { v4 as uuidv4 } from 'uuid'
 
 export const ADD_RECIPE_AUTH_ERROR = 'AUTH_ERROR'
 
+export type EditRecipeResult =
+  | { status: 'success'; recipe: RecipeType }
+  | { status: 'auth-error' }
+  | { status: 'error'; message: string }
+
 class RecipeAPIClass {
   async getAllRecipes(
     page = 0,
@@ -182,7 +187,7 @@ class RecipeAPIClass {
     recipeData: RecipeEditFormType,
     originalRecipe: RecipeType,
     setProgress: (val: number) => void
-  ): Promise<boolean | typeof ADD_RECIPE_AUTH_ERROR> {
+  ): Promise<EditRecipeResult> {
     try {
       setProgress(10)
       // Image: only upload when the user picked a new file. Otherwise the recipe
@@ -216,8 +221,14 @@ class RecipeAPIClass {
         const nutritionDataRes = await this.getRecipeNutrition(
           recipeData.ingredients
         )
-        nutritionData = nutritionDataRes.nutritionData
-        nutritionLabels = nutritionDataRes.dietLabels
+        // getRecipeNutrition soft-fails to null when Edamam is unreachable. Only
+        // overwrite when it actually returned data — otherwise a transient lookup
+        // failure during an ingredient edit would erase the recipe's existing
+        // nutrition facts for all viewers.
+        if (nutritionDataRes.nutritionData) {
+          nutritionData = nutritionDataRes.nutritionData
+          nutritionLabels = nutritionDataRes.dietLabels
+        }
       }
       setProgress(90)
       // Only the editable fields are sent; the server whitelists these and never
@@ -240,14 +251,24 @@ class RecipeAPIClass {
         servingPrice,
         totalTime,
       }
-      await http.put(`api/editRecipe?recipeId=${recipeId}`, payload)
-      return true
+      const res = await http.put<RecipeType>(
+        `api/editRecipe?recipeId=${recipeId}`,
+        payload
+      )
+      return { status: 'success', recipe: res.data }
     } catch (error: unknown) {
       console.error('editRecipe failed:', error)
-      if (axios.isAxiosError(error) && error.response?.status === 401) {
-        return ADD_RECIPE_AUTH_ERROR
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 401) return { status: 'auth-error' }
+        // Surface the server's reason (e.g. 403 Forbidden, 404 Not found) so a
+        // stale edit page doesn't show a misleading "try again" for an error a
+        // retry can't fix.
+        const message =
+          error.response?.data?.error ??
+          'Failed to update recipe. Please try again.'
+        return { status: 'error', message }
       }
-      return false
+      return { status: 'error', message: 'Failed to update recipe. Please try again.' }
     }
   }
   // The exact ingredient strings sent to Edamam for nutrition lookup. Shared by

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -1,10 +1,13 @@
 import React, { FC, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   AddRecipeErrorType,
   IngredientsType,
   InstructionsType,
+  RecipeEditFormType,
   RecipeFormType,
+  RecipeType,
 } from 'types'
 import LoadingBar from 'react-top-loading-bar'
 import RecipeFormInput from 'src/pages/AddRecipe/RecipeFormInput'
@@ -18,6 +21,7 @@ import InstructionsContainer from 'src/pages/AddRecipe/Instructions/Instructions
 import CuisineSelector from 'src/pages/AddRecipe/CuisineSelector/CuisineSelector'
 import MealTypeSelector from 'src/pages/AddRecipe/MealTypeSelector/MealTypeSelector'
 import { hrMinToMin } from 'src/util/hrMinToMin'
+import { minToHrMin } from 'src/util/minToHrMin'
 import {
   TITLE_MAX_LENGTH,
   DESCRIPTION_MAX_LENGTH,
@@ -33,34 +37,59 @@ import AddRecipeSummaryBar from 'src/pages/AddRecipe/AddRecipeSummaryBar'
 import { Helmet } from 'react-helmet-async'
 import { toast } from 'react-hot-toast'
 
-const AddRecipe: FC = () => {
+type TimeVal = { hours: number; minutes: number } | null
+
+// When `initialRecipe` is supplied the form runs in edit mode: every field is
+// pre-populated from the existing recipe and submitting updates it (preserving
+// ratings/saves) instead of creating a new one.
+type AddRecipeProps = { initialRecipe?: RecipeType }
+
+const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
+  const isEditMode = !!initialRecipe
+
   const [addRecipeLoading, setAddRecipeLoading] = useState(false)
   const [loadingProgress, setLoadingProgress] = useState(0)
   const addRecipeFormRef = useRef<HTMLDivElement>(null)
-  const [title, setTitle] = useState('')
+  const [title, setTitle] = useState(initialRecipe?.title ?? '')
   const [recipeImage, setRecipeImage] = useState<File | undefined>()
-  const [description, setDescription] = useState('')
-  const [servings, setServings] = useState<number | ''>('')
-  const [prepTime, setPrepTime] = useState<{
-    hours: number
-    minutes: number
-  } | null>(null)
-  const [cookTime, setCookTime] = useState<{
-    hours: number
-    minutes: number
-  } | null>(null)
-  const [fridgeLife, setFridgeLife] = useState<number>(0)
-  const [freezerLife, setFreezerLife] = useState<number>(0)
-  const [ingredients, setIngredients] = useState<IngredientsType[]>([])
-  const [instructions, setInstructions] = useState<InstructionsType[]>([])
-  const [cuisine, setCuisine] = useState('')
-  const [mealTypes, setMealTypes] = useState<string[]>([])
+  // Edit mode only: the recipe's current image URL, kept when the user doesn't
+  // pick a new file. Cleared if they remove the image (forcing a new pick).
+  const [existingImageUrl, setExistingImageUrl] = useState<string | undefined>(
+    initialRecipe?.recipeImage
+  )
+  const [description, setDescription] = useState(initialRecipe?.description ?? '')
+  const [servings, setServings] = useState<number | ''>(
+    initialRecipe?.servings ?? ''
+  )
+  const [prepTime, setPrepTime] = useState<TimeVal>(
+    initialRecipe ? minToHrMin(initialRecipe.prepTime) : null
+  )
+  const [cookTime, setCookTime] = useState<TimeVal>(
+    initialRecipe ? minToHrMin(initialRecipe.cookTime) : null
+  )
+  const [fridgeLife, setFridgeLife] = useState<number>(
+    initialRecipe?.fridgeLife ?? 0
+  )
+  const [freezerLife, setFreezerLife] = useState<number>(
+    initialRecipe?.freezerLife ?? 0
+  )
+  const [ingredients, setIngredients] = useState<IngredientsType[]>(
+    initialRecipe?.ingredients ?? []
+  )
+  const [instructions, setInstructions] = useState<InstructionsType[]>(
+    initialRecipe?.instructions ?? []
+  )
+  const [cuisine, setCuisine] = useState(initialRecipe?.cuisine ?? '')
+  const [mealTypes, setMealTypes] = useState<string[]>(
+    initialRecipe?.mealTypes ?? []
+  )
   const [errors, setErrors] = useState<Partial<AddRecipeErrorType>>({})
 
   const [isFormValid, setIsFormValid] = useState(false)
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
 
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const validate = (assignErrors: boolean = false) => {
     let newErrors: Partial<AddRecipeErrorType> = {}
@@ -71,7 +100,9 @@ const AddRecipe: FC = () => {
       newErrors.title = `Title cannot exceed ${TITLE_MAX_LENGTH} characters`
     }
 
-    if (!recipeImage) newErrors.image = 'Image is required'
+    // In edit mode a recipe with no newly-picked file is still valid as long as
+    // it has its existing stored image.
+    if (!recipeImage && !existingImageUrl) newErrors.image = 'Image is required'
     if (!description) {
       newErrors.description = 'Description is required'
     } else if (description.length > DESCRIPTION_MAX_LENGTH) {
@@ -94,21 +125,6 @@ const AddRecipe: FC = () => {
     assignErrors && setErrors(newErrors)
     return Object.keys(newErrors).length === 0
   }
-  const clearForm = () => {
-    setTitle('')
-    setRecipeImage(undefined)
-    setDescription('')
-    setServings('')
-    setPrepTime(null)
-    setCookTime(null)
-    setFridgeLife(0)
-    setFreezerLife(0)
-    setIngredients([])
-    setInstructions([])
-    setCuisine('')
-    setMealTypes([])
-    setErrors({})
-  }
   useEffect(() => {
     // Once the user has attempted a submit, keep the displayed errors in sync as
     // fields are fixed (assignErrors=true) so a corrected field clears its message
@@ -120,6 +136,7 @@ const AddRecipe: FC = () => {
   }, [
     title,
     recipeImage,
+    existingImageUrl,
     description,
     servings,
     prepTime,
@@ -128,11 +145,49 @@ const AddRecipe: FC = () => {
     mealTypes,
     hasAttemptedSubmit,
   ])
-  const handleAddRecipe = async () => {
+  const handleSubmit = async () => {
     if (addRecipeLoading) return
     setHasAttemptedSubmit(true)
-    if (validate(true)) {
-      setAddRecipeLoading(true)
+    if (!validate(true)) {
+      addRecipeFormRef?.current && addRecipeFormRef.current.scrollTo(0, 0)
+      return
+    }
+
+    setAddRecipeLoading(true)
+    if (isEditMode && initialRecipe) {
+      const editData: RecipeEditFormType = {
+        title,
+        prepTime: hrMinToMin(prepTime),
+        cookTime: hrMinToMin(cookTime),
+        servings: Number(servings),
+        fridgeLife,
+        freezerLife,
+        description,
+        ingredients,
+        instructions,
+        recipeImage,
+        cuisine,
+        mealTypes,
+      }
+      const result = await RecipeAPI.editRecipe(
+        initialRecipe._id,
+        editData,
+        initialRecipe,
+        setLoadingProgress
+      )
+      if (result === ADD_RECIPE_AUTH_ERROR) {
+        toast.error('Your session has expired — please sign in again and retry.')
+      } else if (result) {
+        // Drop stale cached copies so the recipe page and the user's created
+        // list reflect the edit immediately.
+        queryClient.invalidateQueries({ queryKey: ['recipe', initialRecipe._id] })
+        queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
+        toast.success('Recipe updated!')
+        navigate(`/recipes/${initialRecipe._id}`)
+      } else {
+        toast.error('Failed to update recipe. Please try again.')
+      }
+    } else {
       const recipeData: RecipeFormType = {
         title,
         prepTime: hrMinToMin(prepTime),
@@ -156,17 +211,15 @@ const AddRecipe: FC = () => {
       } else {
         toast.error('Failed to create recipe. Please try again.')
       }
-      setAddRecipeLoading(false)
-      setLoadingProgress(100)
-    } else {
-      addRecipeFormRef?.current && addRecipeFormRef.current.scrollTo(0, 0)
     }
+    setAddRecipeLoading(false)
+    setLoadingProgress(100)
   }
 
   return (
     <>
       <Helmet>
-        <title>Create New Recipe</title>
+        <title>{isEditMode ? 'Edit Recipe' : 'Create New Recipe'}</title>
         <link
           rel='canonical'
           href='https://www.prepifymeals.com/add-recipe'
@@ -182,7 +235,7 @@ const AddRecipe: FC = () => {
           progress={loadingProgress}
           onLoaderFinished={() => setLoadingProgress(0)}
         />
-        <h1>Create New Recipe</h1>
+        <h1>{isEditMode ? 'Edit Recipe' : 'Create New Recipe'}</h1>
         <div className='container'>
           <div className='container-inner' ref={addRecipeFormRef}>
             <div className='title input-field'>
@@ -204,7 +257,12 @@ const AddRecipe: FC = () => {
               {errors.image && (
                 <AddRecipeFormError error={errors.image} id='error-image' />
               )}
-              <ImagePicker image={recipeImage} setImage={setRecipeImage} />
+              <ImagePicker
+                image={recipeImage}
+                setImage={setRecipeImage}
+                initialPreviewUrl={existingImageUrl}
+                onRemove={() => setExistingImageUrl(undefined)}
+              />
             </div>
             <div className='description input-field'>
               <SectionHeader label='Description' required />
@@ -303,7 +361,8 @@ const AddRecipe: FC = () => {
           ingredients={ingredients}
           isValid={isFormValid}
           loading={addRecipeLoading}
-          onSubmit={handleAddRecipe}
+          onSubmit={handleSubmit}
+          submitLabel={isEditMode ? 'Save Changes' : 'Create Recipe'}
         />
       </div>
     </>

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -154,21 +154,23 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
     }
 
     setAddRecipeLoading(true)
+    // Shared form-state → payload mapping; the two branches differ only in the
+    // image field (optional on edit, required on create) and which API they call.
+    const formData = {
+      title,
+      prepTime: hrMinToMin(prepTime),
+      cookTime: hrMinToMin(cookTime),
+      servings: Number(servings),
+      fridgeLife,
+      freezerLife,
+      description,
+      ingredients,
+      instructions,
+      cuisine,
+      mealTypes,
+    }
     if (isEditMode && initialRecipe) {
-      const editData: RecipeEditFormType = {
-        title,
-        prepTime: hrMinToMin(prepTime),
-        cookTime: hrMinToMin(cookTime),
-        servings: Number(servings),
-        fridgeLife,
-        freezerLife,
-        description,
-        ingredients,
-        instructions,
-        recipeImage,
-        cuisine,
-        mealTypes,
-      }
+      const editData: RecipeEditFormType = { ...formData, recipeImage }
       const result = await RecipeAPI.editRecipe(
         initialRecipe._id,
         editData,
@@ -190,20 +192,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
         toast.error(result.message)
       }
     } else {
-      const recipeData: RecipeFormType = {
-        title,
-        prepTime: hrMinToMin(prepTime),
-        cookTime: hrMinToMin(cookTime),
-        servings: Number(servings),
-        fridgeLife,
-        freezerLife,
-        description,
-        ingredients,
-        instructions,
-        recipeImage: recipeImage!,
-        cuisine,
-        mealTypes,
-      }
+      const recipeData: RecipeFormType = { ...formData, recipeImage: recipeImage! }
       const newId = await RecipeAPI.addRecipe(recipeData, setLoadingProgress)
       if (newId === ADD_RECIPE_AUTH_ERROR) {
         toast.error('Your session has expired — please sign in again and retry.')
@@ -224,7 +213,11 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
         <title>{isEditMode ? 'Edit Recipe' : 'Create New Recipe'}</title>
         <link
           rel='canonical'
-          href='https://www.prepifymeals.com/add-recipe'
+          href={
+            isEditMode && initialRecipe
+              ? `https://www.prepifymeals.com/recipes/${initialRecipe._id}`
+              : 'https://www.prepifymeals.com/add-recipe'
+          }
         />
         <meta
           name='description'

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -363,6 +363,11 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
           loading={addRecipeLoading}
           onSubmit={handleSubmit}
           submitLabel={isEditMode ? 'Save Changes' : 'Create Recipe'}
+          onCancel={
+            isEditMode && initialRecipe
+              ? () => navigate(`/recipes/${initialRecipe._id}`)
+              : undefined
+          }
         />
       </div>
     </>

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -175,17 +175,19 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
         initialRecipe,
         setLoadingProgress
       )
-      if (result === ADD_RECIPE_AUTH_ERROR) {
+      if (result.status === 'auth-error') {
         toast.error('Your session has expired — please sign in again and retry.')
-      } else if (result) {
-        // Drop stale cached copies so the recipe page and the user's created
-        // list reflect the edit immediately.
-        queryClient.invalidateQueries({ queryKey: ['recipe', initialRecipe._id] })
+      } else if (result.status === 'success') {
+        // Write the server's updated recipe straight into the cache rather than
+        // invalidating: invalidation would refetch GET /getRecipe (which bumps
+        // the public view counter) and briefly flash stale data. The created
+        // list still needs a refetch to reorder/relabel.
+        queryClient.setQueryData(['recipe', initialRecipe._id], result.recipe)
         queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
         toast.success('Recipe updated!')
         navigate(`/recipes/${initialRecipe._id}`)
       } else {
-        toast.error('Failed to update recipe. Please try again.')
+        toast.error(result.message)
       }
     } else {
       const recipeData: RecipeFormType = {

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.scss
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.scss
@@ -50,6 +50,40 @@
     }
   }
 
+  .summary-actions {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .cancel-btn {
+    flex-shrink: 0;
+    height: 46px;
+    padding: 0 1.25rem;
+    border-radius: s.$border-radius;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    outline: none;
+    background: none;
+    color: s.$secondary-text;
+    border: 1px solid s.$tertiary-background;
+    transition: all 0.1s linear;
+
+    &:hover {
+      color: s.$primary-text;
+      border-color: s.$tertiary-text;
+    }
+    &:focus {
+      @include s.outline();
+    }
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
   .submit-btn {
     display: flex;
     justify-content: center;
@@ -109,6 +143,11 @@
     .submit-btn {
       width: 132px;
       height: 42px;
+      font-size: 0.9rem;
+    }
+    .cancel-btn {
+      height: 42px;
+      padding: 0 0.9rem;
       font-size: 0.9rem;
     }
   }

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
@@ -16,6 +16,8 @@ interface AddRecipeSummaryBarProps {
   loading: boolean
   onSubmit: () => void
   submitLabel?: string
+  // When provided (edit mode), renders a Cancel button alongside submit.
+  onCancel?: () => void
 }
 
 const formatTime = (totalMin: number): string => {
@@ -41,6 +43,7 @@ const AddRecipeSummaryBar: FC<AddRecipeSummaryBarProps> = ({
   loading,
   onSubmit,
   submitLabel = 'Create Recipe',
+  onCancel,
 }) => {
   const ingredientCount = useMemo(
     () => ingredients.filter(ingr => 'parsedIngredient' in ingr).length,
@@ -77,23 +80,35 @@ const AddRecipeSummaryBar: FC<AddRecipeSummaryBarProps> = ({
             </dd>
           </div>
         </dl>
-        <button
-          className={`submit-btn ${isValid ? 'valid' : 'invalid'}`}
-          disabled={loading}
-          aria-busy={loading}
-          onClick={onSubmit}
-        >
-          {loading ? (
-            <TailSpin
-              height='28'
-              width='28'
-              color='white'
-              ariaLabel='loading'
-            />
-          ) : (
-            submitLabel
+        <div className='summary-actions'>
+          {onCancel && (
+            <button
+              type='button'
+              className='cancel-btn'
+              disabled={loading}
+              onClick={onCancel}
+            >
+              Cancel
+            </button>
           )}
-        </button>
+          <button
+            className={`submit-btn ${isValid ? 'valid' : 'invalid'}`}
+            disabled={loading}
+            aria-busy={loading}
+            onClick={onSubmit}
+          >
+            {loading ? (
+              <TailSpin
+                height='28'
+                width='28'
+                color='white'
+                ariaLabel='loading'
+              />
+            ) : (
+              submitLabel
+            )}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
@@ -15,6 +15,7 @@ interface AddRecipeSummaryBarProps {
   isValid: boolean
   loading: boolean
   onSubmit: () => void
+  submitLabel?: string
 }
 
 const formatTime = (totalMin: number): string => {
@@ -39,6 +40,7 @@ const AddRecipeSummaryBar: FC<AddRecipeSummaryBarProps> = ({
   isValid,
   loading,
   onSubmit,
+  submitLabel = 'Create Recipe',
 }) => {
   const ingredientCount = useMemo(
     () => ingredients.filter(ingr => 'parsedIngredient' in ingr).length,
@@ -89,7 +91,7 @@ const AddRecipeSummaryBar: FC<AddRecipeSummaryBarProps> = ({
               ariaLabel='loading'
             />
           ) : (
-            'Create Recipe'
+            submitLabel
           )}
         </button>
       </div>

--- a/src/pages/AddRecipe/ImagePicker/ImagePicker.tsx
+++ b/src/pages/AddRecipe/ImagePicker/ImagePicker.tsx
@@ -9,11 +9,24 @@ const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp']
 interface ImagePickerProps {
   image: File | undefined
   setImage: React.Dispatch<React.SetStateAction<File | undefined>>
+  // Edit mode: the recipe's existing image URL, shown as the initial preview so
+  // the field isn't empty when no new file has been picked yet.
+  initialPreviewUrl?: string
+  // Edit mode: fires when the user clears the image, so the parent can drop the
+  // existing-image URL it tracks for validation.
+  onRemove?: () => void
 }
 
-const ImagePicker: React.FC<ImagePickerProps> = ({ image, setImage }) => {
+const ImagePicker: React.FC<ImagePickerProps> = ({
+  image,
+  setImage,
+  initialPreviewUrl,
+  onRemove,
+}) => {
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const [imagePreview, setImagePreview] = useState<string | undefined>()
+  const [imagePreview, setImagePreview] = useState<string | undefined>(
+    initialPreviewUrl
+  )
 
   const resetInput = () => {
     if (fileInputRef.current) fileInputRef.current.value = ''
@@ -82,6 +95,7 @@ const ImagePicker: React.FC<ImagePickerProps> = ({ image, setImage }) => {
     setImage(undefined)
     setImagePreview(undefined)
     resetInput()
+    onRemove?.()
   }
 
   return (

--- a/src/pages/EditRecipe/EditRecipe.tsx
+++ b/src/pages/EditRecipe/EditRecipe.tsx
@@ -20,22 +20,23 @@ const EditRecipe: FC = () => {
 
   const {
     data: recipe,
-    isPending: recipePending,
+    isPending,
     isError,
   } = useQuery({
     queryKey: ['recipe', recipeId],
     queryFn: () => RecipeAPI.getRecipe(recipeId!),
     enabled: !!recipeId,
+    // Reuse the copy SingleRecipe already cached. GET /getRecipe increments the
+    // public view counter, so refetching just to open the editor would inflate
+    // it; serving the cache avoids that on the common (click-Edit) path.
+    staleTime: Infinity,
   })
 
-  const { data: currUsername, isPending: usernamePending } = useQuery({
-    queryKey: ['username', currUID],
-    queryFn: () => AuthAPI.getUsername(),
-    enabled: !!currUID,
-  })
-
-  const loading = recipePending || (!!currUID && usernamePending)
-  const isOwner = !!recipe && recipe.authorUsername === currUsername
+  const loading = isPending
+  // Key ownership on the Firebase uid, matching the server's `userId === uid`
+  // check. authorUsername is a creation-time snapshot that goes stale after a
+  // rename, which would otherwise lock a legitimate owner out of editing.
+  const isOwner = !!recipe && !!currUID && recipe.userId === currUID
 
   useEffect(() => {
     if (loading) return

--- a/src/pages/EditRecipe/EditRecipe.tsx
+++ b/src/pages/EditRecipe/EditRecipe.tsx
@@ -1,0 +1,70 @@
+import React, { FC, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { TailSpin } from 'react-loader-spinner'
+import toast from 'react-hot-toast'
+import AuthAPI from 'src/api/auth'
+import RecipeAPI from 'src/api/recipes'
+import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
+import styles from 'src/_exports.module.scss'
+
+// Wrapper for /recipes/:recipeId/edit. Fetches the recipe, confirms the signed-in
+// user is its author, then renders the AddRecipe form pre-populated for editing.
+// Ownership is also enforced server-side; this gate is just UX so non-owners
+// don't see (and can't submit) the form.
+const EditRecipe: FC = () => {
+  const { recipeId } = useParams<{ recipeId: string }>()
+  const navigate = useNavigate()
+
+  const currUID = AuthAPI.getUID()
+
+  const {
+    data: recipe,
+    isPending: recipePending,
+    isError,
+  } = useQuery({
+    queryKey: ['recipe', recipeId],
+    queryFn: () => RecipeAPI.getRecipe(recipeId!),
+    enabled: !!recipeId,
+  })
+
+  const { data: currUsername, isPending: usernamePending } = useQuery({
+    queryKey: ['username', currUID],
+    queryFn: () => AuthAPI.getUsername(),
+    enabled: !!currUID,
+  })
+
+  const loading = recipePending || (!!currUID && usernamePending)
+  const isOwner = !!recipe && recipe.authorUsername === currUsername
+
+  useEffect(() => {
+    if (loading) return
+    if (isError || !recipe || !recipe.title) {
+      toast.error('Recipe not found.')
+      navigate('/')
+    } else if (!isOwner) {
+      toast.error('You can only edit your own recipes.')
+      navigate(`/recipes/${recipe._id}`)
+    }
+  }, [loading, isError, recipe, isOwner, navigate])
+
+  if (loading || !recipe || !isOwner) {
+    return (
+      <div
+        className='page'
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: '60vh',
+        }}
+      >
+        <TailSpin height='60' width='60' color={styles.primary} ariaLabel='loading' />
+      </div>
+    )
+  }
+
+  return <AddRecipe initialRecipe={recipe} />
+}
+
+export default EditRecipe

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -103,9 +103,8 @@ const RecipeControls: FC<RecipeControlsType> = ({
       <div className='btns-container'>
         <button
           className='edit-btn'
-          disabled
-          title='Editing is coming soon'
-          aria-label='Edit recipe (coming soon)'
+          onClick={() => navigate(`/recipes/${recipeId}/edit`)}
+          aria-label='Edit recipe'
         >
           <AiOutlineEdit className='icon' aria-hidden='true' />
           Edit

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -12,12 +12,12 @@ import { isAxiosError } from 'axios'
 import toast from 'react-hot-toast'
 import AuthAPI from 'src/api/auth'
 import RecipeAPI from 'src/api/recipes'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import './RecipeControls.scss'
 
 type RecipeControlsType = {
   recipeId: string
-  authorUsername: string
+  recipeUserId?: string
   recipeTitle: string
 }
 
@@ -43,7 +43,7 @@ const customStyles = {
 
 const RecipeControls: FC<RecipeControlsType> = ({
   recipeId,
-  authorUsername,
+  recipeUserId,
   recipeTitle,
 }) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
@@ -59,13 +59,10 @@ const RecipeControls: FC<RecipeControlsType> = ({
 
   const currUID = AuthAPI.getUID()
 
-  const { data: currUsername } = useQuery({
-    queryKey: ['username', currUID],
-    queryFn: () => AuthAPI.getUsername(),
-    enabled: !!currUID,
-  })
-
-  const isUsersRecipe = currUsername === authorUsername
+  // Key ownership on the Firebase uid (what the server authorizes against), not
+  // the snapshotted authorUsername which goes stale after a rename and would
+  // hide these controls from the legitimate owner.
+  const isUsersRecipe = !!currUID && currUID === recipeUserId
 
   if (!isUsersRecipe) return null
 

--- a/src/pages/SingleRecipe/RecipeHeaderContent/RecipeHeaderContent.tsx
+++ b/src/pages/SingleRecipe/RecipeHeaderContent/RecipeHeaderContent.tsx
@@ -4,6 +4,7 @@ import { BsStar } from 'react-icons/bs'
 import Skeleton from 'react-loading-skeleton'
 import { formatRating } from 'src/util/formatRating'
 import { getWindowWidth } from 'src/util/getWindowWidth'
+import { timeElapsedSince } from 'src/util/timeElapsedSince'
 import { RecipeType, ReviewType } from 'types'
 import AddRatingBtn from 'src/pages/SingleRecipe/Buttons/AddRatingBtn'
 import PrintRecipeBtn from 'src/pages/SingleRecipe/Buttons/PrintRecipeBtn'
@@ -95,6 +96,11 @@ const RecipeHeaderContent: FC<RecipeHeaderContentProps> = ({
             }
           />
         </div>
+        {!loading && currRecipe?.editedAt && (
+          <div className='edited-marker'>
+            Edited {timeElapsedSince(new Date(Number(currRecipe.editedAt)))}
+          </div>
+        )}
         <div className='actions'>
           {loading || !currRecipe?._id ? (
             <Skeleton baseColor={skeletonColor} className='action skeleton' />

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -186,6 +186,11 @@
             }
           }
         }
+        .edited-marker {
+          font-size: 0.85rem;
+          font-style: italic;
+          color: s.$secondary-text;
+        }
       }
 
       @media screen and (max-width: 1100px) {

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -122,7 +122,7 @@ const SingleRecipe: FC<Props> = ({ recipe }) => {
               {currRecipe && (
                 <RecipeControls
                   recipeId={currRecipe._id}
-                  authorUsername={currRecipe.authorUsername}
+                  recipeUserId={currRecipe.userId}
                   recipeTitle={currRecipe.title}
                 />
               )}

--- a/src/test/AddRecipe.test.tsx
+++ b/src/test/AddRecipe.test.tsx
@@ -3,6 +3,7 @@ import { vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { HelmetProvider } from 'react-helmet-async'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
 import RecipeAPI from 'src/api/recipes'
 
@@ -125,12 +126,16 @@ vi.mock('src/pages/AddRecipe/TimeInput/TimeInput', () => ({
 
 const mockAddRecipe = RecipeAPI.addRecipe as ReturnType<typeof vi.fn>
 
-const renderAddRecipe = () =>
-  render(
-    <HelmetProvider>
-      <AddRecipe />
-    </HelmetProvider>
+const renderAddRecipe = () => {
+  const queryClient = new QueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <HelmetProvider>
+        <AddRecipe />
+      </HelmetProvider>
+    </QueryClientProvider>
   )
+}
 
 const fillAllFields = async (user: ReturnType<typeof userEvent.setup>) => {
   await user.type(screen.getByPlaceholderText('Add a title to your recipe.'), 'My Great Recipe')

--- a/src/test/RecipesApi.test.ts
+++ b/src/test/RecipesApi.test.ts
@@ -20,15 +20,19 @@ vi.mock('src/api/auth', () => ({
 }))
 
 const httpPost = vi.fn()
+const httpPut = vi.fn()
 const nutritionPost = vi.fn()
 vi.mock('src/api/http-common', () => ({
-  http: { post: (...args: unknown[]) => httpPost(...args) },
+  http: {
+    post: (...args: unknown[]) => httpPost(...args),
+    put: (...args: unknown[]) => httpPut(...args),
+  },
   nutrition: { post: (...args: unknown[]) => nutritionPost(...args) },
 }))
 
 // Import after mocks are in place.
 import RecipeAPI from 'src/api/recipes'
-import type { RecipeFormType } from 'types'
+import type { RecipeEditFormType, RecipeFormType, RecipeType } from 'types'
 
 const makeFormData = (): RecipeFormType => ({
   title: 'Soft-fail Test Recipe',
@@ -94,5 +98,146 @@ describe('RecipeAPI.addRecipe — nutrition soft-fail (High #4)', () => {
 
     expect(result).toBe('srv-2')
     expect(httpPost).toHaveBeenCalledWith('api/addRecipe', expect.any(Object))
+  })
+})
+
+describe('RecipeAPI.editRecipe', () => {
+  const sharedIngredient = () => ({
+    id: 'i1',
+    parsedIngredient: {
+      ingredient: 'Flour',
+      quantity: 2,
+      unit: 'cups',
+      unitPlural: 'cups',
+      symbol: null,
+      minQty: 2,
+      maxQty: 2,
+      originalIngredientString: '2 cups flour',
+      comment: '',
+    },
+    ingredientData: null,
+  })
+
+  const makeOriginal = (): RecipeType => ({
+    _id: 'recipe-1',
+    title: 'Original Title',
+    prepTime: 10,
+    cookTime: 20,
+    servings: 4,
+    fridgeLife: 0,
+    freezerLife: 0,
+    description: 'Original description',
+    ingredients: [sharedIngredient()],
+    instructions: [{ id: 'in1', content: 'Mix well', index: 1 }],
+    recipeImage: 'https://cdn/original.jpg',
+    nutritionData: { uri: 'orig' } as unknown as RecipeType['nutritionData'],
+    totalTime: 30,
+    authorUsername: 'testuser',
+    rating: { rateCount: 5, rateValue: 4 },
+    createdAt: '1000',
+    editedAt: null,
+    servingPrice: 100,
+    cuisine: '',
+    mealTypes: ['Dinner'],
+    nutritionLabels: ['Vegan'],
+    views: 10,
+    numTimesSaved: 2,
+    numTimesMade: 1,
+  })
+
+  const makeEditData = (
+    overrides: Partial<RecipeEditFormType> = {}
+  ): RecipeEditFormType => ({
+    title: 'Edited Title',
+    prepTime: 10,
+    cookTime: 20,
+    servings: 4,
+    fridgeLife: 0,
+    freezerLife: 0,
+    description: 'Edited description',
+    ingredients: [sharedIngredient()],
+    instructions: [{ id: 'in1', content: 'Mix well', index: 1 }],
+    recipeImage: undefined,
+    cuisine: '',
+    mealTypes: ['Dinner'],
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    httpPut.mockReset()
+    nutritionPost.mockReset()
+  })
+
+  it('PUTs to the edit endpoint and resolves true on success', async () => {
+    httpPut.mockResolvedValue({ data: {} })
+    const result = await RecipeAPI.editRecipe(
+      'recipe-1',
+      makeEditData(),
+      makeOriginal(),
+      () => {}
+    )
+    expect(result).toBe(true)
+    expect(httpPut.mock.calls[0][0]).toBe('api/editRecipe?recipeId=recipe-1')
+    expect(httpPut.mock.calls[0][1].title).toBe('Edited Title')
+  })
+
+  it('reuses the existing image and stored nutrition when ingredients are unchanged', async () => {
+    httpPut.mockResolvedValue({ data: {} })
+    await RecipeAPI.editRecipe('recipe-1', makeEditData(), makeOriginal(), () => {})
+
+    // No new file picked + unchanged ingredients => no Edamam call.
+    expect(nutritionPost).not.toHaveBeenCalled()
+    const payload = httpPut.mock.calls[0][1]
+    expect(payload.recipeImage).toBe('https://cdn/original.jpg')
+    expect(payload.nutritionData).toEqual({ uri: 'orig' })
+    expect(payload.nutritionLabels).toEqual(['Vegan'])
+  })
+
+  it('recomputes nutrition when the ingredients change', async () => {
+    nutritionPost.mockResolvedValue({
+      data: { uri: 'new', dietLabels: [], healthLabels: [] },
+    })
+    httpPut.mockResolvedValue({ data: {} })
+
+    const changed = makeEditData({
+      ingredients: [
+        {
+          ...sharedIngredient(),
+          parsedIngredient: {
+            ...sharedIngredient().parsedIngredient,
+            ingredient: 'Sugar',
+            quantity: 1,
+            unit: 'cup',
+            originalIngredientString: '1 cup sugar',
+          },
+        },
+      ],
+    })
+
+    await RecipeAPI.editRecipe('recipe-1', changed, makeOriginal(), () => {})
+
+    expect(nutritionPost).toHaveBeenCalledTimes(1)
+    const payload = httpPut.mock.calls[0][1]
+    expect(payload.nutritionData).toEqual({
+      uri: 'new',
+      dietLabels: [],
+      healthLabels: [],
+    })
+  })
+
+  it('uploads and uses a new image when one is provided', async () => {
+    httpPut.mockResolvedValue({ data: {} })
+    const withImage = makeEditData({
+      recipeImage: new File([''], 'new.jpg', { type: 'image/jpeg' }),
+    })
+
+    await RecipeAPI.editRecipe('recipe-1', withImage, makeOriginal(), () => {})
+
+    const payload = httpPut.mock.calls[0][1]
+    // The test env runs uploadRecipeImage's Cypress branch (VITE_CYPRESS='true'),
+    // which returns this stub URL — proving the upload path ran rather than the
+    // original image being reused.
+    expect(payload.recipeImage).toBe('https://cypress.test/fake-recipe-image.jpg')
+    expect(payload.recipeImage).not.toBe('https://cdn/original.jpg')
   })
 })

--- a/src/test/RecipesApi.test.ts
+++ b/src/test/RecipesApi.test.ts
@@ -168,15 +168,18 @@ describe('RecipeAPI.editRecipe', () => {
     nutritionPost.mockReset()
   })
 
-  it('PUTs to the edit endpoint and resolves true on success', async () => {
-    httpPut.mockResolvedValue({ data: {} })
+  it('PUTs to the edit endpoint and returns the updated recipe on success', async () => {
+    httpPut.mockResolvedValue({ data: { _id: 'recipe-1', title: 'Edited Title' } })
     const result = await RecipeAPI.editRecipe(
       'recipe-1',
       makeEditData(),
       makeOriginal(),
       () => {}
     )
-    expect(result).toBe(true)
+    expect(result).toEqual({
+      status: 'success',
+      recipe: { _id: 'recipe-1', title: 'Edited Title' },
+    })
     expect(httpPut.mock.calls[0][0]).toBe('api/editRecipe?recipeId=recipe-1')
     expect(httpPut.mock.calls[0][1].title).toBe('Edited Title')
   })
@@ -239,5 +242,66 @@ describe('RecipeAPI.editRecipe', () => {
     // original image being reused.
     expect(payload.recipeImage).toBe('https://cypress.test/fake-recipe-image.jpg')
     expect(payload.recipeImage).not.toBe('https://cdn/original.jpg')
+  })
+
+  it('keeps the existing nutrition when an ingredient edit hits a failed Edamam lookup', async () => {
+    // Edamam unreachable => getRecipeNutrition soft-fails to null.
+    nutritionPost.mockRejectedValue(new Error('Edamam down'))
+    httpPut.mockResolvedValue({ data: {} })
+
+    const changed = makeEditData({
+      ingredients: [
+        {
+          ...sharedIngredient(),
+          parsedIngredient: {
+            ...sharedIngredient().parsedIngredient,
+            ingredient: 'Sugar',
+            quantity: 1,
+            unit: 'cup',
+            originalIngredientString: '1 cup sugar',
+          },
+        },
+      ],
+    })
+
+    await RecipeAPI.editRecipe('recipe-1', changed, makeOriginal(), () => {})
+
+    expect(nutritionPost).toHaveBeenCalledTimes(1)
+    const payload = httpPut.mock.calls[0][1]
+    // The soft-fail must NOT erase the recipe's stored nutrition.
+    expect(payload.nutritionData).toEqual({ uri: 'orig' })
+    expect(payload.nutritionLabels).toEqual(['Vegan'])
+  })
+
+  it('returns auth-error on a 401', async () => {
+    httpPut.mockRejectedValue(
+      Object.assign(new Error('unauthorized'), {
+        isAxiosError: true,
+        response: { status: 401, data: {} },
+      })
+    )
+    const result = await RecipeAPI.editRecipe(
+      'recipe-1',
+      makeEditData(),
+      makeOriginal(),
+      () => {}
+    )
+    expect(result).toEqual({ status: 'auth-error' })
+  })
+
+  it('surfaces the server error message on a non-auth failure (e.g. 403)', async () => {
+    httpPut.mockRejectedValue(
+      Object.assign(new Error('request failed'), {
+        isAxiosError: true,
+        response: { status: 403, data: { error: 'Forbidden' } },
+      })
+    )
+    const result = await RecipeAPI.editRecipe(
+      'recipe-1',
+      makeEditData(),
+      makeOriginal(),
+      () => {}
+    )
+    expect(result).toEqual({ status: 'error', message: 'Forbidden' })
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,12 @@ export type RecipeFormType = {
   mealTypes: string[]
 }
 
+// Same shape as RecipeFormType, but the image is optional: when editing, an
+// unchanged recipe keeps its existing stored image URL and no new File is set.
+export type RecipeEditFormType = Omit<RecipeFormType, 'recipeImage'> & {
+  recipeImage?: File
+}
+
 export type LabelType = { label: string; id: string }
 export type IngredientsType =
   | {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,10 @@ import { IngredientData, ParsedIngredient } from '@jclind/ingredient-parser'
 
 export type RecipeType = {
   _id: string
+  // Firebase uid of the author. Stamped server-side and returned by GET
+  // /getRecipe; the source of truth for ownership checks (authorUsername is a
+  // display snapshot that goes stale if the user renames).
+  userId?: string
   title: string
   prepTime: number
   cookTime: number | null

--- a/src/util/minToHrMin.ts
+++ b/src/util/minToHrMin.ts
@@ -1,0 +1,9 @@
+// Inverse of hrMinToMin: splits a stored minute total back into the
+// { hours, minutes } shape TimeInput expects. Returns null for 0/null so the
+// field renders empty (matching an unset prep/cook time).
+export const minToHrMin = (
+  totalMin: number | null
+): { hours: number; minutes: number } | null => {
+  if (!totalMin) return null
+  return { hours: Math.floor(totalMin / 60), minutes: totalMin % 60 }
+}


### PR DESCRIPTION
## Summary

Adds an owner-only **edit recipe** flow. Authors can edit any of their recipes via the existing AddRecipe form running in edit mode, reachable from the (previously-disabled) Edit button on the recipe page.

### Design: how much can change, and what happens to ratings?
Edits **preserve all social state** — ratings, reviews, saves, made-count are never reset. The recipe is stamped with `editedAt` and the page shows an "Edited {time} ago" marker so users who saved it have honest context that it changed. (We chose transparent-edit over versioning/forking, which would be a much larger build; noted as a possible future enhancement.)

## What's included

**Backend**
- `PUT /editRecipe` — owner-gated (403 otherwise). Validates required fields + bounds like add, and `$set`s only a **whitelist** of editable fields. `rating`, `numTimesSaved`, `numTimesMade`, `views`, `createdAt`, `authorUsername`, `userId`, `_id` are never writable, so an edit can't reset a recipe's ratings or saves.

**Frontend**
- `RecipeAPI.editRecipe` — reuses the existing image unless a new one is picked, and only re-runs the paid Edamam nutrition call when the **ingredients actually change** (serving price, a local calc, always recomputes).
- `AddRecipe` — optional `initialRecipe` prop pre-populates the form for editing; image becomes optional (keeps the stored one).
- New `EditRecipe` page + `/recipes/:recipeId/edit` route (private, ownership-gated).
- Enabled the Edit button; added an "Edited" marker on the recipe; added a **Cancel** button on the edit form (returns to the recipe without saving).
- New `minToHrMin` util (inverse of `hrMinToMin`) to seed the time inputs.

**Drive-by fix**
- `single-recipe.json` fixture stored `rating` as strings, crashing the recently-added `RecipeStats` (`rateValue.toFixed`). Set to numeric, coherent values.

## Testing
- **Server (+9):** auth/ownership/whitelist + explicit assertions that ratings/saves/made/views/createdAt are preserved and protected fields in the payload are ignored. Full suite: 141 passing.
- **Frontend (+4):** PUT target, image reuse vs. upload, nutrition recompute only on ingredient change. Full suite passing; `tsc --noEmit` clean.
- **Manual (Cypress, real browser):** verified end-to-end — owner opens edit form (pre-populated incl. existing image) → edits title → save fires `PUT /editRecipe` carrying only editable fields (no `rating`/`numTimesSaved`) → lands back on the recipe with updated title + "Edited" marker. Also verified Cancel returns without saving and is absent on the create form.