### PR TITLE
feat(print): dedicated print layout for single recipe

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -239,101 +239,11 @@ a {
   }
 }
 
-@media print {
-  ::-webkit-scrollbar {
-    width: 0px;
-    background: transparent; /* make scrollbar transparent */
-  }
-  body,
-  html,
-  .single-recipe-page {
-    height: 100% !important;
-    width: 100% !important;
-    display: inline-block;
-    overflow: visible !important;
-  }
-  #root {
-    height: 100% !important;
-    width: 100% !important;
-  }
-  .single-recipe-page {
-    position: fixed;
-    z-index: 1000;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 100%;
-    margin: 0;
-    padding-top: 2rem;
-    background-color: white;
-    .recipe-container {
-      margin: 0 auto;
-      padding: 0;
-      .header-content {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        flex-direction: column;
-        margin: 0 auto;
-        width: 100%;
-        padding: 0;
-        .description-content {
-          display: flex;
-          justify-content: center;
-          flex-direction: column;
-          align-items: center;
-          margin: 0;
-          padding: 0;
-          min-height: 0px !important;
-          h1.title {
-            text-align: center;
-            margin: 0 auto;
-          }
-          .description {
-            text-align: center;
-            padding: 0 !important;
-            margin: 0 !important;
-          }
-          .recipe-data {
-            padding: 0 !important;
-            margin: 0 !important;
-            max-width: 400px !important;
-          }
-        }
-        .actions {
-          display: none !important;
-        }
-      }
-      .recipe-image-container {
-        display: none !important;
-      }
-    }
-  }
-  .ingredients,
-  .directions {
-    padding-left: 2rem;
-    box-sizing: border-box;
-  }
-  .directions {
-    display: block;
-    page-break-before: always;
-    .list {
-      page-break-before: always;
-      .direction {
-        page-break-before: always;
-        .content {
-          page-break-before: always;
-        }
-      }
-    }
-  }
-  .tags-container {
-    display: none;
-  }
-  .recipe-ratings {
-    display: none;
-  }
-}
+// Print styles live with the dedicated print component
+// (src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.scss), which
+// react-to-print clones into an isolated iframe. The previous global
+// `@media print` block targeted the pre-redesign SingleRecipe DOM and no longer
+// matched anything, so it was removed.
 
 // Dnd
 .dragging {

--- a/src/pages/SingleRecipe/Buttons/PrintRecipeBtn.tsx
+++ b/src/pages/SingleRecipe/Buttons/PrintRecipeBtn.tsx
@@ -5,7 +5,7 @@ import { TailSpin } from 'react-loader-spinner'
 import { BsPrinter, BsFillPrinterFill } from 'react-icons/bs'
 
 type PrintRecipeBtnProps = {
-  printedRef: React.RefObject<HTMLInputElement | null>
+  printedRef: React.RefObject<HTMLDivElement | null>
 }
 
 const PrintRecipeBtn: FC<PrintRecipeBtnProps> = ({ printedRef }) => {

--- a/src/pages/SingleRecipe/DataSections/NutritionData/NutritionData.tsx
+++ b/src/pages/SingleRecipe/DataSections/NutritionData/NutritionData.tsx
@@ -1,26 +1,6 @@
 import React, { FC } from 'react'
 import { NutritionDataType } from 'types'
-
-const getQuantity = (num: number | undefined, servings: number) => {
-  // Only treat genuinely-missing data as null; a real 0 (fat-free, sugar-free,
-  // etc.) is a valid value and must render as "0", not be hidden.
-  if (num == null || !servings) {
-    return null
-  }
-  return Math.round(num / servings)
-}
-
-// Some stored recipes have an incomplete `nutritionData` (a missing
-// `totalNutrients` map, or individual nutrient keys absent — sometimes only a
-// calorie count exists). Wrap the map so any missing key yields
-// `{ quantity: undefined }` instead of throwing when a row reads `.quantity`.
-const emptyNutrient = { quantity: undefined as unknown as number }
-const safeNutrientMap = (
-  map: Record<string, { quantity: number }> | undefined | null
-): Record<string, { quantity: number }> =>
-  new Proxy(map ?? {}, {
-    get: (target, key: string) => target[key] ?? emptyNutrient,
-  })
+import { getQuantity, safeNutrientMap } from 'src/util/nutrition'
 
 type NutritionDataProps = {
   data: NutritionDataType

--- a/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.scss
+++ b/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.scss
@@ -1,0 +1,257 @@
+// Dedicated print-only layout for a recipe. Hidden on screen; react-to-print
+// clones this subtree into an isolated iframe and prints it, so the styles here
+// are fully decoupled from the on-screen SingleRecipe design.
+
+// Keep it out of the normal page flow on screen (it stays mounted so the print
+// ref always points at live, current data).
+@media screen {
+  .printable-recipe {
+    display: none;
+  }
+}
+
+.printable-recipe {
+  box-sizing: border-box;
+  color: #000;
+  background: #fff;
+  font-family: Georgia, 'Times New Roman', serif;
+  line-height: 1.45;
+  font-size: 12pt;
+  max-width: 7.5in;
+  margin: 0 auto;
+  padding: 0.25in;
+  // Break long unbroken tokens (URLs, long compound words) so they wrap inside
+  // their column instead of overflowing the page edge.
+  overflow-wrap: break-word;
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  h1,
+  h2 {
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    margin: 0;
+  }
+
+  .pr-header {
+    border-bottom: 2px solid #000;
+    padding-bottom: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .pr-title {
+    font-size: 24pt;
+    line-height: 1.1;
+  }
+
+  .pr-byline {
+    font-size: 10pt;
+    font-style: italic;
+    color: #333;
+    margin-top: 0.25rem;
+  }
+
+  .pr-description {
+    margin: 0.5rem 0 0;
+    font-size: 11pt;
+  }
+
+  .pr-meta {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin: 0.75rem 0 0;
+    padding: 0;
+
+    li {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .pr-meta-label {
+      font-size: 8pt;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #555;
+    }
+
+    .pr-meta-value {
+      font-size: 12pt;
+      font-weight: bold;
+    }
+  }
+
+  .pr-section {
+    margin-bottom: 1.25rem;
+
+    h2 {
+      font-size: 14pt;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      border-bottom: 1px solid #999;
+      padding-bottom: 0.2rem;
+      margin-bottom: 0.5rem;
+    }
+  }
+
+  // Ingredients: two columns to save vertical space, but never split a single
+  // ingredient across a page or column break.
+  .pr-ingredients ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    columns: 2;
+    column-gap: 1.5rem;
+  }
+
+  .pr-ing {
+    padding: 0.15rem 0;
+    break-inside: avoid;
+    page-break-inside: avoid;
+
+    .pr-qty {
+      font-weight: bold;
+    }
+  }
+
+  .pr-ing-group {
+    list-style: none;
+    font-weight: bold;
+    font-style: italic;
+    margin-top: 0.5rem;
+    break-inside: avoid;
+    column-span: all;
+  }
+
+  // Explicit numbering (see component note): no list markers, a flex number
+  // column that grows for double/triple digits, and group labels that sit flush
+  // without consuming a number.
+  .pr-instructions ol {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .pr-step {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.2rem 0;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .pr-step-num {
+    flex-shrink: 0;
+    min-width: 1.6rem;
+    font-weight: bold;
+  }
+
+  .pr-step-text {
+    flex: 1;
+  }
+
+  .pr-step-group {
+    font-weight: bold;
+    font-style: italic;
+    margin-top: 0.5rem;
+  }
+
+  // Nutrition and tags are supporting info — keep them compact with smaller
+  // headings, tight spacing, and condensed text so they don't dominate the page.
+  .pr-nutrition,
+  .pr-tags {
+    margin-bottom: 0.6rem;
+    // Compact supporting blocks shouldn't be torn across a page break.
+    break-inside: avoid;
+    page-break-inside: avoid;
+
+    h2 {
+      font-size: 10pt;
+      padding-bottom: 0.1rem;
+      margin-bottom: 0.3rem;
+    }
+  }
+
+  .pr-nutrition {
+    .pr-per {
+      font-size: 8pt;
+      font-weight: normal;
+      text-transform: none;
+      letter-spacing: 0;
+      color: #555;
+    }
+
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.1rem 1.25rem;
+      font-size: 9pt;
+
+      li {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.5rem;
+        min-width: 1.35in;
+
+        .pr-nutr-label {
+          color: #333;
+        }
+
+        .pr-nutr-value {
+          font-weight: bold;
+        }
+      }
+    }
+  }
+
+  .pr-tags p {
+    margin: 0;
+    font-size: 9pt;
+    color: #333;
+  }
+
+  .pr-footer {
+    margin-top: 1rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid #999;
+    font-size: 9pt;
+    color: #555;
+
+    .pr-price {
+      margin-bottom: 0.2rem;
+    }
+
+    .pr-source {
+      word-break: break-all;
+    }
+  }
+}
+
+// Give every printed sheet a consistent margin via @page (the react-to-print
+// iframe doesn't inherit the browser's default print margins), and let the
+// content fill that printable area instead of the screen's centered max-width.
+@media print {
+  @page {
+    margin: 0.5in 0.6in;
+  }
+  // The app's global `html, body { height: 100%; overflow: hidden }` gets copied
+  // into react-to-print's print iframe and clips the output to a single page.
+  // Reset it so multi-page recipes paginate instead of being cut off.
+  html,
+  body {
+    height: auto !important;
+    overflow: visible !important;
+  }
+  .printable-recipe {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+  }
+}

--- a/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.tsx
+++ b/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.tsx
@@ -1,0 +1,194 @@
+import React, { FC } from 'react'
+
+import './PrintableRecipe.scss'
+
+import { capitalize } from 'src/util/capitalize'
+import { closestFraction } from 'src/util/validateIngredientQuantityStr'
+import { formatRating } from 'src/util/formatRating'
+import { formatMonthYear } from 'src/util/formatDate'
+import { formatPrice } from 'src/util/formatPrice'
+
+import { IngredientsType, InstructionsType, RecipeType } from 'types'
+
+type PrintableRecipeProps = {
+  ref?: React.Ref<HTMLDivElement>
+  recipe: RecipeType
+  // Already scaled to the user's selected serving size.
+  ingredients: IngredientsType[]
+  instructions: InstructionsType[]
+  servingSize: number
+}
+
+// Per-serving nutrition rows derived from the recipe's *total* nutrients, which
+// are stored across the recipe's original serving count (see NutritionData).
+const nutritionRows = (recipe: RecipeType): { label: string; value: string }[] => {
+  const data = recipe.nutritionData
+  if (!data) return []
+  const servings = recipe.servings
+  if (!servings) return []
+
+  const perServing = (num: number | undefined): number | null =>
+    num == null ? null : Math.round(num / servings)
+
+  const nutrient = (key: string) => data.totalNutrients?.[key]?.quantity
+  const cal = perServing(data.calories)
+
+  const rows: ({ label: string; value: string } | null)[] = [
+    cal != null ? { label: 'Calories', value: `${cal}` } : null,
+    fmt('Fat', nutrient('FAT'), 'g', servings),
+    fmt('Carbs', nutrient('CHOCDF'), 'g', servings),
+    fmt('Fiber', nutrient('FIBTG'), 'g', servings),
+    fmt('Sugars', nutrient('SUGAR'), 'g', servings),
+    fmt('Protein', nutrient('PROCNT'), 'g', servings),
+    fmt('Sodium', nutrient('NA'), 'mg', servings),
+  ]
+  return rows.filter((r): r is { label: string; value: string } => r != null)
+}
+
+const fmt = (
+  label: string,
+  num: number | undefined,
+  unit: string,
+  servings: number
+): { label: string; value: string } | null => {
+  if (num == null || !servings) return null
+  return { label, value: `${Math.round(num / servings)} ${unit}` }
+}
+
+const PrintableRecipe: FC<PrintableRecipeProps> = ({
+  ref,
+  recipe,
+  ingredients,
+  instructions,
+  servingSize,
+}) => {
+  const servings = servingSize || recipe.servings
+  const ratingCount = recipe.rating?.rateCount ?? 0
+  const tags = recipe.nutritionLabels ?? []
+  const nutrition = nutritionRows(recipe)
+
+  return (
+    <div className='printable-recipe' ref={ref} aria-hidden='true'>
+      <header className='pr-header'>
+        <h1 className='pr-title'>{capitalize(recipe.title || '')}</h1>
+        <div className='pr-byline'>
+          by @{recipe.authorUsername}
+          {recipe.createdAt && formatMonthYear(recipe.createdAt) && (
+            <> · {formatMonthYear(recipe.createdAt)}</>
+          )}
+        </div>
+        {recipe.description && (
+          <p className='pr-description'>{recipe.description}</p>
+        )}
+        <ul className='pr-meta'>
+          <li>
+            <span className='pr-meta-label'>Total time</span>
+            <span className='pr-meta-value'>{recipe.totalTime ?? '—'} min</span>
+          </li>
+          <li>
+            <span className='pr-meta-label'>Servings</span>
+            <span className='pr-meta-value'>{servings || '—'}</span>
+          </li>
+          {ratingCount > 0 && (
+            <li>
+              <span className='pr-meta-label'>Rating</span>
+              <span className='pr-meta-value'>
+                {formatRating(recipe.rating?.rateValue, ratingCount)} ({ratingCount})
+              </span>
+            </li>
+          )}
+        </ul>
+      </header>
+
+      <div className='pr-body'>
+        <section className='pr-section pr-ingredients'>
+          <h2>Ingredients</h2>
+          <ul>
+            {ingredients.map(ingr =>
+              'parsedIngredient' in ingr ? (
+                <li key={ingr.id} className='pr-ing'>
+                  <span className='pr-qty'>
+                    {ingr.parsedIngredient.quantity
+                      ? closestFraction(ingr.parsedIngredient.quantity)
+                      : ''}
+                    {ingr.parsedIngredient.unit
+                      ? ` ${ingr.parsedIngredient.unit}`
+                      : ''}
+                  </span>{' '}
+                  <span className='pr-name'>
+                    {ingr.parsedIngredient.ingredient}
+                    {ingr.parsedIngredient.comment
+                      ? `, ${ingr.parsedIngredient.comment}`
+                      : ''}
+                  </span>
+                </li>
+              ) : (
+                <li key={ingr.id} className='pr-ing-group'>
+                  {ingr.label.replace(/:/g, '')}
+                </li>
+              )
+            )}
+          </ul>
+        </section>
+
+        <section className='pr-section pr-instructions'>
+          <h2>Instructions</h2>
+          {/* Numbers come from instr.index (not <ol> auto-numbering): group-label
+              rows must not consume a step number, and a flex number column keeps
+              double-digit numbers from being clipped. */}
+          <ol>
+            {instructions.map(instr =>
+              'content' in instr ? (
+                <li key={instr.id} className='pr-step'>
+                  <span className='pr-step-num'>{instr.index}.</span>
+                  <span className='pr-step-text'>{instr.content}</span>
+                </li>
+              ) : (
+                <li key={instr.id} className='pr-step-group'>
+                  {instr.label.replace(/:/g, '')}
+                </li>
+              )
+            )}
+          </ol>
+        </section>
+
+        {nutrition.length > 0 && (
+          <section className='pr-section pr-nutrition'>
+            <h2>
+              Nutrition <span className='pr-per'>per serving</span>
+            </h2>
+            <ul>
+              {nutrition.map(n => (
+                <li key={n.label}>
+                  <span className='pr-nutr-label'>{n.label}</span>
+                  <span className='pr-nutr-value'>{n.value}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {tags.length > 0 && (
+          <section className='pr-section pr-tags'>
+            <h2>Tags</h2>
+            <p>{tags.join(' · ')}</p>
+          </section>
+        )}
+      </div>
+
+      <footer className='pr-footer'>
+        {recipe.servingPrice ? (
+          <div className='pr-price'>
+            Estimated {formatPrice(recipe.servingPrice * servings)} total ·{' '}
+            {formatPrice(recipe.servingPrice)}/serving
+          </div>
+        ) : null}
+        <div className='pr-source'>
+          Printed from Prepify — {window.location.href}
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+export default PrintableRecipe

--- a/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.tsx
+++ b/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.tsx
@@ -7,6 +7,7 @@ import { closestFraction } from 'src/util/validateIngredientQuantityStr'
 import { formatRating } from 'src/util/formatRating'
 import { formatMonthYear } from 'src/util/formatDate'
 import { formatPrice } from 'src/util/formatPrice'
+import { getQuantity, safeNutrientMap } from 'src/util/nutrition'
 
 import { IngredientsType, InstructionsType, RecipeType } from 'types'
 
@@ -21,38 +22,29 @@ type PrintableRecipeProps = {
 
 // Per-serving nutrition rows derived from the recipe's *total* nutrients, which
 // are stored across the recipe's original serving count (see NutritionData).
+// Uses the shared getQuantity/safeNutrientMap so the math matches the on-screen
+// card; only the (compact) labels differ.
 const nutritionRows = (recipe: RecipeType): { label: string; value: string }[] => {
   const data = recipe.nutritionData
   if (!data) return []
   const servings = recipe.servings
   if (!servings) return []
+  const tNutr = safeNutrientMap(data.totalNutrients)
 
-  const perServing = (num: number | undefined): number | null =>
-    num == null ? null : Math.round(num / servings)
+  const row = (label: string, num: number | undefined, unit: string) => {
+    const q = getQuantity(num, servings)
+    return q == null ? null : { label, value: unit ? `${q} ${unit}` : `${q}` }
+  }
 
-  const nutrient = (key: string) => data.totalNutrients?.[key]?.quantity
-  const cal = perServing(data.calories)
-
-  const rows: ({ label: string; value: string } | null)[] = [
-    cal != null ? { label: 'Calories', value: `${cal}` } : null,
-    fmt('Fat', nutrient('FAT'), 'g', servings),
-    fmt('Carbs', nutrient('CHOCDF'), 'g', servings),
-    fmt('Fiber', nutrient('FIBTG'), 'g', servings),
-    fmt('Sugars', nutrient('SUGAR'), 'g', servings),
-    fmt('Protein', nutrient('PROCNT'), 'g', servings),
-    fmt('Sodium', nutrient('NA'), 'mg', servings),
-  ]
-  return rows.filter((r): r is { label: string; value: string } => r != null)
-}
-
-const fmt = (
-  label: string,
-  num: number | undefined,
-  unit: string,
-  servings: number
-): { label: string; value: string } | null => {
-  if (num == null || !servings) return null
-  return { label, value: `${Math.round(num / servings)} ${unit}` }
+  return [
+    row('Calories', data.calories, ''),
+    row('Fat', tNutr['FAT']?.quantity, 'g'),
+    row('Carbs', tNutr['CHOCDF']?.quantity, 'g'),
+    row('Fiber', tNutr['FIBTG']?.quantity, 'g'),
+    row('Sugars', tNutr['SUGAR']?.quantity, 'g'),
+    row('Protein', tNutr['PROCNT']?.quantity, 'g'),
+    row('Sodium', tNutr['NA']?.quantity, 'mg'),
+  ].filter((r): r is { label: string; value: string } => r != null)
 }
 
 const PrintableRecipe: FC<PrintableRecipeProps> = ({

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -19,10 +19,13 @@ import AddRatingBtn from 'src/pages/SingleRecipe/Buttons/AddRatingBtn'
 import PrintRecipeBtn from 'src/pages/SingleRecipe/Buttons/PrintRecipeBtn'
 import RatingsAndReviews from 'src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews'
 import RecipeNotFound from 'src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound'
+import PrintableRecipe from 'src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe'
 
 import { updateIngredients } from 'src/util/updateIngredients'
 import { capitalize } from 'src/util/capitalize'
 import { formatRating } from 'src/util/formatRating'
+import { formatMonthYear } from 'src/util/formatDate'
+import { formatPrice } from 'src/util/formatPrice'
 import { closestFraction } from 'src/util/validateIngredientQuantityStr'
 
 import { IngredientsType, InstructionsType, RecipeType, ReviewType } from 'types'
@@ -32,17 +35,6 @@ import AuthAPI from 'src/api/auth'
 type LocalStorageRecipeType = { recipeId: string; numServings: number }
 
 const skeletonColor = '#d6d6d6'
-
-const formatMonthYear = (iso: string): string => {
-  // `createdAt` is stored as an epoch-ms string (see RecipeAPI.addRecipe), so it
-  // must be coerced with Number() — `new Date(msString)` yields Invalid Date.
-  const d = new Date(Number(iso))
-  return Number.isNaN(d.getTime())
-    ? ''
-    : d.toLocaleDateString('en', { month: 'long', year: 'numeric' })
-}
-
-const formatPrice = (cents: number) => `$${(cents / 100).toFixed(2)}`
 
 const SingleRecipe: FC = () => {
   const { recipeId } = useParams<{ recipeId: string }>()
@@ -67,7 +59,7 @@ const SingleRecipe: FC = () => {
   // in-progress value while typing; the committed numeric value is servingSize.
   const [servDraft, setServDraft] = useState('')
   const [checked, setChecked] = useState<Set<string>>(new Set())
-  const printedRef = useRef<HTMLInputElement>(null)
+  const printedRef = useRef<HTMLDivElement>(null)
 
   const updateRecipeLocalStorage = (recipeId: string, numServings: number) => {
     const arr: LocalStorageRecipeType[] = JSON.parse(
@@ -201,7 +193,7 @@ const SingleRecipe: FC = () => {
       ) : recipe404 ? (
         <RecipeNotFound />
       ) : (
-        <div className='page single-recipe-page' ref={printedRef}>
+        <div className='page single-recipe-page'>
           <div className='sr-controls'>
             <Link to='/recipes' className='sr-back'>
               <BiLeftArrowAlt /> All recipes
@@ -409,6 +401,16 @@ const SingleRecipe: FC = () => {
               currUserReview={currUserReview}
               setCurrUserReview={setCurrUserReview}
               isOwner={isOwner}
+            />
+          )}
+
+          {!loading && currRecipe && (
+            <PrintableRecipe
+              ref={printedRef}
+              recipe={currRecipe}
+              ingredients={ingredients}
+              instructions={instructions}
+              servingSize={servingSize}
             />
           )}
         </div>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,13 @@
 import '@testing-library/jest-dom'
+import { configure } from '@testing-library/dom'
+
+// The print-only PrintableRecipe subtree is always mounted (aria-hidden) so the
+// react-to-print ref points at live data, and it duplicates on-screen text.
+// jsdom doesn't apply the `@media screen { display:none }` that hides it, so
+// ignore aria-hidden content in queries — tests assert on the visible page.
+configure({
+  defaultIgnore: 'script, style, [aria-hidden="true"], [aria-hidden="true"] *',
+})
 
 // react-modal calls Modal.setAppElement('#root') at module scope in several
 // components. The element must exist in jsdom before those modules are imported.

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -24,3 +24,12 @@ export const formatDate = (d: string, short: boolean): string => {
   }
   return `${month} ${day}, ${year}`
 }
+
+// `createdAt` is stored as an epoch-ms string (see RecipeAPI.addRecipe), so it
+// must be coerced with Number() — `new Date(msString)` yields Invalid Date.
+export const formatMonthYear = (iso: string): string => {
+  const d = new Date(Number(iso))
+  return Number.isNaN(d.getTime())
+    ? ''
+    : d.toLocaleDateString('en', { month: 'long', year: 'numeric' })
+}

--- a/src/util/formatPrice.ts
+++ b/src/util/formatPrice.ts
@@ -1,0 +1,3 @@
+// Prices are stored in cents; render as a dollar string e.g. 1234 -> "$12.34".
+export const formatPrice = (cents: number): string =>
+  `$${(cents / 100).toFixed(2)}`

--- a/src/util/nutrition.ts
+++ b/src/util/nutrition.ts
@@ -1,0 +1,28 @@
+// Shared per-serving nutrition primitives, used by both the on-screen
+// NutritionData card and the print layout (PrintableRecipe). Each component
+// owns its own labels/markup; only the number math and missing-key safety live
+// here so they can't drift apart.
+
+export const getQuantity = (
+  num: number | undefined,
+  servings: number
+): number | null => {
+  // Only treat genuinely-missing data as null; a real 0 (fat-free, sugar-free,
+  // etc.) is a valid value and must render as "0", not be hidden.
+  if (num == null || !servings) {
+    return null
+  }
+  return Math.round(num / servings)
+}
+
+// Some stored recipes have an incomplete `nutritionData` (a missing
+// `totalNutrients` map, or individual nutrient keys absent — sometimes only a
+// calorie count exists). Wrap the map so any missing key yields
+// `{ quantity: undefined }` instead of throwing when a row reads `.quantity`.
+const emptyNutrient = { quantity: undefined as unknown as number }
+export const safeNutrientMap = (
+  map: Record<string, { quantity: number }> | undefined | null
+): Record<string, { quantity: number }> =>
+  new Proxy(map ?? {}, {
+    get: (target, key: string) => target[key] ?? emptyNutrient,
+  })


### PR DESCRIPTION
## Summary

Revamps the broken recipe print functionality. Printing previously dumped the raw interactive page onto paper because the global `@media print` block in `index.scss` targeted **pre-redesign** class names (`.recipe-container`, `.header-content`, `.directions`, …) that no longer existed after the SingleRecipe redesign — so the print stylesheet matched nothing.

This replaces that approach with a dedicated, print-only `PrintableRecipe` component that react-to-print clones into its print iframe, fully decoupled from the on-screen design so it won't silently break on the next redesign.

## What's included

- **`PrintableRecipe` component + scoped stylesheet** — clean paper layout: title, byline, description, meta (time/servings/rating), two-column ingredients **at the selected serving size**, numbered instructions, compact nutrition/tags, footer. Hidden on screen via `@media screen`; marked `aria-hidden` since it duplicates page content.
- **Explicit instruction numbering** (not `<ol>` auto-numbering) so group labels don't consume step numbers and double-digit numbers don't clip.
- **Robust pagination** — `overflow-wrap` for long ingredient tokens, `@page` margins, and an `html/body` height/overflow reset so multi-page recipes paginate instead of clipping to one page (the app's global `height:100%/overflow:hidden` was being copied into react-to-print's iframe).
- **Compact nutrition/tags** — smaller headings, condensed rows, `break-inside: avoid` so blocks aren't torn across pages.
- **Shared nutrition math** — extracted `getQuantity` + `safeNutrientMap` into `src/util/nutrition.ts`, used by both the print layout and the on-screen `NutritionData` card (labels stay per-component).
- **Extracted** `formatMonthYear`/`formatPrice` to `src/util` for reuse.
- **Removed** the dead `@media print` block from `index.scss`.
- **Test setup** — ignore `aria-hidden` content in testing-library queries so the duplicated print subtree doesn't break `SingleRecipe` assertions.

## Testing

- `tsc --noEmit` clean; full Vitest suite **153 passed / 2 skipped**.
- Verified at the real surface: clicked the actual **Print** button and captured react-to-print's iframe — correct content, all step numbers, and serving-size scaling (16 servings → "6 cup rolled oats", "$16.00 total").
- Stress-tested long titles, long/unbreakable ingredient tokens, 48-ingredient pagination, 22 long instructions, ingredient/instruction groups, double-digit step numbers, and long tag lists.
- Cypress `recipe.cy.ts` analyzed — unaffected (print uses `pr-`-prefixed classes; the one duplicate `h1` is safe via DOM order + visibility).