### PR TITLE
feat(recipes): autosave drafts in the create-recipe flow

### DIFF
--- a/server/__tests__/drafts.test.js
+++ b/server/__tests__/drafts.test.js
@@ -214,6 +214,23 @@ describe('PUT /api/drafts/:id', () => {
       .send({ title: 'a'.repeat(51) })
     expect(res.status).toBe(400)
   })
+
+  it("checks ownership before bounds (403, not 400, for another user's draft)", async () => {
+    const draft = await seedDraft({ userId: 'other-uid' })
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'a'.repeat(51) })
+    expect(res.status).toBe(403)
+  })
+
+  it('checks existence before bounds (404, not 400, for a missing draft)', async () => {
+    const res = await request(app)
+      .put(`/api/drafts/${new ObjectId()}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'a'.repeat(51) })
+    expect(res.status).toBe(404)
+  })
 })
 
 describe('DELETE /api/drafts/:id', () => {

--- a/server/__tests__/drafts.test.js
+++ b/server/__tests__/drafts.test.js
@@ -1,0 +1,239 @@
+/**
+ * Auth approach mirrors recipes.test.js: server/__mocks__/firebase-admin.js
+ * makes verifyIdToken always resolve to { uid: 'test-uid' }, so any request
+ * with an Authorization header passes verifyToken with req.uid = 'test-uid'.
+ *
+ * Ownership tests seed a draft owned by a *different* uid directly in the DB,
+ * then confirm the 'test-uid' caller is forbidden from reading/writing it.
+ */
+
+const request = require('supertest')
+const { ObjectId } = require('mongodb')
+const app = require('../app')
+const { getDB } = require('../db')
+
+const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
+const TEST_UID = 'test-uid'
+
+afterEach(async () => {
+  await getDB().collection('recipeDrafts').deleteMany({})
+})
+
+async function seedDraft(overrides = {}) {
+  const now = Date.now().toString()
+  const doc = {
+    _id: new ObjectId(),
+    userId: TEST_UID,
+    title: 'Draft title',
+    ingredients: [],
+    instructions: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+  await getDB().collection('recipeDrafts').insertOne(doc)
+  return doc
+}
+
+describe('POST /api/drafts', () => {
+  it('requires auth', async () => {
+    const res = await request(app).post('/api/drafts').send({ title: 'x' })
+    expect(res.status).toBe(401)
+  })
+
+  it('creates a draft owned by the caller and returns it', async () => {
+    const res = await request(app)
+      .post('/api/drafts')
+      .set(AUTH_HEADER)
+      .send({ title: 'WIP recipe', cuisine: 'Italian' })
+    expect(res.status).toBe(201)
+    expect(res.body.title).toBe('WIP recipe')
+    expect(res.body.cuisine).toBe('Italian')
+    expect(res.body.userId).toBe(TEST_UID)
+    expect(res.body._id).toBeDefined()
+    expect(res.body.createdAt).toBeDefined()
+    expect(res.body.updatedAt).toBeDefined()
+  })
+
+  it('ignores client-supplied userId / _id', async () => {
+    const res = await request(app)
+      .post('/api/drafts')
+      .set(AUTH_HEADER)
+      .send({ title: 'x', userId: 'someone-else', _id: 'forced-id' })
+    expect(res.status).toBe(201)
+    expect(res.body.userId).toBe(TEST_UID)
+    expect(res.body._id).not.toBe('forced-id')
+  })
+
+  it('rejects content that exceeds bounds', async () => {
+    const res = await request(app)
+      .post('/api/drafts')
+      .set(AUTH_HEADER)
+      .send({ title: 'a'.repeat(51) })
+    expect(res.status).toBe(400)
+  })
+
+  it('allows an empty/partial draft (no required fields)', async () => {
+    const res = await request(app).post('/api/drafts').set(AUTH_HEADER).send({})
+    expect(res.status).toBe(201)
+  })
+
+  it('rejects creation past the per-user cap with 409 + DRAFT_LIMIT, counting only the caller', async () => {
+    // Fill the caller to the cap, plus some drafts owned by someone else that
+    // must not count toward this user's limit.
+    const now = Date.now().toString()
+    const mine = Array.from({ length: 25 }, (_, i) => ({
+      _id: new ObjectId(),
+      userId: TEST_UID,
+      title: `draft ${i}`,
+      createdAt: now,
+      updatedAt: now,
+    }))
+    const theirs = Array.from({ length: 5 }, () => ({
+      _id: new ObjectId(),
+      userId: 'other-uid',
+      createdAt: now,
+      updatedAt: now,
+    }))
+    await getDB().collection('recipeDrafts').insertMany([...mine, ...theirs])
+
+    const res = await request(app)
+      .post('/api/drafts')
+      .set(AUTH_HEADER)
+      .send({ title: 'one too many' })
+    expect(res.status).toBe(409)
+    expect(res.body.code).toBe('DRAFT_LIMIT')
+  })
+
+  it('still allows editing an existing draft when at the cap', async () => {
+    const now = Date.now().toString()
+    const mine = Array.from({ length: 25 }, (_, i) => ({
+      _id: new ObjectId(),
+      userId: TEST_UID,
+      title: `draft ${i}`,
+      createdAt: now,
+      updatedAt: now,
+    }))
+    await getDB().collection('recipeDrafts').insertMany(mine)
+
+    const res = await request(app)
+      .put(`/api/drafts/${mine[0]._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'edited at cap' })
+    expect(res.status).toBe(200)
+    expect(res.body.title).toBe('edited at cap')
+  })
+})
+
+describe('GET /api/drafts', () => {
+  it('requires auth', async () => {
+    const res = await request(app).get('/api/drafts')
+    expect(res.status).toBe(401)
+  })
+
+  it("returns only the caller's drafts, newest-updated first", async () => {
+    await seedDraft({ title: 'older', updatedAt: '1000' })
+    await seedDraft({ title: 'newer', updatedAt: '2000' })
+    await seedDraft({ title: 'theirs', userId: 'other-uid' })
+
+    const res = await request(app).get('/api/drafts').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveLength(2)
+    expect(res.body.map(d => d.title)).toEqual(['newer', 'older'])
+  })
+})
+
+describe('GET /api/drafts/:id', () => {
+  it('returns the draft for its owner', async () => {
+    const draft = await seedDraft({ title: 'mine' })
+    const res = await request(app)
+      .get(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.title).toBe('mine')
+  })
+
+  it("forbids reading another user's draft", async () => {
+    const draft = await seedDraft({ userId: 'other-uid' })
+    const res = await request(app)
+      .get(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(403)
+  })
+
+  it('404s for a missing or malformed id', async () => {
+    const missing = await request(app)
+      .get(`/api/drafts/${new ObjectId()}`)
+      .set(AUTH_HEADER)
+    expect(missing.status).toBe(404)
+    const malformed = await request(app)
+      .get('/api/drafts/not-an-id')
+      .set(AUTH_HEADER)
+    expect(malformed.status).toBe(404)
+  })
+})
+
+describe('PUT /api/drafts/:id', () => {
+  it('updates content and bumps updatedAt', async () => {
+    const draft = await seedDraft({ title: 'before', updatedAt: '1000' })
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'after', servings: 4 })
+    expect(res.status).toBe(200)
+    expect(res.body.title).toBe('after')
+    expect(res.body.servings).toBe(4)
+    expect(Number(res.body.updatedAt)).toBeGreaterThan(1000)
+  })
+
+  it("forbids updating another user's draft", async () => {
+    const draft = await seedDraft({ userId: 'other-uid' })
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'hijacked' })
+    expect(res.status).toBe(403)
+  })
+
+  it('does not change userId/createdAt even if sent', async () => {
+    const draft = await seedDraft({ createdAt: '500' })
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'x', userId: 'other-uid', createdAt: '999' })
+    expect(res.status).toBe(200)
+    expect(res.body.userId).toBe(TEST_UID)
+    expect(res.body.createdAt).toBe('500')
+  })
+
+  it('rejects content that exceeds bounds', async () => {
+    const draft = await seedDraft()
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'a'.repeat(51) })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('DELETE /api/drafts/:id', () => {
+  it('deletes the draft for its owner', async () => {
+    const draft = await seedDraft()
+    const res = await request(app)
+      .delete(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    const remaining = await getDB()
+      .collection('recipeDrafts')
+      .findOne({ _id: draft._id })
+    expect(remaining).toBeNull()
+  })
+
+  it("forbids deleting another user's draft", async () => {
+    const draft = await seedDraft({ userId: 'other-uid' })
+    const res = await request(app)
+      .delete(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(403)
+  })
+})

--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,7 @@ const reviewRoutes = require('./routes/reviews')
 const userRoutes = require('./routes/users')
 const authRoutes = require('./routes/auth')
 const ingredientRoutes = require('./routes/ingredients')
+const draftRoutes = require('./routes/drafts')
 
 const app = express()
 
@@ -33,5 +34,6 @@ app.use('/api', reviewRoutes)
 app.use('/api', userRoutes)
 app.use('/api', authRoutes)
 app.use('/api/ingredients', ingredientRoutes)
+app.use('/api/drafts', draftRoutes)
 
 module.exports = app

--- a/server/db.js
+++ b/server/db.js
@@ -36,6 +36,15 @@ async function ensureIndexes() {
       err.message
     )
   }
+
+  // Backs GET /api/drafts, which lists a user's drafts newest-updated first
+  // (find({ userId }).sort({ updatedAt: -1 })). Without it that query is a full
+  // collection scan plus an in-memory sort on every Drafts-tab load.
+  try {
+    await db.collection('recipeDrafts').createIndex({ userId: 1, updatedAt: -1 })
+  } catch (err) {
+    console.error('Failed to create index on recipeDrafts.userId:', err.message)
+  }
 }
 
 async function closeDB() {

--- a/server/routes/drafts.js
+++ b/server/routes/drafts.js
@@ -1,0 +1,169 @@
+const { Router } = require('express')
+const { ObjectId } = require('mongodb')
+const { getDB } = require('../db')
+const { verifyToken } = require('../middleware/auth')
+const { validateRecipeBounds } = require('../util/recipeLimits')
+
+const router = Router()
+
+// Max drafts a single user may keep at once. Generous enough that a normal user
+// never hits it; it bounds collection growth and abuse (a client looping POST).
+// Enforced on creation only — editing existing drafts is always allowed.
+const MAX_DRAFTS_PER_USER = 25
+
+// A draft is an in-progress recipe owned by a single user. Unlike a published
+// recipe it is intentionally incomplete: every content field is optional, so
+// only the bounds (max lengths/counts) are validated, never required-field
+// presence. The recipe image is *not* part of a draft — it's re-picked when the
+// user resumes (publishing still requires an image). See src/api/drafts.ts.
+
+// The content fields a draft persists. Whitelisted on write so the client can't
+// stash arbitrary keys (or spoof userId / timestamps) on a draft document.
+const DRAFT_FIELDS = [
+  'title',
+  'prepTime',
+  'cookTime',
+  'servings',
+  'fridgeLife',
+  'freezerLife',
+  'description',
+  'ingredients',
+  'instructions',
+  'cuisine',
+  'mealTypes',
+]
+
+function pickDraftFields(body) {
+  const out = {}
+  for (const field of DRAFT_FIELDS) {
+    if (field in body) out[field] = body[field]
+  }
+  return out
+}
+
+// POST /drafts — create a new draft for the current user. Returns the new _id
+// so the client can switch to update-on-autosave from then on.
+router.post('/', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    const boundsError = validateRecipeBounds(req.body)
+    if (boundsError) {
+      return res.status(400).json({ error: boundsError })
+    }
+    // Cap the number of drafts per user. 409 + a machine-readable code so the
+    // client can show a specific "delete some drafts" message and stop retrying.
+    const draftCount = await db
+      .collection('recipeDrafts')
+      .countDocuments({ userId: req.uid })
+    if (draftCount >= MAX_DRAFTS_PER_USER) {
+      return res.status(409).json({
+        code: 'DRAFT_LIMIT',
+        error: `You've reached the maximum of ${MAX_DRAFTS_PER_USER} saved drafts. Delete some from your Drafts to start a new one.`,
+      })
+    }
+    const now = Date.now().toString()
+    const doc = {
+      _id: new ObjectId(),
+      userId: req.uid,
+      ...pickDraftFields(req.body),
+      createdAt: now,
+      updatedAt: now,
+    }
+    await db.collection('recipeDrafts').insertOne(doc)
+    res.status(201).json(doc)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /drafts — list the current user's drafts, newest-updated first.
+router.get('/', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    const drafts = await db
+      .collection('recipeDrafts')
+      .find({ userId: req.uid })
+      .sort({ updatedAt: -1 })
+      .toArray()
+    res.json(drafts)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /drafts/:id — fetch a single draft (used when resuming). Owner-only.
+router.get('/:id', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    const draft = await db
+      .collection('recipeDrafts')
+      .findOne({ _id: new ObjectId(req.params.id) })
+    if (!draft) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    if (draft.userId !== req.uid) {
+      return res.status(403).json({ error: 'Forbidden' })
+    }
+    res.json(draft)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// PUT /drafts/:id — overwrite a draft's content (autosave). Owner-only. Only
+// whitelisted content fields are written; userId/createdAt/_id are immutable.
+router.put('/:id', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    const boundsError = validateRecipeBounds(req.body)
+    if (boundsError) {
+      return res.status(400).json({ error: boundsError })
+    }
+    const _id = new ObjectId(req.params.id)
+    const draft = await db.collection('recipeDrafts').findOne({ _id })
+    if (!draft) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    if (draft.userId !== req.uid) {
+      return res.status(403).json({ error: 'Forbidden' })
+    }
+    const update = { ...pickDraftFields(req.body), updatedAt: Date.now().toString() }
+    const updated = await db
+      .collection('recipeDrafts')
+      .findOneAndUpdate({ _id }, { $set: update }, { returnDocument: 'after' })
+    res.json(updated)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// DELETE /drafts/:id — remove a draft (manual delete, or cleanup after the
+// recipe is published). Owner-only.
+router.delete('/:id', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    const _id = new ObjectId(req.params.id)
+    const draft = await db.collection('recipeDrafts').findOne({ _id })
+    if (!draft) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    if (draft.userId !== req.uid) {
+      return res.status(403).json({ error: 'Forbidden' })
+    }
+    await db.collection('recipeDrafts').deleteOne({ _id })
+    res.json({ deleted: true })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+module.exports = router

--- a/server/routes/drafts.js
+++ b/server/routes/drafts.js
@@ -3,6 +3,7 @@ const { ObjectId } = require('mongodb')
 const { getDB } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 const { validateRecipeBounds } = require('../util/recipeLimits')
+const { RECIPE_CONTENT_FIELDS, pickFields } = require('../util/recipeFields')
 
 const router = Router()
 
@@ -16,30 +17,10 @@ const MAX_DRAFTS_PER_USER = 25
 // only the bounds (max lengths/counts) are validated, never required-field
 // presence. The recipe image is *not* part of a draft — it's re-picked when the
 // user resumes (publishing still requires an image). See src/api/drafts.ts.
-
-// The content fields a draft persists. Whitelisted on write so the client can't
-// stash arbitrary keys (or spoof userId / timestamps) on a draft document.
-const DRAFT_FIELDS = [
-  'title',
-  'prepTime',
-  'cookTime',
-  'servings',
-  'fridgeLife',
-  'freezerLife',
-  'description',
-  'ingredients',
-  'instructions',
-  'cuisine',
-  'mealTypes',
-]
-
-function pickDraftFields(body) {
-  const out = {}
-  for (const field of DRAFT_FIELDS) {
-    if (field in body) out[field] = body[field]
-  }
-  return out
-}
+//
+// Writes are whitelisted to RECIPE_CONTENT_FIELDS (shared with the recipe-edit
+// route via util/recipeFields) so the client can't stash arbitrary keys or
+// spoof userId / timestamps on a draft document.
 
 // POST /drafts — create a new draft for the current user. Returns the new _id
 // so the client can switch to update-on-autosave from then on.
@@ -65,7 +46,7 @@ router.post('/', verifyToken, async (req, res) => {
     const doc = {
       _id: new ObjectId(),
       userId: req.uid,
-      ...pickDraftFields(req.body),
+      ...pickFields(req.body, RECIPE_CONTENT_FIELDS),
       createdAt: now,
       updatedAt: now,
     }
@@ -121,11 +102,10 @@ router.put('/:id', verifyToken, async (req, res) => {
     if (!ObjectId.isValid(req.params.id)) {
       return res.status(404).json({ error: 'Draft not found' })
     }
-    const boundsError = validateRecipeBounds(req.body)
-    if (boundsError) {
-      return res.status(400).json({ error: boundsError })
-    }
     const _id = new ObjectId(req.params.id)
+    // Check existence and ownership before validating the payload, so a caller
+    // can't probe bounds-validity for a draft they don't own or that doesn't
+    // exist (matches the editRecipe route's ordering).
     const draft = await db.collection('recipeDrafts').findOne({ _id })
     if (!draft) {
       return res.status(404).json({ error: 'Draft not found' })
@@ -133,7 +113,14 @@ router.put('/:id', verifyToken, async (req, res) => {
     if (draft.userId !== req.uid) {
       return res.status(403).json({ error: 'Forbidden' })
     }
-    const update = { ...pickDraftFields(req.body), updatedAt: Date.now().toString() }
+    const boundsError = validateRecipeBounds(req.body)
+    if (boundsError) {
+      return res.status(400).json({ error: boundsError })
+    }
+    const update = {
+      ...pickFields(req.body, RECIPE_CONTENT_FIELDS),
+      updatedAt: Date.now().toString(),
+    }
     const updated = await db
       .collection('recipeDrafts')
       .findOneAndUpdate({ _id }, { $set: update }, { returnDocument: 'after' })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -4,6 +4,7 @@ const { getDB, getClient } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
+const { EDITABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 
 const router = Router()
@@ -162,28 +163,9 @@ router.post('/addRecipe', verifyToken, async (req, res) => {
 })
 
 // PUT /editRecipe — owner-only edit. Social/derived counters and immutable
-// metadata are never writable here (see EDITABLE_FIELDS), so an edit can never
-// reset a recipe's ratings, saves, or made-count. editedAt is stamped so the UI
-// can surface that the recipe changed after people saved it.
-const EDITABLE_FIELDS = [
-  'title',
-  'prepTime',
-  'cookTime',
-  'servings',
-  'fridgeLife',
-  'freezerLife',
-  'description',
-  'ingredients',
-  'instructions',
-  'recipeImage',
-  'cuisine',
-  'mealTypes',
-  'nutritionData',
-  'nutritionLabels',
-  'servingPrice',
-  'totalTime',
-]
-
+// metadata are never writable here (only EDITABLE_RECIPE_FIELDS are copied), so
+// an edit can never reset a recipe's ratings, saves, or made-count. editedAt is
+// stamped so the UI can surface that the recipe changed after people saved it.
 router.put('/editRecipe', verifyToken, async (req, res) => {
   try {
     const db = getDB()
@@ -213,11 +195,10 @@ router.put('/editRecipe', verifyToken, async (req, res) => {
     // Whitelist: copy only editable fields from the client payload. Anything
     // else the client sends (rating, numTimesSaved, views, userId, _id, …) is
     // ignored.
-    const update = {}
-    for (const field of EDITABLE_FIELDS) {
-      if (field in body) update[field] = body[field]
+    const update = {
+      ...pickFields(body, EDITABLE_RECIPE_FIELDS),
+      editedAt: Date.now().toString(),
     }
-    update.editedAt = Date.now().toString()
 
     const updated = await db.collection('recipes').findOneAndUpdate(
       recipeIdQuery(recipeId),

--- a/server/util/recipeFields.js
+++ b/server/util/recipeFields.js
@@ -1,0 +1,41 @@
+// Single source of truth for the recipe content fields a user supplies, shared
+// by the draft routes and the recipe-edit whitelist so the two can't drift.
+// Add a user-entered field here and it propagates to both: drafts won't
+// silently drop it on autosave, and edits will accept it.
+const RECIPE_CONTENT_FIELDS = [
+  'title',
+  'prepTime',
+  'cookTime',
+  'servings',
+  'fridgeLife',
+  'freezerLife',
+  'description',
+  'ingredients',
+  'instructions',
+  'cuisine',
+  'mealTypes',
+]
+
+// Editing a published recipe also writes the image and the server-/client-
+// computed fields; drafts don't carry these.
+const EDITABLE_RECIPE_FIELDS = [
+  ...RECIPE_CONTENT_FIELDS,
+  'recipeImage',
+  'nutritionData',
+  'nutritionLabels',
+  'servingPrice',
+  'totalTime',
+]
+
+// Copy only the whitelisted keys that are present in `body`. Absent keys are
+// left out (callers merge via $set), so a field the client doesn't send is
+// untouched rather than overwritten.
+function pickFields(body, fields) {
+  const out = {}
+  for (const field of fields) {
+    if (field in body) out[field] = body[field]
+  }
+  return out
+}
+
+module.exports = { RECIPE_CONTENT_FIELDS, EDITABLE_RECIPE_FIELDS, pickFields }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Account from 'src/pages/Account/Account'
 import SavedRecipes from 'src/pages/Account/SavedRecipes/SavedRecipes'
 import UserRatings from 'src/pages/Account/UserRatings/UserRatings'
 import UserRecipes from 'src/pages/Account/UserRecipes/UserRecipes'
+import Drafts from 'src/pages/Account/Drafts/Drafts'
 
 import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
 import EditRecipe from 'src/pages/EditRecipe/EditRecipe'
@@ -89,6 +90,7 @@ const App: FC = () => {
                 <Route path='saved-recipes' element={<SavedRecipes />} />
                 <Route path='ratings' element={<UserRatings />} />
                 <Route path='your-recipes' element={<UserRecipes />} />
+                <Route path='drafts' element={<Drafts />} />
               </Route>
               <Route
                 path='/settings'

--- a/src/api/drafts.ts
+++ b/src/api/drafts.ts
@@ -1,0 +1,49 @@
+import { RecipeDraftContent, RecipeDraftType } from 'types'
+import AuthAPI from 'src/api/auth'
+import { http } from 'src/api/http-common'
+
+// Server-set `code` on the 409 returned when a user is at their draft cap
+// (server/routes/drafts.js). createDraft lets this error propagate so callers
+// can distinguish "at limit" from a generic save failure.
+export const DRAFT_LIMIT_CODE = 'DRAFT_LIMIT'
+
+// Client for the recipe-draft endpoints (server/routes/drafts.js). Drafts are
+// the autosaved, in-progress state of the create-recipe flow. The image is not
+// part of a draft — see RecipeDraftContent / AddRecipe autosave.
+class DraftAPIClass {
+  async createDraft(content: RecipeDraftContent): Promise<RecipeDraftType | null> {
+    if (!AuthAPI.getUID()) return null
+    const result = await http.post<RecipeDraftType>('api/drafts', content)
+    return result.data
+  }
+
+  async updateDraft(
+    id: string,
+    content: RecipeDraftContent
+  ): Promise<RecipeDraftType | null> {
+    if (!AuthAPI.getUID()) return null
+    const result = await http.put<RecipeDraftType>(`api/drafts/${id}`, content)
+    return result.data
+  }
+
+  async listDrafts(): Promise<RecipeDraftType[]> {
+    if (!AuthAPI.getUID()) return []
+    const result = await http.get<RecipeDraftType[]>('api/drafts')
+    return result.data
+  }
+
+  async getDraft(id: string): Promise<RecipeDraftType | null> {
+    if (!AuthAPI.getUID()) return null
+    const result = await http.get<RecipeDraftType>(`api/drafts/${id}`)
+    return result.data
+  }
+
+  async deleteDraft(id: string): Promise<void> {
+    if (!AuthAPI.getUID()) return
+    await http.delete(`api/drafts/${id}`)
+  }
+}
+
+const DraftAPI = new DraftAPIClass()
+
+export default DraftAPI

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -110,11 +110,22 @@
       gap: 2rem;
       padding-bottom: 1rem;
       border-bottom: 1px solid s.$tertiary-text;
+      // With four tabs, let the bar scroll on narrow screens instead of
+      // wrapping or shrinking the labels to the point of being unreadable.
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
 
       .selection {
         text-decoration: none;
         font-weight: 700;
         color: s.$tertiary-text;
+        white-space: nowrap;
       }
       @media screen and (max-width: 450px) {
         justify-content: space-around;

--- a/src/pages/Account/Account.tsx
+++ b/src/pages/Account/Account.tsx
@@ -102,6 +102,16 @@ const Account: FC = () => {
             >
               Your Recipes
             </Link>
+            <Link
+              to='/account/drafts'
+              className={
+                currPath === '/account/drafts'
+                  ? 'active selection'
+                  : 'selection'
+              }
+            >
+              Drafts
+            </Link>
           </div>
           <Outlet />
         </div>

--- a/src/pages/Account/Drafts/DraftCard.tsx
+++ b/src/pages/Account/Drafts/DraftCard.tsx
@@ -1,0 +1,78 @@
+import React, { FC, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AiOutlineEdit, AiOutlineDelete } from 'react-icons/ai'
+import { RecipeDraftType } from 'types'
+
+const formatUpdated = (updatedAt: string) => {
+  const ms = Number(updatedAt)
+  if (!ms || Number.isNaN(ms)) return null
+  return new Date(ms).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+type DraftCardProps = {
+  draft: RecipeDraftType
+  onDelete: (id: string) => Promise<void> | void
+}
+
+const DraftCard: FC<DraftCardProps> = ({ draft, onDelete }) => {
+  const navigate = useNavigate()
+  const [deleting, setDeleting] = useState(false)
+
+  const updated = formatUpdated(draft.updatedAt)
+  const ingredientCount = draft.ingredients?.length ?? 0
+  const instructionCount = draft.instructions?.length ?? 0
+  const summaryParts = [
+    `${ingredientCount} ${ingredientCount === 1 ? 'ingredient' : 'ingredients'}`,
+    `${instructionCount} ${instructionCount === 1 ? 'step' : 'steps'}`,
+  ]
+
+  const handleResume = () => navigate(`/add-recipe?draftId=${draft._id}`)
+
+  const handleDelete = async () => {
+    if (deleting) return
+    setDeleting(true)
+    try {
+      await onDelete(draft._id)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <div className='draft-card'>
+      <div className='draft-card-main'>
+        <h3 className='title'>
+          {draft.title?.trim() ? draft.title : 'Untitled draft'}
+        </h3>
+        <div className='meta'>
+          <span className='summary'>{summaryParts.join(' · ')}</span>
+          {updated && <span className='updated'>Last edited {updated}</span>}
+        </div>
+      </div>
+      <div className='draft-card-actions'>
+        <button type='button' className='resume-btn' onClick={handleResume}>
+          <AiOutlineEdit className='icon' />
+          Continue editing
+        </button>
+        <button
+          type='button'
+          className='delete-btn'
+          onClick={handleDelete}
+          disabled={deleting}
+          aria-label='Delete draft'
+          title='Delete draft'
+        >
+          <AiOutlineDelete className='icon' />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default DraftCard

--- a/src/pages/Account/Drafts/Drafts.scss
+++ b/src/pages/Account/Drafts/Drafts.scss
@@ -1,0 +1,143 @@
+@use '../../../helpers.scss' as s;
+
+.drafts {
+  padding: 1rem 0 2rem;
+
+  .drafts-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 720px;
+    margin: 1rem auto 0;
+  }
+
+  .draft-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    background: s.$white;
+    border: 1px solid s.$gray-300;
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+
+    @media screen and (max-width: 560px) {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.85rem;
+      padding: 1rem;
+    }
+
+    .draft-card-main {
+      min-width: 0;
+
+      .title {
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: s.$primary-text;
+        margin: 0 0 0.35rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem 0.75rem;
+        font-size: 0.85rem;
+        color: s.$tertiary-text;
+      }
+    }
+
+    .draft-card-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-shrink: 0;
+
+      @media screen and (max-width: 560px) {
+        // Resume grows to a comfortable tap target; delete stays compact beside it.
+        .resume-btn {
+          flex: 1;
+          justify-content: center;
+          padding: 0.6rem 0.9rem;
+        }
+      }
+
+      .resume-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        white-space: nowrap;
+        cursor: pointer;
+        font-size: 0.9rem;
+        font-weight: 600;
+        padding: 0.5rem 0.9rem;
+        border-radius: s.$border-radius;
+        border: 1px solid s.$gray-300;
+        background: s.$white;
+        color: s.$primary-text;
+        transition: all 0.1s linear;
+
+        &:hover {
+          border-color: s.$primary;
+          color: s.$primary;
+        }
+
+        .icon {
+          font-size: 1rem;
+        }
+      }
+
+      .delete-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: none;
+        border: 1px solid transparent;
+        cursor: pointer;
+        padding: 0.45rem;
+        border-radius: s.$border-radius;
+        color: s.$tertiary-text;
+        transition: all 0.1s linear;
+
+        &:hover:not(:disabled) {
+          color: s.$error-red;
+          border-color: s.$gray-300;
+        }
+
+        &:disabled {
+          opacity: 0.5;
+          cursor: default;
+        }
+
+        .icon {
+          font-size: 1.15rem;
+        }
+      }
+    }
+  }
+
+  .no-data-saved {
+    text-align: center;
+    padding: 3rem 1rem;
+
+    h2 {
+      margin-bottom: 0.5rem;
+    }
+
+    p {
+      color: s.$secondary-text;
+      margin-bottom: 1.5rem;
+      max-width: 420px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .add-recipe-btn {
+      display: inline-block;
+      text-decoration: none;
+    }
+  }
+}

--- a/src/pages/Account/Drafts/Drafts.tsx
+++ b/src/pages/Account/Drafts/Drafts.tsx
@@ -1,0 +1,63 @@
+import React, { FC } from 'react'
+import { Link } from 'react-router-dom'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
+
+import './Drafts.scss'
+import DraftAPI from 'src/api/drafts'
+import DraftCard from './DraftCard'
+
+const Drafts: FC = () => {
+  const queryClient = useQueryClient()
+
+  const { data: drafts, isLoading } = useQuery({
+    queryKey: ['drafts'],
+    queryFn: () => DraftAPI.listDrafts(),
+  })
+
+  const handleDelete = async (id: string) => {
+    await DraftAPI.deleteDraft(id)
+    queryClient.invalidateQueries({ queryKey: ['drafts'] })
+  }
+
+  const hasDrafts = !!drafts && drafts.length > 0
+  const showList = hasDrafts || isLoading
+
+  return (
+    <div className='drafts'>
+      {showList ? (
+        <div className='drafts-list'>
+          {isLoading ? (
+            <>
+              <Skeleton height={92} borderRadius={12} />
+              <Skeleton height={92} borderRadius={12} />
+              <Skeleton height={92} borderRadius={12} />
+            </>
+          ) : (
+            drafts!.map(draft => (
+              <DraftCard
+                key={draft._id}
+                draft={draft}
+                onDelete={handleDelete}
+              />
+            ))
+          )}
+        </div>
+      ) : (
+        <div className='no-data-saved'>
+          <h2>No Drafts Yet</h2>
+          <p>
+            Recipes you start are saved here automatically until you publish
+            them.
+          </p>
+          <Link to='/add-recipe' className='btn add-recipe-btn'>
+            Start a Recipe
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Drafts

--- a/src/pages/AddRecipe/AddRecipe.scss
+++ b/src/pages/AddRecipe/AddRecipe.scss
@@ -29,6 +29,23 @@
     text-align: center;
   }
 
+  // Reminder shown on a resumed draft: the image isn't persisted in drafts, so
+  // prompt the user to re-add it before publishing.
+  .draft-image-hint {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0 0 0.65rem;
+    font-size: 0.85rem;
+    color: s.$secondary-text;
+
+    .icon {
+      flex-shrink: 0;
+      font-size: 1rem;
+      color: s.$primary;
+    }
+  }
+
   .container {
     display: flex;
     justify-content: center;

--- a/src/pages/AddRecipe/AddRecipe.scss
+++ b/src/pages/AddRecipe/AddRecipe.scss
@@ -16,6 +16,13 @@
   // Clear the fixed summary bar at the bottom of the page.
   padding-bottom: 130px;
 
+  .add-recipe-heading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
   h1 {
     font-size: 2rem;
     font-weight: 700;

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -1,10 +1,13 @@
-import React, { FC, useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React, { FC, useEffect, useMemo, useRef, useState } from 'react'
+import axios from 'axios'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import {
   AddRecipeErrorType,
   IngredientsType,
   InstructionsType,
+  RecipeDraftContent,
+  RecipeDraftType,
   RecipeEditFormType,
   RecipeFormType,
   RecipeType,
@@ -36,6 +39,10 @@ import SectionHeader from 'src/pages/AddRecipe/SectionHeader'
 import AddRecipeSummaryBar from 'src/pages/AddRecipe/AddRecipeSummaryBar'
 import { Helmet } from 'react-helmet-async'
 import { toast } from 'react-hot-toast'
+import DraftAPI from 'src/api/drafts'
+import { useDraftAutosave } from 'src/pages/AddRecipe/useDraftAutosave'
+import DraftSaveStatus from 'src/pages/AddRecipe/DraftSaveStatus'
+import DraftResumeBanner from 'src/pages/AddRecipe/DraftResumeBanner'
 
 type TimeVal = { hours: number; minutes: number } | null
 
@@ -90,6 +97,143 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
 
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+
+  // ─── Draft autosave (create flow only) ──────────────────────────────────────
+  // Edit mode never touches drafts. In create mode the form is autosaved to a
+  // server-side draft so unfinished recipes survive a refresh or navigating
+  // away. The image is intentionally not part of a draft — it's re-picked on
+  // resume (publish validation still requires one).
+  const [searchParams, setSearchParams] = useSearchParams()
+  const urlDraftId = isEditMode ? null : searchParams.get('draftId')
+  const [draftId, setDraftId] = useState<string | null>(urlDraftId)
+  // "Hydrated" gates autosave: true for a fresh create, briefly false while a
+  // resumed draft loads into the fields.
+  const [hydrated, setHydrated] = useState(!urlDraftId)
+  // Draft ids whose content is already on screen — either just loaded here, or
+  // just created by autosave. The hydration effect skips these so our own URL
+  // updates (and a resume of the draft we're already editing) don't trigger a
+  // redundant reload.
+  const ownedDraftsRef = useRef<Set<string>>(new Set())
+
+  // Load the draft named in the URL whenever it points at one we haven't loaded
+  // yet. Runs on mount for `?draftId=…`, and again when the resume banner
+  // navigates to a draft while this page is already mounted — same route, so no
+  // remount happens on its own and a mount-only effect would never re-fire.
+  useEffect(() => {
+    if (isEditMode || !urlDraftId || ownedDraftsRef.current.has(urlDraftId)) return
+    let cancelled = false
+    setHydrated(false)
+    DraftAPI.getDraft(urlDraftId)
+      .then(draft => {
+        if (cancelled) return
+        ownedDraftsRef.current.add(urlDraftId)
+        if (draft) {
+          setDraftId(urlDraftId)
+          setTitle(draft.title ?? '')
+          setDescription(draft.description ?? '')
+          setServings(draft.servings ?? '')
+          setPrepTime(draft.prepTime != null ? minToHrMin(draft.prepTime) : null)
+          setCookTime(draft.cookTime != null ? minToHrMin(draft.cookTime) : null)
+          setFridgeLife(draft.fridgeLife ?? 0)
+          setFreezerLife(draft.freezerLife ?? 0)
+          setIngredients(draft.ingredients ?? [])
+          setInstructions(draft.instructions ?? [])
+          setCuisine(draft.cuisine ?? '')
+          setMealTypes(draft.mealTypes ?? [])
+        }
+        setHydrated(true)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        const status = axios.isAxiosError(err) ? err.response?.status : undefined
+        if (status === 404 || status === 403) {
+          // The draft is genuinely gone or not the caller's. Drop only the
+          // draftId param (preserving any other query params) and let the user
+          // start a fresh draft.
+          toast.error("Couldn't load that draft — starting a new one.")
+          setDraftId(null)
+          const next = new URLSearchParams(searchParams)
+          next.delete('draftId')
+          setSearchParams(next, { replace: true })
+          setHydrated(true)
+        } else {
+          // Transient failure (network/5xx) on a draft that likely still
+          // exists. Leave autosave disabled (hydrated stays false) so we don't
+          // create a duplicate or overwrite the unloaded draft with a partial
+          // form; ask the user to retry.
+          toast.error('Could not load your draft. Refresh to try again.')
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlDraftId])
+
+  // Serializable draft content mirrored from form state. Times are stored as
+  // minutes (matching the recipe shape); empty values are omitted.
+  const draftContent: RecipeDraftContent = useMemo(
+    () => ({
+      title,
+      description,
+      // Send explicit null (not undefined) when empty so clearing a field is
+      // persisted rather than silently dropped from the payload — see
+      // RecipeDraftContent.
+      servings: servings === '' ? null : Number(servings),
+      prepTime: prepTime ? hrMinToMin(prepTime) : null,
+      cookTime: cookTime ? hrMinToMin(cookTime) : null,
+      fridgeLife,
+      freezerLife,
+      ingredients,
+      instructions,
+      cuisine,
+      mealTypes,
+    }),
+    [
+      title,
+      description,
+      servings,
+      prepTime,
+      cookTime,
+      fridgeLife,
+      freezerLife,
+      ingredients,
+      instructions,
+      cuisine,
+      mealTypes,
+    ]
+  )
+
+  // A brand-new draft is only created once the recipe has a title. This gates
+  // out throwaway drafts from a stray keystroke (keeping the Drafts list and the
+  // per-user draft count clean); updating an existing draft is unaffected.
+  const canCreateDraft = !!title.trim()
+
+  const { status: draftStatus, clearDraft } = useDraftAutosave({
+    content: draftContent,
+    enabled: !isEditMode && hydrated,
+    canCreate: canCreateDraft,
+    draftId,
+    onDraftCreated: (draft: RecipeDraftType) => {
+      // Mark as owned before the URL sync below points the URL at it, so the
+      // hydration effect doesn't reload the draft we just created.
+      ownedDraftsRef.current.add(draft._id)
+      setDraftId(draft._id)
+      queryClient.invalidateQueries({ queryKey: ['drafts'] })
+    },
+    onLimitReached: (message: string) => toast.error(message),
+  })
+
+  // Reflect the active draft id in the URL (replace) so a refresh resumes the
+  // same draft rather than starting a second one.
+  useEffect(() => {
+    if (isEditMode || !draftId) return
+    if (searchParams.get('draftId') === draftId) return
+    const next = new URLSearchParams(searchParams)
+    next.set('draftId', draftId)
+    setSearchParams(next, { replace: true })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftId])
 
   const validate = (assignErrors: boolean = false) => {
     let newErrors: Partial<AddRecipeErrorType> = {}
@@ -197,6 +341,10 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
       if (newId === ADD_RECIPE_AUTH_ERROR) {
         toast.error('Your session has expired — please sign in again and retry.')
       } else if (newId) {
+        // Recipe is live — remove the now-redundant draft (and stop autosave
+        // from recreating it on unmount) before navigating away.
+        await clearDraft()
+        queryClient.invalidateQueries({ queryKey: ['drafts'] })
         toast.success('Recipe published!')
         navigate(`/recipes/${newId}`)
       } else {
@@ -230,7 +378,11 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
           progress={loadingProgress}
           onLoaderFinished={() => setLoadingProgress(0)}
         />
-        <h1>{isEditMode ? 'Edit Recipe' : 'Create New Recipe'}</h1>
+        <div className='add-recipe-heading'>
+          <h1>{isEditMode ? 'Edit Recipe' : 'Create New Recipe'}</h1>
+          {!isEditMode && <DraftSaveStatus status={draftStatus} />}
+        </div>
+        {!isEditMode && !draftId && <DraftResumeBanner />}
         <div className='container'>
           <div className='container-inner' ref={addRecipeFormRef}>
             <div className='title input-field'>

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useEffect, useMemo, useRef, useState } from 'react'
 import axios from 'axios'
+import { AiOutlineInfoCircle } from 'react-icons/ai'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import {
@@ -114,6 +115,10 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
   // updates (and a resume of the draft we're already editing) don't trigger a
   // redundant reload.
   const ownedDraftsRef = useRef<Set<string>>(new Set())
+  // True once a draft was resumed (loaded from the server) this session, used to
+  // remind the user to re-add the image — drafts don't persist it. Not set for
+  // drafts created in the current session (the user never had an image to lose).
+  const [resumedFromDraft, setResumedFromDraft] = useState(false)
 
   // Load the draft named in the URL whenever it points at one we haven't loaded
   // yet. Runs on mount for `?draftId=…`, and again when the resume banner
@@ -140,6 +145,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
           setInstructions(draft.instructions ?? [])
           setCuisine(draft.cuisine ?? '')
           setMealTypes(draft.mealTypes ?? [])
+          setResumedFromDraft(true)
         }
         setHydrated(true)
       })
@@ -403,6 +409,12 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
               <SectionHeader label='Select Image' required />
               {errors.image && (
                 <AddRecipeFormError error={errors.image} id='error-image' />
+              )}
+              {resumedFromDraft && !recipeImage && (
+                <p className='draft-image-hint'>
+                  <AiOutlineInfoCircle className='icon' />
+                  Drafts don't save your image — add it again before publishing.
+                </p>
               )}
               <ImagePicker
                 image={recipeImage}

--- a/src/pages/AddRecipe/DraftResumeBanner.scss
+++ b/src/pages/AddRecipe/DraftResumeBanner.scss
@@ -1,0 +1,132 @@
+@use '../../helpers.scss' as s;
+
+.draft-resume-banner {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  box-sizing: border-box;
+  // Match the form card's footprint (width 95%, max 800) so it lines up with
+  // the card edges below it.
+  width: 95%;
+  max-width: 800px;
+  background: s.$white;
+  border: 1px solid s.$gray-300;
+  border-left: 3px solid s.$primary;
+  border-radius: s.$border-radius;
+  padding: 0.75rem 1.25rem;
+
+  @media screen and (max-width: 560px) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.85rem;
+    padding: 0.9rem 1rem;
+  }
+
+  .banner-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 0;
+
+    .banner-title {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: s.$primary-text;
+    }
+
+    .banner-sub {
+      font-size: 0.85rem;
+      color: s.$tertiary-text;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      // On phones a single ellipsed line cuts the title off almost immediately
+      // (the "Pick up where you left off on …" prefix eats the width). Let it
+      // wrap to a tidy two lines instead so the recipe name is actually visible.
+      @media screen and (max-width: 560px) {
+        white-space: normal;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+      }
+    }
+
+    // Keep the text clear of the corner dismiss button when stacked.
+    @media screen and (max-width: 560px) {
+      padding-right: 1.75rem;
+    }
+  }
+
+  .banner-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-shrink: 0;
+
+    @media screen and (max-width: 560px) {
+      width: 100%;
+      gap: 0.85rem;
+    }
+
+    .resume-btn {
+      cursor: pointer;
+      font-size: 0.85rem;
+      font-weight: 600;
+      white-space: nowrap;
+      padding: 0.4rem 0.9rem;
+      border-radius: s.$border-radius;
+      border: 1px solid s.$primary;
+      background: s.$primary;
+      color: s.$white;
+      transition: filter 0.1s linear;
+
+      &:hover {
+        filter: brightness(108%);
+      }
+
+      // Comfortable full-width tap target on phones.
+      @media screen and (max-width: 560px) {
+        flex: 1;
+        padding: 0.6rem 0.9rem;
+      }
+    }
+
+    .view-all {
+      font-size: 0.85rem;
+      color: s.$tertiary-text;
+      text-decoration: none;
+      white-space: nowrap;
+
+      &:hover {
+        color: s.$primary-text;
+        text-decoration: underline;
+      }
+    }
+
+    .dismiss-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: s.$tertiary-text;
+      padding: 0.25rem;
+      font-size: 1rem;
+
+      &:hover {
+        color: s.$primary-text;
+      }
+
+      // Tuck into the top-right corner so the stacked layout reads cleanly.
+      @media screen and (max-width: 560px) {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+      }
+    }
+  }
+}

--- a/src/pages/AddRecipe/DraftResumeBanner.tsx
+++ b/src/pages/AddRecipe/DraftResumeBanner.tsx
@@ -1,0 +1,63 @@
+import React, { FC, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { AiOutlineClose } from 'react-icons/ai'
+import DraftAPI from 'src/api/drafts'
+import './DraftResumeBanner.scss'
+
+// Shown at the top of the create-recipe page when the user already has saved
+// drafts and isn't currently editing one. Offers a one-click resume of the most
+// recent draft plus a link to the full Drafts list. Hidden in edit mode and
+// once the current session has an active draft (see AddRecipe).
+const DraftResumeBanner: FC = () => {
+  const navigate = useNavigate()
+  const [dismissed, setDismissed] = useState(false)
+
+  const { data: drafts } = useQuery({
+    queryKey: ['drafts'],
+    queryFn: () => DraftAPI.listDrafts(),
+  })
+
+  if (dismissed || !drafts || drafts.length === 0) return null
+
+  // listDrafts returns newest-updated first.
+  const mostRecent = drafts[0]
+  const title = mostRecent.title?.trim() ? mostRecent.title : 'Untitled draft'
+
+  return (
+    <div className='draft-resume-banner'>
+      <div className='banner-text'>
+        <span className='banner-title'>
+          {drafts.length === 1
+            ? 'You have a saved draft'
+            : `You have ${drafts.length} saved drafts`}
+        </span>
+        <span className='banner-sub'>
+          Pick up where you left off on “{title}”.
+        </span>
+      </div>
+      <div className='banner-actions'>
+        <button
+          type='button'
+          className='resume-btn'
+          onClick={() => navigate(`/add-recipe?draftId=${mostRecent._id}`)}
+        >
+          Resume
+        </button>
+        <Link to='/account/drafts' className='view-all'>
+          View all drafts
+        </Link>
+        <button
+          type='button'
+          className='dismiss-btn'
+          aria-label='Dismiss'
+          onClick={() => setDismissed(true)}
+        >
+          <AiOutlineClose />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default DraftResumeBanner

--- a/src/pages/AddRecipe/DraftSaveStatus.scss
+++ b/src/pages/AddRecipe/DraftSaveStatus.scss
@@ -1,0 +1,27 @@
+@use '../../helpers.scss' as s;
+
+.draft-save-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  // Reserve the line height even when idle/empty so showing or hiding the
+  // status never nudges the form below it.
+  min-height: 1.25rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: s.$tertiary-text;
+
+  svg {
+    font-size: 1rem;
+    flex-shrink: 0;
+  }
+
+  &.saved {
+    color: s.$primary;
+  }
+
+  &.error {
+    color: s.$error-red;
+  }
+}

--- a/src/pages/AddRecipe/DraftSaveStatus.tsx
+++ b/src/pages/AddRecipe/DraftSaveStatus.tsx
@@ -1,0 +1,35 @@
+import React, { FC } from 'react'
+import { AiOutlineCheckCircle, AiOutlineCloud } from 'react-icons/ai'
+import { BiErrorCircle } from 'react-icons/bi'
+import { DraftStatus } from 'src/pages/AddRecipe/useDraftAutosave'
+import './DraftSaveStatus.scss'
+
+type DraftSaveStatusProps = { status: DraftStatus }
+
+const content: Record<
+  Exclude<DraftStatus, 'idle'>,
+  { icon: React.ReactElement; label: string }
+> = {
+  saving: { icon: <AiOutlineCloud />, label: 'Saving draft…' },
+  saved: { icon: <AiOutlineCheckCircle />, label: 'Draft saved' },
+  error: { icon: <BiErrorCircle />, label: "Couldn't save draft" },
+}
+
+// Small inline indicator beneath the page heading reflecting draft autosave
+// state. The element is always rendered (a fixed-height, empty slot when idle)
+// so transitions between states never shift the form below it.
+const DraftSaveStatus: FC<DraftSaveStatusProps> = ({ status }) => {
+  const current = status === 'idle' ? null : content[status]
+  return (
+    <span className={`draft-save-status ${status}`} aria-live='polite'>
+      {current && (
+        <>
+          {current.icon}
+          {current.label}
+        </>
+      )}
+    </span>
+  )
+}
+
+export default DraftSaveStatus

--- a/src/pages/AddRecipe/useDraftAutosave.ts
+++ b/src/pages/AddRecipe/useDraftAutosave.ts
@@ -1,0 +1,215 @@
+import { useEffect, useRef, useState } from 'react'
+import axios from 'axios'
+import { RecipeDraftContent, RecipeDraftType } from 'types'
+import DraftAPI, { DRAFT_LIMIT_CODE } from 'src/api/drafts'
+
+export type DraftStatus = 'idle' | 'saving' | 'saved' | 'error'
+
+// How long after the last edit we wait before autosaving. Long enough that
+// typing doesn't fire a request per keystroke, short enough that work isn't
+// lost if the tab is closed soon after.
+const AUTOSAVE_DELAY = 1500
+
+// The server rejects a new draft past the per-user cap with a 409 + this code.
+function isDraftLimitError(err: unknown): boolean {
+  return (
+    axios.isAxiosError(err) &&
+    err.response?.status === 409 &&
+    (err.response.data as { code?: string } | undefined)?.code ===
+      DRAFT_LIMIT_CODE
+  )
+}
+
+type Params = {
+  // Serializable draft content derived from the form state (no image).
+  content: RecipeDraftContent
+  // Autosave only runs when true: create-mode, and after any resume-hydration
+  // has finished. The first time this flips true the *current* content becomes
+  // the saved baseline (so resuming a draft, or landing on an empty form,
+  // doesn't immediately fire a redundant save).
+  enabled: boolean
+  // Whether a brand-new draft may be created for the current content. Gated on
+  // the form having a title, so a stray keystroke doesn't spawn a throwaway
+  // draft. Only governs creation — an existing draft (draftId set) is always
+  // updated, so clearing fields still persists.
+  canCreate: boolean
+  // The current draft's id, or null until the first save creates one.
+  draftId: string | null
+  // Called once with the created draft after the first successful save so the
+  // caller can adopt the new id (and reflect it in the URL).
+  onDraftCreated: (draft: RecipeDraftType) => void
+  // Called when creation is rejected because the user is at their draft cap,
+  // with the server's message. The caller surfaces it (e.g. a toast).
+  onLimitReached?: (message: string) => void
+}
+
+type DraftAutosave = {
+  status: DraftStatus
+  // Deletes the current draft and disables further autosave. Call after the
+  // recipe is published so the now-redundant draft is cleaned up and the
+  // unmount flush can't recreate it.
+  clearDraft: () => Promise<void>
+}
+
+export function useDraftAutosave({
+  content,
+  enabled,
+  canCreate,
+  draftId,
+  onDraftCreated,
+  onLimitReached,
+}: Params): DraftAutosave {
+  const [status, setStatus] = useState<DraftStatus>('idle')
+
+  // Latest values mirrored into refs so the debounce timer and unmount flush
+  // read current data without being part of their dependency lists.
+  const contentRef = useRef(content)
+  const canCreateRef = useRef(canCreate)
+  const draftIdRef = useRef(draftId)
+  const enabledRef = useRef(enabled)
+  contentRef.current = content
+  canCreateRef.current = canCreate
+  draftIdRef.current = draftId
+  enabledRef.current = enabled
+
+  // Serialized snapshot of the content we last persisted, so a save is skipped
+  // when nothing actually changed.
+  const lastSavedRef = useRef<string | null>(null)
+  // Tracks the enabled edge so we can re-establish the baseline each time
+  // autosave (re)activates — on mount, and again after a resume re-hydrates the
+  // form — without ever treating freshly loaded content as an unsaved edit.
+  const prevEnabledRef = useRef(false)
+  // Set once the recipe is published: stops the unmount flush from recreating
+  // the draft we just deleted.
+  const disabledRef = useRef(false)
+  // True while a save request is in flight. Prevents a fast typist from firing
+  // a second createDraft (→ duplicate drafts) before the first resolves; the
+  // finally block re-runs once for any edits made during the request.
+  const inFlightRef = useRef(false)
+  // Set once the server rejects creation at the draft cap. Stops further create
+  // attempts this session so we don't fire a failing POST on every keystroke.
+  const capReachedRef = useRef(false)
+  const onDraftCreatedRef = useRef(onDraftCreated)
+  const onLimitReachedRef = useRef(onLimitReached)
+  onDraftCreatedRef.current = onDraftCreated
+  onLimitReachedRef.current = onLimitReached
+
+  const saveNow = async () => {
+    // `enabled` is false in edit mode (and before a resume finishes hydrating);
+    // never persist a draft then — most importantly, the unmount flush must not
+    // create a draft out of a recipe the user was only editing.
+    if (!enabledRef.current || disabledRef.current || inFlightRef.current) return
+    const snapshot = JSON.stringify(contentRef.current)
+    if (snapshot === lastSavedRef.current) return
+    const id = draftIdRef.current
+    // Creating a new draft requires a title (canCreate) and that we're not
+    // already at the cap. Updates to an existing draft are always allowed.
+    if (!id && (!canCreateRef.current || capReachedRef.current)) return
+    inFlightRef.current = true
+    try {
+      setStatus('saving')
+      let persisted = false
+      if (id) {
+        const updated = await DraftAPI.updateDraft(id, contentRef.current)
+        persisted = !!updated
+      } else {
+        const created = await DraftAPI.createDraft(contentRef.current)
+        if (created) {
+          // A publish (clearDraft) can land while this create is in flight, when
+          // there's no id yet for clearDraft to delete. If that happened, this
+          // draft is now redundant — delete it instead of adopting it, so the
+          // published recipe doesn't leave an orphaned draft behind.
+          if (disabledRef.current) {
+            void DraftAPI.deleteDraft(created._id).catch(err =>
+              console.error('Failed to delete draft created during publish:', err)
+            )
+            return
+          }
+          // Adopt the id immediately so a save that fires before the parent
+          // re-renders updates this draft instead of creating a second one.
+          draftIdRef.current = created._id
+          onDraftCreatedRef.current(created)
+          persisted = true
+        }
+      }
+      if (persisted) {
+        lastSavedRef.current = snapshot
+        setStatus('saved')
+      } else {
+        // A null result means the request never went out (e.g. no auth), so the
+        // draft was NOT saved. Surface it rather than falsely showing "saved",
+        // and leave the baseline untouched so a later edit retries.
+        setStatus('error')
+      }
+    } catch (err) {
+      if (isDraftLimitError(err)) {
+        // At the per-user cap. Stop trying to create new drafts this session and
+        // let the caller tell the user (with the server's message) to free space.
+        capReachedRef.current = true
+        const message =
+          (axios.isAxiosError(err) &&
+            (err.response?.data as { error?: string } | undefined)?.error) ||
+          'You have too many saved drafts. Delete some to start a new one.'
+        onLimitReachedRef.current?.(message)
+      } else {
+        console.error('Draft autosave failed:', err)
+      }
+      setStatus('error')
+    } finally {
+      inFlightRef.current = false
+      // Re-run only if new edits arrived while this save was in flight. Compare
+      // against the snapshot we just attempted (not the saved baseline): a
+      // non-persisting result leaves the baseline stale, and comparing to it
+      // would spin in a tight retry loop.
+      if (
+        !disabledRef.current &&
+        JSON.stringify(contentRef.current) !== snapshot
+      ) {
+        void saveNow()
+      }
+    }
+  }
+
+  // Debounced autosave on content changes.
+  useEffect(() => {
+    if (!enabled) {
+      prevEnabledRef.current = false
+      return
+    }
+    // Just (re)enabled — on mount, or after a resume loaded a draft into the
+    // form. Treat whatever is on screen as the saved baseline rather than
+    // saving it back.
+    if (!prevEnabledRef.current) {
+      prevEnabledRef.current = true
+      lastSavedRef.current = JSON.stringify(content)
+      return
+    }
+    if (JSON.stringify(content) === lastSavedRef.current) return
+    if (!draftId && (!canCreate || capReachedRef.current)) return
+    const timer = setTimeout(saveNow, AUTOSAVE_DELAY)
+    return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content, enabled, draftId, canCreate])
+
+  // Flush pending (debounced) changes when leaving the page mid-edit. saveNow
+  // no-ops when autosave isn't enabled, so this is safe in edit mode.
+  useEffect(() => {
+    return () => {
+      void saveNow()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const clearDraft = async () => {
+    disabledRef.current = true
+    const id = draftIdRef.current
+    if (!id) return
+    try {
+      await DraftAPI.deleteDraft(id)
+    } catch (err) {
+      console.error('Failed to delete draft after publish:', err)
+    }
+  }
+
+  return { status, clearDraft }
+}

--- a/src/test/AddRecipe.test.tsx
+++ b/src/test/AddRecipe.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { HelmetProvider } from 'react-helmet-async'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
 import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
 import RecipeAPI from 'src/api/recipes'
 
@@ -131,7 +132,9 @@ const renderAddRecipe = () => {
   return render(
     <QueryClientProvider client={queryClient}>
       <HelmetProvider>
-        <AddRecipe />
+        <MemoryRouter>
+          <AddRecipe />
+        </MemoryRouter>
       </HelmetProvider>
     </QueryClientProvider>
   )

--- a/src/test/RecipeDrafts.test.tsx
+++ b/src/test/RecipeDrafts.test.tsx
@@ -1,0 +1,335 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HelmetProvider } from 'react-helmet-async'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, useSearchParams } from 'react-router-dom'
+import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
+import Drafts from 'src/pages/Account/Drafts/Drafts'
+import DraftAPI from 'src/api/drafts'
+import { RecipeDraftType, RecipeType } from 'types'
+
+const { navigateFn } = vi.hoisted(() => ({ navigateFn: vi.fn() }))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom'
+  )
+  return { ...actual, useNavigate: () => navigateFn }
+})
+
+vi.mock('react-hot-toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+  default: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('src/api/recipes', () => ({
+  default: { addRecipe: vi.fn() },
+  ADD_RECIPE_AUTH_ERROR: 'AUTH_ERROR',
+}))
+
+// Signed-in user so DraftAPI methods don't short-circuit on a missing uid.
+vi.mock('src/api/auth', () => ({
+  default: { getUID: vi.fn().mockReturnValue('test-uid') },
+}))
+
+vi.mock('src/api/drafts', () => ({
+  default: {
+    createDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    listDrafts: vi.fn(),
+    getDraft: vi.fn(),
+    deleteDraft: vi.fn(),
+  },
+  DRAFT_LIMIT_CODE: 'DRAFT_LIMIT',
+}))
+
+vi.mock('react-top-loading-bar', () => ({ default: () => null }))
+
+vi.mock('src/pages/AddRecipe/RecipeFormInput', () => ({
+  default: ({ val, setVal, placeholder }: any) => (
+    <input
+      placeholder={placeholder}
+      value={val ?? ''}
+      onChange={e => setVal(e.target.value)}
+    />
+  ),
+}))
+
+vi.mock('src/pages/AddRecipe/ImagePicker/ImagePicker', () => ({
+  default: () => null,
+}))
+vi.mock('src/pages/AddRecipe/MealTypeSelector/MealTypeSelector', () => ({
+  default: () => null,
+}))
+vi.mock('src/pages/AddRecipe/CuisineSelector/CuisineSelector', () => ({
+  default: () => null,
+}))
+vi.mock(
+  'src/pages/AddRecipe/Ingredients/IngredientsContainer/IngredientsContainer',
+  () => ({ default: () => null })
+)
+vi.mock('src/pages/AddRecipe/Instructions/InstructionsContainer', () => ({
+  default: () => null,
+}))
+vi.mock('src/pages/AddRecipe/TimeInput/TimeInput', () => ({
+  default: () => null,
+}))
+
+const mockedDraftAPI = DraftAPI as unknown as {
+  createDraft: ReturnType<typeof vi.fn>
+  updateDraft: ReturnType<typeof vi.fn>
+  listDrafts: ReturnType<typeof vi.fn>
+  getDraft: ReturnType<typeof vi.fn>
+  deleteDraft: ReturnType<typeof vi.fn>
+}
+
+const makeDraft = (overrides: Partial<RecipeDraftType> = {}): RecipeDraftType => ({
+  _id: 'draft-1',
+  userId: 'test-uid',
+  title: 'Resumed Recipe',
+  ingredients: [],
+  instructions: [],
+  createdAt: '1000',
+  updatedAt: '2000',
+  ...overrides,
+})
+
+const renderAt = (ui: React.ReactNode, initialEntry = '/add-recipe') => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <HelmetProvider>
+        <MemoryRouter initialEntries={[initialEntry]}>{ui}</MemoryRouter>
+      </HelmetProvider>
+    </QueryClientProvider>
+  )
+}
+
+beforeAll(() => {
+  HTMLElement.prototype.scrollTo = vi.fn() as any
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedDraftAPI.listDrafts.mockResolvedValue([])
+  mockedDraftAPI.createDraft.mockResolvedValue(makeDraft())
+  mockedDraftAPI.updateDraft.mockResolvedValue(makeDraft())
+  mockedDraftAPI.getDraft.mockResolvedValue(makeDraft())
+  mockedDraftAPI.deleteDraft.mockResolvedValue(undefined)
+})
+
+describe('AddRecipe draft autosave', () => {
+  it('does not create a draft for an empty form', async () => {
+    renderAt(<AddRecipe />)
+    // Give any debounce window time to (not) fire.
+    await new Promise(r => setTimeout(r, 1700))
+    expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+  })
+
+  it('autosaves a new draft once the user enters content', async () => {
+    const user = userEvent.setup()
+    renderAt(<AddRecipe />)
+    await user.type(
+      screen.getByPlaceholderText('Add a title to your recipe.'),
+      'Soup'
+    )
+    await waitFor(
+      () => expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1),
+      { timeout: 3000 }
+    )
+    // Empty numeric fields are sent as explicit null (not omitted) so a later
+    // clear is actually persisted rather than dropped from the payload.
+    expect(mockedDraftAPI.createDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Soup',
+        servings: null,
+        prepTime: null,
+        cookTime: null,
+      })
+    )
+    await screen.findByText('Draft saved')
+  })
+
+  it('re-hydrates when the draft id changes in-place (banner resume, no remount)', async () => {
+    // The resume banner navigates to /add-recipe?draftId=… while AddRecipe is
+    // already mounted — the route doesn't change, so only the query updates.
+    // A harness that flips the query via useSearchParams reproduces that path.
+    mockedDraftAPI.getDraft.mockResolvedValue(
+      makeDraft({ _id: 'draft-9', title: 'Resumed In Place' })
+    )
+    const ResumeHarness: React.FC = () => {
+      const [, setSearchParams] = useSearchParams()
+      return (
+        <>
+          <button onClick={() => setSearchParams({ draftId: 'draft-9' })}>
+            go
+          </button>
+          <AddRecipe />
+        </>
+      )
+    }
+    const user = userEvent.setup()
+    renderAt(<ResumeHarness />)
+    expect(mockedDraftAPI.getDraft).not.toHaveBeenCalled()
+
+    await user.click(screen.getByText('go'))
+    await waitFor(() =>
+      expect(mockedDraftAPI.getDraft).toHaveBeenCalledWith('draft-9')
+    )
+    await waitFor(() =>
+      expect(
+        screen.getByPlaceholderText('Add a title to your recipe.')
+      ).toHaveValue('Resumed In Place')
+    )
+  })
+
+  it('hydrates the form from an existing draft when resuming via ?draftId', async () => {
+    mockedDraftAPI.getDraft.mockResolvedValue(
+      makeDraft({ _id: 'draft-9', title: 'Leftover Stew' })
+    )
+    renderAt(<AddRecipe />, '/add-recipe?draftId=draft-9')
+    expect(mockedDraftAPI.getDraft).toHaveBeenCalledWith('draft-9')
+    await waitFor(() =>
+      expect(
+        screen.getByPlaceholderText('Add a title to your recipe.')
+      ).toHaveValue('Leftover Stew')
+    )
+    // Resuming alone must not create a brand-new draft.
+    expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+  })
+
+  it('on a transient load error keeps the draftId and does NOT start a duplicate (finding #3)', async () => {
+    // A 500 (vs a 404/403) means the draft probably still exists.
+    mockedDraftAPI.getDraft.mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 500 },
+    })
+    const user = userEvent.setup()
+    renderAt(<AddRecipe />, '/add-recipe?draftId=draft-7')
+    await waitFor(() =>
+      expect(mockedDraftAPI.getDraft).toHaveBeenCalledWith('draft-7')
+    )
+    // Typing must not spawn a new draft (autosave stays disabled) — otherwise
+    // the real draft-7 would be orphaned and duplicated.
+    await user.type(
+      screen.getByPlaceholderText('Add a title to your recipe.'),
+      'Soup'
+    )
+    await new Promise(r => setTimeout(r, 1700))
+    expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+    expect(mockedDraftAPI.updateDraft).not.toHaveBeenCalled()
+  })
+
+  it('on a 404 load error clears the draftId and lets a fresh draft start (finding #3)', async () => {
+    mockedDraftAPI.getDraft.mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 404 },
+    })
+    const user = userEvent.setup()
+    renderAt(<AddRecipe />, '/add-recipe?draftId=gone')
+    await waitFor(() =>
+      expect(mockedDraftAPI.getDraft).toHaveBeenCalledWith('gone')
+    )
+    // The stale id is dropped, so typing starts a brand-new draft.
+    await user.type(
+      screen.getByPlaceholderText('Add a title to your recipe.'),
+      'Soup'
+    )
+    await waitFor(
+      () => expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1),
+      { timeout: 3000 }
+    )
+  })
+
+  it('shows an error (not "Draft saved") when the save does not persist (finding #5)', async () => {
+    // createDraft resolving null models the no-auth short-circuit: nothing was
+    // written, so the indicator must not claim success.
+    mockedDraftAPI.createDraft.mockResolvedValue(null)
+    const user = userEvent.setup()
+    renderAt(<AddRecipe />)
+    await user.type(
+      screen.getByPlaceholderText('Add a title to your recipe.'),
+      'Soup'
+    )
+    await waitFor(
+      () => expect(mockedDraftAPI.createDraft).toHaveBeenCalled(),
+      { timeout: 3000 }
+    )
+    expect(await screen.findByText("Couldn't save draft")).toBeInTheDocument()
+    expect(screen.queryByText('Draft saved')).toBeNull()
+  })
+})
+
+describe('AddRecipe edit mode', () => {
+  const recipe: RecipeType = {
+    _id: 'recipe-1',
+    userId: 'test-uid',
+    title: 'Existing Recipe',
+    prepTime: 10,
+    cookTime: 20,
+    servings: 4,
+    fridgeLife: 3,
+    freezerLife: 30,
+    description: 'An existing recipe being edited',
+    ingredients: [],
+    instructions: [],
+    recipeImage: 'https://example.com/img.jpg',
+    nutritionData: null,
+    totalTime: 30,
+    authorUsername: 'chef',
+    rating: { rateCount: 0, rateValue: 0 },
+    createdAt: '1000',
+    editedAt: null,
+    servingPrice: 100,
+    cuisine: 'Italian',
+    mealTypes: ['dinner'],
+    nutritionLabels: [],
+    views: 0,
+    numTimesSaved: 0,
+    numTimesMade: 0,
+  }
+
+  it('never creates a draft, even when unmounting (e.g. cancel)', async () => {
+    const { unmount } = renderAt(<AddRecipe initialRecipe={recipe} />)
+    // Let any debounce window pass while the editor is open.
+    await new Promise(r => setTimeout(r, 1700))
+    // Leaving the editor (cancel/navigation) triggers the unmount flush.
+    unmount()
+    await new Promise(r => setTimeout(r, 50))
+    expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+    expect(mockedDraftAPI.updateDraft).not.toHaveBeenCalled()
+  })
+})
+
+describe('Drafts tab', () => {
+  it('shows an empty state when there are no drafts', async () => {
+    mockedDraftAPI.listDrafts.mockResolvedValue([])
+    renderAt(<Drafts />)
+    expect(await screen.findByText('No Drafts Yet')).toBeInTheDocument()
+  })
+
+  it('lists drafts and deletes one', async () => {
+    mockedDraftAPI.listDrafts.mockResolvedValue([
+      makeDraft({ _id: 'd1', title: 'Pasta Bake' }),
+    ])
+    const user = userEvent.setup()
+    renderAt(<Drafts />)
+    expect(await screen.findByText('Pasta Bake')).toBeInTheDocument()
+    await user.click(screen.getByLabelText('Delete draft'))
+    await waitFor(() =>
+      expect(mockedDraftAPI.deleteDraft).toHaveBeenCalledWith('d1')
+    )
+  })
+
+  it('falls back to "Untitled draft" when a draft has no title', async () => {
+    mockedDraftAPI.listDrafts.mockResolvedValue([
+      makeDraft({ _id: 'd2', title: '' }),
+    ])
+    renderAt(<Drafts />)
+    expect(await screen.findByText('Untitled draft')).toBeInTheDocument()
+  })
+})

--- a/src/test/RecipeDrafts.test.tsx
+++ b/src/test/RecipeDrafts.test.tsx
@@ -200,6 +200,21 @@ describe('AddRecipe draft autosave', () => {
     )
     // Resuming alone must not create a brand-new draft.
     expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+    // Drafts don't persist the image, so resuming prompts the user to re-add it.
+    expect(
+      screen.getByText(/Drafts don't save your image/i)
+    ).toBeInTheDocument()
+  })
+
+  it('does not show the re-add-image hint on a fresh create form', async () => {
+    const user = userEvent.setup()
+    renderAt(<AddRecipe />)
+    await user.type(
+      screen.getByPlaceholderText('Add a title to your recipe.'),
+      'Brand New'
+    )
+    // The user never had an image to lose on a fresh draft.
+    expect(screen.queryByText(/Drafts don't save your image/i)).toBeNull()
   })
 
   it('on a transient load error keeps the draftId and does NOT start a duplicate (finding #3)', async () => {

--- a/src/test/useDraftAutosave.test.tsx
+++ b/src/test/useDraftAutosave.test.tsx
@@ -1,0 +1,136 @@
+import { vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useDraftAutosave } from 'src/pages/AddRecipe/useDraftAutosave'
+import DraftAPI from 'src/api/drafts'
+import { RecipeDraftType } from 'types'
+
+vi.mock('src/api/drafts', () => ({
+  default: {
+    createDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    deleteDraft: vi.fn(),
+  },
+  DRAFT_LIMIT_CODE: 'DRAFT_LIMIT',
+}))
+
+const mockedDraftAPI = DraftAPI as unknown as {
+  createDraft: ReturnType<typeof vi.fn>
+  updateDraft: ReturnType<typeof vi.fn>
+  deleteDraft: ReturnType<typeof vi.fn>
+}
+
+// A promise whose resolution we control, to model an in-flight network request.
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(r => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+const createdDraft: RecipeDraftType = {
+  _id: 'new-draft',
+  userId: 'test-uid',
+  title: 'Soup',
+  createdAt: '1000',
+  updatedAt: '1000',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useDraftAutosave — publish during in-flight create (finding #2)', () => {
+  it('deletes the draft that finishes creating after publish, instead of orphaning it', async () => {
+    const created = deferred<RecipeDraftType>()
+    mockedDraftAPI.createDraft.mockReturnValue(created.promise)
+    const onDraftCreated = vi.fn()
+
+    const { result, rerender } = renderHook(
+      ({ content }) =>
+        useDraftAutosave({
+          content,
+          enabled: true,
+          canCreate: true,
+          draftId: null,
+          onDraftCreated,
+        }),
+      { initialProps: { content: { title: '' } as Record<string, unknown> } }
+    )
+
+    // First enable establishes the baseline; an edit then schedules the save.
+    rerender({ content: { title: 'Soup' } })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+    // createDraft is now in flight (its promise hasn't resolved).
+    expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1)
+
+    // User publishes: clearDraft disables autosave. No id exists yet to delete.
+    await act(async () => {
+      await result.current.clearDraft()
+    })
+
+    // The create now resolves — the hook must delete the just-created draft
+    // rather than adopt it (which would leave an orphan after publish). Flush
+    // the saveNow continuation that runs after createDraft's promise settles.
+    await act(async () => {
+      created.resolve(createdDraft)
+      await created.promise
+      await Promise.resolve()
+    })
+
+    expect(mockedDraftAPI.deleteDraft).toHaveBeenCalledWith('new-draft')
+    expect(onDraftCreated).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDraftAutosave — draft cap (finding #4)', () => {
+  it('notifies once and stops retrying creation when the server reports the cap', async () => {
+    mockedDraftAPI.createDraft.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        status: 409,
+        data: { code: 'DRAFT_LIMIT', error: 'Too many drafts — delete some.' },
+      },
+    })
+    const onLimitReached = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ content }) =>
+        useDraftAutosave({
+          content,
+          enabled: true,
+          canCreate: true,
+          draftId: null,
+          onDraftCreated: vi.fn(),
+          onLimitReached,
+        }),
+      { initialProps: { content: { title: '' } as Record<string, unknown> } }
+    )
+
+    rerender({ content: { title: 'Soup' } })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+
+    expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1)
+    expect(onLimitReached).toHaveBeenCalledWith('Too many drafts — delete some.')
+
+    // A further edit must NOT fire another create attempt (no per-keystroke
+    // request storm against a known-full account).
+    rerender({ content: { title: 'Soup updated' } })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+    expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1)
+    expect(onLimitReached).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,39 @@ export type RecipeEditFormType = Omit<RecipeFormType, 'recipeImage'> & {
   recipeImage?: File
 }
 
+// An in-progress recipe autosaved during the create flow. Every content field
+// is optional — a draft is intentionally incomplete — and the image is *not*
+// persisted (it's re-picked when the user resumes; publishing still requires
+// one). `RecipeDraftContent` is what the client sends on autosave;
+// `RecipeDraftType` is the stored document the server returns.
+//
+// Clearable numeric fields are `number | null` (not just optional): autosave
+// sends an explicit `null` when the user empties them so the clear is
+// persisted. Omitting the key (sending `undefined`) would be dropped by
+// JSON.stringify, and the server's field-present `$set` whitelist would then
+// leave the stale value in place — a cleared field would silently resurrect on
+// resume.
+export type RecipeDraftContent = {
+  title?: string
+  description?: string
+  servings?: number | null
+  prepTime?: number | null
+  cookTime?: number | null
+  fridgeLife?: number | null
+  freezerLife?: number | null
+  ingredients?: IngredientsType[]
+  instructions?: InstructionsType[]
+  cuisine?: string
+  mealTypes?: string[]
+}
+
+export type RecipeDraftType = RecipeDraftContent & {
+  _id: string
+  userId: string
+  createdAt: string
+  updatedAt: string
+}
+
 export type LabelType = { label: string; id: string }
 export type IngredientsType =
   | {


### PR DESCRIPTION
## Summary

Adds a server-backed **draft** system for the create-recipe workflow: a recipe in progress is autosaved so it survives a refresh or navigating away, with a place to find and resume drafts later.

- **Backend** — new `recipeDrafts` collection with owner-checked CRUD at `/api/drafts` (POST / GET list / GET one / PUT / DELETE), a **25-draft per-user cap** (`409 DRAFT_LIMIT`, creation only — editing existing drafts always works), and a `{ userId, updatedAt }` index.
- **Autosave** — `AddRecipe` debounce-saves a draft in create mode once the recipe has a **title** (title-gating keeps throwaway drafts out). Resumes via `?draftId=`, deletes the draft on publish, and shows a save-status indicator. Edit mode never creates drafts.
- **UI** — new **Drafts** tab in Account (list / continue editing / delete) and a **resume banner** on the create page.
- The recipe **image is intentionally not part of a draft** — it's re-picked on resume (publish still requires one).

## Notable correctness handling
- Cleared numeric fields (`servings`/`prepTime`/`cookTime`) persist via explicit `null` rather than silently resurrecting on resume.
- A `createDraft` that resolves **after** publish deletes itself instead of orphaning a draft.
- Transient load errors (network/5xx) keep the `draftId` and ask the user to retry; only 404/403 start a fresh draft (no accidental duplicates).
- The save indicator only shows "saved" when the draft was actually persisted.
- Shared recipe-field whitelist (`util/recipeFields`) between the draft routes and `editRecipe` so the two can't drift.

## Testing
- Frontend (vitest): autosave/resume/empty-form/edit-mode, the publish-race and cap behaviors, plus the Drafts tab. 
- Server (jest): drafts CRUD, ownership/authz, the draft cap, and PUT validation ordering.
- Full suites green: **161 server**, **156 frontend** (+2 skipped); typecheck and production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)