### PR TITLE
fix(single-recipe): render nutrition facts table

### DIFF
--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -8,6 +8,7 @@ import './SingleRecipe.scss'
 import Ingredients from 'src/pages/SingleRecipe/DataSections/Ingredients/Ingredients'
 import Instructions from 'src/pages/SingleRecipe/DataSections/Instructions/Instructions'
 import Tags from 'src/pages/SingleRecipe/DataSections/Tags'
+import NutritionData from 'src/pages/SingleRecipe/DataSections/NutritionData/NutritionData'
 import RecipeControls from 'src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls'
 import RecipeStats from 'src/pages/SingleRecipe/DataSections/RecipeStats/RecipeStats'
 import MadeRecipeBtn from 'src/pages/SingleRecipe/Buttons/MadeRecipeBtn'
@@ -145,6 +146,12 @@ const SingleRecipe: FC<Props> = ({ recipe }) => {
                   loading={loading}
                 />
                 <Tags loading={loading} currRecipe={currRecipe} />
+                {currRecipe?.nutritionData && (
+                  <NutritionData
+                    data={currRecipe.nutritionData}
+                    servings={currRecipe.servings}
+                  />
+                )}
                 {recipeId && <MadeRecipeBtn recipeId={recipeId} />}
                 <div className='recipe-stats'>
                   <RecipeStats currRecipe={currRecipe} loading={loading} />

--- a/src/test/SingleRecipe.test.tsx
+++ b/src/test/SingleRecipe.test.tsx
@@ -89,6 +89,24 @@ const baseRecipe = {
   numTimesMade: 5,
 }
 
+// Minimal Edamam-shaped nutrition payload covering every nutrient the
+// NutritionData table reads, so the component renders without throwing.
+const nutrientKeys = [
+  'FAT', 'FASAT', 'FATRN', 'CHOLE', 'NA', 'CHOCDF',
+  'FIBTG', 'SUGAR', 'PROCNT', 'VITD', 'CA', 'FE', 'K',
+]
+const buildNutrientMap = () =>
+  Object.fromEntries(
+    nutrientKeys.map(k => [k, { label: k, quantity: 40, unit: 'g' }])
+  )
+const nutritionDataFixture = {
+  calories: 800,
+  totalNutrients: buildNutrientMap(),
+  totalDaily: buildNutrientMap(),
+  dietLabels: [],
+  healthLabels: [],
+}
+
 const createTestQueryClient = () =>
   new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
@@ -183,6 +201,29 @@ describe('SingleRecipe page', () => {
         ])
       )
     })
+  })
+
+  it('renders the nutrition facts table when the recipe has nutritionData', async () => {
+    mockGetRecipe.mockResolvedValue({
+      ...baseRecipe,
+      nutritionData: nutritionDataFixture,
+    })
+    renderSingleRecipe()
+    await screen.findByText('Chicken Tacos')
+    expect(
+      screen.getByRole('button', { name: /nutrition data/i })
+    ).toBeInTheDocument()
+    // calories per serving = round(800 / 4 servings) = 200
+    expect(screen.getByText('200')).toBeInTheDocument()
+  })
+
+  it('omits the nutrition facts table when nutritionData is null', async () => {
+    mockGetRecipe.mockResolvedValue(baseRecipe)
+    renderSingleRecipe()
+    await screen.findByText('Chicken Tacos')
+    expect(
+      screen.queryByRole('button', { name: /nutrition data/i })
+    ).toBeNull()
   })
 
   it('shows error message and does not crash when getRecipe throws', async () => {


### PR DESCRIPTION
## Problem

The nutrition facts table disappeared from single recipe pages. Investigation showed the **data side is healthy** — nutrition is still computed (Edamam), saved, and returned by the API correctly (verified against the 5 newest recipes in the DB, all with well-formed `nutritionData`).

The real issue: the `NutritionData` component was **orphaned during the `Components/` → `pages/` feature-first refactor**. The component file was carried over, but the render call (previously `{currRecipe && currRecipe.nutritionData && <NutritionData />}`) was never re-added to the migrated `SingleRecipe.tsx`.

## Fix

- Re-render `<NutritionData>` in the recipe body, after `<Tags>`.
- Gate on `currRecipe?.nutritionData` so recipes without nutrition (or where the Edamam lookup soft-failed to `null`) render nothing instead of crashing.
- Pass `currRecipe.servings` (base servings) — the stored totals cover the full ingredient list, so per-serving = total ÷ base servings, independent of the user's live serving adjustment.
- Note: the prior render passed **no props** (`<NutritionData />`); this passes the required `data`/`servings`.

## Tests

Added two cases to `SingleRecipe.test.tsx` with a realistic Edamam-shaped fixture:
- Table renders (with correct per-serving calories) when `nutritionData` is present.
- Table is omitted when `nutritionData` is `null`.

Typecheck clean. Full frontend suite: 159 passed, 2 pre-existing skips.