### PR TITLE
Release: recipe editing, drafts autosave, author stats &   username uniqueness fixes

### DIFF
--- a/cypress/fixtures/single-recipe.json
+++ b/cypress/fixtures/single-recipe.json
@@ -444,8 +444,8 @@
   },
   "totalTime": 40,
   "rating": {
-    "rateCount": "3",
-    "rateValue": "13"
+    "rateCount": 3,
+    "rateValue": 4.3
   },
   "createdAt": "1678299721258",
   "editedAt": null,

--- a/design-explorations/single-recipe/author-stats.html
+++ b/design-explorations/single-recipe/author-stats.html
@@ -1,0 +1,408 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Author Stats &amp; Controls · Single Recipe Explorations</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --primary:#ff5722; --secondary:#00adb5;
+    --primary-text:#303841; --secondary-text:#595f66; --tertiary-text:#979ba0;
+    --white:#fff; --gray-50:#fafafa; --gray-200:#eeeeee; --gray-300:#e6e6e6;
+    --gray-400:#d6d6d6; --gray-500:#bebebe; --gray-600:#a6a6a6;
+    --success-green:#28a745; --error-red:#dc3545; --error-red-hover:#b02a37;
+    --radius:10px; --shadow:rgba(0,0,0,0.24) 0px 3px 8px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0;}
+  body{font-family:'Montserrat',sans-serif;background:var(--gray-200);color:var(--primary-text);-webkit-font-smoothing:antialiased;}
+
+  /* ---------- switcher ---------- */
+  .switcher{position:sticky;top:0;z-index:50;background:var(--primary-text);color:#fff;
+    display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;padding:.85rem 1.25rem;box-shadow:0 2px 10px rgba(0,0,0,.25);}
+  .switcher .brand{font-weight:800;letter-spacing:-.01em;margin-right:.5rem;}
+  .switcher .brand span{color:var(--primary);}
+  .switcher button{font-family:inherit;font-weight:700;font-size:.85rem;color:#fff;background:rgba(255,255,255,.08);
+    border:1px solid rgba(255,255,255,.18);border-radius:999px;padding:.4rem .9rem;cursor:pointer;transition:.12s;}
+  .switcher button:hover{background:rgba(255,255,255,.18);}
+  .switcher button.active{background:var(--primary);border-color:var(--primary);}
+  .switcher .hint{margin-left:auto;font-size:.75rem;color:var(--gray-500);font-weight:600;}
+
+  .desc-strip{background:var(--gray-50);border-bottom:1px solid var(--gray-400);padding:.85rem 1.25rem;}
+  .desc-strip .v-name{font-weight:800;font-size:1rem;}
+  .desc-strip .v-name b{color:var(--primary);}
+  .desc-strip p{font-size:.85rem;color:var(--secondary-text);font-weight:500;margin-top:.2rem;max-width:90ch;}
+
+  /* ---------- mock page chrome (shared) ---------- */
+  .stage{padding:2.5rem 1.25rem 6rem;}
+  .page{max-width:1000px;margin:0 auto;background:var(--gray-200);}
+  .recipe-header{display:flex;gap:3rem;padding-bottom:2rem;margin-bottom:2rem;border-bottom:1px solid var(--gray-400);}
+  .recipe-header .img{flex:0 0 320px;height:320px;border-radius:6px;
+    background:linear-gradient(135deg,#f6b59c,#ff5722 70%);position:relative;overflow:hidden;}
+  .recipe-header .img::after{content:'recipe photo';position:absolute;inset:auto 0 12px 0;text-align:center;
+    color:rgba(255,255,255,.85);font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:2px;}
+  .desc{display:flex;flex-direction:column;gap:.9rem;flex:1;}
+  .price{font-size:.75rem;font-weight:700;color:var(--primary);text-transform:uppercase;letter-spacing:1.2px;}
+  .title{font-size:2rem;font-weight:600;line-height:1.1;}
+  .description{font-size:1rem;font-weight:500;color:var(--primary-text);max-width:560px;flex:1;}
+  .recipe-data{display:flex;gap:2.5rem;}
+  .recipe-data .rd{display:flex;flex-direction:column;align-items:center;gap:.4rem;}
+  .recipe-data .rd .icon{height:26px;width:26px;color:var(--primary-text);}
+  .recipe-data .rd h4{font-size:.95rem;font-weight:700;}
+  .recipe-data .rd .d{font-size:.9rem;color:var(--secondary-text);}
+  .body-spacer{text-align:center;color:var(--gray-600);font-weight:700;font-size:.8rem;letter-spacing:2px;
+    text-transform:uppercase;padding:3rem 0;border-bottom:1px dashed var(--gray-500);margin-bottom:2.5rem;}
+
+  /* shared building blocks */
+  .section-label{font-size:.8rem;color:var(--primary);font-weight:700;text-transform:uppercase;letter-spacing:1.2px;}
+  .icon{display:inline-block;vertical-align:middle;}
+  .btn{display:inline-flex;align-items:center;gap:.45rem;font-family:inherit;font-weight:600;font-size:.9rem;
+    border-radius:var(--radius);cursor:pointer;transition:all .12s linear;}
+  .btn .icon{height:17px;width:17px;}
+
+  .variation{display:none;}
+  .variation.active{display:block;}
+
+  /* ========================================================= */
+  /* V1 — Owner banner (top) + clean icon stat row (bottom)    */
+  /* ========================================================= */
+  #v1 .owner-banner{display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap;
+    background:var(--gray-50);border:1px solid var(--gray-400);border-radius:var(--radius);
+    padding:.7rem 1.25rem;margin-bottom:2rem;}
+  #v1 .owner-banner .who{display:flex;align-items:center;gap:.6rem;font-weight:600;color:var(--secondary-text);font-size:.9rem;}
+  #v1 .owner-banner .who .icon{height:20px;width:20px;color:var(--secondary);}
+  #v1 .owner-banner .who b{color:var(--primary-text);}
+  #v1 .owner-banner .acts{display:flex;gap:.6rem;}
+  #v1 .owner-banner .btn{border:1px solid var(--gray-500);background:transparent;padding:.4rem .8rem;color:var(--primary-text);}
+  #v1 .owner-banner .btn.delete:hover{background:var(--error-red);border-color:var(--error-red);color:#fff;}
+  #v1 .owner-banner .btn.edit:disabled{opacity:.5;cursor:not-allowed;}
+  #v1 .stats{margin-top:1rem;}
+  #v1 .stats .section-label{display:block;margin-bottom:1.5rem;}
+  #v1 .stat-row{display:flex;justify-content:space-around;flex-wrap:wrap;gap:1.5rem;}
+  #v1 .stat{display:flex;flex-direction:column;align-items:center;gap:.4rem;}
+  #v1 .stat .icon{height:28px;width:28px;color:var(--secondary-text);}
+  #v1 .stat .num{font-size:1.6rem;font-weight:700;color:var(--primary-text);}
+  #v1 .stat .lbl{font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:1px;color:var(--secondary-text);}
+
+  /* ========================================================= */
+  /* V2 — Title pill badge (top) + refined stat cards (bottom) */
+  /* ========================================================= */
+  #v2 .owner-pill{display:inline-flex;align-items:center;gap:.4rem;align-self:flex-start;
+    border:1.5px solid var(--primary);color:var(--primary);border-radius:999px;
+    padding:.28rem .8rem;font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.6px;}
+  #v2 .owner-pill .icon{height:14px;width:14px;}
+  #v2 .stats .section-label{display:block;margin-bottom:1.25rem;}
+  #v2 .stat-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1rem;}
+  #v2 .stat{background:var(--white);border-radius:var(--radius);box-shadow:var(--shadow);
+    padding:1.25rem 1rem;display:flex;flex-direction:column;align-items:center;gap:.35rem;}
+  #v2 .stat .icon{height:24px;width:24px;color:var(--primary);}
+  #v2 .stat .num{font-size:1.5rem;font-weight:700;}
+  #v2 .stat .lbl{font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--secondary-text);}
+  #v2 .controls{display:flex;justify-content:flex-end;gap:.75rem;margin-top:1.25rem;}
+  #v2 .controls .btn{padding:.5rem 1rem;border:1px solid var(--primary-text);background:transparent;color:var(--primary-text);}
+  #v2 .controls .btn.edit:disabled{opacity:.45;cursor:not-allowed;}
+  #v2 .controls .btn.delete{border-color:var(--error-red);color:var(--error-red);}
+  #v2 .controls .btn.delete:hover{background:var(--error-red);color:#fff;}
+
+  /* ========================================================= */
+  /* V3 — Accent label (top) + divided inline bar w/ controls  */
+  /* ========================================================= */
+  #v3 .owner-tag{font-size:.75rem;font-weight:700;color:var(--primary);text-transform:uppercase;letter-spacing:1.5px;
+    display:flex;align-items:center;gap:.4rem;}
+  #v3 .owner-tag .icon{height:14px;width:14px;}
+  #v3 .stats-bar{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:1.5rem;
+    border:1px solid var(--gray-400);border-radius:var(--radius);background:var(--gray-50);padding:1.1rem 1.75rem;}
+  #v3 .stats-inline{display:flex;}
+  #v3 .stats-inline .stat{display:flex;flex-direction:column;align-items:center;gap:.2rem;padding:0 1.75rem;
+    border-right:1px solid var(--gray-400);}
+  #v3 .stats-inline .stat:last-child{border-right:none;}
+  #v3 .stats-inline .stat:first-child{padding-left:0;}
+  #v3 .stat .num{font-size:1.4rem;font-weight:700;}
+  #v3 .stat .lbl{font-size:.68rem;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--secondary-text);}
+  #v3 .stat .num .star{color:var(--primary);}
+  #v3 .controls{display:flex;gap:.6rem;}
+  #v3 .controls .btn{padding:.45rem .85rem;border:1px solid var(--gray-500);background:var(--white);color:var(--primary-text);}
+  #v3 .controls .btn.edit:disabled{opacity:.45;cursor:not-allowed;}
+  #v3 .controls .btn.delete:hover{background:var(--error-red);border-color:var(--error-red);color:#fff;}
+
+  /* ========================================================= */
+  /* V4 — Image corner chip (top) + combined owner card        */
+  /* ========================================================= */
+  #v4 .recipe-header .img .chip{position:absolute;top:12px;left:12px;z-index:2;
+    display:flex;align-items:center;gap:.35rem;background:rgba(48,56,65,.92);color:#fff;
+    padding:.3rem .7rem;border-radius:999px;font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.6px;}
+  #v4 .recipe-header .img .chip .icon{height:13px;width:13px;}
+  #v4 .owner-card{background:var(--white);border-left:4px solid var(--primary);border-radius:var(--radius);
+    box-shadow:var(--shadow);padding:1.5rem 1.75rem;}
+  #v4 .owner-card .head{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:1rem;
+    padding-bottom:1.25rem;margin-bottom:1.25rem;border-bottom:1px solid var(--gray-300);}
+  #v4 .owner-card .head .ttl{font-size:1.1rem;font-weight:700;}
+  #v4 .owner-card .head .sub{font-size:.8rem;color:var(--secondary-text);font-weight:500;margin-top:.15rem;}
+  #v4 .owner-card .head .acts{display:flex;gap:.6rem;}
+  #v4 .owner-card .btn{padding:.5rem 1rem;border:1px solid var(--primary-text);background:transparent;color:var(--primary-text);}
+  #v4 .owner-card .btn.edit:disabled{opacity:.45;cursor:not-allowed;}
+  #v4 .owner-card .btn.delete{border-color:var(--error-red);color:var(--error-red);}
+  #v4 .owner-card .btn.delete:hover{background:var(--error-red);color:#fff;}
+  #v4 .owner-card .stat-row{display:flex;gap:3rem;flex-wrap:wrap;}
+  #v4 .stat{display:flex;align-items:center;gap:.7rem;}
+  #v4 .stat .icon{height:26px;width:26px;color:var(--primary);}
+  #v4 .stat .num{font-size:1.35rem;font-weight:700;line-height:1;}
+  #v4 .stat .lbl{font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--secondary-text);}
+
+  /* ========================================================= */
+  /* V5 — Minimal editorial line (top) + light inline stats    */
+  /* ========================================================= */
+  #v5 .owner-line{font-size:.85rem;color:var(--secondary-text);font-weight:600;display:flex;align-items:center;gap:.5rem;}
+  #v5 .owner-line .dot{color:var(--gray-500);}
+  #v5 .owner-line a{color:var(--primary);text-decoration:none;font-weight:700;}
+  #v5 .owner-line a:hover{text-decoration:underline;}
+  #v5 .stats-foot{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:1.25rem;
+    padding-top:1.5rem;border-top:1px solid var(--gray-400);}
+  #v5 .stats-minimal{display:flex;align-items:center;gap:1.1rem;color:var(--secondary-text);font-weight:600;font-size:.95rem;}
+  #v5 .stats-minimal .stat{display:flex;align-items:center;gap:.45rem;}
+  #v5 .stats-minimal .stat .icon{height:18px;width:18px;color:var(--tertiary-text);}
+  #v5 .stats-minimal .stat b{color:var(--primary-text);font-weight:700;}
+  #v5 .stats-minimal .star{color:var(--primary);}
+  #v5 .stats-minimal .sep{color:var(--gray-500);}
+  #v5 .controls{display:flex;gap:1.25rem;}
+  #v5 .controls .btn{background:none;border:none;padding:0;font-weight:700;font-size:.9rem;color:var(--secondary-text);}
+  #v5 .controls .btn:hover{text-decoration:underline;}
+  #v5 .controls .btn.delete{color:var(--error-red);}
+  #v5 .controls .btn.edit:disabled{opacity:.5;cursor:not-allowed;text-decoration:none;}
+
+  @media(max-width:760px){
+    .recipe-header{flex-direction:column;gap:1.5rem;}
+    .recipe-header .img{flex-basis:auto;width:100%;height:240px;}
+    #v2 .stat-grid{grid-template-columns:repeat(2,1fr);}
+  }
+</style>
+</head>
+<body>
+  <!-- icon symbols -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+    <symbol id="i-eye" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></symbol>
+    <symbol id="i-bookmark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></symbol>
+    <symbol id="i-star" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></symbol>
+    <symbol id="i-edit" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></symbol>
+    <symbol id="i-trash" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></symbol>
+    <symbol id="i-user" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></symbol>
+    <symbol id="i-clock" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></symbol>
+  </svg>
+
+  <div class="switcher">
+    <span class="brand">Prep<span>ify</span> · Author stats</span>
+    <button data-v="1" class="active">V1 · Banner</button>
+    <button data-v="2">V2 · Pill + cards</button>
+    <button data-v="3">V3 · Inline bar</button>
+    <button data-v="4">V4 · Owner card</button>
+    <button data-v="5">V5 · Minimal</button>
+    <span class="hint">press 1–5 to switch</span>
+  </div>
+
+  <div class="desc-strip" id="desc"></div>
+
+  <div class="stage">
+
+    <!-- ============ V1 ============ -->
+    <section class="variation active" id="v1">
+      <div class="page">
+        <div class="owner-banner">
+          <div class="who"><svg class="icon"><use href="#i-user"/></svg><span><b>You</b> created this recipe</span></div>
+          <div class="acts">
+            <button class="btn edit" disabled title="Editing coming soon"><svg class="icon"><use href="#i-edit"/></svg>Edit</button>
+            <button class="btn delete"><svg class="icon"><use href="#i-trash"/></svg>Delete</button>
+          </div>
+        </div>
+        <div class="recipe-header">
+          <div class="img"></div>
+          <div class="desc">
+            <p class="price">$2.00 / serving</p>
+            <h1 class="title">Chicken Tacos</h1>
+            <p class="description">Tender spiced chicken, crisp slaw, and a quick lime crema folded into warm corn tortillas — a 30-minute weeknight favorite.</p>
+            <div class="recipe-data">
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Prep</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Cook</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-user"/></svg><h4>Serves</h4><span class="d">4</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="body-spacer">ingredients · instructions · tags</div>
+        <div class="stats">
+          <span class="section-label">Recipe Stats</span>
+          <div class="stat-row">
+            <div class="stat"><svg class="icon"><use href="#i-eye"/></svg><span class="num">1,234</span><span class="lbl">Views</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-bookmark"/></svg><span class="num">1</span><span class="lbl">Save</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-check"/></svg><span class="num">5</span><span class="lbl">Made</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-star"/></svg><span class="num">4.2</span><span class="lbl">8 Ratings</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ V2 ============ -->
+    <section class="variation" id="v2">
+      <div class="page">
+        <div class="recipe-header">
+          <div class="img"></div>
+          <div class="desc">
+            <span class="owner-pill"><svg class="icon"><use href="#i-user"/></svg>Your recipe</span>
+            <p class="price">$2.00 / serving</p>
+            <h1 class="title">Chicken Tacos</h1>
+            <p class="description">Tender spiced chicken, crisp slaw, and a quick lime crema folded into warm corn tortillas — a 30-minute weeknight favorite.</p>
+            <div class="recipe-data">
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Prep</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Cook</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-user"/></svg><h4>Serves</h4><span class="d">4</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="body-spacer">ingredients · instructions · tags</div>
+        <div class="stats">
+          <span class="section-label">Recipe Stats</span>
+          <div class="stat-grid">
+            <div class="stat"><svg class="icon"><use href="#i-eye"/></svg><span class="num">1,234</span><span class="lbl">Views</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-bookmark"/></svg><span class="num">1</span><span class="lbl">Save</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-check"/></svg><span class="num">5</span><span class="lbl">Made</span></div>
+            <div class="stat"><svg class="icon"><use href="#i-star"/></svg><span class="num">4.2</span><span class="lbl">8 Ratings</span></div>
+          </div>
+          <div class="controls">
+            <button class="btn edit" disabled title="Editing coming soon"><svg class="icon"><use href="#i-edit"/></svg>Edit</button>
+            <button class="btn delete"><svg class="icon"><use href="#i-trash"/></svg>Delete</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ V3 ============ -->
+    <section class="variation" id="v3">
+      <div class="page">
+        <div class="recipe-header">
+          <div class="img"></div>
+          <div class="desc">
+            <span class="owner-tag"><svg class="icon"><use href="#i-user"/></svg>Your recipe</span>
+            <p class="price">$2.00 / serving</p>
+            <h1 class="title">Chicken Tacos</h1>
+            <p class="description">Tender spiced chicken, crisp slaw, and a quick lime crema folded into warm corn tortillas — a 30-minute weeknight favorite.</p>
+            <div class="recipe-data">
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Prep</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Cook</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-user"/></svg><h4>Serves</h4><span class="d">4</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="body-spacer">ingredients · instructions · tags</div>
+        <div class="stats-bar">
+          <div class="stats-inline">
+            <div class="stat"><span class="num">1,234</span><span class="lbl">Views</span></div>
+            <div class="stat"><span class="num">1</span><span class="lbl">Save</span></div>
+            <div class="stat"><span class="num">5</span><span class="lbl">Made</span></div>
+            <div class="stat"><span class="num"><span class="star">★</span> 4.2</span><span class="lbl">8 Ratings</span></div>
+          </div>
+          <div class="controls">
+            <button class="btn edit" disabled title="Editing coming soon"><svg class="icon"><use href="#i-edit"/></svg>Edit</button>
+            <button class="btn delete"><svg class="icon"><use href="#i-trash"/></svg>Delete</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ V4 ============ -->
+    <section class="variation" id="v4">
+      <div class="page">
+        <div class="recipe-header">
+          <div class="img"><span class="chip"><svg class="icon"><use href="#i-user"/></svg>Your recipe</span></div>
+          <div class="desc">
+            <p class="price">$2.00 / serving</p>
+            <h1 class="title">Chicken Tacos</h1>
+            <p class="description">Tender spiced chicken, crisp slaw, and a quick lime crema folded into warm corn tortillas — a 30-minute weeknight favorite.</p>
+            <div class="recipe-data">
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Prep</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Cook</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-user"/></svg><h4>Serves</h4><span class="d">4</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="body-spacer">ingredients · instructions · tags</div>
+        <div class="owner-card">
+          <div class="head">
+            <div>
+              <div class="ttl">Your Recipe</div>
+              <div class="sub">Only you can see these controls and stats.</div>
+            </div>
+            <div class="acts">
+              <button class="btn edit" disabled title="Editing coming soon"><svg class="icon"><use href="#i-edit"/></svg>Edit</button>
+              <button class="btn delete"><svg class="icon"><use href="#i-trash"/></svg>Delete</button>
+            </div>
+          </div>
+          <div class="stat-row">
+            <div class="stat"><svg class="icon"><use href="#i-eye"/></svg><div><div class="num">1,234</div><div class="lbl">Views</div></div></div>
+            <div class="stat"><svg class="icon"><use href="#i-bookmark"/></svg><div><div class="num">1</div><div class="lbl">Save</div></div></div>
+            <div class="stat"><svg class="icon"><use href="#i-check"/></svg><div><div class="num">5</div><div class="lbl">Made</div></div></div>
+            <div class="stat"><svg class="icon"><use href="#i-star"/></svg><div><div class="num">4.2</div><div class="lbl">8 Ratings</div></div></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ V5 ============ -->
+    <section class="variation" id="v5">
+      <div class="page">
+        <div class="recipe-header">
+          <div class="img"></div>
+          <div class="desc">
+            <p class="price">$2.00 / serving</p>
+            <h1 class="title">Chicken Tacos</h1>
+            <div class="owner-line"><svg class="icon" style="height:16px;width:16px;color:var(--secondary)"><use href="#i-user"/></svg>By you <span class="dot">·</span> <a href="#">Manage recipe</a></div>
+            <p class="description">Tender spiced chicken, crisp slaw, and a quick lime crema folded into warm corn tortillas — a 30-minute weeknight favorite.</p>
+            <div class="recipe-data">
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Prep</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-clock"/></svg><h4>Cook</h4><span class="d">15 min</span></div>
+              <div class="rd"><svg class="icon"><use href="#i-user"/></svg><h4>Serves</h4><span class="d">4</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="body-spacer">ingredients · instructions · tags</div>
+        <div class="stats-foot">
+          <div class="stats-minimal">
+            <span class="stat"><svg class="icon"><use href="#i-eye"/></svg><b>1,234</b> views</span>
+            <span class="sep">·</span>
+            <span class="stat"><svg class="icon"><use href="#i-bookmark"/></svg><b>1</b> save</span>
+            <span class="sep">·</span>
+            <span class="stat"><svg class="icon"><use href="#i-check"/></svg><b>5</b> made</span>
+            <span class="sep">·</span>
+            <span class="stat"><span class="star">★</span> <b>4.2</b> (8)</span>
+          </div>
+          <div class="controls">
+            <button class="btn edit" disabled title="Editing coming soon">Edit</button>
+            <button class="btn delete">Delete</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </div>
+
+  <script>
+    const descriptions = {
+      1: ['<span class="v-name">V1 · <b>Owner banner</b></span>','A slim ownership bar sits above the recipe with the Edit/Delete actions on the right; stats live at the bottom as a clean centered icon row (mirrors the existing prep/cook/serves data row). Controls are up top where you notice them first.'],
+      2: ['<span class="v-name">V2 · <b>Pill badge + cards</b></span>','A small orange-outline "Your recipe" pill tucks in beside the title. Stats become elevated white cards with the page\'s card shadow; Edit/Delete sit as a tidy button group beneath them.'],
+      3: ['<span class="v-name">V3 · <b>Inline divided bar</b></span>','An orange uppercase "Your recipe" tag (same treatment as the price label) marks ownership near the title. Stats + controls share one bordered bar at the bottom, stats divided by thin rules, actions on the right.'],
+      4: ['<span class="v-name">V4 · <b>Owner card</b></span>','A subtle dark chip on the photo flags ownership. Everything author-only is consolidated into one shadowed card with an orange accent edge: a titled header with Edit/Delete, and the stats laid out as labeled rows below.'],
+      5: ['<span class="v-name">V5 · <b>Minimal editorial</b></span>','The lightest touch — a "By you · Manage recipe" line under the title, and a single understated stats line with text buttons at the bottom. Closest to a content-first, low-chrome feel.'],
+    };
+    const buttons = [...document.querySelectorAll('.switcher button')];
+    const desc = document.getElementById('desc');
+    function show(v){
+      document.querySelectorAll('.variation').forEach(s=>s.classList.toggle('active', s.id==='v'+v));
+      buttons.forEach(b=>b.classList.toggle('active', b.dataset.v===String(v)));
+      desc.innerHTML = '<div>'+descriptions[v][0]+'</div><p>'+descriptions[v][1]+'</p>';
+      window.scrollTo({top:0,behavior:'smooth'});
+    }
+    buttons.forEach(b=>b.addEventListener('click',()=>show(b.dataset.v)));
+    window.addEventListener('keydown',e=>{ if(e.key>='1'&&e.key<='5') show(e.key); });
+    show(1);
+  </script>
+</body>
+</html>

--- a/server/__mocks__/firebase-admin.js
+++ b/server/__mocks__/firebase-admin.js
@@ -1,4 +1,6 @@
 // apps is non-empty so the initializeApp guard in middleware/auth.js is skipped
+const deleteFile = jest.fn().mockResolvedValue([{}])
+
 const admin = {
   apps: [{}],
   initializeApp: jest.fn(),
@@ -6,6 +8,14 @@ const admin = {
   auth: jest.fn(() => ({
     verifyIdToken: jest.fn().mockResolvedValue({ uid: 'test-uid' }),
   })),
+  // Storage chain used by util/firebaseStorage.deleteRecipeImage. deleteFile is
+  // exported so tests can assert (or override) image-deletion behavior.
+  storage: jest.fn(() => ({
+    bucket: jest.fn(() => ({
+      file: jest.fn(() => ({ delete: deleteFile })),
+    })),
+  })),
+  __deleteFile: deleteFile,
 }
 
 module.exports = admin

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -63,6 +63,12 @@ describe('GET /checkUsernameAvailability', () => {
     expect(res.status).toBe(200)
     expect(res.body).toBe(false)
   })
+
+  it('treats availability case-insensitively', async () => {
+    const res = await request(app).get('/api/checkUsernameAvailability?username=TAKEN')
+    expect(res.status).toBe(200)
+    expect(res.body).toBe(false)
+  })
 })
 
 // ─── POST /setUsername ────────────────────────────────────────────────────────
@@ -94,6 +100,53 @@ describe('POST /setUsername', () => {
 
     const doc = await getDB().collection('usernames').findOne({ _id: TEST_UID })
     expect(doc.username).toBe('newuser')
+    expect(doc.username_lower).toBe('newuser')
+  })
+
+  it('stores a lowercased username_lower while preserving original casing', async () => {
+    const res = await request(app)
+      .post(`/api/setUsername?username=NewUser`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+
+    const doc = await getDB().collection('usernames').findOne({ _id: TEST_UID })
+    expect(doc.username).toBe('NewUser')
+    expect(doc.username_lower).toBe('newuser')
+  })
+
+  it('returns 409 for a case-variant of a name taken by another user', async () => {
+    await seedUser('other-uid', 'taken')
+
+    const res = await request(app)
+      .post(`/api/setUsername?username=TAKEN`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(409)
+  })
+
+  it('rejects a username with whitespace (400)', async () => {
+    const res = await request(app)
+      .post(`/api/setUsername?username=${encodeURIComponent('has space')}`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a username shorter than 3 characters (400)', async () => {
+    const res = await request(app)
+      .post(`/api/setUsername?username=ab`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a username longer than 30 characters (400)', async () => {
+    const res = await request(app)
+      .post(`/api/setUsername?username=${'a'.repeat(31)}`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(400)
   })
 
   it('updates an existing username entry', async () => {

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -13,28 +13,32 @@ afterEach(async () => {
 // ─── GET /getUsername ─────────────────────────────────────────────────────────
 
 describe('GET /getUsername', () => {
-  beforeEach(async () => {
-    await seedUser(TEST_UID, 'testuser')
-  })
-
-  it('returns 400 if userId is missing', async () => {
+  it('rejects request with no auth token (401)', async () => {
     const res = await request(app).get('/api/getUsername')
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(401)
   })
 
-  it('returns 400 if userId is the string "null"', async () => {
-    const res = await request(app).get('/api/getUsername?userId=null')
-    expect(res.status).toBe(400)
+  it("returns the authenticated user's own username", async () => {
+    await seedUser(TEST_UID, 'testuser')
+    const res = await request(app).get('/api/getUsername').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('testuser')
   })
 
-  it('returns 200 with null body if userId is not found', async () => {
-    const res = await request(app).get('/api/getUsername?userId=unknown')
+  it('returns null when the authenticated user has no username yet', async () => {
+    const res = await request(app).get('/api/getUsername').set(AUTH_HEADER)
     expect(res.status).toBe(200)
     expect(res.body).toBeNull()
   })
 
-  it('returns the username for a valid userId', async () => {
-    const res = await request(app).get(`/api/getUsername?userId=${TEST_UID}`)
+  it('ignores a userId query param and only returns the caller\'s own username', async () => {
+    await seedUser(TEST_UID, 'testuser')
+    await seedUser('other-uid', 'otheruser')
+
+    const res = await request(app)
+      .get('/api/getUsername?userId=other-uid')
+      .set(AUTH_HEADER)
+
     expect(res.status).toBe(200)
     expect(res.body).toBe('testuser')
   })

--- a/server/__tests__/drafts.test.js
+++ b/server/__tests__/drafts.test.js
@@ -214,6 +214,23 @@ describe('PUT /api/drafts/:id', () => {
       .send({ title: 'a'.repeat(51) })
     expect(res.status).toBe(400)
   })
+
+  it("checks ownership before bounds (403, not 400, for another user's draft)", async () => {
+    const draft = await seedDraft({ userId: 'other-uid' })
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'a'.repeat(51) })
+    expect(res.status).toBe(403)
+  })
+
+  it('checks existence before bounds (404, not 400, for a missing draft)', async () => {
+    const res = await request(app)
+      .put(`/api/drafts/${new ObjectId()}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'a'.repeat(51) })
+    expect(res.status).toBe(404)
+  })
 })
 
 describe('DELETE /api/drafts/:id', () => {

--- a/server/__tests__/drafts.test.js
+++ b/server/__tests__/drafts.test.js
@@ -1,0 +1,239 @@
+/**
+ * Auth approach mirrors recipes.test.js: server/__mocks__/firebase-admin.js
+ * makes verifyIdToken always resolve to { uid: 'test-uid' }, so any request
+ * with an Authorization header passes verifyToken with req.uid = 'test-uid'.
+ *
+ * Ownership tests seed a draft owned by a *different* uid directly in the DB,
+ * then confirm the 'test-uid' caller is forbidden from reading/writing it.
+ */
+
+const request = require('supertest')
+const { ObjectId } = require('mongodb')
+const app = require('../app')
+const { getDB } = require('../db')
+
+const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
+const TEST_UID = 'test-uid'
+
+afterEach(async () => {
+  await getDB().collection('recipeDrafts').deleteMany({})
+})
+
+async function seedDraft(overrides = {}) {
+  const now = Date.now().toString()
+  const doc = {
+    _id: new ObjectId(),
+    userId: TEST_UID,
+    title: 'Draft title',
+    ingredients: [],
+    instructions: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+  await getDB().collection('recipeDrafts').insertOne(doc)
+  return doc
+}
+
+describe('POST /api/drafts', () => {
+  it('requires auth', async () => {
+    const res = await request(app).post('/api/drafts').send({ title: 'x' })
+    expect(res.status).toBe(401)
+  })
+
+  it('creates a draft owned by the caller and returns it', async () => {
+    const res = await request(app)
+      .post('/api/drafts')
+      .set(AUTH_HEADER)
+      .send({ title: 'WIP recipe', cuisine: 'Italian' })
+    expect(res.status).toBe(201)
+    expect(res.body.title).toBe('WIP recipe')
+    expect(res.body.cuisine).toBe('Italian')
+    expect(res.body.userId).toBe(TEST_UID)
+    expect(res.body._id).toBeDefined()
+    expect(res.body.createdAt).toBeDefined()
+    expect(res.body.updatedAt).toBeDefined()
+  })
+
+  it('ignores client-supplied userId / _id', async () => {
+    const res = await request(app)
+      .post('/api/drafts')
+      .set(AUTH_HEADER)
+      .send({ title: 'x', userId: 'someone-else', _id: 'forced-id' })
+    expect(res.status).toBe(201)
+    expect(res.body.userId).toBe(TEST_UID)
+    expect(res.body._id).not.toBe('forced-id')
+  })
+
+  it('rejects content that exceeds bounds', async () => {
+    const res = await request(app)
+      .post('/api/drafts')
+      .set(AUTH_HEADER)
+      .send({ title: 'a'.repeat(51) })
+    expect(res.status).toBe(400)
+  })
+
+  it('allows an empty/partial draft (no required fields)', async () => {
+    const res = await request(app).post('/api/drafts').set(AUTH_HEADER).send({})
+    expect(res.status).toBe(201)
+  })
+
+  it('rejects creation past the per-user cap with 409 + DRAFT_LIMIT, counting only the caller', async () => {
+    // Fill the caller to the cap, plus some drafts owned by someone else that
+    // must not count toward this user's limit.
+    const now = Date.now().toString()
+    const mine = Array.from({ length: 25 }, (_, i) => ({
+      _id: new ObjectId(),
+      userId: TEST_UID,
+      title: `draft ${i}`,
+      createdAt: now,
+      updatedAt: now,
+    }))
+    const theirs = Array.from({ length: 5 }, () => ({
+      _id: new ObjectId(),
+      userId: 'other-uid',
+      createdAt: now,
+      updatedAt: now,
+    }))
+    await getDB().collection('recipeDrafts').insertMany([...mine, ...theirs])
+
+    const res = await request(app)
+      .post('/api/drafts')
+      .set(AUTH_HEADER)
+      .send({ title: 'one too many' })
+    expect(res.status).toBe(409)
+    expect(res.body.code).toBe('DRAFT_LIMIT')
+  })
+
+  it('still allows editing an existing draft when at the cap', async () => {
+    const now = Date.now().toString()
+    const mine = Array.from({ length: 25 }, (_, i) => ({
+      _id: new ObjectId(),
+      userId: TEST_UID,
+      title: `draft ${i}`,
+      createdAt: now,
+      updatedAt: now,
+    }))
+    await getDB().collection('recipeDrafts').insertMany(mine)
+
+    const res = await request(app)
+      .put(`/api/drafts/${mine[0]._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'edited at cap' })
+    expect(res.status).toBe(200)
+    expect(res.body.title).toBe('edited at cap')
+  })
+})
+
+describe('GET /api/drafts', () => {
+  it('requires auth', async () => {
+    const res = await request(app).get('/api/drafts')
+    expect(res.status).toBe(401)
+  })
+
+  it("returns only the caller's drafts, newest-updated first", async () => {
+    await seedDraft({ title: 'older', updatedAt: '1000' })
+    await seedDraft({ title: 'newer', updatedAt: '2000' })
+    await seedDraft({ title: 'theirs', userId: 'other-uid' })
+
+    const res = await request(app).get('/api/drafts').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveLength(2)
+    expect(res.body.map(d => d.title)).toEqual(['newer', 'older'])
+  })
+})
+
+describe('GET /api/drafts/:id', () => {
+  it('returns the draft for its owner', async () => {
+    const draft = await seedDraft({ title: 'mine' })
+    const res = await request(app)
+      .get(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.title).toBe('mine')
+  })
+
+  it("forbids reading another user's draft", async () => {
+    const draft = await seedDraft({ userId: 'other-uid' })
+    const res = await request(app)
+      .get(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(403)
+  })
+
+  it('404s for a missing or malformed id', async () => {
+    const missing = await request(app)
+      .get(`/api/drafts/${new ObjectId()}`)
+      .set(AUTH_HEADER)
+    expect(missing.status).toBe(404)
+    const malformed = await request(app)
+      .get('/api/drafts/not-an-id')
+      .set(AUTH_HEADER)
+    expect(malformed.status).toBe(404)
+  })
+})
+
+describe('PUT /api/drafts/:id', () => {
+  it('updates content and bumps updatedAt', async () => {
+    const draft = await seedDraft({ title: 'before', updatedAt: '1000' })
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'after', servings: 4 })
+    expect(res.status).toBe(200)
+    expect(res.body.title).toBe('after')
+    expect(res.body.servings).toBe(4)
+    expect(Number(res.body.updatedAt)).toBeGreaterThan(1000)
+  })
+
+  it("forbids updating another user's draft", async () => {
+    const draft = await seedDraft({ userId: 'other-uid' })
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'hijacked' })
+    expect(res.status).toBe(403)
+  })
+
+  it('does not change userId/createdAt even if sent', async () => {
+    const draft = await seedDraft({ createdAt: '500' })
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'x', userId: 'other-uid', createdAt: '999' })
+    expect(res.status).toBe(200)
+    expect(res.body.userId).toBe(TEST_UID)
+    expect(res.body.createdAt).toBe('500')
+  })
+
+  it('rejects content that exceeds bounds', async () => {
+    const draft = await seedDraft()
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'a'.repeat(51) })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('DELETE /api/drafts/:id', () => {
+  it('deletes the draft for its owner', async () => {
+    const draft = await seedDraft()
+    const res = await request(app)
+      .delete(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    const remaining = await getDB()
+      .collection('recipeDrafts')
+      .findOne({ _id: draft._id })
+    expect(remaining).toBeNull()
+  })
+
+  it("forbids deleting another user's draft", async () => {
+    const draft = await seedDraft({ userId: 'other-uid' })
+    const res = await request(app)
+      .delete(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(403)
+  })
+})

--- a/server/__tests__/firebaseStorage.test.js
+++ b/server/__tests__/firebaseStorage.test.js
@@ -1,0 +1,43 @@
+const admin = require('firebase-admin') // auto-mocked
+const { parseStorageUrl, deleteRecipeImage } = require('../util/firebaseStorage')
+
+describe('parseStorageUrl', () => {
+  it('extracts bucket and decoded path from a Firebase download URL', () => {
+    const url =
+      'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ftuscan.jpg?alt=media&token=abc'
+    expect(parseStorageUrl(url)).toEqual({
+      bucket: 'test-bucket',
+      path: 'recipeImages/tuscan.jpg',
+    })
+  })
+
+  it('returns null for empty, non-string, or non-Firebase values', () => {
+    expect(parseStorageUrl('')).toBeNull()
+    expect(parseStorageUrl(null)).toBeNull()
+    expect(parseStorageUrl(undefined)).toBeNull()
+    expect(parseStorageUrl('https://example.com/image.jpg')).toBeNull()
+  })
+})
+
+describe('deleteRecipeImage', () => {
+  beforeEach(() => admin.__deleteFile.mockClear())
+
+  it('deletes the parsed file and returns true', async () => {
+    const url =
+      'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ftuscan.jpg?alt=media&token=abc'
+    await expect(deleteRecipeImage(url)).resolves.toBe(true)
+    expect(admin.__deleteFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns false without calling storage for an unparseable url', async () => {
+    await expect(deleteRecipeImage('')).resolves.toBe(false)
+    expect(admin.__deleteFile).not.toHaveBeenCalled()
+  })
+
+  it('swallows storage errors and returns false', async () => {
+    admin.__deleteFile.mockRejectedValueOnce(new Error('boom'))
+    const url =
+      'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ftuscan.jpg?alt=media&token=abc'
+    await expect(deleteRecipeImage(url)).resolves.toBe(false)
+  })
+})

--- a/server/__tests__/helpers/seed.js
+++ b/server/__tests__/helpers/seed.js
@@ -9,7 +9,9 @@ async function seedRecipes(recipes) {
 }
 
 async function seedUser(uid, username) {
-  await getDB().collection('usernames').insertOne({ _id: uid, username })
+  await getDB()
+    .collection('usernames')
+    .insertOne({ _id: uid, username, username_lower: username.toLowerCase() })
 }
 
 async function seedUserRecipeData(uid, data) {

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -233,6 +233,148 @@ describe('POST /addRecipe', () => {
   })
 })
 
+// ─── PUT /editRecipe ──────────────────────────────────────────────────────────
+
+describe('PUT /editRecipe', () => {
+  const OWNED_RECIPE = {
+    ...BASE_RECIPE,
+    userId: TEST_UID,
+    rating: { rateCount: 12, rateValue: 4.5 },
+    numTimesSaved: 7,
+    numTimesMade: 3,
+    views: 99,
+    editedAt: null,
+  }
+
+  const validEdit = () => ({
+    title: 'Updated Title',
+    description: 'An updated description',
+    ingredients: [{ id: 'i1', name: 'chicken' }],
+    instructions: [{ content: 'Cook it well', index: 1, id: 's1' }],
+    mealTypes: ['dinner'],
+  })
+
+  beforeEach(async () => {
+    await seedRecipe({ ...OWNED_RECIPE })
+  })
+
+  it('rejects request with no auth token (401)', async () => {
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .send(validEdit())
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when recipeId is missing', async () => {
+    const res = await request(app)
+      .put('/api/editRecipe')
+      .set(AUTH_HEADER)
+      .send(validEdit())
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 if the recipe does not exist', async () => {
+    const res = await request(app)
+      .put('/api/editRecipe?recipeId=nonexistent')
+      .set(AUTH_HEADER)
+      .send(validEdit())
+    expect(res.status).toBe(404)
+  })
+
+  it('rejects an edit by a non-owner (403) and leaves the recipe unchanged', async () => {
+    const db = getDB()
+    await db.collection('recipes').deleteOne({ _id: RECIPE_ID })
+    await seedRecipe({ ...OWNED_RECIPE, userId: 'someone-else' })
+
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send(validEdit())
+
+    expect(res.status).toBe(403)
+    const stored = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(stored.title).toBe(OWNED_RECIPE.title)
+    expect(stored.editedAt).toBeNull()
+  })
+
+  it('rejects missing required fields (400)', async () => {
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send({ description: 'no title/ingredients/etc' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Missing required fields/)
+  })
+
+  it('enforces input bounds (400)', async () => {
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send({ ...validEdit(), title: 'A'.repeat(51) })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Title cannot exceed/)
+  })
+
+  it('updates editable fields and stamps editedAt', async () => {
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send(validEdit())
+
+    expect(res.status).toBe(200)
+
+    const db = getDB()
+    const stored = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(stored.title).toBe('Updated Title')
+    expect(stored.description).toBe('An updated description')
+    expect(typeof stored.editedAt).toBe('string')
+    expect(stored.editedAt).not.toBeNull()
+  })
+
+  it('never resets ratings, saves, made-count, views, or createdAt on edit', async () => {
+    await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send(validEdit())
+
+    const db = getDB()
+    const stored = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(stored.rating).toEqual({ rateCount: 12, rateValue: 4.5 })
+    expect(stored.numTimesSaved).toBe(7)
+    expect(stored.numTimesMade).toBe(3)
+    expect(stored.views).toBe(99)
+    expect(stored.createdAt).toBe(OWNED_RECIPE.createdAt)
+  })
+
+  it('ignores attempts to overwrite protected fields via the payload', async () => {
+    const res = await request(app)
+      .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+      .send({
+        ...validEdit(),
+        // Malicious / stray fields the whitelist must drop:
+        rating: { rateCount: 9999, rateValue: 1 },
+        numTimesSaved: 0,
+        numTimesMade: 0,
+        views: 0,
+        userId: 'someone-else',
+        _id: 'hijacked-id',
+        createdAt: '1',
+      })
+
+    expect(res.status).toBe(200)
+    const db = getDB()
+    const stored = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(stored.rating).toEqual({ rateCount: 12, rateValue: 4.5 })
+    expect(stored.numTimesSaved).toBe(7)
+    expect(stored.numTimesMade).toBe(3)
+    expect(stored.views).toBe(99)
+    expect(stored.userId).toBe(TEST_UID)
+    expect(stored._id).toBe(RECIPE_ID)
+    expect(stored.createdAt).toBe(OWNED_RECIPE.createdAt)
+  })
+})
+
 // ─── POST /recipes/:id/save ───────────────────────────────────────────────────
 
 describe('POST /recipes/:id/save', () => {

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -11,9 +11,15 @@
  */
 
 const request = require('supertest')
+const admin = require('firebase-admin') // auto-mocked (server/__mocks__/firebase-admin.js)
 const app = require('../app')
 const { getDB } = require('../db')
-const { seedRecipe, seedRecipes, seedUserRecipeData } = require('./helpers/seed')
+const {
+  seedRecipe,
+  seedRecipes,
+  seedUserRecipeData,
+  seedRating,
+} = require('./helpers/seed')
 
 const TEST_UID = 'test-uid'
 const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
@@ -33,6 +39,8 @@ const BASE_RECIPE = {
   description: 'A great dish',
   ingredients: [{ id: 'i1', name: 'chicken' }],
   instructions: [{ step: 'Cook the chicken' }],
+  recipeImage:
+    'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ftuscan.jpg?alt=media&token=abc',
 }
 
 afterEach(async () => {
@@ -41,6 +49,7 @@ afterEach(async () => {
     db.collection('recipes').deleteMany({}),
     db.collection('userRecipeData').deleteMany({}),
     db.collection('stats').deleteMany({}),
+    db.collection('ratings').deleteMany({}),
   ])
 })
 
@@ -349,9 +358,32 @@ describe('GET /getRecipe', () => {
 // ─── DELETE /deleteRecipe ─────────────────────────────────────────────────────
 
 describe('DELETE /deleteRecipe', () => {
+  const OTHER_UID = 'other-user'
+  const KEEP_ID = 'recipe-keep'
+
   beforeEach(async () => {
+    admin.__deleteFile.mockClear()
     await seedRecipe({ ...BASE_RECIPE, userId: TEST_UID })
-    await seedUserRecipeData(TEST_UID, { userRecipes: [{ recipeId: RECIPE_ID }] })
+
+    // Owner's created/saved/made lists all reference the recipe.
+    await seedUserRecipeData(TEST_UID, {
+      userRecipes: [{ recipeId: RECIPE_ID }],
+      savedRecipes: [{ recipeId: RECIPE_ID, dateSaved: '1000' }],
+      madeRecipes: [{ recipeId: RECIPE_ID }],
+    })
+    // A different user who saved and made it — plus an unrelated recipe that
+    // must survive the delete.
+    await seedUserRecipeData(OTHER_UID, {
+      savedRecipes: [
+        { recipeId: RECIPE_ID, dateSaved: '2000' },
+        { recipeId: KEEP_ID, dateSaved: '3000' },
+      ],
+      madeRecipes: [{ recipeId: RECIPE_ID }],
+    })
+    // Ratings/reviews for the recipe, and one for an unrelated recipe.
+    await seedRating({ username: 'someone', recipeId: RECIPE_ID, rating: 5, reviewText: 'Great' })
+    await seedRating({ username: 'another', recipeId: RECIPE_ID, rating: 4 })
+    await seedRating({ username: 'someone', recipeId: KEEP_ID, rating: 3 })
   })
 
   it('rejects request with no auth token (401)', async () => {
@@ -377,11 +409,13 @@ describe('DELETE /deleteRecipe', () => {
       .set(AUTH_HEADER)
 
     expect(res.status).toBe(403)
-    // Recipe must still exist
+    // Recipe must still exist, and nothing should have been cleaned up.
     expect(await db.collection('recipes').findOne({ _id: RECIPE_ID })).not.toBeNull()
+    expect(await db.collection('ratings').countDocuments({ recipeId: RECIPE_ID })).toBe(2)
+    expect(admin.__deleteFile).not.toHaveBeenCalled()
   })
 
-  it('deletes the recipe and removes it from userRecipes', async () => {
+  it('deletes the recipe and removes it from the owner\'s created/saved/made lists', async () => {
     const res = await request(app)
       .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
@@ -394,6 +428,62 @@ describe('DELETE /deleteRecipe', () => {
 
     const userData = await db.collection('userRecipeData').findOne({ _id: TEST_UID })
     expect(userData.userRecipes).toHaveLength(0)
+    expect(userData.savedRecipes).toHaveLength(0)
+    expect(userData.madeRecipes).toHaveLength(0)
+  })
+
+  it('removes the recipe\'s ratings/reviews but leaves other recipes\' ratings', async () => {
+    await request(app)
+      .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+
+    const db = getDB()
+    expect(await db.collection('ratings').countDocuments({ recipeId: RECIPE_ID })).toBe(0)
+    expect(await db.collection('ratings').countDocuments({ recipeId: KEEP_ID })).toBe(1)
+  })
+
+  it('removes the recipeId from other users\' saved/made lists without touching unrelated entries', async () => {
+    await request(app)
+      .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+
+    const db = getDB()
+    const other = await db.collection('userRecipeData').findOne({ _id: OTHER_UID })
+    expect(other.savedRecipes).toEqual([{ recipeId: KEEP_ID, dateSaved: '3000' }])
+    expect(other.madeRecipes).toHaveLength(0)
+  })
+
+  it('deletes the recipe image from storage', async () => {
+    await request(app)
+      .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+
+    expect(admin.__deleteFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('succeeds (200) and still deletes the recipe when there is no stored image', async () => {
+    const db = getDB()
+    await db.collection('recipes').updateOne({ _id: RECIPE_ID }, { $set: { recipeImage: '' } })
+
+    const res = await request(app)
+      .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    expect(admin.__deleteFile).not.toHaveBeenCalled()
+    expect(await db.collection('recipes').findOne({ _id: RECIPE_ID })).toBeNull()
+  })
+
+  it('succeeds (200) even if storage image deletion fails', async () => {
+    admin.__deleteFile.mockRejectedValueOnce(new Error('storage down'))
+
+    const res = await request(app)
+      .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    const db = getDB()
+    expect(await db.collection('recipes').findOne({ _id: RECIPE_ID })).toBeNull()
   })
 })
 

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -41,8 +41,8 @@ const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
 beforeEach(async () => {
   const db = getDB()
   await db.collection('usernames').insertMany([
-    { _id: TEST_UID, username: TEST_USERNAME },
-    { _id: OTHER_UID, username: OTHER_USERNAME },
+    { _id: TEST_UID, username: TEST_USERNAME, username_lower: TEST_USERNAME.toLowerCase() },
+    { _id: OTHER_UID, username: OTHER_USERNAME, username_lower: OTHER_USERNAME.toLowerCase() },
   ])
   await db.collection('recipes').insertOne({
     _id: RECIPE_ID,

--- a/server/__tests__/setup.js
+++ b/server/__tests__/setup.js
@@ -1,12 +1,15 @@
-const { MongoMemoryServer } = require('mongodb-memory-server')
+const { MongoMemoryReplSet } = require('mongodb-memory-server')
 const { connectDB, closeDB } = require('../db')
 
 let mongod
 
+// A single-node replica set (rather than a standalone) so multi-document
+// transactions — used by DELETE /deleteRecipe — work in tests, matching the
+// replica-set topology of the production Atlas deployment.
 beforeAll(async () => {
-  mongod = await MongoMemoryServer.create()
+  mongod = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
   await connectDB(mongod.getUri())
-}, 30000)
+}, 60000)
 
 afterAll(async () => {
   await closeDB()

--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,7 @@ const reviewRoutes = require('./routes/reviews')
 const userRoutes = require('./routes/users')
 const authRoutes = require('./routes/auth')
 const ingredientRoutes = require('./routes/ingredients')
+const draftRoutes = require('./routes/drafts')
 
 const app = express()
 
@@ -33,5 +34,6 @@ app.use('/api', reviewRoutes)
 app.use('/api', userRoutes)
 app.use('/api', authRoutes)
 app.use('/api/ingredients', ingredientRoutes)
+app.use('/api/drafts', draftRoutes)
 
 module.exports = app

--- a/server/db.js
+++ b/server/db.js
@@ -13,6 +13,29 @@ async function connectDB(uri) {
   await client.connect()
   db = client.db('prepify')
   console.log('Connected to MongoDB')
+  await ensureIndexes()
+}
+
+// Enforces case-insensitive username uniqueness at the database level. Legacy
+// docs created before `username_lower` existed are backfilled first so the
+// unique index can be built over the whole collection.
+async function ensureIndexes() {
+  const usernames = db.collection('usernames')
+  await usernames.updateMany(
+    { username_lower: { $exists: false }, username: { $type: 'string' } },
+    [{ $set: { username_lower: { $toLower: '$username' } } }]
+  )
+  try {
+    await usernames.createIndex({ username_lower: 1 }, { unique: true })
+  } catch (err) {
+    // Pre-existing case-variant duplicates would make the unique index fail to
+    // build. Log it rather than crashing startup; the duplicates need manual
+    // cleanup, but the rest of the server should still come up.
+    console.error(
+      'Failed to create unique index on usernames.username_lower:',
+      err.message
+    )
+  }
 }
 
 async function closeDB() {

--- a/server/db.js
+++ b/server/db.js
@@ -36,6 +36,15 @@ async function ensureIndexes() {
       err.message
     )
   }
+
+  // Backs GET /api/drafts, which lists a user's drafts newest-updated first
+  // (find({ userId }).sort({ updatedAt: -1 })). Without it that query is a full
+  // collection scan plus an in-memory sort on every Drafts-tab load.
+  try {
+    await db.collection('recipeDrafts').createIndex({ userId: 1, updatedAt: -1 })
+  } catch (err) {
+    console.error('Failed to create index on recipeDrafts.userId:', err.message)
+  }
 }
 
 async function closeDB() {

--- a/server/db.js
+++ b/server/db.js
@@ -51,4 +51,9 @@ function getDB() {
   return db
 }
 
-module.exports = { connectDB, closeDB, getDB }
+function getClient() {
+  if (!client) throw new Error('DB not initialized. Call connectDB() first.')
+  return client
+}
+
+module.exports = { connectDB, closeDB, getDB, getClient }

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -25,16 +25,14 @@ function validateUsername(username) {
   return null
 }
 
-// GET /getUsername?userId=...
-// Returns the username for a given uid
-router.get('/getUsername', async (req, res) => {
+// GET /getUsername
+// Returns the authenticated user's own username, or null if not set yet.
+// Scoped to req.uid so a user can't enumerate other users' usernames by id;
+// other users' usernames are surfaced through the reviews endpoints instead.
+router.get('/getUsername', verifyToken, async (req, res) => {
   try {
-    const { userId } = req.query
-    if (!userId || userId === 'null') {
-      return res.status(400).json({ error: 'userId is required' })
-    }
     const db = getDB()
-    const doc = await db.collection('usernames').findOne({ _id: userId })
+    const doc = await db.collection('usernames').findOne({ _id: req.uid })
     if (!doc) return res.json(null)
     res.json(doc.username)
   } catch (err) {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -3,6 +3,28 @@ const router = express.Router()
 const { getDB } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 
+const USERNAME_MIN_LENGTH = 3
+const USERNAME_MAX_LENGTH = 30
+
+// Mirrors the client-side rules in src/Components/Form/UsernameInput.tsx so the
+// API can't be bypassed by calling it directly. Returns an error string, or
+// null when the username is valid.
+function validateUsername(username) {
+  if (typeof username !== 'string' || !username) {
+    return 'username is required'
+  }
+  if (/\s/.test(username)) {
+    return 'Username cannot contain whitespace'
+  }
+  if (username.length < USERNAME_MIN_LENGTH) {
+    return `Username must be at least ${USERNAME_MIN_LENGTH} characters`
+  }
+  if (username.length > USERNAME_MAX_LENGTH) {
+    return `Username must be at most ${USERNAME_MAX_LENGTH} characters`
+  }
+  return null
+}
+
 // GET /getUsername?userId=...
 // Returns the username for a given uid
 router.get('/getUsername', async (req, res) => {
@@ -27,7 +49,9 @@ router.get('/checkUsernameAvailability', async (req, res) => {
     const { username } = req.query
     if (!username) return res.status(400).json({ error: 'username is required' })
     const db = getDB()
-    const existing = await db.collection('usernames').findOne({ username })
+    const existing = await db
+      .collection('usernames')
+      .findOne({ username_lower: username.toLowerCase() })
     res.json(existing === null)
   } catch (err) {
     res.status(500).json({ error: err.message })
@@ -39,23 +63,37 @@ router.get('/checkUsernameAvailability', async (req, res) => {
 router.post('/setUsername', verifyToken, async (req, res) => {
   try {
     const { username } = req.query
-    if (!username) {
-      return res.status(400).json({ error: 'username is required' })
+    const validationError = validateUsername(username)
+    if (validationError) {
+      return res.status(400).json({ error: validationError })
     }
+    const usernameLower = username.toLowerCase()
     const uid = req.uid
     const db = getDB()
 
-    // Check username is not already taken by someone else
-    const existing = await db.collection('usernames').findOne({ username })
+    // Check the name isn't already taken by someone else (case-insensitive).
+    const existing = await db
+      .collection('usernames')
+      .findOne({ username_lower: usernameLower })
     if (existing && existing._id !== uid) {
       return res.status(409).json({ error: 'Username already taken' })
     }
 
-    await db.collection('usernames').updateOne(
-      { _id: uid },
-      { $set: { username } },
-      { upsert: true }
-    )
+    try {
+      await db.collection('usernames').updateOne(
+        { _id: uid },
+        { $set: { username, username_lower: usernameLower } },
+        { upsert: true }
+      )
+    } catch (err) {
+      // The unique index on username_lower is the source of truth: it closes
+      // the race between the check above and this write, where two concurrent
+      // requests could both pass the findOne.
+      if (err.code === 11000) {
+        return res.status(409).json({ error: 'Username already taken' })
+      }
+      throw err
+    }
     res.json({ success: true })
   } catch (err) {
     res.status(500).json({ error: err.message })

--- a/server/routes/drafts.js
+++ b/server/routes/drafts.js
@@ -1,0 +1,169 @@
+const { Router } = require('express')
+const { ObjectId } = require('mongodb')
+const { getDB } = require('../db')
+const { verifyToken } = require('../middleware/auth')
+const { validateRecipeBounds } = require('../util/recipeLimits')
+
+const router = Router()
+
+// Max drafts a single user may keep at once. Generous enough that a normal user
+// never hits it; it bounds collection growth and abuse (a client looping POST).
+// Enforced on creation only — editing existing drafts is always allowed.
+const MAX_DRAFTS_PER_USER = 25
+
+// A draft is an in-progress recipe owned by a single user. Unlike a published
+// recipe it is intentionally incomplete: every content field is optional, so
+// only the bounds (max lengths/counts) are validated, never required-field
+// presence. The recipe image is *not* part of a draft — it's re-picked when the
+// user resumes (publishing still requires an image). See src/api/drafts.ts.
+
+// The content fields a draft persists. Whitelisted on write so the client can't
+// stash arbitrary keys (or spoof userId / timestamps) on a draft document.
+const DRAFT_FIELDS = [
+  'title',
+  'prepTime',
+  'cookTime',
+  'servings',
+  'fridgeLife',
+  'freezerLife',
+  'description',
+  'ingredients',
+  'instructions',
+  'cuisine',
+  'mealTypes',
+]
+
+function pickDraftFields(body) {
+  const out = {}
+  for (const field of DRAFT_FIELDS) {
+    if (field in body) out[field] = body[field]
+  }
+  return out
+}
+
+// POST /drafts — create a new draft for the current user. Returns the new _id
+// so the client can switch to update-on-autosave from then on.
+router.post('/', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    const boundsError = validateRecipeBounds(req.body)
+    if (boundsError) {
+      return res.status(400).json({ error: boundsError })
+    }
+    // Cap the number of drafts per user. 409 + a machine-readable code so the
+    // client can show a specific "delete some drafts" message and stop retrying.
+    const draftCount = await db
+      .collection('recipeDrafts')
+      .countDocuments({ userId: req.uid })
+    if (draftCount >= MAX_DRAFTS_PER_USER) {
+      return res.status(409).json({
+        code: 'DRAFT_LIMIT',
+        error: `You've reached the maximum of ${MAX_DRAFTS_PER_USER} saved drafts. Delete some from your Drafts to start a new one.`,
+      })
+    }
+    const now = Date.now().toString()
+    const doc = {
+      _id: new ObjectId(),
+      userId: req.uid,
+      ...pickDraftFields(req.body),
+      createdAt: now,
+      updatedAt: now,
+    }
+    await db.collection('recipeDrafts').insertOne(doc)
+    res.status(201).json(doc)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /drafts — list the current user's drafts, newest-updated first.
+router.get('/', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    const drafts = await db
+      .collection('recipeDrafts')
+      .find({ userId: req.uid })
+      .sort({ updatedAt: -1 })
+      .toArray()
+    res.json(drafts)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /drafts/:id — fetch a single draft (used when resuming). Owner-only.
+router.get('/:id', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    const draft = await db
+      .collection('recipeDrafts')
+      .findOne({ _id: new ObjectId(req.params.id) })
+    if (!draft) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    if (draft.userId !== req.uid) {
+      return res.status(403).json({ error: 'Forbidden' })
+    }
+    res.json(draft)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// PUT /drafts/:id — overwrite a draft's content (autosave). Owner-only. Only
+// whitelisted content fields are written; userId/createdAt/_id are immutable.
+router.put('/:id', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    const boundsError = validateRecipeBounds(req.body)
+    if (boundsError) {
+      return res.status(400).json({ error: boundsError })
+    }
+    const _id = new ObjectId(req.params.id)
+    const draft = await db.collection('recipeDrafts').findOne({ _id })
+    if (!draft) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    if (draft.userId !== req.uid) {
+      return res.status(403).json({ error: 'Forbidden' })
+    }
+    const update = { ...pickDraftFields(req.body), updatedAt: Date.now().toString() }
+    const updated = await db
+      .collection('recipeDrafts')
+      .findOneAndUpdate({ _id }, { $set: update }, { returnDocument: 'after' })
+    res.json(updated)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// DELETE /drafts/:id — remove a draft (manual delete, or cleanup after the
+// recipe is published). Owner-only.
+router.delete('/:id', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    const _id = new ObjectId(req.params.id)
+    const draft = await db.collection('recipeDrafts').findOne({ _id })
+    if (!draft) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    if (draft.userId !== req.uid) {
+      return res.status(403).json({ error: 'Forbidden' })
+    }
+    await db.collection('recipeDrafts').deleteOne({ _id })
+    res.json({ deleted: true })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+module.exports = router

--- a/server/routes/drafts.js
+++ b/server/routes/drafts.js
@@ -3,6 +3,7 @@ const { ObjectId } = require('mongodb')
 const { getDB } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 const { validateRecipeBounds } = require('../util/recipeLimits')
+const { RECIPE_CONTENT_FIELDS, pickFields } = require('../util/recipeFields')
 
 const router = Router()
 
@@ -16,30 +17,10 @@ const MAX_DRAFTS_PER_USER = 25
 // only the bounds (max lengths/counts) are validated, never required-field
 // presence. The recipe image is *not* part of a draft — it's re-picked when the
 // user resumes (publishing still requires an image). See src/api/drafts.ts.
-
-// The content fields a draft persists. Whitelisted on write so the client can't
-// stash arbitrary keys (or spoof userId / timestamps) on a draft document.
-const DRAFT_FIELDS = [
-  'title',
-  'prepTime',
-  'cookTime',
-  'servings',
-  'fridgeLife',
-  'freezerLife',
-  'description',
-  'ingredients',
-  'instructions',
-  'cuisine',
-  'mealTypes',
-]
-
-function pickDraftFields(body) {
-  const out = {}
-  for (const field of DRAFT_FIELDS) {
-    if (field in body) out[field] = body[field]
-  }
-  return out
-}
+//
+// Writes are whitelisted to RECIPE_CONTENT_FIELDS (shared with the recipe-edit
+// route via util/recipeFields) so the client can't stash arbitrary keys or
+// spoof userId / timestamps on a draft document.
 
 // POST /drafts — create a new draft for the current user. Returns the new _id
 // so the client can switch to update-on-autosave from then on.
@@ -65,7 +46,7 @@ router.post('/', verifyToken, async (req, res) => {
     const doc = {
       _id: new ObjectId(),
       userId: req.uid,
-      ...pickDraftFields(req.body),
+      ...pickFields(req.body, RECIPE_CONTENT_FIELDS),
       createdAt: now,
       updatedAt: now,
     }
@@ -121,11 +102,10 @@ router.put('/:id', verifyToken, async (req, res) => {
     if (!ObjectId.isValid(req.params.id)) {
       return res.status(404).json({ error: 'Draft not found' })
     }
-    const boundsError = validateRecipeBounds(req.body)
-    if (boundsError) {
-      return res.status(400).json({ error: boundsError })
-    }
     const _id = new ObjectId(req.params.id)
+    // Check existence and ownership before validating the payload, so a caller
+    // can't probe bounds-validity for a draft they don't own or that doesn't
+    // exist (matches the editRecipe route's ordering).
     const draft = await db.collection('recipeDrafts').findOne({ _id })
     if (!draft) {
       return res.status(404).json({ error: 'Draft not found' })
@@ -133,7 +113,14 @@ router.put('/:id', verifyToken, async (req, res) => {
     if (draft.userId !== req.uid) {
       return res.status(403).json({ error: 'Forbidden' })
     }
-    const update = { ...pickDraftFields(req.body), updatedAt: Date.now().toString() }
+    const boundsError = validateRecipeBounds(req.body)
+    if (boundsError) {
+      return res.status(400).json({ error: boundsError })
+    }
+    const update = {
+      ...pickFields(req.body, RECIPE_CONTENT_FIELDS),
+      updatedAt: Date.now().toString(),
+    }
     const updated = await db
       .collection('recipeDrafts')
       .findOneAndUpdate({ _id }, { $set: update }, { returnDocument: 'after' })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -1,9 +1,10 @@
 const { Router } = require('express')
 const { ObjectId } = require('mongodb')
-const { getDB } = require('../db')
+const { getDB, getClient } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { validateRecipeBounds } = require('../util/recipeLimits')
+const { deleteRecipeImage } = require('../util/firebaseStorage')
 
 const router = Router()
 
@@ -180,11 +181,36 @@ router.delete('/deleteRecipe', verifyToken, async (req, res) => {
     if (recipe.userId !== uid) {
       return res.status(403).json({ error: 'Forbidden' })
     }
-    await db.collection('recipes').deleteOne(recipeIdQuery(recipeId))
-    await db.collection('userRecipeData').updateOne(
-      { _id: uid },
-      { $pull: { userRecipes: { recipeId } } }
-    )
+
+    // Remove the recipe and every reference to it atomically: its ratings/
+    // reviews, and the recipeId entry from any user's saved/made/created lists.
+    // userRecipes only ever lives on the owner's doc, but pulling it across all
+    // docs in the same updateMany is harmless and keeps this to one write.
+    const session = getClient().startSession()
+    try {
+      await session.withTransaction(async () => {
+        await db.collection('recipes').deleteOne(recipeIdQuery(recipeId), { session })
+        await db.collection('ratings').deleteMany({ recipeId }, { session })
+        await db.collection('userRecipeData').updateMany(
+          {},
+          {
+            $pull: {
+              savedRecipes: { recipeId },
+              madeRecipes: { recipeId },
+              userRecipes: { recipeId },
+            },
+          },
+          { session }
+        )
+      })
+    } finally {
+      await session.endSession()
+    }
+
+    // External side effect — runs after the transaction commits and never
+    // fails the request (an orphaned image is preferable to a 500 here).
+    await deleteRecipeImage(recipe.recipeImage)
+
     res.json({ deleted: true })
   } catch (err) {
     res.status(500).json({ error: err.message })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -165,6 +165,79 @@ router.post('/addRecipe', verifyToken, async (req, res) => {
   }
 })
 
+// PUT /editRecipe — owner-only edit. Social/derived counters and immutable
+// metadata are never writable here (see EDITABLE_FIELDS), so an edit can never
+// reset a recipe's ratings, saves, or made-count. editedAt is stamped so the UI
+// can surface that the recipe changed after people saved it.
+const EDITABLE_FIELDS = [
+  'title',
+  'prepTime',
+  'cookTime',
+  'servings',
+  'fridgeLife',
+  'freezerLife',
+  'description',
+  'ingredients',
+  'instructions',
+  'recipeImage',
+  'cuisine',
+  'mealTypes',
+  'nutritionData',
+  'nutritionLabels',
+  'servingPrice',
+  'totalTime',
+]
+
+router.put('/editRecipe', verifyToken, async (req, res) => {
+  try {
+    const db = getDB()
+    const { recipeId } = req.query
+    if (!recipeId) {
+      return res.status(400).json({ error: 'recipeId is required' })
+    }
+    const uid = req.uid
+    const recipe = await db.collection('recipes').findOne(recipeIdQuery(recipeId))
+    if (!recipe) {
+      return res.status(404).json({ error: 'Recipe not found' })
+    }
+    if (recipe.userId !== uid) {
+      return res.status(403).json({ error: 'Forbidden' })
+    }
+
+    const body = req.body
+    const requiredFields = ['title', 'ingredients', 'instructions', 'mealTypes']
+    const missing = requiredFields.filter(f => {
+      const val = body[f]
+      return val == null || val === '' || (Array.isArray(val) && val.length === 0)
+    })
+    if (missing.length > 0) {
+      return res.status(400).json({ error: `Missing required fields: ${missing.join(', ')}` })
+    }
+    const boundsError = validateRecipeBounds(body)
+    if (boundsError) {
+      return res.status(400).json({ error: boundsError })
+    }
+
+    // Whitelist: copy only editable fields from the client payload. Anything
+    // else the client sends (rating, numTimesSaved, views, userId, _id, …) is
+    // ignored.
+    const update = {}
+    for (const field of EDITABLE_FIELDS) {
+      if (field in body) update[field] = body[field]
+    }
+    update.editedAt = Date.now().toString()
+
+    const updated = await db.collection('recipes').findOneAndUpdate(
+      recipeIdQuery(recipeId),
+      { $set: update },
+      { returnDocument: 'after' }
+    )
+    res.json(updated)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
 // DELETE /deleteRecipe
 router.delete('/deleteRecipe', verifyToken, async (req, res) => {
   try {

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -3,7 +3,7 @@ const { ObjectId } = require('mongodb')
 const { getDB, getClient } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
-const { validateRecipeBounds } = require('../util/recipeLimits')
+const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 
 const router = Router()
@@ -138,13 +138,9 @@ router.post('/addRecipe', verifyToken, async (req, res) => {
     const db = getDB()
     const body = req.body
     const uid = req.uid
-    const requiredFields = ['title', 'ingredients', 'instructions', 'mealTypes']
-    const missing = requiredFields.filter(f => {
-      const val = body[f]
-      return val == null || val === '' || (Array.isArray(val) && val.length === 0)
-    })
-    if (missing.length > 0) {
-      return res.status(400).json({ error: `Missing required fields: ${missing.join(', ')}` })
+    const requiredError = validateRequiredRecipeFields(body)
+    if (requiredError) {
+      return res.status(400).json({ error: requiredError })
     }
     const boundsError = validateRecipeBounds(body)
     if (boundsError) {
@@ -205,13 +201,9 @@ router.put('/editRecipe', verifyToken, async (req, res) => {
     }
 
     const body = req.body
-    const requiredFields = ['title', 'ingredients', 'instructions', 'mealTypes']
-    const missing = requiredFields.filter(f => {
-      const val = body[f]
-      return val == null || val === '' || (Array.isArray(val) && val.length === 0)
-    })
-    if (missing.length > 0) {
-      return res.status(400).json({ error: `Missing required fields: ${missing.join(', ')}` })
+    const requiredError = validateRequiredRecipeFields(body)
+    if (requiredError) {
+      return res.status(400).json({ error: requiredError })
     }
     const boundsError = validateRecipeBounds(body)
     if (boundsError) {

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -4,6 +4,7 @@ const { getDB, getClient } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
+const { EDITABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 
 const router = Router()
@@ -162,28 +163,9 @@ router.post('/addRecipe', verifyToken, async (req, res) => {
 })
 
 // PUT /editRecipe — owner-only edit. Social/derived counters and immutable
-// metadata are never writable here (see EDITABLE_FIELDS), so an edit can never
-// reset a recipe's ratings, saves, or made-count. editedAt is stamped so the UI
-// can surface that the recipe changed after people saved it.
-const EDITABLE_FIELDS = [
-  'title',
-  'prepTime',
-  'cookTime',
-  'servings',
-  'fridgeLife',
-  'freezerLife',
-  'description',
-  'ingredients',
-  'instructions',
-  'recipeImage',
-  'cuisine',
-  'mealTypes',
-  'nutritionData',
-  'nutritionLabels',
-  'servingPrice',
-  'totalTime',
-]
-
+// metadata are never writable here (only EDITABLE_RECIPE_FIELDS are copied), so
+// an edit can never reset a recipe's ratings, saves, or made-count. editedAt is
+// stamped so the UI can surface that the recipe changed after people saved it.
 router.put('/editRecipe', verifyToken, async (req, res) => {
   try {
     const db = getDB()
@@ -213,11 +195,10 @@ router.put('/editRecipe', verifyToken, async (req, res) => {
     // Whitelist: copy only editable fields from the client payload. Anything
     // else the client sends (rating, numTimesSaved, views, userId, _id, …) is
     // ignored.
-    const update = {}
-    for (const field of EDITABLE_FIELDS) {
-      if (field in body) update[field] = body[field]
+    const update = {
+      ...pickFields(body, EDITABLE_RECIPE_FIELDS),
+      editedAt: Date.now().toString(),
     }
-    update.editedAt = Date.now().toString()
 
     const updated = await db.collection('recipes').findOneAndUpdate(
       recipeIdQuery(recipeId),

--- a/server/scripts/check-username-dupes.js
+++ b/server/scripts/check-username-dupes.js
@@ -1,0 +1,81 @@
+/**
+ * READ-ONLY precheck for the unique index on usernames.username_lower.
+ *
+ * The migration in db.js (ensureIndexes) builds a UNIQUE index on the
+ * lowercased username. If the collection already contains two usernames that
+ * differ only by case (e.g. "John" and "john"), that index will fail to build.
+ * This script finds those collisions BEFORE you deploy, without writing
+ * anything — it opens its own connection and never calls ensureIndexes().
+ *
+ * Usage (from the repo root or the server dir):
+ *   node server/scripts/check-username-dupes.js
+ *
+ * Exit code 0 = clean (index will build), 1 = collisions found, 2 = error.
+ */
+const path = require('path')
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') })
+const { MongoClient } = require('mongodb')
+
+async function main() {
+  const uri = process.env.MONGO_URI
+  if (!uri) {
+    console.error('MONGO_URI is not set (looked in server/.env).')
+    process.exit(2)
+  }
+
+  const client = new MongoClient(uri, { serverSelectionTimeoutMS: 10000 })
+
+  try {
+    await client.connect()
+    const usernames = client.db('prepify').collection('usernames')
+
+    const total = await usernames.countDocuments()
+    const missingLower = await usernames.countDocuments({
+      username_lower: { $exists: false },
+      username: { $type: 'string' },
+    })
+
+    // Group by the lowercased username and keep only groups with >1 doc.
+    const collisions = await usernames
+      .aggregate([
+        { $match: { username: { $type: 'string' } } },
+        {
+          $group: {
+            _id: { $toLower: '$username' },
+            count: { $sum: 1 },
+            ids: { $push: '$_id' },
+            originals: { $push: '$username' },
+          },
+        },
+        { $match: { count: { $gt: 1 } } },
+        { $sort: { count: -1 } },
+      ])
+      .toArray()
+
+    console.log(`\nusernames documents:        ${total}`)
+    console.log(`missing username_lower:     ${missingLower} (will be backfilled on deploy)`)
+    console.log(`case-insensitive collisions: ${collisions.length}\n`)
+
+    if (collisions.length === 0) {
+      console.log('✅ No case-variant duplicates. The unique index will build cleanly.')
+      process.exit(0)
+    }
+
+    console.log('❌ Found usernames that collide once lowercased. Resolve these before deploying:\n')
+    for (const c of collisions) {
+      console.log(`  "${c._id}" x${c.count}`)
+      c.originals.forEach((name, i) => {
+        console.log(`      - ${JSON.stringify(name)}  (uid: ${c.ids[i]})`)
+      })
+    }
+    console.log('')
+    process.exit(1)
+  } catch (err) {
+    console.error('Precheck failed:', err.message)
+    process.exit(2)
+  } finally {
+    await client.close()
+  }
+}
+
+main()

--- a/server/util/firebaseStorage.js
+++ b/server/util/firebaseStorage.js
@@ -1,0 +1,30 @@
+const admin = require('firebase-admin')
+
+// Firebase Storage download URLs look like:
+//   https://firebasestorage.googleapis.com/v0/b/<bucket>/o/<url-encoded-path>?alt=media&token=...
+// Pull out the bucket and the decoded object path so the file can be deleted
+// server-side. Returns null for anything that isn't a recognizable URL (e.g.
+// empty string, an already-relative path, or a non-Firebase URL).
+function parseStorageUrl(url) {
+  if (typeof url !== 'string') return null
+  const match = url.match(/\/b\/([^/]+)\/o\/([^?]+)/)
+  if (!match) return null
+  return { bucket: match[1], path: decodeURIComponent(match[2]) }
+}
+
+// Best-effort deletion of a recipe's image from Firebase Storage. Never throws:
+// an orphaned image is undesirable but must not fail (or roll back) the recipe
+// deletion it accompanies. Returns true only when a file was actually deleted.
+async function deleteRecipeImage(url) {
+  const parsed = parseStorageUrl(url)
+  if (!parsed) return false
+  try {
+    await admin.storage().bucket(parsed.bucket).file(parsed.path).delete()
+    return true
+  } catch (err) {
+    console.error('Failed to delete recipe image from storage:', err.message)
+    return false
+  }
+}
+
+module.exports = { parseStorageUrl, deleteRecipeImage }

--- a/server/util/recipeFields.js
+++ b/server/util/recipeFields.js
@@ -1,0 +1,41 @@
+// Single source of truth for the recipe content fields a user supplies, shared
+// by the draft routes and the recipe-edit whitelist so the two can't drift.
+// Add a user-entered field here and it propagates to both: drafts won't
+// silently drop it on autosave, and edits will accept it.
+const RECIPE_CONTENT_FIELDS = [
+  'title',
+  'prepTime',
+  'cookTime',
+  'servings',
+  'fridgeLife',
+  'freezerLife',
+  'description',
+  'ingredients',
+  'instructions',
+  'cuisine',
+  'mealTypes',
+]
+
+// Editing a published recipe also writes the image and the server-/client-
+// computed fields; drafts don't carry these.
+const EDITABLE_RECIPE_FIELDS = [
+  ...RECIPE_CONTENT_FIELDS,
+  'recipeImage',
+  'nutritionData',
+  'nutritionLabels',
+  'servingPrice',
+  'totalTime',
+]
+
+// Copy only the whitelisted keys that are present in `body`. Absent keys are
+// left out (callers merge via $set), so a field the client doesn't send is
+// untouched rather than overwritten.
+function pickFields(body, fields) {
+  const out = {}
+  for (const field of fields) {
+    if (field in body) out[field] = body[field]
+  }
+  return out
+}
+
+module.exports = { RECIPE_CONTENT_FIELDS, EDITABLE_RECIPE_FIELDS, pickFields }

--- a/server/util/recipeLimits.js
+++ b/server/util/recipeLimits.js
@@ -7,6 +7,22 @@ const INSTRUCTION_MAX_LENGTH = 1000
 const MAX_INGREDIENTS = 50
 const MAX_INSTRUCTIONS = 50
 
+// Fields a recipe must carry to be created or edited. Shared by both routes so
+// the requirement can't drift between create and edit.
+const REQUIRED_RECIPE_FIELDS = ['title', 'ingredients', 'instructions', 'mealTypes']
+
+// Returns an error string when a required field is missing/empty, or null when
+// all are present. An array field counts as missing when empty.
+function validateRequiredRecipeFields(body) {
+  const missing = REQUIRED_RECIPE_FIELDS.filter(f => {
+    const val = body[f]
+    return val == null || val === '' || (Array.isArray(val) && val.length === 0)
+  })
+  return missing.length > 0
+    ? `Missing required fields: ${missing.join(', ')}`
+    : null
+}
+
 // Returns an error string when `body` violates a bound, or null when it's within
 // limits. Only checks fields that are present — required-field presence is
 // validated separately by the route.
@@ -46,5 +62,7 @@ module.exports = {
   INSTRUCTION_MAX_LENGTH,
   MAX_INGREDIENTS,
   MAX_INSTRUCTIONS,
+  REQUIRED_RECIPE_FIELDS,
+  validateRequiredRecipeFields,
   validateRecipeBounds,
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Account from 'src/pages/Account/Account'
 import SavedRecipes from 'src/pages/Account/SavedRecipes/SavedRecipes'
 import UserRatings from 'src/pages/Account/UserRatings/UserRatings'
 import UserRecipes from 'src/pages/Account/UserRecipes/UserRecipes'
+import Drafts from 'src/pages/Account/Drafts/Drafts'
 
 import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
 import EditRecipe from 'src/pages/EditRecipe/EditRecipe'
@@ -89,6 +90,7 @@ const App: FC = () => {
                 <Route path='saved-recipes' element={<SavedRecipes />} />
                 <Route path='ratings' element={<UserRatings />} />
                 <Route path='your-recipes' element={<UserRecipes />} />
+                <Route path='drafts' element={<Drafts />} />
               </Route>
               <Route
                 path='/settings'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import UserRatings from 'src/pages/Account/UserRatings/UserRatings'
 import UserRecipes from 'src/pages/Account/UserRecipes/UserRecipes'
 
 import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
+import EditRecipe from 'src/pages/EditRecipe/EditRecipe'
 import Layout from 'src/Components/Layout/Layout'
 import Help from 'src/pages/Help/Help'
 import NotFound from 'src/pages/404/404'
@@ -113,6 +114,14 @@ const App: FC = () => {
                 element={
                   <Layout darkNavLinks={true}>
                     <AddRecipe />
+                  </Layout>
+                }
+              />
+              <Route
+                path='/recipes/:recipeId/edit'
+                element={
+                  <Layout darkNavLinks={true}>
+                    <EditRecipe />
                   </Layout>
                 }
               />

--- a/src/Components/Form/UsernameInput.tsx
+++ b/src/Components/Form/UsernameInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, FC, useState } from 'react'
+import React, { useEffect, FC } from 'react'
 import FormInput from 'src/Components/Form/FormInput'
 import { MdAlternateEmail } from 'react-icons/md'
 import AuthAPI from 'src/api/auth'
@@ -20,9 +20,7 @@ const UsernameInput: FC<UsernameInputProps> = ({
   isUsernameAvailable,
   setIsUsernameAvailable,
 }) => {
-  const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout | null>(null)
-
-  // on username change, check username availability against firestore 'usernames' collection
+  // on username change, check availability against the 'usernames' collection
   useEffect(() => {
     setError('')
     setSuccess('')
@@ -31,21 +29,25 @@ const UsernameInput: FC<UsernameInputProps> = ({
       return setError('Cannot have white space in username')
     if (!username || username.length < 3) return setIsUsernameAvailable(null)
 
-    if (timeoutId) clearTimeout(timeoutId)
+    // `cancelled` guards against a slow in-flight request resolving after a
+    // newer keystroke's request and clobbering the result with stale data.
+    let cancelled = false
 
-    const newTimeoutId = setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       AuthAPI.checkUsernameAvailability(username)
         .then(val => {
-          setIsUsernameAvailable(val)
+          if (!cancelled) setIsUsernameAvailable(val)
         })
-        .catch(err => setError(err.code))
+        .catch(err => {
+          if (!cancelled) setError(err.code)
+        })
     }, 500) // 500 milliseconds debounce time
 
-    setTimeoutId(newTimeoutId)
-
-    // cleanup function to clear timeout on unmount or username change
+    // Clears the pending debounce and ignores any in-flight response on the
+    // next keystroke or unmount.
     return () => {
-      if (timeoutId) clearTimeout(timeoutId)
+      cancelled = true
+      clearTimeout(timeoutId)
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Components/Navbar/Navbar.tsx
+++ b/src/Components/Navbar/Navbar.tsx
@@ -37,7 +37,7 @@ const Navbar: FC<NavbarProps> = ({
 
   const { data } = useQuery({
     queryKey: ['username', uid],
-    queryFn: () => AuthAPI.getUsername(uid!),
+    queryFn: () => AuthAPI.getUsername(),
     enabled: !!uid && !!authRes?.user,
   })
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -11,17 +11,19 @@ class AuthAPIClass {
       uid = this.getUID()
     }
     if (!uid) return null
-    const result = await http.get(`api/getUsername?userId=${uid}`)
+    const result = await http.get(
+      `api/getUsername?userId=${encodeURIComponent(uid)}`
+    )
     return result.data
   }
   async checkUsernameAvailability(username: string): Promise<boolean> {
     const result = await http.get(
-      `api/checkUsernameAvailability?username=${username}`
+      `api/checkUsernameAvailability?username=${encodeURIComponent(username)}`
     )
     return result.data
   }
   async setUsername(username: string) {
-    await http.post(`api/setUsername?username=${username}`)
+    await http.post(`api/setUsername?username=${encodeURIComponent(username)}`)
   }
 }
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -5,15 +5,12 @@ class AuthAPIClass {
   getUID(): string | null {
     return auth?.currentUser?.uid ?? null
   }
-  async getUsername(userId?: string): Promise<string | null> {
-    let uid: string | null = userId ?? null
-    if (!userId) {
-      uid = this.getUID()
-    }
-    if (!uid) return null
-    const result = await http.get(
-      `api/getUsername?userId=${encodeURIComponent(uid)}`
-    )
+  // The server resolves the username from the auth token, so this always
+  // returns the current user's own username. Skip the request when nobody is
+  // signed in (it would just 401).
+  async getUsername(): Promise<string | null> {
+    if (!this.getUID()) return null
+    const result = await http.get('api/getUsername')
     return result.data
   }
   async checkUsernameAvailability(username: string): Promise<boolean> {

--- a/src/api/drafts.ts
+++ b/src/api/drafts.ts
@@ -1,0 +1,49 @@
+import { RecipeDraftContent, RecipeDraftType } from 'types'
+import AuthAPI from 'src/api/auth'
+import { http } from 'src/api/http-common'
+
+// Server-set `code` on the 409 returned when a user is at their draft cap
+// (server/routes/drafts.js). createDraft lets this error propagate so callers
+// can distinguish "at limit" from a generic save failure.
+export const DRAFT_LIMIT_CODE = 'DRAFT_LIMIT'
+
+// Client for the recipe-draft endpoints (server/routes/drafts.js). Drafts are
+// the autosaved, in-progress state of the create-recipe flow. The image is not
+// part of a draft — see RecipeDraftContent / AddRecipe autosave.
+class DraftAPIClass {
+  async createDraft(content: RecipeDraftContent): Promise<RecipeDraftType | null> {
+    if (!AuthAPI.getUID()) return null
+    const result = await http.post<RecipeDraftType>('api/drafts', content)
+    return result.data
+  }
+
+  async updateDraft(
+    id: string,
+    content: RecipeDraftContent
+  ): Promise<RecipeDraftType | null> {
+    if (!AuthAPI.getUID()) return null
+    const result = await http.put<RecipeDraftType>(`api/drafts/${id}`, content)
+    return result.data
+  }
+
+  async listDrafts(): Promise<RecipeDraftType[]> {
+    if (!AuthAPI.getUID()) return []
+    const result = await http.get<RecipeDraftType[]>('api/drafts')
+    return result.data
+  }
+
+  async getDraft(id: string): Promise<RecipeDraftType | null> {
+    if (!AuthAPI.getUID()) return null
+    const result = await http.get<RecipeDraftType>(`api/drafts/${id}`)
+    return result.data
+  }
+
+  async deleteDraft(id: string): Promise<void> {
+    if (!AuthAPI.getUID()) return
+    await http.delete(`api/drafts/${id}`)
+  }
+}
+
+const DraftAPI = new DraftAPIClass()
+
+export default DraftAPI

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -119,6 +119,40 @@ class RecipeAPIClass {
     }
   }
 
+  // The editable subset of a recipe document, assembled from the form data plus
+  // the values computed at submit time. addRecipe layers creation-only fields
+  // (authorUsername, rating, counters…) on top; editRecipe sends it as-is. Single
+  // source for the field list so the two paths can't drift.
+  private buildEditableRecipeFields(
+    data: RecipeFormType | RecipeEditFormType,
+    computed: {
+      recipeImage: string
+      nutritionData: NutritionDataType | null
+      nutritionLabels: string[] | null
+      servingPrice: number
+      totalTime: number
+    }
+  ) {
+    return {
+      title: data.title,
+      prepTime: data.prepTime,
+      cookTime: data.cookTime,
+      servings: data.servings,
+      fridgeLife: data.fridgeLife,
+      freezerLife: data.freezerLife,
+      description: data.description,
+      ingredients: data.ingredients,
+      instructions: data.instructions,
+      cuisine: data.cuisine,
+      mealTypes: data.mealTypes,
+      recipeImage: computed.recipeImage,
+      nutritionData: computed.nutritionData,
+      nutritionLabels: computed.nutritionLabels,
+      servingPrice: computed.servingPrice,
+      totalTime: computed.totalTime,
+    }
+  }
+
   async addRecipe(
     recipeData: RecipeFormType,
     setProgress: (val: number) => void
@@ -143,18 +177,13 @@ class RecipeAPIClass {
       const nutritionData = nutritionDataRes.nutritionData
       const nutritionLabels = nutritionDataRes.dietLabels
       const returnRecipeData: Omit<RecipeType, '_id'> = {
-        title: recipeData.title,
-        prepTime: recipeData.prepTime,
-        cookTime: recipeData.cookTime,
-        servings: recipeData.servings,
-        fridgeLife: recipeData.fridgeLife,
-        freezerLife: recipeData.freezerLife,
-        description: recipeData.description,
-        ingredients: recipeData.ingredients,
-        instructions: recipeData.instructions,
-        recipeImage,
-        nutritionData,
-        totalTime,
+        ...this.buildEditableRecipeFields(recipeData, {
+          recipeImage,
+          nutritionData,
+          nutritionLabels,
+          servingPrice,
+          totalTime,
+        }),
         authorUsername,
         rating: {
           rateCount: 0,
@@ -162,10 +191,6 @@ class RecipeAPIClass {
         },
         createdAt: new Date().getTime().toString(),
         editedAt: null,
-        servingPrice,
-        cuisine: recipeData.cuisine,
-        mealTypes: recipeData.mealTypes,
-        nutritionLabels,
         views: 0,
         numTimesSaved: 0,
         numTimesMade: 0,
@@ -210,10 +235,13 @@ class RecipeAPIClass {
 
       // Nutrition is a paid Edamam call, so only re-run it when the ingredient set
       // actually changed; minor edits (title, instructions, times) reuse the
-      // stored nutrition data and labels.
+      // stored nutrition data and labels. Compare the exact strings the lookup
+      // would send, element-wise.
+      const newIngredients = this.buildNutritionIngredients(recipeData.ingredients)
+      const oldIngredients = this.buildNutritionIngredients(originalRecipe.ingredients)
       const ingredientsChanged =
-        JSON.stringify(this.buildNutritionIngredients(recipeData.ingredients)) !==
-        JSON.stringify(this.buildNutritionIngredients(originalRecipe.ingredients))
+        newIngredients.length !== oldIngredients.length ||
+        newIngredients.some((ingr, i) => ingr !== oldIngredients[i])
 
       let nutritionData = originalRecipe.nutritionData
       let nutritionLabels = originalRecipe.nutritionLabels
@@ -233,24 +261,13 @@ class RecipeAPIClass {
       setProgress(90)
       // Only the editable fields are sent; the server whitelists these and never
       // lets ratings/saves/counters be overwritten.
-      const payload = {
-        title: recipeData.title,
-        prepTime: recipeData.prepTime,
-        cookTime: recipeData.cookTime,
-        servings: recipeData.servings,
-        fridgeLife: recipeData.fridgeLife,
-        freezerLife: recipeData.freezerLife,
-        description: recipeData.description,
-        ingredients: recipeData.ingredients,
-        instructions: recipeData.instructions,
+      const payload = this.buildEditableRecipeFields(recipeData, {
         recipeImage,
-        cuisine: recipeData.cuisine,
-        mealTypes: recipeData.mealTypes,
         nutritionData,
         nutritionLabels,
         servingPrice,
         totalTime,
-      }
+      })
       const res = await http.put<RecipeType>(
         `api/editRecipe?recipeId=${recipeId}`,
         payload

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -9,6 +9,7 @@ import {
   NutritionDataType,
   OptionalReviewType,
   RecipeDBResponseType,
+  RecipeEditFormType,
   RecipeFormType,
   RecipeSearchResponseType,
   RecipeType,
@@ -175,23 +176,101 @@ class RecipeAPIClass {
       return null
     }
   }
+
+  async editRecipe(
+    recipeId: string,
+    recipeData: RecipeEditFormType,
+    originalRecipe: RecipeType,
+    setProgress: (val: number) => void
+  ): Promise<boolean | typeof ADD_RECIPE_AUTH_ERROR> {
+    try {
+      setProgress(10)
+      // Image: only upload when the user picked a new file. Otherwise the recipe
+      // keeps its existing stored image URL.
+      let recipeImage = originalRecipe.recipeImage
+      if (recipeData.recipeImage) {
+        recipeImage = await this.uploadRecipeImage(
+          recipeData.recipeImage,
+          setProgress
+        )
+      }
+      setProgress(80)
+      // Serving price is a local calculation (no API cost), so always recompute —
+      // it depends on both ingredients and servings.
+      const servingPrice: number = calculateServingPrice(
+        recipeData.ingredients,
+        recipeData.servings
+      )
+      const totalTime: number = recipeData.prepTime + (recipeData.cookTime ?? 0)
+
+      // Nutrition is a paid Edamam call, so only re-run it when the ingredient set
+      // actually changed; minor edits (title, instructions, times) reuse the
+      // stored nutrition data and labels.
+      const ingredientsChanged =
+        JSON.stringify(this.buildNutritionIngredients(recipeData.ingredients)) !==
+        JSON.stringify(this.buildNutritionIngredients(originalRecipe.ingredients))
+
+      let nutritionData = originalRecipe.nutritionData
+      let nutritionLabels = originalRecipe.nutritionLabels
+      if (ingredientsChanged) {
+        const nutritionDataRes = await this.getRecipeNutrition(
+          recipeData.ingredients
+        )
+        nutritionData = nutritionDataRes.nutritionData
+        nutritionLabels = nutritionDataRes.dietLabels
+      }
+      setProgress(90)
+      // Only the editable fields are sent; the server whitelists these and never
+      // lets ratings/saves/counters be overwritten.
+      const payload = {
+        title: recipeData.title,
+        prepTime: recipeData.prepTime,
+        cookTime: recipeData.cookTime,
+        servings: recipeData.servings,
+        fridgeLife: recipeData.fridgeLife,
+        freezerLife: recipeData.freezerLife,
+        description: recipeData.description,
+        ingredients: recipeData.ingredients,
+        instructions: recipeData.instructions,
+        recipeImage,
+        cuisine: recipeData.cuisine,
+        mealTypes: recipeData.mealTypes,
+        nutritionData,
+        nutritionLabels,
+        servingPrice,
+        totalTime,
+      }
+      await http.put(`api/editRecipe?recipeId=${recipeId}`, payload)
+      return true
+    } catch (error: unknown) {
+      console.error('editRecipe failed:', error)
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        return ADD_RECIPE_AUTH_ERROR
+      }
+      return false
+    }
+  }
+  // The exact ingredient strings sent to Edamam for nutrition lookup. Shared by
+  // getRecipeNutrition and editRecipe so the "did the ingredients change?" check
+  // compares the same representation that actually drives the nutrition result.
+  buildNutritionIngredients(ingrArr: IngredientsType[]): string[] {
+    const ingr: string[] = []
+    ingrArr.forEach(ing => {
+      if ('parsedIngredient' in ing) {
+        const { quantity, unit, ingredient } = ing.parsedIngredient
+        if (quantity) {
+          ingr.push(`${quantity} ${unit || ''} ${ingredient}`)
+        }
+      }
+    })
+    return ingr
+  }
   async getRecipeNutrition(ingrArr: IngredientsType[]): Promise<{ nutritionData: NutritionDataType | null; dietLabels: string[] | null }> {
     try {
       const ingrData: { title: string; ingr: string[] } = {
         title: 'recipe 1',
-        ingr: [],
+        ingr: this.buildNutritionIngredients(ingrArr),
       }
-
-      ingrArr.forEach(ingr => {
-        if ('parsedIngredient' in ingr) {
-          const { quantity, unit, ingredient } = ingr.parsedIngredient
-
-          if (quantity) {
-            const str = `${quantity} ${unit || ''} ${ingredient}`
-            ingrData.ingr.push(str)
-          }
-        }
-      })
       const nutritionResultRes = await nutrition.post(
         `nutrition-details?app_id=${import.meta.env.VITE_EDAMAM_APP_ID}&app_key=${import.meta.env.VITE_EDAMAM_APP_KEY}`,
         ingrData

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -22,6 +22,11 @@ import { v4 as uuidv4 } from 'uuid'
 
 export const ADD_RECIPE_AUTH_ERROR = 'AUTH_ERROR'
 
+export type EditRecipeResult =
+  | { status: 'success'; recipe: RecipeType }
+  | { status: 'auth-error' }
+  | { status: 'error'; message: string }
+
 class RecipeAPIClass {
   async getAllRecipes(
     page = 0,
@@ -182,7 +187,7 @@ class RecipeAPIClass {
     recipeData: RecipeEditFormType,
     originalRecipe: RecipeType,
     setProgress: (val: number) => void
-  ): Promise<boolean | typeof ADD_RECIPE_AUTH_ERROR> {
+  ): Promise<EditRecipeResult> {
     try {
       setProgress(10)
       // Image: only upload when the user picked a new file. Otherwise the recipe
@@ -216,8 +221,14 @@ class RecipeAPIClass {
         const nutritionDataRes = await this.getRecipeNutrition(
           recipeData.ingredients
         )
-        nutritionData = nutritionDataRes.nutritionData
-        nutritionLabels = nutritionDataRes.dietLabels
+        // getRecipeNutrition soft-fails to null when Edamam is unreachable. Only
+        // overwrite when it actually returned data — otherwise a transient lookup
+        // failure during an ingredient edit would erase the recipe's existing
+        // nutrition facts for all viewers.
+        if (nutritionDataRes.nutritionData) {
+          nutritionData = nutritionDataRes.nutritionData
+          nutritionLabels = nutritionDataRes.dietLabels
+        }
       }
       setProgress(90)
       // Only the editable fields are sent; the server whitelists these and never
@@ -240,14 +251,24 @@ class RecipeAPIClass {
         servingPrice,
         totalTime,
       }
-      await http.put(`api/editRecipe?recipeId=${recipeId}`, payload)
-      return true
+      const res = await http.put<RecipeType>(
+        `api/editRecipe?recipeId=${recipeId}`,
+        payload
+      )
+      return { status: 'success', recipe: res.data }
     } catch (error: unknown) {
       console.error('editRecipe failed:', error)
-      if (axios.isAxiosError(error) && error.response?.status === 401) {
-        return ADD_RECIPE_AUTH_ERROR
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 401) return { status: 'auth-error' }
+        // Surface the server's reason (e.g. 403 Forbidden, 404 Not found) so a
+        // stale edit page doesn't show a misleading "try again" for an error a
+        // retry can't fix.
+        const message =
+          error.response?.data?.error ??
+          'Failed to update recipe. Please try again.'
+        return { status: 'error', message }
       }
-      return false
+      return { status: 'error', message: 'Failed to update recipe. Please try again.' }
     }
   }
   // The exact ingredient strings sent to Edamam for nutrition lookup. Shared by

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -262,7 +262,6 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
     if (loading || !user || !user.uid) return
 
     let cancelled = false
-    const uid = user.uid
     const MAX_ATTEMPTS = 3
     const BASE_DELAY_MS = 500
     const delay = (ms: number) =>
@@ -271,7 +270,7 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
     const verifyUsername = async () => {
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         try {
-          const username = await AuthAPI.getUsername(uid)
+          const username = await AuthAPI.getUsername()
           if (cancelled) return
           if (!username) navigate('/create-username')
           return

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -254,21 +254,44 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
     return () => unsubscribe()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-  // Check if user has username after auth is loaded and user exists
+  // Check if user has username after auth is loaded and user exists. A failed
+  // lookup leaves a username-less user (e.g. a fresh Google sign-in) stranded
+  // without the redirect, so retry transient failures with backoff before
+  // giving up rather than surfacing a non-actionable error to the user.
   useEffect(() => {
-    if (!loading && user && user.uid) {
-      AuthAPI.getUsername(user.uid)
-        .then(username => {
-          if (!username) {
-            navigate('/create-username')
+    if (loading || !user || !user.uid) return
+
+    let cancelled = false
+    const uid = user.uid
+    const MAX_ATTEMPTS = 3
+    const BASE_DELAY_MS = 500
+    const delay = (ms: number) =>
+      new Promise(resolve => setTimeout(resolve, ms))
+
+    const verifyUsername = async () => {
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+          const username = await AuthAPI.getUsername(uid)
+          if (cancelled) return
+          if (!username) navigate('/create-username')
+          return
+        } catch (err) {
+          if (cancelled) return
+          if (attempt === MAX_ATTEMPTS) {
+            console.error('Failed to verify username on auth load:', err)
+            return
           }
-        })
-        .catch(err => {
-          // Don't silently swallow the failure: if we can't confirm the user
-          // has a username we surface it rather than letting them proceed in a
-          // half-onboarded state that breaks username-dependent features.
-          console.error('Failed to verify username on auth load:', err)
-        })
+          // Exponential backoff: 500ms, then 1000ms.
+          await delay(BASE_DELAY_MS * 2 ** (attempt - 1))
+          if (cancelled) return
+        }
+      }
+    }
+
+    verifyUsername()
+
+    return () => {
+      cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, user])

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -257,11 +257,18 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
   // Check if user has username after auth is loaded and user exists
   useEffect(() => {
     if (!loading && user && user.uid) {
-      AuthAPI.getUsername(user.uid).then(username => {
-        if (!username) {
-          navigate('/create-username')
-        }
-      })
+      AuthAPI.getUsername(user.uid)
+        .then(username => {
+          if (!username) {
+            navigate('/create-username')
+          }
+        })
+        .catch(err => {
+          // Don't silently swallow the failure: if we can't confirm the user
+          // has a username we surface it rather than letting them proceed in a
+          // half-onboarded state that breaks username-dependent features.
+          console.error('Failed to verify username on auth load:', err)
+        })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, user])

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -110,11 +110,22 @@
       gap: 2rem;
       padding-bottom: 1rem;
       border-bottom: 1px solid s.$tertiary-text;
+      // With four tabs, let the bar scroll on narrow screens instead of
+      // wrapping or shrinking the labels to the point of being unreadable.
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
 
       .selection {
         text-decoration: none;
         font-weight: 700;
         color: s.$tertiary-text;
+        white-space: nowrap;
       }
       @media screen and (max-width: 450px) {
         justify-content: space-around;

--- a/src/pages/Account/Account.tsx
+++ b/src/pages/Account/Account.tsx
@@ -18,7 +18,7 @@ const Account: FC = () => {
 
   const { data } = useQuery({
     queryKey: ['username', uid],
-    queryFn: () => AuthAPI.getUsername(uid!),
+    queryFn: () => AuthAPI.getUsername(),
     enabled: !!uid && !authRes?.user?.displayName,
   })
 

--- a/src/pages/Account/Account.tsx
+++ b/src/pages/Account/Account.tsx
@@ -102,6 +102,16 @@ const Account: FC = () => {
             >
               Your Recipes
             </Link>
+            <Link
+              to='/account/drafts'
+              className={
+                currPath === '/account/drafts'
+                  ? 'active selection'
+                  : 'selection'
+              }
+            >
+              Drafts
+            </Link>
           </div>
           <Outlet />
         </div>

--- a/src/pages/Account/Drafts/DraftCard.tsx
+++ b/src/pages/Account/Drafts/DraftCard.tsx
@@ -1,0 +1,78 @@
+import React, { FC, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AiOutlineEdit, AiOutlineDelete } from 'react-icons/ai'
+import { RecipeDraftType } from 'types'
+
+const formatUpdated = (updatedAt: string) => {
+  const ms = Number(updatedAt)
+  if (!ms || Number.isNaN(ms)) return null
+  return new Date(ms).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+type DraftCardProps = {
+  draft: RecipeDraftType
+  onDelete: (id: string) => Promise<void> | void
+}
+
+const DraftCard: FC<DraftCardProps> = ({ draft, onDelete }) => {
+  const navigate = useNavigate()
+  const [deleting, setDeleting] = useState(false)
+
+  const updated = formatUpdated(draft.updatedAt)
+  const ingredientCount = draft.ingredients?.length ?? 0
+  const instructionCount = draft.instructions?.length ?? 0
+  const summaryParts = [
+    `${ingredientCount} ${ingredientCount === 1 ? 'ingredient' : 'ingredients'}`,
+    `${instructionCount} ${instructionCount === 1 ? 'step' : 'steps'}`,
+  ]
+
+  const handleResume = () => navigate(`/add-recipe?draftId=${draft._id}`)
+
+  const handleDelete = async () => {
+    if (deleting) return
+    setDeleting(true)
+    try {
+      await onDelete(draft._id)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <div className='draft-card'>
+      <div className='draft-card-main'>
+        <h3 className='title'>
+          {draft.title?.trim() ? draft.title : 'Untitled draft'}
+        </h3>
+        <div className='meta'>
+          <span className='summary'>{summaryParts.join(' · ')}</span>
+          {updated && <span className='updated'>Last edited {updated}</span>}
+        </div>
+      </div>
+      <div className='draft-card-actions'>
+        <button type='button' className='resume-btn' onClick={handleResume}>
+          <AiOutlineEdit className='icon' />
+          Continue editing
+        </button>
+        <button
+          type='button'
+          className='delete-btn'
+          onClick={handleDelete}
+          disabled={deleting}
+          aria-label='Delete draft'
+          title='Delete draft'
+        >
+          <AiOutlineDelete className='icon' />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default DraftCard

--- a/src/pages/Account/Drafts/Drafts.scss
+++ b/src/pages/Account/Drafts/Drafts.scss
@@ -1,0 +1,143 @@
+@use '../../../helpers.scss' as s;
+
+.drafts {
+  padding: 1rem 0 2rem;
+
+  .drafts-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 720px;
+    margin: 1rem auto 0;
+  }
+
+  .draft-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    background: s.$white;
+    border: 1px solid s.$gray-300;
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+
+    @media screen and (max-width: 560px) {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.85rem;
+      padding: 1rem;
+    }
+
+    .draft-card-main {
+      min-width: 0;
+
+      .title {
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: s.$primary-text;
+        margin: 0 0 0.35rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem 0.75rem;
+        font-size: 0.85rem;
+        color: s.$tertiary-text;
+      }
+    }
+
+    .draft-card-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-shrink: 0;
+
+      @media screen and (max-width: 560px) {
+        // Resume grows to a comfortable tap target; delete stays compact beside it.
+        .resume-btn {
+          flex: 1;
+          justify-content: center;
+          padding: 0.6rem 0.9rem;
+        }
+      }
+
+      .resume-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        white-space: nowrap;
+        cursor: pointer;
+        font-size: 0.9rem;
+        font-weight: 600;
+        padding: 0.5rem 0.9rem;
+        border-radius: s.$border-radius;
+        border: 1px solid s.$gray-300;
+        background: s.$white;
+        color: s.$primary-text;
+        transition: all 0.1s linear;
+
+        &:hover {
+          border-color: s.$primary;
+          color: s.$primary;
+        }
+
+        .icon {
+          font-size: 1rem;
+        }
+      }
+
+      .delete-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: none;
+        border: 1px solid transparent;
+        cursor: pointer;
+        padding: 0.45rem;
+        border-radius: s.$border-radius;
+        color: s.$tertiary-text;
+        transition: all 0.1s linear;
+
+        &:hover:not(:disabled) {
+          color: s.$error-red;
+          border-color: s.$gray-300;
+        }
+
+        &:disabled {
+          opacity: 0.5;
+          cursor: default;
+        }
+
+        .icon {
+          font-size: 1.15rem;
+        }
+      }
+    }
+  }
+
+  .no-data-saved {
+    text-align: center;
+    padding: 3rem 1rem;
+
+    h2 {
+      margin-bottom: 0.5rem;
+    }
+
+    p {
+      color: s.$secondary-text;
+      margin-bottom: 1.5rem;
+      max-width: 420px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .add-recipe-btn {
+      display: inline-block;
+      text-decoration: none;
+    }
+  }
+}

--- a/src/pages/Account/Drafts/Drafts.tsx
+++ b/src/pages/Account/Drafts/Drafts.tsx
@@ -1,0 +1,63 @@
+import React, { FC } from 'react'
+import { Link } from 'react-router-dom'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
+
+import './Drafts.scss'
+import DraftAPI from 'src/api/drafts'
+import DraftCard from './DraftCard'
+
+const Drafts: FC = () => {
+  const queryClient = useQueryClient()
+
+  const { data: drafts, isLoading } = useQuery({
+    queryKey: ['drafts'],
+    queryFn: () => DraftAPI.listDrafts(),
+  })
+
+  const handleDelete = async (id: string) => {
+    await DraftAPI.deleteDraft(id)
+    queryClient.invalidateQueries({ queryKey: ['drafts'] })
+  }
+
+  const hasDrafts = !!drafts && drafts.length > 0
+  const showList = hasDrafts || isLoading
+
+  return (
+    <div className='drafts'>
+      {showList ? (
+        <div className='drafts-list'>
+          {isLoading ? (
+            <>
+              <Skeleton height={92} borderRadius={12} />
+              <Skeleton height={92} borderRadius={12} />
+              <Skeleton height={92} borderRadius={12} />
+            </>
+          ) : (
+            drafts!.map(draft => (
+              <DraftCard
+                key={draft._id}
+                draft={draft}
+                onDelete={handleDelete}
+              />
+            ))
+          )}
+        </div>
+      ) : (
+        <div className='no-data-saved'>
+          <h2>No Drafts Yet</h2>
+          <p>
+            Recipes you start are saved here automatically until you publish
+            them.
+          </p>
+          <Link to='/add-recipe' className='btn add-recipe-btn'>
+            Start a Recipe
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Drafts

--- a/src/pages/AddRecipe/AddRecipe.scss
+++ b/src/pages/AddRecipe/AddRecipe.scss
@@ -29,6 +29,23 @@
     text-align: center;
   }
 
+  // Reminder shown on a resumed draft: the image isn't persisted in drafts, so
+  // prompt the user to re-add it before publishing.
+  .draft-image-hint {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0 0 0.65rem;
+    font-size: 0.85rem;
+    color: s.$secondary-text;
+
+    .icon {
+      flex-shrink: 0;
+      font-size: 1rem;
+      color: s.$primary;
+    }
+  }
+
   .container {
     display: flex;
     justify-content: center;

--- a/src/pages/AddRecipe/AddRecipe.scss
+++ b/src/pages/AddRecipe/AddRecipe.scss
@@ -16,6 +16,13 @@
   // Clear the fixed summary bar at the bottom of the page.
   padding-bottom: 130px;
 
+  .add-recipe-heading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
   h1 {
     font-size: 2rem;
     font-weight: 700;

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -1,10 +1,13 @@
 import React, { FC, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   AddRecipeErrorType,
   IngredientsType,
   InstructionsType,
+  RecipeEditFormType,
   RecipeFormType,
+  RecipeType,
 } from 'types'
 import LoadingBar from 'react-top-loading-bar'
 import RecipeFormInput from 'src/pages/AddRecipe/RecipeFormInput'
@@ -18,6 +21,7 @@ import InstructionsContainer from 'src/pages/AddRecipe/Instructions/Instructions
 import CuisineSelector from 'src/pages/AddRecipe/CuisineSelector/CuisineSelector'
 import MealTypeSelector from 'src/pages/AddRecipe/MealTypeSelector/MealTypeSelector'
 import { hrMinToMin } from 'src/util/hrMinToMin'
+import { minToHrMin } from 'src/util/minToHrMin'
 import {
   TITLE_MAX_LENGTH,
   DESCRIPTION_MAX_LENGTH,
@@ -33,34 +37,59 @@ import AddRecipeSummaryBar from 'src/pages/AddRecipe/AddRecipeSummaryBar'
 import { Helmet } from 'react-helmet-async'
 import { toast } from 'react-hot-toast'
 
-const AddRecipe: FC = () => {
+type TimeVal = { hours: number; minutes: number } | null
+
+// When `initialRecipe` is supplied the form runs in edit mode: every field is
+// pre-populated from the existing recipe and submitting updates it (preserving
+// ratings/saves) instead of creating a new one.
+type AddRecipeProps = { initialRecipe?: RecipeType }
+
+const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
+  const isEditMode = !!initialRecipe
+
   const [addRecipeLoading, setAddRecipeLoading] = useState(false)
   const [loadingProgress, setLoadingProgress] = useState(0)
   const addRecipeFormRef = useRef<HTMLDivElement>(null)
-  const [title, setTitle] = useState('')
+  const [title, setTitle] = useState(initialRecipe?.title ?? '')
   const [recipeImage, setRecipeImage] = useState<File | undefined>()
-  const [description, setDescription] = useState('')
-  const [servings, setServings] = useState<number | ''>('')
-  const [prepTime, setPrepTime] = useState<{
-    hours: number
-    minutes: number
-  } | null>(null)
-  const [cookTime, setCookTime] = useState<{
-    hours: number
-    minutes: number
-  } | null>(null)
-  const [fridgeLife, setFridgeLife] = useState<number>(0)
-  const [freezerLife, setFreezerLife] = useState<number>(0)
-  const [ingredients, setIngredients] = useState<IngredientsType[]>([])
-  const [instructions, setInstructions] = useState<InstructionsType[]>([])
-  const [cuisine, setCuisine] = useState('')
-  const [mealTypes, setMealTypes] = useState<string[]>([])
+  // Edit mode only: the recipe's current image URL, kept when the user doesn't
+  // pick a new file. Cleared if they remove the image (forcing a new pick).
+  const [existingImageUrl, setExistingImageUrl] = useState<string | undefined>(
+    initialRecipe?.recipeImage
+  )
+  const [description, setDescription] = useState(initialRecipe?.description ?? '')
+  const [servings, setServings] = useState<number | ''>(
+    initialRecipe?.servings ?? ''
+  )
+  const [prepTime, setPrepTime] = useState<TimeVal>(
+    initialRecipe ? minToHrMin(initialRecipe.prepTime) : null
+  )
+  const [cookTime, setCookTime] = useState<TimeVal>(
+    initialRecipe ? minToHrMin(initialRecipe.cookTime) : null
+  )
+  const [fridgeLife, setFridgeLife] = useState<number>(
+    initialRecipe?.fridgeLife ?? 0
+  )
+  const [freezerLife, setFreezerLife] = useState<number>(
+    initialRecipe?.freezerLife ?? 0
+  )
+  const [ingredients, setIngredients] = useState<IngredientsType[]>(
+    initialRecipe?.ingredients ?? []
+  )
+  const [instructions, setInstructions] = useState<InstructionsType[]>(
+    initialRecipe?.instructions ?? []
+  )
+  const [cuisine, setCuisine] = useState(initialRecipe?.cuisine ?? '')
+  const [mealTypes, setMealTypes] = useState<string[]>(
+    initialRecipe?.mealTypes ?? []
+  )
   const [errors, setErrors] = useState<Partial<AddRecipeErrorType>>({})
 
   const [isFormValid, setIsFormValid] = useState(false)
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
 
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const validate = (assignErrors: boolean = false) => {
     let newErrors: Partial<AddRecipeErrorType> = {}
@@ -71,7 +100,9 @@ const AddRecipe: FC = () => {
       newErrors.title = `Title cannot exceed ${TITLE_MAX_LENGTH} characters`
     }
 
-    if (!recipeImage) newErrors.image = 'Image is required'
+    // In edit mode a recipe with no newly-picked file is still valid as long as
+    // it has its existing stored image.
+    if (!recipeImage && !existingImageUrl) newErrors.image = 'Image is required'
     if (!description) {
       newErrors.description = 'Description is required'
     } else if (description.length > DESCRIPTION_MAX_LENGTH) {
@@ -94,21 +125,6 @@ const AddRecipe: FC = () => {
     assignErrors && setErrors(newErrors)
     return Object.keys(newErrors).length === 0
   }
-  const clearForm = () => {
-    setTitle('')
-    setRecipeImage(undefined)
-    setDescription('')
-    setServings('')
-    setPrepTime(null)
-    setCookTime(null)
-    setFridgeLife(0)
-    setFreezerLife(0)
-    setIngredients([])
-    setInstructions([])
-    setCuisine('')
-    setMealTypes([])
-    setErrors({})
-  }
   useEffect(() => {
     // Once the user has attempted a submit, keep the displayed errors in sync as
     // fields are fixed (assignErrors=true) so a corrected field clears its message
@@ -120,6 +136,7 @@ const AddRecipe: FC = () => {
   }, [
     title,
     recipeImage,
+    existingImageUrl,
     description,
     servings,
     prepTime,
@@ -128,11 +145,49 @@ const AddRecipe: FC = () => {
     mealTypes,
     hasAttemptedSubmit,
   ])
-  const handleAddRecipe = async () => {
+  const handleSubmit = async () => {
     if (addRecipeLoading) return
     setHasAttemptedSubmit(true)
-    if (validate(true)) {
-      setAddRecipeLoading(true)
+    if (!validate(true)) {
+      addRecipeFormRef?.current && addRecipeFormRef.current.scrollTo(0, 0)
+      return
+    }
+
+    setAddRecipeLoading(true)
+    if (isEditMode && initialRecipe) {
+      const editData: RecipeEditFormType = {
+        title,
+        prepTime: hrMinToMin(prepTime),
+        cookTime: hrMinToMin(cookTime),
+        servings: Number(servings),
+        fridgeLife,
+        freezerLife,
+        description,
+        ingredients,
+        instructions,
+        recipeImage,
+        cuisine,
+        mealTypes,
+      }
+      const result = await RecipeAPI.editRecipe(
+        initialRecipe._id,
+        editData,
+        initialRecipe,
+        setLoadingProgress
+      )
+      if (result === ADD_RECIPE_AUTH_ERROR) {
+        toast.error('Your session has expired — please sign in again and retry.')
+      } else if (result) {
+        // Drop stale cached copies so the recipe page and the user's created
+        // list reflect the edit immediately.
+        queryClient.invalidateQueries({ queryKey: ['recipe', initialRecipe._id] })
+        queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
+        toast.success('Recipe updated!')
+        navigate(`/recipes/${initialRecipe._id}`)
+      } else {
+        toast.error('Failed to update recipe. Please try again.')
+      }
+    } else {
       const recipeData: RecipeFormType = {
         title,
         prepTime: hrMinToMin(prepTime),
@@ -156,17 +211,15 @@ const AddRecipe: FC = () => {
       } else {
         toast.error('Failed to create recipe. Please try again.')
       }
-      setAddRecipeLoading(false)
-      setLoadingProgress(100)
-    } else {
-      addRecipeFormRef?.current && addRecipeFormRef.current.scrollTo(0, 0)
     }
+    setAddRecipeLoading(false)
+    setLoadingProgress(100)
   }
 
   return (
     <>
       <Helmet>
-        <title>Create New Recipe</title>
+        <title>{isEditMode ? 'Edit Recipe' : 'Create New Recipe'}</title>
         <link
           rel='canonical'
           href='https://www.prepifymeals.com/add-recipe'
@@ -182,7 +235,7 @@ const AddRecipe: FC = () => {
           progress={loadingProgress}
           onLoaderFinished={() => setLoadingProgress(0)}
         />
-        <h1>Create New Recipe</h1>
+        <h1>{isEditMode ? 'Edit Recipe' : 'Create New Recipe'}</h1>
         <div className='container'>
           <div className='container-inner' ref={addRecipeFormRef}>
             <div className='title input-field'>
@@ -204,7 +257,12 @@ const AddRecipe: FC = () => {
               {errors.image && (
                 <AddRecipeFormError error={errors.image} id='error-image' />
               )}
-              <ImagePicker image={recipeImage} setImage={setRecipeImage} />
+              <ImagePicker
+                image={recipeImage}
+                setImage={setRecipeImage}
+                initialPreviewUrl={existingImageUrl}
+                onRemove={() => setExistingImageUrl(undefined)}
+              />
             </div>
             <div className='description input-field'>
               <SectionHeader label='Description' required />
@@ -303,7 +361,8 @@ const AddRecipe: FC = () => {
           ingredients={ingredients}
           isValid={isFormValid}
           loading={addRecipeLoading}
-          onSubmit={handleAddRecipe}
+          onSubmit={handleSubmit}
+          submitLabel={isEditMode ? 'Save Changes' : 'Create Recipe'}
         />
       </div>
     </>

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -1,10 +1,13 @@
-import React, { FC, useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React, { FC, useEffect, useMemo, useRef, useState } from 'react'
+import axios from 'axios'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import {
   AddRecipeErrorType,
   IngredientsType,
   InstructionsType,
+  RecipeDraftContent,
+  RecipeDraftType,
   RecipeEditFormType,
   RecipeFormType,
   RecipeType,
@@ -36,6 +39,10 @@ import SectionHeader from 'src/pages/AddRecipe/SectionHeader'
 import AddRecipeSummaryBar from 'src/pages/AddRecipe/AddRecipeSummaryBar'
 import { Helmet } from 'react-helmet-async'
 import { toast } from 'react-hot-toast'
+import DraftAPI from 'src/api/drafts'
+import { useDraftAutosave } from 'src/pages/AddRecipe/useDraftAutosave'
+import DraftSaveStatus from 'src/pages/AddRecipe/DraftSaveStatus'
+import DraftResumeBanner from 'src/pages/AddRecipe/DraftResumeBanner'
 
 type TimeVal = { hours: number; minutes: number } | null
 
@@ -90,6 +97,143 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
 
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+
+  // ─── Draft autosave (create flow only) ──────────────────────────────────────
+  // Edit mode never touches drafts. In create mode the form is autosaved to a
+  // server-side draft so unfinished recipes survive a refresh or navigating
+  // away. The image is intentionally not part of a draft — it's re-picked on
+  // resume (publish validation still requires one).
+  const [searchParams, setSearchParams] = useSearchParams()
+  const urlDraftId = isEditMode ? null : searchParams.get('draftId')
+  const [draftId, setDraftId] = useState<string | null>(urlDraftId)
+  // "Hydrated" gates autosave: true for a fresh create, briefly false while a
+  // resumed draft loads into the fields.
+  const [hydrated, setHydrated] = useState(!urlDraftId)
+  // Draft ids whose content is already on screen — either just loaded here, or
+  // just created by autosave. The hydration effect skips these so our own URL
+  // updates (and a resume of the draft we're already editing) don't trigger a
+  // redundant reload.
+  const ownedDraftsRef = useRef<Set<string>>(new Set())
+
+  // Load the draft named in the URL whenever it points at one we haven't loaded
+  // yet. Runs on mount for `?draftId=…`, and again when the resume banner
+  // navigates to a draft while this page is already mounted — same route, so no
+  // remount happens on its own and a mount-only effect would never re-fire.
+  useEffect(() => {
+    if (isEditMode || !urlDraftId || ownedDraftsRef.current.has(urlDraftId)) return
+    let cancelled = false
+    setHydrated(false)
+    DraftAPI.getDraft(urlDraftId)
+      .then(draft => {
+        if (cancelled) return
+        ownedDraftsRef.current.add(urlDraftId)
+        if (draft) {
+          setDraftId(urlDraftId)
+          setTitle(draft.title ?? '')
+          setDescription(draft.description ?? '')
+          setServings(draft.servings ?? '')
+          setPrepTime(draft.prepTime != null ? minToHrMin(draft.prepTime) : null)
+          setCookTime(draft.cookTime != null ? minToHrMin(draft.cookTime) : null)
+          setFridgeLife(draft.fridgeLife ?? 0)
+          setFreezerLife(draft.freezerLife ?? 0)
+          setIngredients(draft.ingredients ?? [])
+          setInstructions(draft.instructions ?? [])
+          setCuisine(draft.cuisine ?? '')
+          setMealTypes(draft.mealTypes ?? [])
+        }
+        setHydrated(true)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        const status = axios.isAxiosError(err) ? err.response?.status : undefined
+        if (status === 404 || status === 403) {
+          // The draft is genuinely gone or not the caller's. Drop only the
+          // draftId param (preserving any other query params) and let the user
+          // start a fresh draft.
+          toast.error("Couldn't load that draft — starting a new one.")
+          setDraftId(null)
+          const next = new URLSearchParams(searchParams)
+          next.delete('draftId')
+          setSearchParams(next, { replace: true })
+          setHydrated(true)
+        } else {
+          // Transient failure (network/5xx) on a draft that likely still
+          // exists. Leave autosave disabled (hydrated stays false) so we don't
+          // create a duplicate or overwrite the unloaded draft with a partial
+          // form; ask the user to retry.
+          toast.error('Could not load your draft. Refresh to try again.')
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlDraftId])
+
+  // Serializable draft content mirrored from form state. Times are stored as
+  // minutes (matching the recipe shape); empty values are omitted.
+  const draftContent: RecipeDraftContent = useMemo(
+    () => ({
+      title,
+      description,
+      // Send explicit null (not undefined) when empty so clearing a field is
+      // persisted rather than silently dropped from the payload — see
+      // RecipeDraftContent.
+      servings: servings === '' ? null : Number(servings),
+      prepTime: prepTime ? hrMinToMin(prepTime) : null,
+      cookTime: cookTime ? hrMinToMin(cookTime) : null,
+      fridgeLife,
+      freezerLife,
+      ingredients,
+      instructions,
+      cuisine,
+      mealTypes,
+    }),
+    [
+      title,
+      description,
+      servings,
+      prepTime,
+      cookTime,
+      fridgeLife,
+      freezerLife,
+      ingredients,
+      instructions,
+      cuisine,
+      mealTypes,
+    ]
+  )
+
+  // A brand-new draft is only created once the recipe has a title. This gates
+  // out throwaway drafts from a stray keystroke (keeping the Drafts list and the
+  // per-user draft count clean); updating an existing draft is unaffected.
+  const canCreateDraft = !!title.trim()
+
+  const { status: draftStatus, clearDraft } = useDraftAutosave({
+    content: draftContent,
+    enabled: !isEditMode && hydrated,
+    canCreate: canCreateDraft,
+    draftId,
+    onDraftCreated: (draft: RecipeDraftType) => {
+      // Mark as owned before the URL sync below points the URL at it, so the
+      // hydration effect doesn't reload the draft we just created.
+      ownedDraftsRef.current.add(draft._id)
+      setDraftId(draft._id)
+      queryClient.invalidateQueries({ queryKey: ['drafts'] })
+    },
+    onLimitReached: (message: string) => toast.error(message),
+  })
+
+  // Reflect the active draft id in the URL (replace) so a refresh resumes the
+  // same draft rather than starting a second one.
+  useEffect(() => {
+    if (isEditMode || !draftId) return
+    if (searchParams.get('draftId') === draftId) return
+    const next = new URLSearchParams(searchParams)
+    next.set('draftId', draftId)
+    setSearchParams(next, { replace: true })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftId])
 
   const validate = (assignErrors: boolean = false) => {
     let newErrors: Partial<AddRecipeErrorType> = {}
@@ -197,6 +341,10 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
       if (newId === ADD_RECIPE_AUTH_ERROR) {
         toast.error('Your session has expired — please sign in again and retry.')
       } else if (newId) {
+        // Recipe is live — remove the now-redundant draft (and stop autosave
+        // from recreating it on unmount) before navigating away.
+        await clearDraft()
+        queryClient.invalidateQueries({ queryKey: ['drafts'] })
         toast.success('Recipe published!')
         navigate(`/recipes/${newId}`)
       } else {
@@ -230,7 +378,11 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
           progress={loadingProgress}
           onLoaderFinished={() => setLoadingProgress(0)}
         />
-        <h1>{isEditMode ? 'Edit Recipe' : 'Create New Recipe'}</h1>
+        <div className='add-recipe-heading'>
+          <h1>{isEditMode ? 'Edit Recipe' : 'Create New Recipe'}</h1>
+          {!isEditMode && <DraftSaveStatus status={draftStatus} />}
+        </div>
+        {!isEditMode && !draftId && <DraftResumeBanner />}
         <div className='container'>
           <div className='container-inner' ref={addRecipeFormRef}>
             <div className='title input-field'>

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -154,21 +154,23 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
     }
 
     setAddRecipeLoading(true)
+    // Shared form-state → payload mapping; the two branches differ only in the
+    // image field (optional on edit, required on create) and which API they call.
+    const formData = {
+      title,
+      prepTime: hrMinToMin(prepTime),
+      cookTime: hrMinToMin(cookTime),
+      servings: Number(servings),
+      fridgeLife,
+      freezerLife,
+      description,
+      ingredients,
+      instructions,
+      cuisine,
+      mealTypes,
+    }
     if (isEditMode && initialRecipe) {
-      const editData: RecipeEditFormType = {
-        title,
-        prepTime: hrMinToMin(prepTime),
-        cookTime: hrMinToMin(cookTime),
-        servings: Number(servings),
-        fridgeLife,
-        freezerLife,
-        description,
-        ingredients,
-        instructions,
-        recipeImage,
-        cuisine,
-        mealTypes,
-      }
+      const editData: RecipeEditFormType = { ...formData, recipeImage }
       const result = await RecipeAPI.editRecipe(
         initialRecipe._id,
         editData,
@@ -190,20 +192,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
         toast.error(result.message)
       }
     } else {
-      const recipeData: RecipeFormType = {
-        title,
-        prepTime: hrMinToMin(prepTime),
-        cookTime: hrMinToMin(cookTime),
-        servings: Number(servings),
-        fridgeLife,
-        freezerLife,
-        description,
-        ingredients,
-        instructions,
-        recipeImage: recipeImage!,
-        cuisine,
-        mealTypes,
-      }
+      const recipeData: RecipeFormType = { ...formData, recipeImage: recipeImage! }
       const newId = await RecipeAPI.addRecipe(recipeData, setLoadingProgress)
       if (newId === ADD_RECIPE_AUTH_ERROR) {
         toast.error('Your session has expired — please sign in again and retry.')
@@ -224,7 +213,11 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
         <title>{isEditMode ? 'Edit Recipe' : 'Create New Recipe'}</title>
         <link
           rel='canonical'
-          href='https://www.prepifymeals.com/add-recipe'
+          href={
+            isEditMode && initialRecipe
+              ? `https://www.prepifymeals.com/recipes/${initialRecipe._id}`
+              : 'https://www.prepifymeals.com/add-recipe'
+          }
         />
         <meta
           name='description'

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useEffect, useMemo, useRef, useState } from 'react'
 import axios from 'axios'
+import { AiOutlineInfoCircle } from 'react-icons/ai'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import {
@@ -114,6 +115,10 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
   // updates (and a resume of the draft we're already editing) don't trigger a
   // redundant reload.
   const ownedDraftsRef = useRef<Set<string>>(new Set())
+  // True once a draft was resumed (loaded from the server) this session, used to
+  // remind the user to re-add the image — drafts don't persist it. Not set for
+  // drafts created in the current session (the user never had an image to lose).
+  const [resumedFromDraft, setResumedFromDraft] = useState(false)
 
   // Load the draft named in the URL whenever it points at one we haven't loaded
   // yet. Runs on mount for `?draftId=…`, and again when the resume banner
@@ -140,6 +145,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
           setInstructions(draft.instructions ?? [])
           setCuisine(draft.cuisine ?? '')
           setMealTypes(draft.mealTypes ?? [])
+          setResumedFromDraft(true)
         }
         setHydrated(true)
       })
@@ -403,6 +409,12 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
               <SectionHeader label='Select Image' required />
               {errors.image && (
                 <AddRecipeFormError error={errors.image} id='error-image' />
+              )}
+              {resumedFromDraft && !recipeImage && (
+                <p className='draft-image-hint'>
+                  <AiOutlineInfoCircle className='icon' />
+                  Drafts don't save your image — add it again before publishing.
+                </p>
               )}
               <ImagePicker
                 image={recipeImage}

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -363,6 +363,11 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
           loading={addRecipeLoading}
           onSubmit={handleSubmit}
           submitLabel={isEditMode ? 'Save Changes' : 'Create Recipe'}
+          onCancel={
+            isEditMode && initialRecipe
+              ? () => navigate(`/recipes/${initialRecipe._id}`)
+              : undefined
+          }
         />
       </div>
     </>

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -175,17 +175,19 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
         initialRecipe,
         setLoadingProgress
       )
-      if (result === ADD_RECIPE_AUTH_ERROR) {
+      if (result.status === 'auth-error') {
         toast.error('Your session has expired — please sign in again and retry.')
-      } else if (result) {
-        // Drop stale cached copies so the recipe page and the user's created
-        // list reflect the edit immediately.
-        queryClient.invalidateQueries({ queryKey: ['recipe', initialRecipe._id] })
+      } else if (result.status === 'success') {
+        // Write the server's updated recipe straight into the cache rather than
+        // invalidating: invalidation would refetch GET /getRecipe (which bumps
+        // the public view counter) and briefly flash stale data. The created
+        // list still needs a refetch to reorder/relabel.
+        queryClient.setQueryData(['recipe', initialRecipe._id], result.recipe)
         queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
         toast.success('Recipe updated!')
         navigate(`/recipes/${initialRecipe._id}`)
       } else {
-        toast.error('Failed to update recipe. Please try again.')
+        toast.error(result.message)
       }
     } else {
       const recipeData: RecipeFormType = {

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.scss
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.scss
@@ -50,6 +50,40 @@
     }
   }
 
+  .summary-actions {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .cancel-btn {
+    flex-shrink: 0;
+    height: 46px;
+    padding: 0 1.25rem;
+    border-radius: s.$border-radius;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    outline: none;
+    background: none;
+    color: s.$secondary-text;
+    border: 1px solid s.$tertiary-background;
+    transition: all 0.1s linear;
+
+    &:hover {
+      color: s.$primary-text;
+      border-color: s.$tertiary-text;
+    }
+    &:focus {
+      @include s.outline();
+    }
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
   .submit-btn {
     display: flex;
     justify-content: center;
@@ -109,6 +143,11 @@
     .submit-btn {
       width: 132px;
       height: 42px;
+      font-size: 0.9rem;
+    }
+    .cancel-btn {
+      height: 42px;
+      padding: 0 0.9rem;
       font-size: 0.9rem;
     }
   }

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
@@ -16,6 +16,8 @@ interface AddRecipeSummaryBarProps {
   loading: boolean
   onSubmit: () => void
   submitLabel?: string
+  // When provided (edit mode), renders a Cancel button alongside submit.
+  onCancel?: () => void
 }
 
 const formatTime = (totalMin: number): string => {
@@ -41,6 +43,7 @@ const AddRecipeSummaryBar: FC<AddRecipeSummaryBarProps> = ({
   loading,
   onSubmit,
   submitLabel = 'Create Recipe',
+  onCancel,
 }) => {
   const ingredientCount = useMemo(
     () => ingredients.filter(ingr => 'parsedIngredient' in ingr).length,
@@ -77,23 +80,35 @@ const AddRecipeSummaryBar: FC<AddRecipeSummaryBarProps> = ({
             </dd>
           </div>
         </dl>
-        <button
-          className={`submit-btn ${isValid ? 'valid' : 'invalid'}`}
-          disabled={loading}
-          aria-busy={loading}
-          onClick={onSubmit}
-        >
-          {loading ? (
-            <TailSpin
-              height='28'
-              width='28'
-              color='white'
-              ariaLabel='loading'
-            />
-          ) : (
-            submitLabel
+        <div className='summary-actions'>
+          {onCancel && (
+            <button
+              type='button'
+              className='cancel-btn'
+              disabled={loading}
+              onClick={onCancel}
+            >
+              Cancel
+            </button>
           )}
-        </button>
+          <button
+            className={`submit-btn ${isValid ? 'valid' : 'invalid'}`}
+            disabled={loading}
+            aria-busy={loading}
+            onClick={onSubmit}
+          >
+            {loading ? (
+              <TailSpin
+                height='28'
+                width='28'
+                color='white'
+                ariaLabel='loading'
+              />
+            ) : (
+              submitLabel
+            )}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
@@ -15,6 +15,7 @@ interface AddRecipeSummaryBarProps {
   isValid: boolean
   loading: boolean
   onSubmit: () => void
+  submitLabel?: string
 }
 
 const formatTime = (totalMin: number): string => {
@@ -39,6 +40,7 @@ const AddRecipeSummaryBar: FC<AddRecipeSummaryBarProps> = ({
   isValid,
   loading,
   onSubmit,
+  submitLabel = 'Create Recipe',
 }) => {
   const ingredientCount = useMemo(
     () => ingredients.filter(ingr => 'parsedIngredient' in ingr).length,
@@ -89,7 +91,7 @@ const AddRecipeSummaryBar: FC<AddRecipeSummaryBarProps> = ({
               ariaLabel='loading'
             />
           ) : (
-            'Create Recipe'
+            submitLabel
           )}
         </button>
       </div>

--- a/src/pages/AddRecipe/DraftResumeBanner.scss
+++ b/src/pages/AddRecipe/DraftResumeBanner.scss
@@ -1,0 +1,132 @@
+@use '../../helpers.scss' as s;
+
+.draft-resume-banner {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  box-sizing: border-box;
+  // Match the form card's footprint (width 95%, max 800) so it lines up with
+  // the card edges below it.
+  width: 95%;
+  max-width: 800px;
+  background: s.$white;
+  border: 1px solid s.$gray-300;
+  border-left: 3px solid s.$primary;
+  border-radius: s.$border-radius;
+  padding: 0.75rem 1.25rem;
+
+  @media screen and (max-width: 560px) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.85rem;
+    padding: 0.9rem 1rem;
+  }
+
+  .banner-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 0;
+
+    .banner-title {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: s.$primary-text;
+    }
+
+    .banner-sub {
+      font-size: 0.85rem;
+      color: s.$tertiary-text;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      // On phones a single ellipsed line cuts the title off almost immediately
+      // (the "Pick up where you left off on …" prefix eats the width). Let it
+      // wrap to a tidy two lines instead so the recipe name is actually visible.
+      @media screen and (max-width: 560px) {
+        white-space: normal;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+      }
+    }
+
+    // Keep the text clear of the corner dismiss button when stacked.
+    @media screen and (max-width: 560px) {
+      padding-right: 1.75rem;
+    }
+  }
+
+  .banner-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-shrink: 0;
+
+    @media screen and (max-width: 560px) {
+      width: 100%;
+      gap: 0.85rem;
+    }
+
+    .resume-btn {
+      cursor: pointer;
+      font-size: 0.85rem;
+      font-weight: 600;
+      white-space: nowrap;
+      padding: 0.4rem 0.9rem;
+      border-radius: s.$border-radius;
+      border: 1px solid s.$primary;
+      background: s.$primary;
+      color: s.$white;
+      transition: filter 0.1s linear;
+
+      &:hover {
+        filter: brightness(108%);
+      }
+
+      // Comfortable full-width tap target on phones.
+      @media screen and (max-width: 560px) {
+        flex: 1;
+        padding: 0.6rem 0.9rem;
+      }
+    }
+
+    .view-all {
+      font-size: 0.85rem;
+      color: s.$tertiary-text;
+      text-decoration: none;
+      white-space: nowrap;
+
+      &:hover {
+        color: s.$primary-text;
+        text-decoration: underline;
+      }
+    }
+
+    .dismiss-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: s.$tertiary-text;
+      padding: 0.25rem;
+      font-size: 1rem;
+
+      &:hover {
+        color: s.$primary-text;
+      }
+
+      // Tuck into the top-right corner so the stacked layout reads cleanly.
+      @media screen and (max-width: 560px) {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+      }
+    }
+  }
+}

--- a/src/pages/AddRecipe/DraftResumeBanner.tsx
+++ b/src/pages/AddRecipe/DraftResumeBanner.tsx
@@ -1,0 +1,63 @@
+import React, { FC, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { AiOutlineClose } from 'react-icons/ai'
+import DraftAPI from 'src/api/drafts'
+import './DraftResumeBanner.scss'
+
+// Shown at the top of the create-recipe page when the user already has saved
+// drafts and isn't currently editing one. Offers a one-click resume of the most
+// recent draft plus a link to the full Drafts list. Hidden in edit mode and
+// once the current session has an active draft (see AddRecipe).
+const DraftResumeBanner: FC = () => {
+  const navigate = useNavigate()
+  const [dismissed, setDismissed] = useState(false)
+
+  const { data: drafts } = useQuery({
+    queryKey: ['drafts'],
+    queryFn: () => DraftAPI.listDrafts(),
+  })
+
+  if (dismissed || !drafts || drafts.length === 0) return null
+
+  // listDrafts returns newest-updated first.
+  const mostRecent = drafts[0]
+  const title = mostRecent.title?.trim() ? mostRecent.title : 'Untitled draft'
+
+  return (
+    <div className='draft-resume-banner'>
+      <div className='banner-text'>
+        <span className='banner-title'>
+          {drafts.length === 1
+            ? 'You have a saved draft'
+            : `You have ${drafts.length} saved drafts`}
+        </span>
+        <span className='banner-sub'>
+          Pick up where you left off on “{title}”.
+        </span>
+      </div>
+      <div className='banner-actions'>
+        <button
+          type='button'
+          className='resume-btn'
+          onClick={() => navigate(`/add-recipe?draftId=${mostRecent._id}`)}
+        >
+          Resume
+        </button>
+        <Link to='/account/drafts' className='view-all'>
+          View all drafts
+        </Link>
+        <button
+          type='button'
+          className='dismiss-btn'
+          aria-label='Dismiss'
+          onClick={() => setDismissed(true)}
+        >
+          <AiOutlineClose />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default DraftResumeBanner

--- a/src/pages/AddRecipe/DraftSaveStatus.scss
+++ b/src/pages/AddRecipe/DraftSaveStatus.scss
@@ -1,0 +1,27 @@
+@use '../../helpers.scss' as s;
+
+.draft-save-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  // Reserve the line height even when idle/empty so showing or hiding the
+  // status never nudges the form below it.
+  min-height: 1.25rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: s.$tertiary-text;
+
+  svg {
+    font-size: 1rem;
+    flex-shrink: 0;
+  }
+
+  &.saved {
+    color: s.$primary;
+  }
+
+  &.error {
+    color: s.$error-red;
+  }
+}

--- a/src/pages/AddRecipe/DraftSaveStatus.tsx
+++ b/src/pages/AddRecipe/DraftSaveStatus.tsx
@@ -1,0 +1,35 @@
+import React, { FC } from 'react'
+import { AiOutlineCheckCircle, AiOutlineCloud } from 'react-icons/ai'
+import { BiErrorCircle } from 'react-icons/bi'
+import { DraftStatus } from 'src/pages/AddRecipe/useDraftAutosave'
+import './DraftSaveStatus.scss'
+
+type DraftSaveStatusProps = { status: DraftStatus }
+
+const content: Record<
+  Exclude<DraftStatus, 'idle'>,
+  { icon: React.ReactElement; label: string }
+> = {
+  saving: { icon: <AiOutlineCloud />, label: 'Saving draft…' },
+  saved: { icon: <AiOutlineCheckCircle />, label: 'Draft saved' },
+  error: { icon: <BiErrorCircle />, label: "Couldn't save draft" },
+}
+
+// Small inline indicator beneath the page heading reflecting draft autosave
+// state. The element is always rendered (a fixed-height, empty slot when idle)
+// so transitions between states never shift the form below it.
+const DraftSaveStatus: FC<DraftSaveStatusProps> = ({ status }) => {
+  const current = status === 'idle' ? null : content[status]
+  return (
+    <span className={`draft-save-status ${status}`} aria-live='polite'>
+      {current && (
+        <>
+          {current.icon}
+          {current.label}
+        </>
+      )}
+    </span>
+  )
+}
+
+export default DraftSaveStatus

--- a/src/pages/AddRecipe/ImagePicker/ImagePicker.tsx
+++ b/src/pages/AddRecipe/ImagePicker/ImagePicker.tsx
@@ -9,11 +9,24 @@ const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp']
 interface ImagePickerProps {
   image: File | undefined
   setImage: React.Dispatch<React.SetStateAction<File | undefined>>
+  // Edit mode: the recipe's existing image URL, shown as the initial preview so
+  // the field isn't empty when no new file has been picked yet.
+  initialPreviewUrl?: string
+  // Edit mode: fires when the user clears the image, so the parent can drop the
+  // existing-image URL it tracks for validation.
+  onRemove?: () => void
 }
 
-const ImagePicker: React.FC<ImagePickerProps> = ({ image, setImage }) => {
+const ImagePicker: React.FC<ImagePickerProps> = ({
+  image,
+  setImage,
+  initialPreviewUrl,
+  onRemove,
+}) => {
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const [imagePreview, setImagePreview] = useState<string | undefined>()
+  const [imagePreview, setImagePreview] = useState<string | undefined>(
+    initialPreviewUrl
+  )
 
   const resetInput = () => {
     if (fileInputRef.current) fileInputRef.current.value = ''
@@ -82,6 +95,7 @@ const ImagePicker: React.FC<ImagePickerProps> = ({ image, setImage }) => {
     setImage(undefined)
     setImagePreview(undefined)
     resetInput()
+    onRemove?.()
   }
 
   return (

--- a/src/pages/AddRecipe/useDraftAutosave.ts
+++ b/src/pages/AddRecipe/useDraftAutosave.ts
@@ -1,0 +1,215 @@
+import { useEffect, useRef, useState } from 'react'
+import axios from 'axios'
+import { RecipeDraftContent, RecipeDraftType } from 'types'
+import DraftAPI, { DRAFT_LIMIT_CODE } from 'src/api/drafts'
+
+export type DraftStatus = 'idle' | 'saving' | 'saved' | 'error'
+
+// How long after the last edit we wait before autosaving. Long enough that
+// typing doesn't fire a request per keystroke, short enough that work isn't
+// lost if the tab is closed soon after.
+const AUTOSAVE_DELAY = 1500
+
+// The server rejects a new draft past the per-user cap with a 409 + this code.
+function isDraftLimitError(err: unknown): boolean {
+  return (
+    axios.isAxiosError(err) &&
+    err.response?.status === 409 &&
+    (err.response.data as { code?: string } | undefined)?.code ===
+      DRAFT_LIMIT_CODE
+  )
+}
+
+type Params = {
+  // Serializable draft content derived from the form state (no image).
+  content: RecipeDraftContent
+  // Autosave only runs when true: create-mode, and after any resume-hydration
+  // has finished. The first time this flips true the *current* content becomes
+  // the saved baseline (so resuming a draft, or landing on an empty form,
+  // doesn't immediately fire a redundant save).
+  enabled: boolean
+  // Whether a brand-new draft may be created for the current content. Gated on
+  // the form having a title, so a stray keystroke doesn't spawn a throwaway
+  // draft. Only governs creation — an existing draft (draftId set) is always
+  // updated, so clearing fields still persists.
+  canCreate: boolean
+  // The current draft's id, or null until the first save creates one.
+  draftId: string | null
+  // Called once with the created draft after the first successful save so the
+  // caller can adopt the new id (and reflect it in the URL).
+  onDraftCreated: (draft: RecipeDraftType) => void
+  // Called when creation is rejected because the user is at their draft cap,
+  // with the server's message. The caller surfaces it (e.g. a toast).
+  onLimitReached?: (message: string) => void
+}
+
+type DraftAutosave = {
+  status: DraftStatus
+  // Deletes the current draft and disables further autosave. Call after the
+  // recipe is published so the now-redundant draft is cleaned up and the
+  // unmount flush can't recreate it.
+  clearDraft: () => Promise<void>
+}
+
+export function useDraftAutosave({
+  content,
+  enabled,
+  canCreate,
+  draftId,
+  onDraftCreated,
+  onLimitReached,
+}: Params): DraftAutosave {
+  const [status, setStatus] = useState<DraftStatus>('idle')
+
+  // Latest values mirrored into refs so the debounce timer and unmount flush
+  // read current data without being part of their dependency lists.
+  const contentRef = useRef(content)
+  const canCreateRef = useRef(canCreate)
+  const draftIdRef = useRef(draftId)
+  const enabledRef = useRef(enabled)
+  contentRef.current = content
+  canCreateRef.current = canCreate
+  draftIdRef.current = draftId
+  enabledRef.current = enabled
+
+  // Serialized snapshot of the content we last persisted, so a save is skipped
+  // when nothing actually changed.
+  const lastSavedRef = useRef<string | null>(null)
+  // Tracks the enabled edge so we can re-establish the baseline each time
+  // autosave (re)activates — on mount, and again after a resume re-hydrates the
+  // form — without ever treating freshly loaded content as an unsaved edit.
+  const prevEnabledRef = useRef(false)
+  // Set once the recipe is published: stops the unmount flush from recreating
+  // the draft we just deleted.
+  const disabledRef = useRef(false)
+  // True while a save request is in flight. Prevents a fast typist from firing
+  // a second createDraft (→ duplicate drafts) before the first resolves; the
+  // finally block re-runs once for any edits made during the request.
+  const inFlightRef = useRef(false)
+  // Set once the server rejects creation at the draft cap. Stops further create
+  // attempts this session so we don't fire a failing POST on every keystroke.
+  const capReachedRef = useRef(false)
+  const onDraftCreatedRef = useRef(onDraftCreated)
+  const onLimitReachedRef = useRef(onLimitReached)
+  onDraftCreatedRef.current = onDraftCreated
+  onLimitReachedRef.current = onLimitReached
+
+  const saveNow = async () => {
+    // `enabled` is false in edit mode (and before a resume finishes hydrating);
+    // never persist a draft then — most importantly, the unmount flush must not
+    // create a draft out of a recipe the user was only editing.
+    if (!enabledRef.current || disabledRef.current || inFlightRef.current) return
+    const snapshot = JSON.stringify(contentRef.current)
+    if (snapshot === lastSavedRef.current) return
+    const id = draftIdRef.current
+    // Creating a new draft requires a title (canCreate) and that we're not
+    // already at the cap. Updates to an existing draft are always allowed.
+    if (!id && (!canCreateRef.current || capReachedRef.current)) return
+    inFlightRef.current = true
+    try {
+      setStatus('saving')
+      let persisted = false
+      if (id) {
+        const updated = await DraftAPI.updateDraft(id, contentRef.current)
+        persisted = !!updated
+      } else {
+        const created = await DraftAPI.createDraft(contentRef.current)
+        if (created) {
+          // A publish (clearDraft) can land while this create is in flight, when
+          // there's no id yet for clearDraft to delete. If that happened, this
+          // draft is now redundant — delete it instead of adopting it, so the
+          // published recipe doesn't leave an orphaned draft behind.
+          if (disabledRef.current) {
+            void DraftAPI.deleteDraft(created._id).catch(err =>
+              console.error('Failed to delete draft created during publish:', err)
+            )
+            return
+          }
+          // Adopt the id immediately so a save that fires before the parent
+          // re-renders updates this draft instead of creating a second one.
+          draftIdRef.current = created._id
+          onDraftCreatedRef.current(created)
+          persisted = true
+        }
+      }
+      if (persisted) {
+        lastSavedRef.current = snapshot
+        setStatus('saved')
+      } else {
+        // A null result means the request never went out (e.g. no auth), so the
+        // draft was NOT saved. Surface it rather than falsely showing "saved",
+        // and leave the baseline untouched so a later edit retries.
+        setStatus('error')
+      }
+    } catch (err) {
+      if (isDraftLimitError(err)) {
+        // At the per-user cap. Stop trying to create new drafts this session and
+        // let the caller tell the user (with the server's message) to free space.
+        capReachedRef.current = true
+        const message =
+          (axios.isAxiosError(err) &&
+            (err.response?.data as { error?: string } | undefined)?.error) ||
+          'You have too many saved drafts. Delete some to start a new one.'
+        onLimitReachedRef.current?.(message)
+      } else {
+        console.error('Draft autosave failed:', err)
+      }
+      setStatus('error')
+    } finally {
+      inFlightRef.current = false
+      // Re-run only if new edits arrived while this save was in flight. Compare
+      // against the snapshot we just attempted (not the saved baseline): a
+      // non-persisting result leaves the baseline stale, and comparing to it
+      // would spin in a tight retry loop.
+      if (
+        !disabledRef.current &&
+        JSON.stringify(contentRef.current) !== snapshot
+      ) {
+        void saveNow()
+      }
+    }
+  }
+
+  // Debounced autosave on content changes.
+  useEffect(() => {
+    if (!enabled) {
+      prevEnabledRef.current = false
+      return
+    }
+    // Just (re)enabled — on mount, or after a resume loaded a draft into the
+    // form. Treat whatever is on screen as the saved baseline rather than
+    // saving it back.
+    if (!prevEnabledRef.current) {
+      prevEnabledRef.current = true
+      lastSavedRef.current = JSON.stringify(content)
+      return
+    }
+    if (JSON.stringify(content) === lastSavedRef.current) return
+    if (!draftId && (!canCreate || capReachedRef.current)) return
+    const timer = setTimeout(saveNow, AUTOSAVE_DELAY)
+    return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content, enabled, draftId, canCreate])
+
+  // Flush pending (debounced) changes when leaving the page mid-edit. saveNow
+  // no-ops when autosave isn't enabled, so this is safe in edit mode.
+  useEffect(() => {
+    return () => {
+      void saveNow()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const clearDraft = async () => {
+    disabledRef.current = true
+    const id = draftIdRef.current
+    if (!id) return
+    try {
+      await DraftAPI.deleteDraft(id)
+    } catch (err) {
+      console.error('Failed to delete draft after publish:', err)
+    }
+  }
+
+  return { status, clearDraft }
+}

--- a/src/pages/CreateUsername/CreateUsername.scss
+++ b/src/pages/CreateUsername/CreateUsername.scss
@@ -1,0 +1,23 @@
+@use '../../helpers.scss' as s;
+
+.create-username-page {
+  .loading-state {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 200px;
+  }
+
+  .logout-prompt {
+    margin-top: 1rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-decoration: underline;
+    font-weight: 500;
+    font-size: 0.875rem;
+    color: s.$secondary-text;
+    width: fit-content;
+    align-self: center;
+  }
+}

--- a/src/pages/CreateUsername/CreateUsername.tsx
+++ b/src/pages/CreateUsername/CreateUsername.tsx
@@ -36,7 +36,7 @@ const CreateUsername: FC = () => {
       return
     }
     let cancelled = false
-    AuthAPI.getUsername(user.uid)
+    AuthAPI.getUsername()
       .then(username => {
         if (cancelled) return
         if (username) navigate('/')

--- a/src/pages/CreateUsername/CreateUsername.tsx
+++ b/src/pages/CreateUsername/CreateUsername.tsx
@@ -3,6 +3,7 @@ import '../../Components/Form/FormStyles.scss'
 import './CreateUsername.scss'
 import { TailSpin } from 'react-loader-spinner'
 import { useNavigate } from 'react-router-dom'
+import toast from 'react-hot-toast'
 import UsernameInput from 'src/Components/Form/UsernameInput'
 import AuthAPI from 'src/api/auth'
 import { useAuth } from 'src/context/AuthContext'
@@ -19,7 +20,6 @@ const CreateUsername: FC = () => {
   const [checkingExisting, setCheckingExisting] = useState(true)
 
   const [error, setError] = useState('')
-  const [success, setSuccess] = useState('')
 
   const navigate = useNavigate()
 
@@ -64,12 +64,13 @@ const CreateUsername: FC = () => {
 
     setLoadingCreateUsername(true)
     setError('')
-    setSuccess('')
 
     AuthAPI.setUsername(currUsername)
       .then(() => {
         setLoadingCreateUsername(false)
-        setSuccess('Username Created Successfully!')
+        // A toast (rendered at the app root) survives the redirect, unlike an
+        // inline message on a page we immediately navigate away from.
+        toast.success('Username created successfully!')
         navigate('/')
       })
       .catch((error: unknown) => {
@@ -96,13 +97,12 @@ const CreateUsername: FC = () => {
           <p className='prompt'>
             Create a unique username to identify yourself with.
           </p>
-          {success ? <div className='success'>{success}</div> : null}
           {error ? <div className='error'>{error}</div> : null}
           <div className='input-fields'>
             <UsernameInput
               username={currUsername}
               setUsername={setCurrUsername}
-              setSuccess={setSuccess}
+              setSuccess={() => {}}
               setError={setError}
               isUsernameAvailable={isUsernameAvailable}
               setIsUsernameAvailable={setIsUsernameAvailable}

--- a/src/pages/CreateUsername/CreateUsername.tsx
+++ b/src/pages/CreateUsername/CreateUsername.tsx
@@ -1,10 +1,11 @@
-import React, { ChangeEvent, FC, useState } from 'react'
+import React, { ChangeEvent, FC, useEffect, useState } from 'react'
 import '../../Components/Form/FormStyles.scss'
 import './CreateUsername.scss'
 import { TailSpin } from 'react-loader-spinner'
 import { useNavigate } from 'react-router-dom'
 import UsernameInput from 'src/Components/Form/UsernameInput'
 import AuthAPI from 'src/api/auth'
+import { useAuth } from 'src/context/AuthContext'
 
 const CreateUsername: FC = () => {
   const [currUsername, setCurrUsername] = useState('')
@@ -13,33 +14,78 @@ const CreateUsername: FC = () => {
   >(null)
 
   const [loadingCreateUsername, setLoadingCreateUsername] = useState(false)
+  // Block rendering the form until we've confirmed the user actually needs it,
+  // so a user who already has a username never sees a flash of the form.
+  const [checkingExisting, setCheckingExisting] = useState(true)
 
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
 
   const navigate = useNavigate()
 
-  const uid = AuthAPI.getUID()
+  const auth = useAuth()
+  const user = auth?.user ?? null
+  const authLoading = auth?.authLoading ?? false
+
+  // Guard the page: only username-less, signed-in users belong here. Send
+  // everyone else away rather than letting them set/overwrite a username.
+  useEffect(() => {
+    if (authLoading) return
+    if (!user) {
+      navigate('/login')
+      return
+    }
+    let cancelled = false
+    AuthAPI.getUsername(user.uid)
+      .then(username => {
+        if (cancelled) return
+        if (username) navigate('/')
+        else setCheckingExisting(false)
+      })
+      .catch(() => {
+        // If we can't confirm, let them proceed — setting a username is
+        // idempotent and the server still enforces uniqueness.
+        if (!cancelled) setCheckingExisting(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [authLoading, user, navigate])
 
   const handleCreateUsernameForm = (e: ChangeEvent<HTMLFormElement>) => {
-    if (uid && isUsernameAvailable) {
-      e.preventDefault()
-      setLoadingCreateUsername(true)
+    e.preventDefault()
 
-      setError('')
-      setSuccess('')
-
-      AuthAPI.setUsername(currUsername)
-        .then(() => {
-          setLoadingCreateUsername(false)
-          setSuccess('Username Created Successfully!')
-          navigate('/')
-        })
-        .catch((error: unknown) => {
-          setLoadingCreateUsername(false)
-          setError(error instanceof Error ? error.message : String(error))
-        })
+    const uid = user?.uid
+    if (!uid) {
+      setError('You must be signed in to create a username.')
+      return
     }
+    if (!isUsernameAvailable) return
+
+    setLoadingCreateUsername(true)
+    setError('')
+    setSuccess('')
+
+    AuthAPI.setUsername(currUsername)
+      .then(() => {
+        setLoadingCreateUsername(false)
+        setSuccess('Username Created Successfully!')
+        navigate('/')
+      })
+      .catch((error: unknown) => {
+        setLoadingCreateUsername(false)
+        setError(error instanceof Error ? error.message : String(error))
+      })
+  }
+
+  if (authLoading || checkingExisting) {
+    return (
+      <div className='create-username-page form-format'>
+        <div className='login-form-container loading-state'>
+          <TailSpin height='50' width='50' color='gray' ariaLabel='loading' />
+        </div>
+      </div>
+    )
   }
 
   return (
@@ -76,6 +122,13 @@ const CreateUsername: FC = () => {
             ) : (
               'Create Username'
             )}
+          </button>
+          <button
+            type='button'
+            className='logout-prompt'
+            onClick={() => auth?.logout()}
+          >
+            Cancel and log out
           </button>
         </form>
       </div>

--- a/src/pages/EditRecipe/EditRecipe.tsx
+++ b/src/pages/EditRecipe/EditRecipe.tsx
@@ -20,22 +20,23 @@ const EditRecipe: FC = () => {
 
   const {
     data: recipe,
-    isPending: recipePending,
+    isPending,
     isError,
   } = useQuery({
     queryKey: ['recipe', recipeId],
     queryFn: () => RecipeAPI.getRecipe(recipeId!),
     enabled: !!recipeId,
+    // Reuse the copy SingleRecipe already cached. GET /getRecipe increments the
+    // public view counter, so refetching just to open the editor would inflate
+    // it; serving the cache avoids that on the common (click-Edit) path.
+    staleTime: Infinity,
   })
 
-  const { data: currUsername, isPending: usernamePending } = useQuery({
-    queryKey: ['username', currUID],
-    queryFn: () => AuthAPI.getUsername(),
-    enabled: !!currUID,
-  })
-
-  const loading = recipePending || (!!currUID && usernamePending)
-  const isOwner = !!recipe && recipe.authorUsername === currUsername
+  const loading = isPending
+  // Key ownership on the Firebase uid, matching the server's `userId === uid`
+  // check. authorUsername is a creation-time snapshot that goes stale after a
+  // rename, which would otherwise lock a legitimate owner out of editing.
+  const isOwner = !!recipe && !!currUID && recipe.userId === currUID
 
   useEffect(() => {
     if (loading) return

--- a/src/pages/EditRecipe/EditRecipe.tsx
+++ b/src/pages/EditRecipe/EditRecipe.tsx
@@ -1,0 +1,70 @@
+import React, { FC, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { TailSpin } from 'react-loader-spinner'
+import toast from 'react-hot-toast'
+import AuthAPI from 'src/api/auth'
+import RecipeAPI from 'src/api/recipes'
+import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
+import styles from 'src/_exports.module.scss'
+
+// Wrapper for /recipes/:recipeId/edit. Fetches the recipe, confirms the signed-in
+// user is its author, then renders the AddRecipe form pre-populated for editing.
+// Ownership is also enforced server-side; this gate is just UX so non-owners
+// don't see (and can't submit) the form.
+const EditRecipe: FC = () => {
+  const { recipeId } = useParams<{ recipeId: string }>()
+  const navigate = useNavigate()
+
+  const currUID = AuthAPI.getUID()
+
+  const {
+    data: recipe,
+    isPending: recipePending,
+    isError,
+  } = useQuery({
+    queryKey: ['recipe', recipeId],
+    queryFn: () => RecipeAPI.getRecipe(recipeId!),
+    enabled: !!recipeId,
+  })
+
+  const { data: currUsername, isPending: usernamePending } = useQuery({
+    queryKey: ['username', currUID],
+    queryFn: () => AuthAPI.getUsername(),
+    enabled: !!currUID,
+  })
+
+  const loading = recipePending || (!!currUID && usernamePending)
+  const isOwner = !!recipe && recipe.authorUsername === currUsername
+
+  useEffect(() => {
+    if (loading) return
+    if (isError || !recipe || !recipe.title) {
+      toast.error('Recipe not found.')
+      navigate('/')
+    } else if (!isOwner) {
+      toast.error('You can only edit your own recipes.')
+      navigate(`/recipes/${recipe._id}`)
+    }
+  }, [loading, isError, recipe, isOwner, navigate])
+
+  if (loading || !recipe || !isOwner) {
+    return (
+      <div
+        className='page'
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: '60vh',
+        }}
+      >
+        <TailSpin height='60' width='60' color={styles.primary} ariaLabel='loading' />
+      </div>
+    )
+  }
+
+  return <AddRecipe initialRecipe={recipe} />
+}
+
+export default EditRecipe

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewOptions.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewOptions.tsx
@@ -26,7 +26,7 @@ const ReviewOptions: FC<ReviewOptionsProps> = ({
 
   const { data: currUsername } = useQuery({
     queryKey: ['username', uid],
-    queryFn: () => AuthAPI.getUsername(uid!),
+    queryFn: () => AuthAPI.getUsername(),
     enabled: !!uid,
   })
 

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
@@ -2,21 +2,53 @@
 
 .recipe-controls-container {
   display: flex;
-  justify-content: flex-end;
-  padding-bottom: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  padding: 0.7rem 1.25rem;
   width: 100%;
+  background: s.$gray-50;
+  border: 1px solid s.$gray-400;
+  border-radius: s.$border-radius;
+  .who {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: s.$secondary-text;
+    .icon {
+      height: 20px;
+      width: 20px;
+      color: s.$secondary;
+    }
+    strong {
+      color: s.$primary-text;
+      font-weight: 700;
+    }
+  }
   .btns-container {
     display: flex;
-    gap: 1rem;
+    gap: 0.6rem;
   }
   button {
-    border: 1px solid s.$secondary-text;
-    padding: 0.5rem 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    border: 1px solid s.$gray-500;
+    padding: 0.4rem 0.8rem;
     border-radius: s.$border-radius;
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 600;
     color: s.$primary-text;
+    background: transparent;
+    .icon {
+      height: 17px;
+      width: 17px;
+    }
     &:focus {
       @include s.outline();
     }
@@ -28,10 +60,16 @@
       color: s.$primary-background;
       background: s.$primary-text;
     }
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      &:hover {
+        color: s.$primary-text;
+        background: none;
+      }
+    }
   }
   button.delete-btn {
-    // background: s.$primary-text;
-    // color: s.$primary-background;
     background: none;
     transition: all 0.1s linear;
     &:hover {

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -103,9 +103,8 @@ const RecipeControls: FC<RecipeControlsType> = ({
       <div className='btns-container'>
         <button
           className='edit-btn'
-          disabled
-          title='Editing is coming soon'
-          aria-label='Edit recipe (coming soon)'
+          onClick={() => navigate(`/recipes/${recipeId}/edit`)}
+          aria-label='Edit recipe'
         >
           <AiOutlineEdit className='icon' aria-hidden='true' />
           Edit

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -9,6 +9,7 @@ import { TailSpin } from 'react-loader-spinner'
 import Modal from 'react-modal'
 import { useNavigate } from 'react-router-dom'
 import { isAxiosError } from 'axios'
+import toast from 'react-hot-toast'
 import AuthAPI from 'src/api/auth'
 import RecipeAPI from 'src/api/recipes'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -78,6 +79,8 @@ const RecipeControls: FC<RecipeControlsType> = ({
       queryClient.removeQueries({ queryKey: ['recipe', recipeId] })
       queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
       closeDeleteModal()
+      // Toaster is mounted at the app root, so the toast survives the redirect.
+      toast.success('Recipe deleted.')
       navigate('/')
     } catch (err: unknown) {
       const message = isAxiosError(err)

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -80,7 +80,7 @@ const RecipeControls: FC<RecipeControlsType> = ({
       queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
       closeDeleteModal()
       // Toaster is mounted at the app root, so the toast survives the redirect.
-      toast.success('Recipe deleted.')
+      toast.success(`"${recipeTitle}" deleted.`)
       navigate('/')
     } catch (err: unknown) {
       const message = isAxiosError(err)

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -53,7 +53,7 @@ const RecipeControls: FC<RecipeControlsType> = ({
 
   const { data: currUsername } = useQuery({
     queryKey: ['username', currUID],
-    queryFn: () => AuthAPI.getUsername(currUID!),
+    queryFn: () => AuthAPI.getUsername(),
     enabled: !!currUID,
   })
 

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -1,11 +1,17 @@
 import React, { FC, useState } from 'react'
-import { AiOutlineClose } from 'react-icons/ai'
+import {
+  AiOutlineClose,
+  AiOutlineEdit,
+  AiOutlineDelete,
+  AiOutlineUser,
+} from 'react-icons/ai'
 import { TailSpin } from 'react-loader-spinner'
 import Modal from 'react-modal'
 import { useNavigate } from 'react-router-dom'
+import { isAxiosError } from 'axios'
 import AuthAPI from 'src/api/auth'
 import RecipeAPI from 'src/api/recipes'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import './RecipeControls.scss'
 
 type RecipeControlsType = {
@@ -45,6 +51,7 @@ const RecipeControls: FC<RecipeControlsType> = ({
   }
 
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const [deleteLoading, setDeleteLoading] = useState(false)
   const [deleteError, setDeleteError] = useState('')
@@ -61,30 +68,50 @@ const RecipeControls: FC<RecipeControlsType> = ({
 
   if (!isUsersRecipe) return null
 
-  const handleDeleteRecipe = () => {
-    if (currUID) {
-      setDeleteLoading(true)
-      RecipeAPI.deleteRecipe(recipeId).then(res => {
-        const response = res as { error?: string }
-        if (response.error) {
-          setDeleteError(response.error)
-        } else {
-          closeDeleteModal()
-          navigate('/')
-        }
-        setDeleteLoading(false)
-      })
+  const handleDeleteRecipe = async () => {
+    if (!currUID) return
+    setDeleteLoading(true)
+    setDeleteError('')
+    try {
+      await RecipeAPI.deleteRecipe(recipeId)
+      // Drop cached copies so lists/pages don't show the deleted recipe.
+      queryClient.removeQueries({ queryKey: ['recipe', recipeId] })
+      queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
+      closeDeleteModal()
+      navigate('/')
+    } catch (err: unknown) {
+      const message = isAxiosError(err)
+        ? err.response?.data?.error ?? err.message
+        : 'Failed to delete recipe. Please try again.'
+      setDeleteError(message)
+    } finally {
+      setDeleteLoading(false)
     }
   }
 
   return (
     <div className='recipe-controls-container'>
+      <span className='who'>
+        <AiOutlineUser className='icon' aria-hidden='true' />
+        <span>
+          <strong>You</strong> created this recipe
+        </span>
+      </span>
       <div className='btns-container'>
-        {/* <button className='edit-btn'>Edit</button> */}
+        <button
+          className='edit-btn'
+          disabled
+          title='Editing is coming soon'
+          aria-label='Edit recipe (coming soon)'
+        >
+          <AiOutlineEdit className='icon' aria-hidden='true' />
+          Edit
+        </button>
         <button
           className='delete-btn'
           onClick={() => setIsDeleteModalOpen(true)}
         >
+          <AiOutlineDelete className='icon' aria-hidden='true' />
           Delete
         </button>
       </div>

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -12,12 +12,12 @@ import { isAxiosError } from 'axios'
 import toast from 'react-hot-toast'
 import AuthAPI from 'src/api/auth'
 import RecipeAPI from 'src/api/recipes'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import './RecipeControls.scss'
 
 type RecipeControlsType = {
   recipeId: string
-  authorUsername: string
+  recipeUserId?: string
   recipeTitle: string
 }
 
@@ -43,7 +43,7 @@ const customStyles = {
 
 const RecipeControls: FC<RecipeControlsType> = ({
   recipeId,
-  authorUsername,
+  recipeUserId,
   recipeTitle,
 }) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
@@ -59,13 +59,10 @@ const RecipeControls: FC<RecipeControlsType> = ({
 
   const currUID = AuthAPI.getUID()
 
-  const { data: currUsername } = useQuery({
-    queryKey: ['username', currUID],
-    queryFn: () => AuthAPI.getUsername(),
-    enabled: !!currUID,
-  })
-
-  const isUsersRecipe = currUsername === authorUsername
+  // Key ownership on the Firebase uid (what the server authorizes against), not
+  // the snapshotted authorUsername which goes stale after a rename and would
+  // hide these controls from the legitimate owner.
+  const isUsersRecipe = !!currUID && currUID === recipeUserId
 
   if (!isUsersRecipe) return null
 

--- a/src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats.scss
@@ -1,0 +1,50 @@
+@use '../../../../helpers.scss' as s;
+
+.recipe-stats-foot {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid s.$gray-400;
+
+  .stats-minimal {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1.1rem;
+    color: s.$secondary-text;
+    font-weight: 600;
+    font-size: 0.95rem;
+
+    .stat {
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+
+      .icon {
+        height: 18px;
+        width: 18px;
+        color: s.$tertiary-text;
+      }
+      .icon.star {
+        color: s.$primary;
+      }
+      b {
+        color: s.$primary-text;
+        font-weight: 700;
+      }
+    }
+
+    .sep {
+      color: s.$gray-500;
+    }
+  }
+
+  @media screen and (max-width: 500px) {
+    .stats-minimal {
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      .sep {
+        display: none;
+      }
+    }
+  }
+}

--- a/src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats.tsx
@@ -1,0 +1,66 @@
+import React, { FC } from 'react'
+import { AiOutlineEye } from 'react-icons/ai'
+import { BsBookmark, BsCheck2Circle, BsStarFill } from 'react-icons/bs'
+import { RecipeType } from 'types'
+import './RecipeStats.scss'
+
+type RecipeStatsProps = {
+  currRecipe: RecipeType | null
+  loading: boolean
+}
+
+const formatCount = (n: number | null | undefined): string =>
+  (n ?? 0).toLocaleString()
+
+const RecipeStats: FC<RecipeStatsProps> = ({ currRecipe, loading }) => {
+  if (loading || !currRecipe) return null
+
+  const views = currRecipe.views ?? 0
+  const numTimesSaved = currRecipe.numTimesSaved ?? 0
+  const numTimesMade = currRecipe.numTimesMade ?? 0
+  const rateValue = currRecipe.rating?.rateValue ?? 0
+  const rateCount = currRecipe.rating?.rateCount ?? 0
+
+  return (
+    <div className='recipe-stats-foot'>
+      <div className='stats-minimal' aria-label='Recipe statistics'>
+        <span className='stat'>
+          <AiOutlineEye className='icon' aria-hidden='true' />
+          <b>{formatCount(views)}</b> {views === 1 ? 'view' : 'views'}
+        </span>
+        <span className='sep' aria-hidden='true'>
+          ·
+        </span>
+        <span className='stat'>
+          <BsBookmark className='icon' aria-hidden='true' />
+          <b>{formatCount(numTimesSaved)}</b>{' '}
+          {numTimesSaved === 1 ? 'save' : 'saves'}
+        </span>
+        <span className='sep' aria-hidden='true'>
+          ·
+        </span>
+        <span className='stat'>
+          <BsCheck2Circle className='icon' aria-hidden='true' />
+          <b>{formatCount(numTimesMade)}</b> made
+        </span>
+        <span className='sep' aria-hidden='true'>
+          ·
+        </span>
+        <span className='stat'>
+          <BsStarFill className='icon star' aria-hidden='true' />
+          {rateCount > 0 ? (
+            <>
+              <b>{rateValue.toFixed(1)}</b> ({formatCount(rateCount)})
+            </>
+          ) : (
+            <>
+              <b>—</b> no ratings
+            </>
+          )}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export default RecipeStats

--- a/src/pages/SingleRecipe/RecipeHeaderContent/RecipeHeaderContent.tsx
+++ b/src/pages/SingleRecipe/RecipeHeaderContent/RecipeHeaderContent.tsx
@@ -4,6 +4,7 @@ import { BsStar } from 'react-icons/bs'
 import Skeleton from 'react-loading-skeleton'
 import { formatRating } from 'src/util/formatRating'
 import { getWindowWidth } from 'src/util/getWindowWidth'
+import { timeElapsedSince } from 'src/util/timeElapsedSince'
 import { RecipeType, ReviewType } from 'types'
 import AddRatingBtn from 'src/pages/SingleRecipe/Buttons/AddRatingBtn'
 import PrintRecipeBtn from 'src/pages/SingleRecipe/Buttons/PrintRecipeBtn'
@@ -95,6 +96,11 @@ const RecipeHeaderContent: FC<RecipeHeaderContentProps> = ({
             }
           />
         </div>
+        {!loading && currRecipe?.editedAt && (
+          <div className='edited-marker'>
+            Edited {timeElapsedSince(new Date(Number(currRecipe.editedAt)))}
+          </div>
+        )}
         <div className='actions'>
           {loading || !currRecipe?._id ? (
             <Skeleton baseColor={skeletonColor} className='action skeleton' />

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -186,6 +186,11 @@
             }
           }
         }
+        .edited-marker {
+          font-size: 0.85rem;
+          font-style: italic;
+          color: s.$secondary-text;
+        }
       }
 
       @media screen and (max-width: 1100px) {

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -122,7 +122,7 @@ const SingleRecipe: FC<Props> = ({ recipe }) => {
               {currRecipe && (
                 <RecipeControls
                   recipeId={currRecipe._id}
-                  authorUsername={currRecipe.authorUsername}
+                  recipeUserId={currRecipe.userId}
                   recipeTitle={currRecipe.title}
                 />
               )}

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -9,6 +9,7 @@ import Ingredients from 'src/pages/SingleRecipe/DataSections/Ingredients/Ingredi
 import Instructions from 'src/pages/SingleRecipe/DataSections/Instructions/Instructions'
 import Tags from 'src/pages/SingleRecipe/DataSections/Tags'
 import RecipeControls from 'src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls'
+import RecipeStats from 'src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats'
 import MadeRecipeBtn from 'src/pages/SingleRecipe/Buttons/MadeRecipeBtn'
 
 import { updateIngredients } from 'src/util/updateIngredients'
@@ -145,7 +146,9 @@ const SingleRecipe: FC<Props> = ({ recipe }) => {
                 />
                 <Tags loading={loading} currRecipe={currRecipe} />
                 {recipeId && <MadeRecipeBtn recipeId={recipeId} />}
-                <div className='recipe-stats'></div>
+                <div className='recipe-stats'>
+                  <RecipeStats currRecipe={currRecipe} loading={loading} />
+                </div>
               </div>
               {!loading && currRecipe && (
                 <RatingsAndReviews

--- a/src/test/Account.test.tsx
+++ b/src/test/Account.test.tsx
@@ -124,7 +124,7 @@ describe('Account page', () => {
       })
       mockGetUsername.mockResolvedValue('johndoe')
       renderAccount()
-      await waitFor(() => expect(mockGetUsername).toHaveBeenCalledWith('u1'))
+      await waitFor(() => expect(mockGetUsername).toHaveBeenCalled())
     })
 
     it('displays the resolved username in the h1.username element', async () => {

--- a/src/test/AddRecipe.test.tsx
+++ b/src/test/AddRecipe.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { HelmetProvider } from 'react-helmet-async'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
 import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
 import RecipeAPI from 'src/api/recipes'
 
@@ -131,7 +132,9 @@ const renderAddRecipe = () => {
   return render(
     <QueryClientProvider client={queryClient}>
       <HelmetProvider>
-        <AddRecipe />
+        <MemoryRouter>
+          <AddRecipe />
+        </MemoryRouter>
       </HelmetProvider>
     </QueryClientProvider>
   )

--- a/src/test/AddRecipe.test.tsx
+++ b/src/test/AddRecipe.test.tsx
@@ -3,6 +3,7 @@ import { vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { HelmetProvider } from 'react-helmet-async'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
 import RecipeAPI from 'src/api/recipes'
 
@@ -125,12 +126,16 @@ vi.mock('src/pages/AddRecipe/TimeInput/TimeInput', () => ({
 
 const mockAddRecipe = RecipeAPI.addRecipe as ReturnType<typeof vi.fn>
 
-const renderAddRecipe = () =>
-  render(
-    <HelmetProvider>
-      <AddRecipe />
-    </HelmetProvider>
+const renderAddRecipe = () => {
+  const queryClient = new QueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <HelmetProvider>
+        <AddRecipe />
+      </HelmetProvider>
+    </QueryClientProvider>
   )
+}
 
 const fillAllFields = async (user: ReturnType<typeof userEvent.setup>) => {
   await user.type(screen.getByPlaceholderText('Add a title to your recipe.'), 'My Great Recipe')

--- a/src/test/RecipeDrafts.test.tsx
+++ b/src/test/RecipeDrafts.test.tsx
@@ -1,0 +1,335 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HelmetProvider } from 'react-helmet-async'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, useSearchParams } from 'react-router-dom'
+import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
+import Drafts from 'src/pages/Account/Drafts/Drafts'
+import DraftAPI from 'src/api/drafts'
+import { RecipeDraftType, RecipeType } from 'types'
+
+const { navigateFn } = vi.hoisted(() => ({ navigateFn: vi.fn() }))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom'
+  )
+  return { ...actual, useNavigate: () => navigateFn }
+})
+
+vi.mock('react-hot-toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+  default: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('src/api/recipes', () => ({
+  default: { addRecipe: vi.fn() },
+  ADD_RECIPE_AUTH_ERROR: 'AUTH_ERROR',
+}))
+
+// Signed-in user so DraftAPI methods don't short-circuit on a missing uid.
+vi.mock('src/api/auth', () => ({
+  default: { getUID: vi.fn().mockReturnValue('test-uid') },
+}))
+
+vi.mock('src/api/drafts', () => ({
+  default: {
+    createDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    listDrafts: vi.fn(),
+    getDraft: vi.fn(),
+    deleteDraft: vi.fn(),
+  },
+  DRAFT_LIMIT_CODE: 'DRAFT_LIMIT',
+}))
+
+vi.mock('react-top-loading-bar', () => ({ default: () => null }))
+
+vi.mock('src/pages/AddRecipe/RecipeFormInput', () => ({
+  default: ({ val, setVal, placeholder }: any) => (
+    <input
+      placeholder={placeholder}
+      value={val ?? ''}
+      onChange={e => setVal(e.target.value)}
+    />
+  ),
+}))
+
+vi.mock('src/pages/AddRecipe/ImagePicker/ImagePicker', () => ({
+  default: () => null,
+}))
+vi.mock('src/pages/AddRecipe/MealTypeSelector/MealTypeSelector', () => ({
+  default: () => null,
+}))
+vi.mock('src/pages/AddRecipe/CuisineSelector/CuisineSelector', () => ({
+  default: () => null,
+}))
+vi.mock(
+  'src/pages/AddRecipe/Ingredients/IngredientsContainer/IngredientsContainer',
+  () => ({ default: () => null })
+)
+vi.mock('src/pages/AddRecipe/Instructions/InstructionsContainer', () => ({
+  default: () => null,
+}))
+vi.mock('src/pages/AddRecipe/TimeInput/TimeInput', () => ({
+  default: () => null,
+}))
+
+const mockedDraftAPI = DraftAPI as unknown as {
+  createDraft: ReturnType<typeof vi.fn>
+  updateDraft: ReturnType<typeof vi.fn>
+  listDrafts: ReturnType<typeof vi.fn>
+  getDraft: ReturnType<typeof vi.fn>
+  deleteDraft: ReturnType<typeof vi.fn>
+}
+
+const makeDraft = (overrides: Partial<RecipeDraftType> = {}): RecipeDraftType => ({
+  _id: 'draft-1',
+  userId: 'test-uid',
+  title: 'Resumed Recipe',
+  ingredients: [],
+  instructions: [],
+  createdAt: '1000',
+  updatedAt: '2000',
+  ...overrides,
+})
+
+const renderAt = (ui: React.ReactNode, initialEntry = '/add-recipe') => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <HelmetProvider>
+        <MemoryRouter initialEntries={[initialEntry]}>{ui}</MemoryRouter>
+      </HelmetProvider>
+    </QueryClientProvider>
+  )
+}
+
+beforeAll(() => {
+  HTMLElement.prototype.scrollTo = vi.fn() as any
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedDraftAPI.listDrafts.mockResolvedValue([])
+  mockedDraftAPI.createDraft.mockResolvedValue(makeDraft())
+  mockedDraftAPI.updateDraft.mockResolvedValue(makeDraft())
+  mockedDraftAPI.getDraft.mockResolvedValue(makeDraft())
+  mockedDraftAPI.deleteDraft.mockResolvedValue(undefined)
+})
+
+describe('AddRecipe draft autosave', () => {
+  it('does not create a draft for an empty form', async () => {
+    renderAt(<AddRecipe />)
+    // Give any debounce window time to (not) fire.
+    await new Promise(r => setTimeout(r, 1700))
+    expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+  })
+
+  it('autosaves a new draft once the user enters content', async () => {
+    const user = userEvent.setup()
+    renderAt(<AddRecipe />)
+    await user.type(
+      screen.getByPlaceholderText('Add a title to your recipe.'),
+      'Soup'
+    )
+    await waitFor(
+      () => expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1),
+      { timeout: 3000 }
+    )
+    // Empty numeric fields are sent as explicit null (not omitted) so a later
+    // clear is actually persisted rather than dropped from the payload.
+    expect(mockedDraftAPI.createDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Soup',
+        servings: null,
+        prepTime: null,
+        cookTime: null,
+      })
+    )
+    await screen.findByText('Draft saved')
+  })
+
+  it('re-hydrates when the draft id changes in-place (banner resume, no remount)', async () => {
+    // The resume banner navigates to /add-recipe?draftId=… while AddRecipe is
+    // already mounted — the route doesn't change, so only the query updates.
+    // A harness that flips the query via useSearchParams reproduces that path.
+    mockedDraftAPI.getDraft.mockResolvedValue(
+      makeDraft({ _id: 'draft-9', title: 'Resumed In Place' })
+    )
+    const ResumeHarness: React.FC = () => {
+      const [, setSearchParams] = useSearchParams()
+      return (
+        <>
+          <button onClick={() => setSearchParams({ draftId: 'draft-9' })}>
+            go
+          </button>
+          <AddRecipe />
+        </>
+      )
+    }
+    const user = userEvent.setup()
+    renderAt(<ResumeHarness />)
+    expect(mockedDraftAPI.getDraft).not.toHaveBeenCalled()
+
+    await user.click(screen.getByText('go'))
+    await waitFor(() =>
+      expect(mockedDraftAPI.getDraft).toHaveBeenCalledWith('draft-9')
+    )
+    await waitFor(() =>
+      expect(
+        screen.getByPlaceholderText('Add a title to your recipe.')
+      ).toHaveValue('Resumed In Place')
+    )
+  })
+
+  it('hydrates the form from an existing draft when resuming via ?draftId', async () => {
+    mockedDraftAPI.getDraft.mockResolvedValue(
+      makeDraft({ _id: 'draft-9', title: 'Leftover Stew' })
+    )
+    renderAt(<AddRecipe />, '/add-recipe?draftId=draft-9')
+    expect(mockedDraftAPI.getDraft).toHaveBeenCalledWith('draft-9')
+    await waitFor(() =>
+      expect(
+        screen.getByPlaceholderText('Add a title to your recipe.')
+      ).toHaveValue('Leftover Stew')
+    )
+    // Resuming alone must not create a brand-new draft.
+    expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+  })
+
+  it('on a transient load error keeps the draftId and does NOT start a duplicate (finding #3)', async () => {
+    // A 500 (vs a 404/403) means the draft probably still exists.
+    mockedDraftAPI.getDraft.mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 500 },
+    })
+    const user = userEvent.setup()
+    renderAt(<AddRecipe />, '/add-recipe?draftId=draft-7')
+    await waitFor(() =>
+      expect(mockedDraftAPI.getDraft).toHaveBeenCalledWith('draft-7')
+    )
+    // Typing must not spawn a new draft (autosave stays disabled) — otherwise
+    // the real draft-7 would be orphaned and duplicated.
+    await user.type(
+      screen.getByPlaceholderText('Add a title to your recipe.'),
+      'Soup'
+    )
+    await new Promise(r => setTimeout(r, 1700))
+    expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+    expect(mockedDraftAPI.updateDraft).not.toHaveBeenCalled()
+  })
+
+  it('on a 404 load error clears the draftId and lets a fresh draft start (finding #3)', async () => {
+    mockedDraftAPI.getDraft.mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 404 },
+    })
+    const user = userEvent.setup()
+    renderAt(<AddRecipe />, '/add-recipe?draftId=gone')
+    await waitFor(() =>
+      expect(mockedDraftAPI.getDraft).toHaveBeenCalledWith('gone')
+    )
+    // The stale id is dropped, so typing starts a brand-new draft.
+    await user.type(
+      screen.getByPlaceholderText('Add a title to your recipe.'),
+      'Soup'
+    )
+    await waitFor(
+      () => expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1),
+      { timeout: 3000 }
+    )
+  })
+
+  it('shows an error (not "Draft saved") when the save does not persist (finding #5)', async () => {
+    // createDraft resolving null models the no-auth short-circuit: nothing was
+    // written, so the indicator must not claim success.
+    mockedDraftAPI.createDraft.mockResolvedValue(null)
+    const user = userEvent.setup()
+    renderAt(<AddRecipe />)
+    await user.type(
+      screen.getByPlaceholderText('Add a title to your recipe.'),
+      'Soup'
+    )
+    await waitFor(
+      () => expect(mockedDraftAPI.createDraft).toHaveBeenCalled(),
+      { timeout: 3000 }
+    )
+    expect(await screen.findByText("Couldn't save draft")).toBeInTheDocument()
+    expect(screen.queryByText('Draft saved')).toBeNull()
+  })
+})
+
+describe('AddRecipe edit mode', () => {
+  const recipe: RecipeType = {
+    _id: 'recipe-1',
+    userId: 'test-uid',
+    title: 'Existing Recipe',
+    prepTime: 10,
+    cookTime: 20,
+    servings: 4,
+    fridgeLife: 3,
+    freezerLife: 30,
+    description: 'An existing recipe being edited',
+    ingredients: [],
+    instructions: [],
+    recipeImage: 'https://example.com/img.jpg',
+    nutritionData: null,
+    totalTime: 30,
+    authorUsername: 'chef',
+    rating: { rateCount: 0, rateValue: 0 },
+    createdAt: '1000',
+    editedAt: null,
+    servingPrice: 100,
+    cuisine: 'Italian',
+    mealTypes: ['dinner'],
+    nutritionLabels: [],
+    views: 0,
+    numTimesSaved: 0,
+    numTimesMade: 0,
+  }
+
+  it('never creates a draft, even when unmounting (e.g. cancel)', async () => {
+    const { unmount } = renderAt(<AddRecipe initialRecipe={recipe} />)
+    // Let any debounce window pass while the editor is open.
+    await new Promise(r => setTimeout(r, 1700))
+    // Leaving the editor (cancel/navigation) triggers the unmount flush.
+    unmount()
+    await new Promise(r => setTimeout(r, 50))
+    expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+    expect(mockedDraftAPI.updateDraft).not.toHaveBeenCalled()
+  })
+})
+
+describe('Drafts tab', () => {
+  it('shows an empty state when there are no drafts', async () => {
+    mockedDraftAPI.listDrafts.mockResolvedValue([])
+    renderAt(<Drafts />)
+    expect(await screen.findByText('No Drafts Yet')).toBeInTheDocument()
+  })
+
+  it('lists drafts and deletes one', async () => {
+    mockedDraftAPI.listDrafts.mockResolvedValue([
+      makeDraft({ _id: 'd1', title: 'Pasta Bake' }),
+    ])
+    const user = userEvent.setup()
+    renderAt(<Drafts />)
+    expect(await screen.findByText('Pasta Bake')).toBeInTheDocument()
+    await user.click(screen.getByLabelText('Delete draft'))
+    await waitFor(() =>
+      expect(mockedDraftAPI.deleteDraft).toHaveBeenCalledWith('d1')
+    )
+  })
+
+  it('falls back to "Untitled draft" when a draft has no title', async () => {
+    mockedDraftAPI.listDrafts.mockResolvedValue([
+      makeDraft({ _id: 'd2', title: '' }),
+    ])
+    renderAt(<Drafts />)
+    expect(await screen.findByText('Untitled draft')).toBeInTheDocument()
+  })
+})

--- a/src/test/RecipeDrafts.test.tsx
+++ b/src/test/RecipeDrafts.test.tsx
@@ -200,6 +200,21 @@ describe('AddRecipe draft autosave', () => {
     )
     // Resuming alone must not create a brand-new draft.
     expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+    // Drafts don't persist the image, so resuming prompts the user to re-add it.
+    expect(
+      screen.getByText(/Drafts don't save your image/i)
+    ).toBeInTheDocument()
+  })
+
+  it('does not show the re-add-image hint on a fresh create form', async () => {
+    const user = userEvent.setup()
+    renderAt(<AddRecipe />)
+    await user.type(
+      screen.getByPlaceholderText('Add a title to your recipe.'),
+      'Brand New'
+    )
+    // The user never had an image to lose on a fresh draft.
+    expect(screen.queryByText(/Drafts don't save your image/i)).toBeNull()
   })
 
   it('on a transient load error keeps the draftId and does NOT start a duplicate (finding #3)', async () => {

--- a/src/test/RecipeStats.test.tsx
+++ b/src/test/RecipeStats.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import RecipeStats from 'src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats'
+import { RecipeType } from 'types'
+
+const baseRecipe = {
+  _id: 'recipe-1',
+  title: 'Chicken Tacos',
+  views: 1234,
+  numTimesSaved: 1,
+  numTimesMade: 5,
+  rating: { rateValue: 4.2, rateCount: 8 },
+} as unknown as RecipeType
+
+describe('RecipeStats', () => {
+  it('renders nothing while loading', () => {
+    const { container } = render(
+      <RecipeStats currRecipe={baseRecipe} loading={true} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when there is no recipe', () => {
+    const { container } = render(
+      <RecipeStats currRecipe={null} loading={false} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('displays formatted views, saves, made and rating', () => {
+    render(<RecipeStats currRecipe={baseRecipe} loading={false} />)
+
+    expect(screen.getByText('1,234')).toBeInTheDocument()
+    expect(screen.getByText('views')).toBeInTheDocument()
+    // numTimesSaved of 1 should be singular
+    expect(screen.getByText('save')).toBeInTheDocument()
+    expect(screen.getByText('made')).toBeInTheDocument()
+    expect(screen.getByText('4.2')).toBeInTheDocument()
+    expect(screen.getByText(/\(8\)/)).toBeInTheDocument()
+  })
+
+  it('pluralizes saves when there is more than one', () => {
+    const manySaves = { ...baseRecipe, numTimesSaved: 3 } as unknown as RecipeType
+    render(<RecipeStats currRecipe={manySaves} loading={false} />)
+    expect(screen.getByText('saves')).toBeInTheDocument()
+  })
+
+  it('shows "no ratings" with an em dash when there are no ratings', () => {
+    const noRatings = {
+      ...baseRecipe,
+      rating: { rateValue: 0, rateCount: 0 },
+    } as unknown as RecipeType
+    render(<RecipeStats currRecipe={noRatings} loading={false} />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.getByText('no ratings')).toBeInTheDocument()
+  })
+
+  it('defaults missing counts to zero', () => {
+    const sparse = { _id: 'r2', title: 'x' } as unknown as RecipeType
+    render(<RecipeStats currRecipe={sparse} loading={false} />)
+    // views, saves, made all default to 0
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/src/test/RecipesApi.test.ts
+++ b/src/test/RecipesApi.test.ts
@@ -20,15 +20,19 @@ vi.mock('src/api/auth', () => ({
 }))
 
 const httpPost = vi.fn()
+const httpPut = vi.fn()
 const nutritionPost = vi.fn()
 vi.mock('src/api/http-common', () => ({
-  http: { post: (...args: unknown[]) => httpPost(...args) },
+  http: {
+    post: (...args: unknown[]) => httpPost(...args),
+    put: (...args: unknown[]) => httpPut(...args),
+  },
   nutrition: { post: (...args: unknown[]) => nutritionPost(...args) },
 }))
 
 // Import after mocks are in place.
 import RecipeAPI from 'src/api/recipes'
-import type { RecipeFormType } from 'types'
+import type { RecipeEditFormType, RecipeFormType, RecipeType } from 'types'
 
 const makeFormData = (): RecipeFormType => ({
   title: 'Soft-fail Test Recipe',
@@ -94,5 +98,146 @@ describe('RecipeAPI.addRecipe — nutrition soft-fail (High #4)', () => {
 
     expect(result).toBe('srv-2')
     expect(httpPost).toHaveBeenCalledWith('api/addRecipe', expect.any(Object))
+  })
+})
+
+describe('RecipeAPI.editRecipe', () => {
+  const sharedIngredient = () => ({
+    id: 'i1',
+    parsedIngredient: {
+      ingredient: 'Flour',
+      quantity: 2,
+      unit: 'cups',
+      unitPlural: 'cups',
+      symbol: null,
+      minQty: 2,
+      maxQty: 2,
+      originalIngredientString: '2 cups flour',
+      comment: '',
+    },
+    ingredientData: null,
+  })
+
+  const makeOriginal = (): RecipeType => ({
+    _id: 'recipe-1',
+    title: 'Original Title',
+    prepTime: 10,
+    cookTime: 20,
+    servings: 4,
+    fridgeLife: 0,
+    freezerLife: 0,
+    description: 'Original description',
+    ingredients: [sharedIngredient()],
+    instructions: [{ id: 'in1', content: 'Mix well', index: 1 }],
+    recipeImage: 'https://cdn/original.jpg',
+    nutritionData: { uri: 'orig' } as unknown as RecipeType['nutritionData'],
+    totalTime: 30,
+    authorUsername: 'testuser',
+    rating: { rateCount: 5, rateValue: 4 },
+    createdAt: '1000',
+    editedAt: null,
+    servingPrice: 100,
+    cuisine: '',
+    mealTypes: ['Dinner'],
+    nutritionLabels: ['Vegan'],
+    views: 10,
+    numTimesSaved: 2,
+    numTimesMade: 1,
+  })
+
+  const makeEditData = (
+    overrides: Partial<RecipeEditFormType> = {}
+  ): RecipeEditFormType => ({
+    title: 'Edited Title',
+    prepTime: 10,
+    cookTime: 20,
+    servings: 4,
+    fridgeLife: 0,
+    freezerLife: 0,
+    description: 'Edited description',
+    ingredients: [sharedIngredient()],
+    instructions: [{ id: 'in1', content: 'Mix well', index: 1 }],
+    recipeImage: undefined,
+    cuisine: '',
+    mealTypes: ['Dinner'],
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    httpPut.mockReset()
+    nutritionPost.mockReset()
+  })
+
+  it('PUTs to the edit endpoint and resolves true on success', async () => {
+    httpPut.mockResolvedValue({ data: {} })
+    const result = await RecipeAPI.editRecipe(
+      'recipe-1',
+      makeEditData(),
+      makeOriginal(),
+      () => {}
+    )
+    expect(result).toBe(true)
+    expect(httpPut.mock.calls[0][0]).toBe('api/editRecipe?recipeId=recipe-1')
+    expect(httpPut.mock.calls[0][1].title).toBe('Edited Title')
+  })
+
+  it('reuses the existing image and stored nutrition when ingredients are unchanged', async () => {
+    httpPut.mockResolvedValue({ data: {} })
+    await RecipeAPI.editRecipe('recipe-1', makeEditData(), makeOriginal(), () => {})
+
+    // No new file picked + unchanged ingredients => no Edamam call.
+    expect(nutritionPost).not.toHaveBeenCalled()
+    const payload = httpPut.mock.calls[0][1]
+    expect(payload.recipeImage).toBe('https://cdn/original.jpg')
+    expect(payload.nutritionData).toEqual({ uri: 'orig' })
+    expect(payload.nutritionLabels).toEqual(['Vegan'])
+  })
+
+  it('recomputes nutrition when the ingredients change', async () => {
+    nutritionPost.mockResolvedValue({
+      data: { uri: 'new', dietLabels: [], healthLabels: [] },
+    })
+    httpPut.mockResolvedValue({ data: {} })
+
+    const changed = makeEditData({
+      ingredients: [
+        {
+          ...sharedIngredient(),
+          parsedIngredient: {
+            ...sharedIngredient().parsedIngredient,
+            ingredient: 'Sugar',
+            quantity: 1,
+            unit: 'cup',
+            originalIngredientString: '1 cup sugar',
+          },
+        },
+      ],
+    })
+
+    await RecipeAPI.editRecipe('recipe-1', changed, makeOriginal(), () => {})
+
+    expect(nutritionPost).toHaveBeenCalledTimes(1)
+    const payload = httpPut.mock.calls[0][1]
+    expect(payload.nutritionData).toEqual({
+      uri: 'new',
+      dietLabels: [],
+      healthLabels: [],
+    })
+  })
+
+  it('uploads and uses a new image when one is provided', async () => {
+    httpPut.mockResolvedValue({ data: {} })
+    const withImage = makeEditData({
+      recipeImage: new File([''], 'new.jpg', { type: 'image/jpeg' }),
+    })
+
+    await RecipeAPI.editRecipe('recipe-1', withImage, makeOriginal(), () => {})
+
+    const payload = httpPut.mock.calls[0][1]
+    // The test env runs uploadRecipeImage's Cypress branch (VITE_CYPRESS='true'),
+    // which returns this stub URL — proving the upload path ran rather than the
+    // original image being reused.
+    expect(payload.recipeImage).toBe('https://cypress.test/fake-recipe-image.jpg')
+    expect(payload.recipeImage).not.toBe('https://cdn/original.jpg')
   })
 })

--- a/src/test/RecipesApi.test.ts
+++ b/src/test/RecipesApi.test.ts
@@ -168,15 +168,18 @@ describe('RecipeAPI.editRecipe', () => {
     nutritionPost.mockReset()
   })
 
-  it('PUTs to the edit endpoint and resolves true on success', async () => {
-    httpPut.mockResolvedValue({ data: {} })
+  it('PUTs to the edit endpoint and returns the updated recipe on success', async () => {
+    httpPut.mockResolvedValue({ data: { _id: 'recipe-1', title: 'Edited Title' } })
     const result = await RecipeAPI.editRecipe(
       'recipe-1',
       makeEditData(),
       makeOriginal(),
       () => {}
     )
-    expect(result).toBe(true)
+    expect(result).toEqual({
+      status: 'success',
+      recipe: { _id: 'recipe-1', title: 'Edited Title' },
+    })
     expect(httpPut.mock.calls[0][0]).toBe('api/editRecipe?recipeId=recipe-1')
     expect(httpPut.mock.calls[0][1].title).toBe('Edited Title')
   })
@@ -239,5 +242,66 @@ describe('RecipeAPI.editRecipe', () => {
     // original image being reused.
     expect(payload.recipeImage).toBe('https://cypress.test/fake-recipe-image.jpg')
     expect(payload.recipeImage).not.toBe('https://cdn/original.jpg')
+  })
+
+  it('keeps the existing nutrition when an ingredient edit hits a failed Edamam lookup', async () => {
+    // Edamam unreachable => getRecipeNutrition soft-fails to null.
+    nutritionPost.mockRejectedValue(new Error('Edamam down'))
+    httpPut.mockResolvedValue({ data: {} })
+
+    const changed = makeEditData({
+      ingredients: [
+        {
+          ...sharedIngredient(),
+          parsedIngredient: {
+            ...sharedIngredient().parsedIngredient,
+            ingredient: 'Sugar',
+            quantity: 1,
+            unit: 'cup',
+            originalIngredientString: '1 cup sugar',
+          },
+        },
+      ],
+    })
+
+    await RecipeAPI.editRecipe('recipe-1', changed, makeOriginal(), () => {})
+
+    expect(nutritionPost).toHaveBeenCalledTimes(1)
+    const payload = httpPut.mock.calls[0][1]
+    // The soft-fail must NOT erase the recipe's stored nutrition.
+    expect(payload.nutritionData).toEqual({ uri: 'orig' })
+    expect(payload.nutritionLabels).toEqual(['Vegan'])
+  })
+
+  it('returns auth-error on a 401', async () => {
+    httpPut.mockRejectedValue(
+      Object.assign(new Error('unauthorized'), {
+        isAxiosError: true,
+        response: { status: 401, data: {} },
+      })
+    )
+    const result = await RecipeAPI.editRecipe(
+      'recipe-1',
+      makeEditData(),
+      makeOriginal(),
+      () => {}
+    )
+    expect(result).toEqual({ status: 'auth-error' })
+  })
+
+  it('surfaces the server error message on a non-auth failure (e.g. 403)', async () => {
+    httpPut.mockRejectedValue(
+      Object.assign(new Error('request failed'), {
+        isAxiosError: true,
+        response: { status: 403, data: { error: 'Forbidden' } },
+      })
+    )
+    const result = await RecipeAPI.editRecipe(
+      'recipe-1',
+      makeEditData(),
+      makeOriginal(),
+      () => {}
+    )
+    expect(result).toEqual({ status: 'error', message: 'Forbidden' })
   })
 })

--- a/src/test/useDraftAutosave.test.tsx
+++ b/src/test/useDraftAutosave.test.tsx
@@ -1,0 +1,136 @@
+import { vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useDraftAutosave } from 'src/pages/AddRecipe/useDraftAutosave'
+import DraftAPI from 'src/api/drafts'
+import { RecipeDraftType } from 'types'
+
+vi.mock('src/api/drafts', () => ({
+  default: {
+    createDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    deleteDraft: vi.fn(),
+  },
+  DRAFT_LIMIT_CODE: 'DRAFT_LIMIT',
+}))
+
+const mockedDraftAPI = DraftAPI as unknown as {
+  createDraft: ReturnType<typeof vi.fn>
+  updateDraft: ReturnType<typeof vi.fn>
+  deleteDraft: ReturnType<typeof vi.fn>
+}
+
+// A promise whose resolution we control, to model an in-flight network request.
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(r => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+const createdDraft: RecipeDraftType = {
+  _id: 'new-draft',
+  userId: 'test-uid',
+  title: 'Soup',
+  createdAt: '1000',
+  updatedAt: '1000',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useDraftAutosave — publish during in-flight create (finding #2)', () => {
+  it('deletes the draft that finishes creating after publish, instead of orphaning it', async () => {
+    const created = deferred<RecipeDraftType>()
+    mockedDraftAPI.createDraft.mockReturnValue(created.promise)
+    const onDraftCreated = vi.fn()
+
+    const { result, rerender } = renderHook(
+      ({ content }) =>
+        useDraftAutosave({
+          content,
+          enabled: true,
+          canCreate: true,
+          draftId: null,
+          onDraftCreated,
+        }),
+      { initialProps: { content: { title: '' } as Record<string, unknown> } }
+    )
+
+    // First enable establishes the baseline; an edit then schedules the save.
+    rerender({ content: { title: 'Soup' } })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+    // createDraft is now in flight (its promise hasn't resolved).
+    expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1)
+
+    // User publishes: clearDraft disables autosave. No id exists yet to delete.
+    await act(async () => {
+      await result.current.clearDraft()
+    })
+
+    // The create now resolves — the hook must delete the just-created draft
+    // rather than adopt it (which would leave an orphan after publish). Flush
+    // the saveNow continuation that runs after createDraft's promise settles.
+    await act(async () => {
+      created.resolve(createdDraft)
+      await created.promise
+      await Promise.resolve()
+    })
+
+    expect(mockedDraftAPI.deleteDraft).toHaveBeenCalledWith('new-draft')
+    expect(onDraftCreated).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDraftAutosave — draft cap (finding #4)', () => {
+  it('notifies once and stops retrying creation when the server reports the cap', async () => {
+    mockedDraftAPI.createDraft.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        status: 409,
+        data: { code: 'DRAFT_LIMIT', error: 'Too many drafts — delete some.' },
+      },
+    })
+    const onLimitReached = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ content }) =>
+        useDraftAutosave({
+          content,
+          enabled: true,
+          canCreate: true,
+          draftId: null,
+          onDraftCreated: vi.fn(),
+          onLimitReached,
+        }),
+      { initialProps: { content: { title: '' } as Record<string, unknown> } }
+    )
+
+    rerender({ content: { title: 'Soup' } })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+
+    expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1)
+    expect(onLimitReached).toHaveBeenCalledWith('Too many drafts — delete some.')
+
+    // A further edit must NOT fire another create attempt (no per-keystroke
+    // request storm against a known-full account).
+    rerender({ content: { title: 'Soup updated' } })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+    expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1)
+    expect(onLimitReached).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,39 @@ export type RecipeEditFormType = Omit<RecipeFormType, 'recipeImage'> & {
   recipeImage?: File
 }
 
+// An in-progress recipe autosaved during the create flow. Every content field
+// is optional — a draft is intentionally incomplete — and the image is *not*
+// persisted (it's re-picked when the user resumes; publishing still requires
+// one). `RecipeDraftContent` is what the client sends on autosave;
+// `RecipeDraftType` is the stored document the server returns.
+//
+// Clearable numeric fields are `number | null` (not just optional): autosave
+// sends an explicit `null` when the user empties them so the clear is
+// persisted. Omitting the key (sending `undefined`) would be dropped by
+// JSON.stringify, and the server's field-present `$set` whitelist would then
+// leave the stale value in place — a cleared field would silently resurrect on
+// resume.
+export type RecipeDraftContent = {
+  title?: string
+  description?: string
+  servings?: number | null
+  prepTime?: number | null
+  cookTime?: number | null
+  fridgeLife?: number | null
+  freezerLife?: number | null
+  ingredients?: IngredientsType[]
+  instructions?: InstructionsType[]
+  cuisine?: string
+  mealTypes?: string[]
+}
+
+export type RecipeDraftType = RecipeDraftContent & {
+  _id: string
+  userId: string
+  createdAt: string
+  updatedAt: string
+}
+
 export type LabelType = { label: string; id: string }
 export type IngredientsType =
   | {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,12 @@ export type RecipeFormType = {
   mealTypes: string[]
 }
 
+// Same shape as RecipeFormType, but the image is optional: when editing, an
+// unchanged recipe keeps its existing stored image URL and no new File is set.
+export type RecipeEditFormType = Omit<RecipeFormType, 'recipeImage'> & {
+  recipeImage?: File
+}
+
 export type LabelType = { label: string; id: string }
 export type IngredientsType =
   | {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,10 @@ import { IngredientData, ParsedIngredient } from '@jclind/ingredient-parser'
 
 export type RecipeType = {
   _id: string
+  // Firebase uid of the author. Stamped server-side and returned by GET
+  // /getRecipe; the source of truth for ownership checks (authorUsername is a
+  // display snapshot that goes stale if the user renames).
+  userId?: string
   title: string
   prepTime: number
   cookTime: number | null

--- a/src/util/minToHrMin.ts
+++ b/src/util/minToHrMin.ts
@@ -1,0 +1,9 @@
+// Inverse of hrMinToMin: splits a stored minute total back into the
+// { hours, minutes } shape TimeInput expects. Returns null for 0/null so the
+// field renders empty (matching an unset prep/cook time).
+export const minToHrMin = (
+  totalMin: number | null
+): { hours: number; minutes: number } | null => {
+  if (!totalMin) return null
+  return { hours: Math.floor(totalMin / 60), minutes: totalMin % 60 }
+}


### PR DESCRIPTION
## Overview
  This release rolls four merged feature PRs (#98–#101) from
  `development` into production. It adds recipe editing,
  autosaving drafts, public author stats on recipes, and hardens
  username uniqueness validation. ~60 files changed (+4,202 /
  −257), including new backend routes, tests, and UI.

  ## What's included

  ### Recipe editing (#100)
  - Authors can now edit their own recipes via a new
  `EditRecipe` page
  - Added a **Cancel** button to the edit form
  - Delete flow now cleans up all references to a recipe and
  shows a toast (with the recipe title) on successful deletion

  ### Recipe drafts — autosave create flow (#101)
  - New `useDraftAutosave` hook autosaves the create-recipe form
  as a draft
  - Draft save-status indicator + resume banner in the Add
  Recipe flow
  - New **Drafts** section in the Account page to view/resume
  drafts
  - Prompts to re-add the image when resuming a draft (images
  aren't persisted in drafts)
  - New backend `routes/drafts.js`, shared recipe field
  whitelist (`util/recipeFields.js`), and Firebase Storage
  helper

  ### Recipe author stats (#99)
  - Author banner and public recipe stats on the single-recipe
  page (`RecipeStats` component)
  - New `minToHrMin` time-formatting util

  ### Username uniqueness & auth hardening (#98)
  - Enforce **case-insensitive** username uniqueness with
  server-side validation
  - URL-encode username params, retry on transient verification
  failures, ignore stale availability responses
  - Guard the Create Username page, add a logout escape, fix
  silent submit
  - Toast on successful username creation
  - Added a read-only precheck script for `username_lower` index
  collisions

  ## Testing
  New/updated test coverage: `drafts.test.js`,
  `firebaseStorage.test.js`, `RecipeDrafts.test.tsx`,
  `RecipeStats.test.tsx`, `useDraftAutosave.test.tsx`, plus
  updated `RecipesApi`, `AddRecipe`, `auth`, `recipes`, and
  `reviews` suites.

  ## Commits
  Bundles 4 merge PRs: #98, #99, #100, #101 (20 non-merge
  commits).