### PR TITLE
Single recipe: mobile layout polish + stat-tile action bar

### DIFF
--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
@@ -9,6 +9,9 @@
   margin-bottom: 2rem;
   padding: 0.9rem 1.4rem;
   width: 100%;
+  // there's no global border-box reset, so without this the padding + border
+  // push the 100%-wide banner past its parent (clipped by #root overflow:hidden)
+  box-sizing: border-box;
   background: linear-gradient(135deg, rgba(s.$secondary, 0.13), rgba(s.$primary, 0.09));
   border: 1.5px solid rgba(s.$primary, 0.22);
   border-radius: 16px;
@@ -96,6 +99,32 @@
       color: s.$primary-background;
       background: s.$error-red;
       border-color: s.$error-red;
+    }
+  }
+
+  // ── mobile: stack into a tidy card — heading, equal Edit/Delete row, evenly
+  // spaced stats ──────────────────────────────────────────────────────────────
+  @media screen and (max-width: 600px) {
+    gap: 0.85rem;
+    padding: 1rem 1.1rem;
+    .who {
+      flex-basis: 100%;
+      font-size: 0.88rem;
+    }
+    .btns-container {
+      width: 100%;
+      gap: 0.6rem;
+      button {
+        flex: 1;
+        justify-content: center;
+        padding: 0.55rem 0.5rem;
+      }
+    }
+    .owner-stats {
+      justify-content: space-between;
+      gap: 0.5rem 0.75rem;
+      padding-top: 0.8rem;
+      .stat { font-size: 0.8rem; }
     }
   }
 }

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -200,7 +200,7 @@ $danger: #d23f31;
     border-radius: $soft-radius;
     box-shadow: $soft-shadow;
     padding: 1.5rem 1.75rem;
-    @media screen and (max-width: 540px) { padding: 1.25rem; }
+    @media screen and (max-width: 600px) { padding: 1.25rem 1rem; }
     > h2 { font-size: 1.35rem; font-weight: 700; margin-bottom: 1.1rem; }
   }
 
@@ -259,7 +259,7 @@ $danger: #d23f31;
 
       .ing {
         display: grid;
-        grid-template-columns: 22px 40px auto 1fr;
+        grid-template-columns: 22px 40px 1fr;
         align-items: center;
         gap: 0.65rem;
         padding: 0.5rem 0.4rem;
@@ -267,6 +267,9 @@ $danger: #d23f31;
         cursor: pointer;
         font-size: 0.94rem;
         &:hover { background: s.$primary-background; }
+        // qty + name flow as one inline text block, so a long name wraps
+        // naturally under the quantity instead of in its own cramped column
+        .ing-text { line-height: 1.45; }
         .box {
           width: 20px;
           height: 20px;
@@ -481,7 +484,7 @@ $danger: #d23f31;
       }
     }
 
-    .ratings-reviews-container { gap: 1.75rem; }
+    .ratings-reviews-container { gap: 0.5rem; }
 
     // overview → "rate this recipe" card (the average now lives in the header).
     // Selector nested under .ratings-reviews-container to outrank the component's
@@ -503,21 +506,32 @@ $danger: #d23f31;
         align-items: flex-start;
         gap: 0.55rem;
         height: auto;
+        // The shared RatingsAndReviews.scss clamps .user-rating to width:170px at
+        // ≤450px (old layout). That squeezes the star row + pill on phones, so
+        // reset it here for the redesigned card.
+        width: auto;
+        max-width: none;
+        .user-rate-container { width: auto; height: auto !important; }
         .rate-heading { font-size: 0.95rem; font-weight: 700; color: s.$primary-text; }
         .rate-active {
           display: flex;
           align-items: center;
-          gap: 0.6rem;
+          flex-wrap: wrap;
+          gap: 0.4rem 0.6rem;
           .rate-hint { font-size: 0.8rem; color: s.$tertiary-text; font-weight: 700; }
         }
         .signin-rate {
           display: inline-flex;
           align-items: center;
-          gap: 0.6rem;
+          flex-wrap: wrap;
+          gap: 0.4rem 0.6rem;
           text-decoration: none;
           .signin-label {
             font-size: 0.85rem;
             font-weight: 700;
+            // keep the pill on one line; flex-wrap drops it below the stars when
+            // space is tight rather than collapsing it into a circle
+            white-space: nowrap;
             text-transform: none;
             letter-spacing: 0;
             color: s.$primary;
@@ -613,8 +627,63 @@ $danger: #d23f31;
   }
 
   // ── responsive ──────────────────────────────────────────────────────────────
+  // Pull the page in toward the screen edges on phones — the global .page is
+  // 90% wide (≈19px gutter at 375px), which wastes room the cards need. Scoped
+  // to ≤640px so tablets keep a comfortable margin.
+  @media screen and (max-width: 640px) {
+    width: calc(100% - 1.5rem); // 0.75rem (12px) gutter each side
+  }
+
   @media screen and (max-width: 600px) {
     .hero-text h1 { font-size: 1.9rem; }
-    .action-bar { padding: 1rem 1.15rem; }
+
+    // ── action bar: stack the meta over a full-width, equal 3-up button row ──
+    .action-bar {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 1rem;
+      padding: 1rem 1.1rem;
+    }
+    // Evenly space the meta stats; drop the left-border separators (and their
+    // 1.4rem inset) that misalign once items wrap.
+    .meta {
+      width: 100%;
+      justify-content: space-between;
+      column-gap: 0.75rem;
+      row-gap: 0.6rem;
+      .m-item {
+        padding: 0;
+        & + .m-item { border-left: none; }
+      }
+    }
+    .sr-actions {
+      width: 100%;
+      gap: 0.5rem;
+      .save-recipe, .add-rating, .print-recipe { flex: 1 1 0; min-width: 0; }
+      .save-recipe-btn, .add-rating-btn, .print-recipe-btn {
+        width: 100%;
+        justify-content: center;
+        padding: 0.7rem 0.5rem;
+      }
+    }
+
+    // ── ingredients: smaller checkbox + thumb, tighter gaps → more name room ──
+    .ingredients-card .ing-list .ing {
+      grid-template-columns: 18px 30px 1fr;
+      gap: 0.45rem;
+      padding: 0.45rem 0.1rem;
+      font-size: 0.92rem;
+      .box { width: 18px; height: 18px; }
+      .thumb { width: 30px; height: 30px; img { width: 24px; height: 24px; } }
+    }
+
+    // ── instructions: smaller number badge, less inset → wider text column ──
+    .instructions-card .step-list .step {
+      grid-template-columns: 26px 1fr;
+      gap: 0.7rem;
+      margin-bottom: 1.25rem;
+      .num { width: 26px; height: 26px; font-size: 0.8rem; }
+      p { line-height: 1.6; }
+    }
   }
 }

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -130,6 +130,7 @@ $danger: #d23f31;
       &:first-child { padding-left: 0; }
       & + .m-item { border-left: 1px solid s.$gray-300; }
     }
+    .m-top { display: inline-flex; align-items: baseline; gap: 0.45rem; }
     .m-ic { align-self: center; color: s.$primary; font-size: 1.1rem; }
     .m-v { font-weight: 800; font-size: 1.1rem; }
     .m-l {
@@ -644,16 +645,33 @@ $danger: #d23f31;
       gap: 1rem;
       padding: 1rem 1.1rem;
     }
-    // Evenly space the meta stats; drop the left-border separators (and their
-    // 1.4rem inset) that misalign once items wrap.
+    // Variation A — stats as centered tiles in a soft inset panel. Each tile is
+    // a flex column: the icon + value sit on one centered row (.m-top), with the
+    // label centered beneath.
     .meta {
       width: 100%;
-      justify-content: space-between;
-      column-gap: 0.75rem;
-      row-gap: 0.6rem;
+      // no global border-box reset, so the panel's padding + border would push
+      // it ~14px past the right edge (out of line with the buttons below)
+      box-sizing: border-box;
+      flex-wrap: nowrap;
+      gap: 0;
+      background: s.$gray-50;
+      border: 1px solid s.$gray-200;
+      border-radius: 12px;
+      padding: 0.7rem 0.35rem;
       .m-item {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.12rem;
         padding: 0;
-        & + .m-item { border-left: none; }
+        .m-top { display: inline-flex; align-items: center; gap: 0.3rem; }
+        .m-ic { font-size: 0.9rem; }
+        .m-v { font-size: 1rem; white-space: nowrap; }
+        .m-l { text-align: center; font-size: 0.62rem; }
+        & + .m-item { border-left: 1px solid s.$gray-300; }
       }
     }
     .sr-actions {

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -267,21 +267,29 @@ const SingleRecipe: FC = () => {
           <div className='action-bar'>
             <div className='meta'>
               <div className='m-item'>
-                <AiOutlineClockCircle className='m-ic' />
-                <span className='m-v'>{currRecipe?.totalTime ?? '—'} min</span>
+                <span className='m-top'>
+                  <AiOutlineClockCircle className='m-ic' />
+                  <span className='m-v'>{currRecipe?.totalTime ?? '—'} min</span>
+                </span>
                 <span className='m-l'>Total time</span>
               </div>
               <div className='m-item'>
-                <AiOutlineUsergroupAdd className='m-ic' />
-                <span className='m-v'>{servingSize || currRecipe?.servings || '—'}</span>
+                <span className='m-top'>
+                  <AiOutlineUsergroupAdd className='m-ic' />
+                  <span className='m-v'>{servingSize || currRecipe?.servings || '—'}</span>
+                </span>
                 <span className='m-l'>Servings</span>
               </div>
               <div className='m-item'>
-                <BsStar className='m-ic' />
-                <span className='m-v'>
-                  {currRecipe ? formatRating(currRecipe.rating?.rateValue, ratingCount) : '—'}
+                <span className='m-top'>
+                  <BsStar className='m-ic' />
+                  <span className='m-v'>
+                    {currRecipe && ratingCount > 0
+                      ? formatRating(currRecipe.rating?.rateValue, ratingCount)
+                      : '—'}
+                  </span>
                 </span>
-                <span className='m-l'>{ratingCount > 0 ? `(${ratingCount})` : 'Rating'}</span>
+                <span className='m-l'>{ratingCount > 0 ? `(${ratingCount})` : 'No ratings'}</span>
               </div>
             </div>
             <div className='sr-actions'>

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -145,13 +145,15 @@ const SingleRecipe: FC = () => {
               <CiShoppingBasket className='no-img' />
             )}
           </span>
-          <span className='qty'>
-            {quantity ? closestFraction(quantity) : ''}
-            {unit ? ` ${unit}` : ''}
-          </span>
-          <span className='name'>
-            {ingredient}
-            {comment ? `, ${comment}` : ''}
+          <span className='ing-text'>
+            <span className='qty'>
+              {quantity ? closestFraction(quantity) : ''}
+              {unit ? ` ${unit}` : ''}
+            </span>{' '}
+            <span className='name'>
+              {ingredient}
+              {comment ? `, ${comment}` : ''}
+            </span>
           </span>
         </li>
       )


### PR DESCRIPTION
## Summary
Mobile-focused pass over the redesigned Single Recipe page. Fixes several layout breaks on phones and adds a polished "stat-tile" action bar (Variation A). Almost entirely CSS, with one small markup tweak each in the ingredients list and the action-bar meta.

## Fixes
- **Rate card / "Sign In To Rate" pill** no longer collapses into a text-filled circle on phones (old `RatingsAndReviews.scss` clamped `.user-rating` to `width:170px`; reset for the redesigned card, with graceful wrap at narrow widths).
- **Owner controls banner** no longer overflows ~48px past the page edge (`box-sizing: border-box` — no global border-box reset in this project).
- **Action-bar meta separators** no longer misalign when items wrap.
- **Stat panel** right edge now lines up with the buttons below it (same `box-sizing` class of bug).

## Polish
- Cards pulled to a 12px gutter on phones (≤640px) for more usable width.
- Tighter card padding; smaller ingredient checkbox/thumb; **quantity now inline with the ingredient name** so long names wrap naturally.
- Instructions: smaller number badges with less inset → wider text column.
- Owner controls/stats: equal Edit/Delete row + evenly spaced stats on mobile.
- Tightened the gap between the "Rate this recipe" card and the reviews.

## Variation A — stat-tile action bar (mobile)
- Meta becomes a soft inset panel of three centered tiles (icon+value over a label, divided), above a full-width equal Save/Rate/Print row.
- Rating value shows a short number or `—` with "No ratings" as the label, so the tile never overflows.
- Desktop layout unchanged.

## Notes
- The colorful circle that appears bottom-right in dev screenshots is the React Query Devtools button — already guarded by `process.env.NODE_ENV !== 'production'`, not shipped.

## Testing
- `npx vitest run src/test/SingleRecipe.test.tsx` → 12/12 pass.
- Verified headless at 320 / 375 / 560px and desktop: no horizontal overflow, panel/button alignment correct, no console errors.