### PR TITLE
feat(nav): purpose-built mobile menu (full-screen gradient + cards)

### DIFF
--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -161,18 +161,32 @@ Chunky design efforts that are bigger than a single checkbox. Tag each as **(blo
     (`Footer.tsx:16`, see blockers section), and (2) adding the Privacy/Terms links that Section C
     requires. If you do the overhaul before 1.0, do those here rather than twice.
 
-- `[ ]` **Mobile Nav Bar redesign** — **(blocker)**
-  - **Now:** `src/Components/Navbar/Navbar.tsx` toggles a `hamburger-react` button (`navOpen` state)
-    that simply shows/hides the *same* desktop `nav-links` via a `.nav-content.show` CSS class — there's
-    no purpose-built mobile menu, just the desktop links reflowed. `Navbar.scss` is already ~8 KB.
-    Logged-out users see recipes/login/signup; logged-in users get an account dropdown holding Help +
-    logout.
-  - **Audit (2026-06-09):** functional — the menu opens to a clean full-screen overlay
-    (Recipes/Login/Signup) with no console errors. This is discretionary polish, **not** a bug fix.
-  - **Goal:** _(fill in)_ — a dedicated mobile nav (e.g. full-screen / slide-in panel, larger tap
-    targets, clearer hierarchy) rather than the reflowed desktop links.
-  - **Touches:** `src/Components/Navbar/Navbar.tsx`, `src/Components/Navbar/Navbar.scss`, and
-    `src/Components/Navbar/PrepifyLogo.tsx` (where the `Beta` button decision also lives).
+- `[~]` **Mobile Nav Bar redesign** — **(blocker)**
+  - **Done (on `feat/mobile-nav-redesign`, pending merge):** replaced the reflowed-desktop-links
+    overlay with a purpose-built mobile menu — a full-screen panel with a subtle brand gradient,
+    frosted cards grouping the nav (Browse / Create / Account), an in-menu recipe search, larger
+    tap-target rows with icons + active-route highlighting, an account card (avatar + username +
+    email + logout when signed in; prominent Login/Signup CTAs when signed out), backdrop blur,
+    body-scroll lock, Esc-to-close, and safe-area padding. Desktop nav is unchanged. Built under
+    `src/Components/Navbar/menu/`; the legacy `.nav-content` overlay is disabled below 725px.
+  - **Still to do:** merge to `development`. The in-menu search reuses the shared `SearchRecipesInput`
+    autocomplete as-is — its visual overhaul is split out as its own item below.
+  - **Touches:** `src/Components/Navbar/Navbar.tsx`, `src/Components/Navbar/Navbar.scss`,
+    `src/Components/Navbar/menu/*`, and `src/Components/Navbar/PrepifyLogo.tsx` (where the `Beta`
+    button decision also lives).
+
+- `[ ]` **Search autocomplete redesign** — **(nice-to-have)**
+  - **Now:** `src/Components/SearchRecipesInput/SearchRecipesInput.tsx` (+ `.scss`) is shared by the
+    Home hero and the new mobile nav menu. Its autocomplete dropdown renders recipe result cards
+    (thumbnail, cook time, servings, rating) in an absolutely-positioned panel below the input.
+  - **Goal:** _(planned for a dedicated session)_ — overhaul the autocomplete designs across the app
+    (home hero + in-menu): rethink the dropdown styling/layout and result-card design, add proper
+    empty / loading / no-results states, and improve how it floats inside the mobile menu (it
+    currently overlays the nav cards as a plain white box — wants a card-style treatment matching the
+    menu).
+  - **Touches:** `src/Components/SearchRecipesInput/SearchRecipesInput.tsx` (+ `.scss`) and its
+    usages (Home hero, `src/Components/Navbar/menu/`).
+  - Gates nothing for 1.0 — tracked here so it isn't lost.
 
 - `[ ]` **Homepage redesign** — **(blocker)**
   - **Now:** `src/pages/Home/Home.tsx` is sparse — it renders only `<HomeHero />` and

--- a/src/Components/Navbar/Navbar.scss
+++ b/src/Components/Navbar/Navbar.scss
@@ -269,6 +269,16 @@ nav {
     // gap: 5rem;
   }
 
+  // Mobile menu is now handled by the redesigned <NavMenu> overlay
+  // (src/Components/Navbar/menu). The legacy full-screen .nav-content overlay
+  // is disabled below 725px; desktop keeps using it for the inline links.
+  @media screen and (max-width: 725px) {
+    .nav-content,
+    .nav-content.show {
+      display: none !important;
+    }
+  }
+
   .nav-links.dark-nav-links {
     .nav-link {
       color: s.$primary-text !important;

--- a/src/Components/Navbar/Navbar.tsx
+++ b/src/Components/Navbar/Navbar.tsx
@@ -9,6 +9,8 @@ import { AiOutlineUser } from 'react-icons/ai'
 import { BiHelpCircle, BiLogOut } from 'react-icons/bi'
 import AuthAPI from 'src/api/auth'
 import Skeleton from 'react-loading-skeleton'
+import NavMenu from 'src/Components/Navbar/menu/NavMenu'
+import { useNavMenu } from 'src/Components/Navbar/menu/useNavMenu'
 
 const skeletonColor = '#d6d6d6'
 
@@ -30,6 +32,9 @@ const Navbar: FC<NavbarProps> = ({
   const uid = AuthAPI.getUID()
 
   const location = useLocation()
+
+  // Mobile menu (redesign): shared auth/profile data for the menu.
+  const menu = useNavMenu()
 
   useEffect(() => {
     setNavOpen(false)
@@ -143,6 +148,7 @@ const Navbar: FC<NavbarProps> = ({
   )
 
   return (
+    <>
     <nav className={`nav background-${navBackgroundColor}`}>
       <div className='nav-center'>
         <div className='nav-header'>
@@ -168,6 +174,11 @@ const Navbar: FC<NavbarProps> = ({
         </div>
       </div>
     </nav>
+
+      {/* Redesigned mobile menu — rendered outside <nav> so the bar (logo +
+          hamburger/X) stays above the overlay and remains tappable to close. */}
+      <NavMenu open={navOpen} onClose={() => setNavOpen(false)} {...menu} />
+    </>
   )
 }
 

--- a/src/Components/Navbar/Navbar.tsx
+++ b/src/Components/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, FC } from 'react'
+import React, { useState, useEffect, useCallback, FC } from 'react'
 import './Navbar.scss'
 import { NavLink, useLocation } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
@@ -11,6 +11,7 @@ import AuthAPI from 'src/api/auth'
 import Skeleton from 'react-loading-skeleton'
 import NavMenu from 'src/Components/Navbar/menu/NavMenu'
 import { useNavMenu } from 'src/Components/Navbar/menu/useNavMenu'
+import { useIsMobile } from 'src/Components/Navbar/menu/useIsMobile'
 
 const skeletonColor = '#d6d6d6'
 
@@ -33,8 +34,10 @@ const Navbar: FC<NavbarProps> = ({
 
   const location = useLocation()
 
-  // Mobile menu (redesign): shared auth/profile data for the menu.
+  // Mobile menu (redesign): shared auth/profile data + mobile-only mount.
   const menu = useNavMenu()
+  const isMobile = useIsMobile()
+  const closeNav = useCallback(() => setNavOpen(false), [])
 
   useEffect(() => {
     setNavOpen(false)
@@ -176,8 +179,9 @@ const Navbar: FC<NavbarProps> = ({
     </nav>
 
       {/* Redesigned mobile menu — rendered outside <nav> so the bar (logo +
-          hamburger/X) stays above the overlay and remains tappable to close. */}
-      <NavMenu open={navOpen} onClose={() => setNavOpen(false)} {...menu} />
+          hamburger/X) stays above the overlay and remains tappable to close.
+          Mounted only at mobile widths, where the hamburger is reachable. */}
+      {isMobile && <NavMenu open={navOpen} onClose={closeNav} {...menu} />}
     </>
   )
 }

--- a/src/Components/Navbar/menu/AccountCard.tsx
+++ b/src/Components/Navbar/menu/AccountCard.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { BiLogOut } from 'react-icons/bi'
 import { NavMenuData } from './types'
@@ -12,7 +12,7 @@ type AccountCardProps = Pick<
 
 /**
  * Logged-in: profile identity (avatar + name + email) and a logout button.
- * Logged-out: prominent Login / Signup CTAs. Skinned via CSS variables per variant.
+ * Logged-out: prominent Login / Signup CTAs. Skinned via CSS variables in NavMenu.scss.
  */
 const AccountCard: FC<AccountCardProps> = ({
   isLoggedIn,
@@ -23,6 +23,9 @@ const AccountCard: FC<AccountCardProps> = ({
   logout,
   onClose,
 }) => {
+  // Fall back to the initial avatar if the profile image fails to load.
+  const [imgFailed, setImgFailed] = useState(false)
+
   if (!isLoggedIn) {
     return (
       <div className='account-card account-card--logged-out'>
@@ -51,8 +54,13 @@ const AccountCard: FC<AccountCardProps> = ({
         className='account-card__identity'
         onClick={onClose}
       >
-        {photoURL ? (
-          <img src={photoURL} alt='Profile' className='account-card__avatar' />
+        {photoURL && !imgFailed ? (
+          <img
+            src={photoURL}
+            alt='Profile'
+            className='account-card__avatar'
+            onError={() => setImgFailed(true)}
+          />
         ) : (
           <div className='account-card__avatar account-card__avatar--initial'>
             {nameInitial}

--- a/src/Components/Navbar/menu/AccountCard.tsx
+++ b/src/Components/Navbar/menu/AccountCard.tsx
@@ -1,0 +1,80 @@
+import React, { FC } from 'react'
+import { NavLink } from 'react-router-dom'
+import { BiLogOut } from 'react-icons/bi'
+import { NavMenuData } from './types'
+
+type AccountCardProps = Pick<
+  NavMenuData,
+  'isLoggedIn' | 'username' | 'email' | 'nameInitial' | 'photoURL' | 'logout'
+> & {
+  onClose: () => void
+}
+
+/**
+ * Logged-in: profile identity (avatar + name + email) and a logout button.
+ * Logged-out: prominent Login / Signup CTAs. Skinned via CSS variables per variant.
+ */
+const AccountCard: FC<AccountCardProps> = ({
+  isLoggedIn,
+  username,
+  email,
+  nameInitial,
+  photoURL,
+  logout,
+  onClose,
+}) => {
+  if (!isLoggedIn) {
+    return (
+      <div className='account-card account-card--logged-out'>
+        <NavLink
+          to='/login'
+          className='account-cta account-cta--login'
+          onClick={onClose}
+        >
+          Log in
+        </NavLink>
+        <NavLink
+          to='/signup'
+          className='account-cta account-cta--signup'
+          onClick={onClose}
+        >
+          Sign up
+        </NavLink>
+      </div>
+    )
+  }
+
+  return (
+    <div className='account-card'>
+      <NavLink
+        to='/account'
+        className='account-card__identity'
+        onClick={onClose}
+      >
+        {photoURL ? (
+          <img src={photoURL} alt='Profile' className='account-card__avatar' />
+        ) : (
+          <div className='account-card__avatar account-card__avatar--initial'>
+            {nameInitial}
+          </div>
+        )}
+        <div className='account-card__meta'>
+          <span className='account-card__name'>{username || 'Your account'}</span>
+          {email && <span className='account-card__email'>{email}</span>}
+        </div>
+      </NavLink>
+      <button
+        className='account-card__logout'
+        onClick={() => {
+          onClose()
+          logout()
+        }}
+      >
+        <BiLogOut className='icon' />
+        <span>Log out</span>
+      </button>
+    </div>
+  )
+}
+
+export default AccountCard

--- a/src/Components/Navbar/menu/MenuLink.tsx
+++ b/src/Components/Navbar/menu/MenuLink.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from 'react'
+import { NavLink } from 'react-router-dom'
+import { NavItem } from './types'
+
+type MenuLinkProps = {
+  item: NavItem
+  onClose: () => void
+  showIcon?: boolean
+}
+
+/** A single nav row (icon + label) used across variants. */
+const MenuLink: FC<MenuLinkProps> = ({ item, onClose, showIcon = true }) => {
+  const Icon = item.icon
+  return (
+    <NavLink
+      to={item.to}
+      end={item.to === '/'}
+      onClick={onClose}
+      className={({ isActive }) => (isActive ? 'menu-link is-active' : 'menu-link')}
+    >
+      {showIcon && <Icon className='menu-link__icon' />}
+      <span className='menu-link__label'>{item.label}</span>
+    </NavLink>
+  )
+}
+
+export default MenuLink

--- a/src/Components/Navbar/menu/MenuLink.tsx
+++ b/src/Components/Navbar/menu/MenuLink.tsx
@@ -5,11 +5,10 @@ import { NavItem } from './types'
 type MenuLinkProps = {
   item: NavItem
   onClose: () => void
-  showIcon?: boolean
 }
 
-/** A single nav row (icon + label) used across variants. */
-const MenuLink: FC<MenuLinkProps> = ({ item, onClose, showIcon = true }) => {
+/** A single nav row (icon + label) in the mobile menu. */
+const MenuLink: FC<MenuLinkProps> = ({ item, onClose }) => {
   const Icon = item.icon
   return (
     <NavLink
@@ -18,7 +17,7 @@ const MenuLink: FC<MenuLinkProps> = ({ item, onClose, showIcon = true }) => {
       onClick={onClose}
       className={({ isActive }) => (isActive ? 'menu-link is-active' : 'menu-link')}
     >
-      {showIcon && <Icon className='menu-link__icon' />}
+      <Icon className='menu-link__icon' />
       <span className='menu-link__label'>{item.label}</span>
     </NavLink>
   )

--- a/src/Components/Navbar/menu/MenuShell.tsx
+++ b/src/Components/Navbar/menu/MenuShell.tsx
@@ -1,0 +1,41 @@
+import React, { FC, ReactNode, useEffect } from 'react'
+import { useBodyScrollLock } from './useBodyScrollLock'
+
+type MenuShellProps = {
+  open: boolean
+  onClose: () => void
+  children: ReactNode
+}
+
+/**
+ * Scaffold for the mobile nav menu: a full-screen overlay with Esc-to-close and
+ * a body-scroll lock. The panel itself is styled in NavMenu.scss; the bar (logo
+ * + hamburger/X) stays above it so it remains tappable to close.
+ */
+const MenuShell: FC<MenuShellProps> = ({ open, onClose, children }) => {
+  useBodyScrollLock(open)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  return (
+    <div className={`nav-menu${open ? ' is-open' : ''}`} aria-hidden={!open}>
+      <div
+        className='nav-menu__panel'
+        role='dialog'
+        aria-modal='true'
+        aria-label='Navigation menu'
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default MenuShell

--- a/src/Components/Navbar/menu/MenuShell.tsx
+++ b/src/Components/Navbar/menu/MenuShell.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useEffect } from 'react'
+import React, { FC, ReactNode, useEffect, useRef } from 'react'
 import { useBodyScrollLock } from './useBodyScrollLock'
 
 type MenuShellProps = {
@@ -7,18 +7,59 @@ type MenuShellProps = {
   children: ReactNode
 }
 
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
 /**
- * Scaffold for the mobile nav menu: a full-screen overlay with Esc-to-close and
- * a body-scroll lock. The panel itself is styled in NavMenu.scss; the bar (logo
- * + hamburger/X) stays above it so it remains tappable to close.
+ * Scaffold for the mobile nav menu: a full-screen overlay with Esc-to-close, a
+ * body-scroll lock, and modal focus handling (focus moves into the panel on
+ * open, is trapped within it, and is restored on close). The bar (logo +
+ * hamburger/X) stays above it so it remains tappable to close.
  */
 const MenuShell: FC<MenuShellProps> = ({ open, onClose, children }) => {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const restoreFocusRef = useRef<HTMLElement | null>(null)
+
   useBodyScrollLock(open)
 
+  // Focus move-in / restore — keyed only on `open` so an unstable `onClose`
+  // identity can't re-capture the restore target or steal focus mid-session.
+  useEffect(() => {
+    if (!open) return
+    restoreFocusRef.current = document.activeElement as HTMLElement | null
+    // focus the panel itself (not the search input) to avoid popping the
+    // mobile keyboard the moment the menu opens
+    panelRef.current?.focus()
+    return () => restoreFocusRef.current?.focus?.()
+  }, [open])
+
+  // Esc-to-close + Tab focus trap within the panel.
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') {
+        onClose()
+        return
+      }
+      if (e.key !== 'Tab') return
+      const panel = panelRef.current
+      if (!panel) return
+      const items = panel.querySelectorAll<HTMLElement>(FOCUSABLE)
+      if (items.length === 0) {
+        e.preventDefault()
+        panel.focus()
+        return
+      }
+      const first = items[0]
+      const last = items[items.length - 1]
+      const active = document.activeElement
+      if (e.shiftKey && (active === first || active === panel)) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
+      }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
@@ -27,6 +68,8 @@ const MenuShell: FC<MenuShellProps> = ({ open, onClose, children }) => {
   return (
     <div className={`nav-menu${open ? ' is-open' : ''}`} aria-hidden={!open}>
       <div
+        ref={panelRef}
+        tabIndex={-1}
         className='nav-menu__panel'
         role='dialog'
         aria-modal='true'

--- a/src/Components/Navbar/menu/NavMenu.scss
+++ b/src/Components/Navbar/menu/NavMenu.scss
@@ -1,0 +1,242 @@
+@use '../../../helpers.scss' as s;
+
+// =============================================================
+// Mobile navigation menu (≤725px): full-screen panel with a subtle brand
+// gradient, frosted cards grouping the nav, an in-menu recipe search, and an
+// account card. Desktop nav is untouched; the legacy .nav-content overlay is
+// disabled below 725px in Navbar.scss.
+// =============================================================
+
+.nav-menu {
+  // theming knobs
+  --menu-text: #{s.$primary-text};
+  --menu-muted: #{s.$secondary-text};
+  --menu-accent: #{s.$primary};
+  --menu-border: #{s.$gray-300};
+  --menu-link-hover: #{s.$gray-50};
+  --menu-active-bg: #{rgba(s.$primary, 0.12)};
+  --menu-avatar-bg: #{s.$primary-text};
+  --menu-avatar-text: #{s.$white};
+  --menu-radius: #{s.$border-radius};
+
+  position: fixed;
+  inset: 0;
+  z-index: 90; // below the bar (z-index 100) so the hamburger/X stays tappable
+  visibility: hidden;
+  pointer-events: none;
+
+  // mobile only — desktop keeps the inline nav links
+  @media screen and (min-width: 726px) {
+    display: none;
+  }
+
+  &.is-open {
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  // ---- full-screen panel ----
+  .nav-menu__panel {
+    position: absolute;
+    inset: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: s.$max-width;
+    margin: 0 auto;
+    padding: calc(#{s.$nav-height} + env(safe-area-inset-top, 0px)) 2rem
+      calc(2rem + env(safe-area-inset-bottom, 0px));
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    color: var(--menu-text);
+
+    // solid base + subtle diagonal brand gradient (base keeps the page from
+    // bleeding through, since there's no backdrop behind a full-screen panel)
+    background-color: s.$white;
+    background-image: linear-gradient(
+      170deg,
+      #{rgba(s.$primary, 0.12)} 0%,
+      #{rgba(s.$secondary, 0.06)} 45%,
+      #{rgba(s.$white, 0)} 100%
+    );
+
+    opacity: 0;
+    transform: scale(1.03);
+    transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.25s ease;
+  }
+  &.is-open .nav-menu__panel {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  // ---- search slot ----
+  .menu-search {
+    width: 100%;
+    margin-bottom: 0.25rem;
+
+    // SearchRecipesInput is sized for page layouts (90% / max 800px); inside
+    // the menu it should fill the column so it lines up with the cards below.
+    .search-recipes-form {
+      width: 100%;
+      max-width: none;
+    }
+  }
+
+  // ---- grouped sections (frosted cards) ----
+  .menu-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.85rem 0.75rem;
+    background: rgba(255, 255, 255, 0.72);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    border: 1px solid rgba(255, 255, 255, 0.9);
+    border-radius: var(--menu-radius);
+    box-shadow: 0 4px 16px rgba(48, 56, 65, 0.08);
+  }
+  .menu-group__heading {
+    margin: 0 0 0.35rem 0.5rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--menu-muted);
+  }
+
+  // ---- nav rows ----
+  .menu-link {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 1rem;
+    border-radius: var(--menu-radius);
+    color: var(--menu-text);
+    text-decoration: none;
+    font-size: 1.25rem;
+    font-weight: 600;
+    transition: background 0.12s linear, color 0.12s linear;
+
+    .menu-link__icon {
+      flex-shrink: 0;
+      height: 22px;
+      width: 22px;
+      color: var(--menu-accent);
+    }
+    &:hover {
+      background: var(--menu-link-hover);
+    }
+    &.is-active {
+      background: var(--menu-active-bg);
+      color: var(--menu-accent);
+    }
+  }
+
+  // ---- account card ----
+  .account-card {
+    margin-top: auto;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--menu-border);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .account-card__identity {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    text-decoration: none;
+    color: var(--menu-text);
+  }
+  .account-card__avatar {
+    flex-shrink: 0;
+    height: 48px;
+    width: 48px;
+    border-radius: 50%;
+    object-fit: cover;
+    overflow: hidden;
+  }
+  .account-card__avatar--initial {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--menu-avatar-bg);
+    color: var(--menu-avatar-text);
+    font-size: 1.4rem;
+    font-weight: 600;
+  }
+  .account-card__meta {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+  .account-card__name {
+    font-weight: 700;
+    font-size: 1.05rem;
+  }
+  .account-card__email {
+    font-size: 0.82rem;
+    color: var(--menu-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .account-card__logout {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.75rem;
+    border: 1px solid var(--menu-border);
+    border-radius: var(--menu-radius);
+    background: none;
+    color: var(--menu-text);
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 0.12s linear, background 0.12s linear;
+    .icon {
+      height: 20px;
+      width: 20px;
+    }
+    &:hover {
+      border-color: var(--menu-accent);
+      color: var(--menu-accent);
+    }
+  }
+
+  // ---- logged-out CTAs ----
+  .account-card--logged-out {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .account-cta {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem;
+    border-radius: var(--menu-radius);
+    font-size: 1.05rem;
+    font-weight: 700;
+    text-decoration: none;
+    transition: filter 0.12s linear, background 0.12s linear;
+  }
+  .account-cta--signup {
+    background: var(--menu-accent);
+    color: #fff;
+    &:hover {
+      filter: brightness(1.07);
+    }
+  }
+  .account-cta--login {
+    background: none;
+    color: var(--menu-text);
+    border: 2px solid var(--menu-border);
+    &:hover {
+      border-color: var(--menu-accent);
+      color: var(--menu-accent);
+    }
+  }
+}

--- a/src/Components/Navbar/menu/NavMenu.tsx
+++ b/src/Components/Navbar/menu/NavMenu.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from 'react'
+import './NavMenu.scss'
+import MenuShell from './MenuShell'
+import MenuLink from './MenuLink'
+import AccountCard from './AccountCard'
+import SearchRecipesInput from 'src/Components/SearchRecipesInput/SearchRecipesInput'
+import { getNavGroups } from './navItems'
+import { NavMenuVariantProps } from './types'
+
+/**
+ * Mobile navigation menu (≤725px): full-screen panel with a subtle brand
+ * gradient, an in-menu recipe search, frosted cards grouping the nav, and an
+ * account card. Data comes from `useNavMenu` (see Navbar.tsx).
+ */
+const NavMenu: FC<NavMenuVariantProps> = ({ open, onClose, ...menu }) => (
+  <MenuShell open={open} onClose={onClose}>
+    <div className='menu-search'>
+      <SearchRecipesInput autoComplete={true} />
+    </div>
+    {getNavGroups(menu.isLoggedIn).map(group => (
+      <div className='menu-group' key={group.heading}>
+        <p className='menu-group__heading'>{group.heading}</p>
+        {group.items.map(item => (
+          <MenuLink key={item.to} item={item} onClose={onClose} />
+        ))}
+      </div>
+    ))}
+    <AccountCard {...menu} onClose={onClose} />
+  </MenuShell>
+)
+
+export default NavMenu

--- a/src/Components/Navbar/menu/NavMenu.tsx
+++ b/src/Components/Navbar/menu/NavMenu.tsx
@@ -5,14 +5,14 @@ import MenuLink from './MenuLink'
 import AccountCard from './AccountCard'
 import SearchRecipesInput from 'src/Components/SearchRecipesInput/SearchRecipesInput'
 import { getNavGroups } from './navItems'
-import { NavMenuVariantProps } from './types'
+import { NavMenuProps } from './types'
 
 /**
  * Mobile navigation menu (≤725px): full-screen panel with a subtle brand
  * gradient, an in-menu recipe search, frosted cards grouping the nav, and an
  * account card. Data comes from `useNavMenu` (see Navbar.tsx).
  */
-const NavMenu: FC<NavMenuVariantProps> = ({ open, onClose, ...menu }) => (
+const NavMenu: FC<NavMenuProps> = ({ open, onClose, ...menu }) => (
   <MenuShell open={open} onClose={onClose}>
     <div className='menu-search'>
       <SearchRecipesInput autoComplete={true} />

--- a/src/Components/Navbar/menu/navItems.ts
+++ b/src/Components/Navbar/menu/navItems.ts
@@ -1,0 +1,31 @@
+import { AiOutlineHome, AiOutlineUser, AiOutlinePlusCircle } from 'react-icons/ai'
+import { MdOutlineRestaurantMenu } from 'react-icons/md'
+import { BiHelpCircle } from 'react-icons/bi'
+import { NavItem, NavGroup } from './types'
+
+/** Browse links — always shown (logged in or out). */
+export const browseItems: NavItem[] = [
+  { label: 'Home', to: '/', icon: AiOutlineHome },
+  { label: 'Recipes', to: '/recipes', icon: MdOutlineRestaurantMenu },
+]
+
+/** Create links — logged-in only. */
+export const createItems: NavItem[] = [
+  { label: 'Create Recipe', to: '/add-recipe', icon: AiOutlinePlusCircle },
+]
+
+/** Account links — logged-in only (Logout is rendered separately as a button). */
+export const accountNavItems: NavItem[] = [
+  { label: 'Account', to: '/account', icon: AiOutlineUser },
+  { label: 'Help', to: '/help', icon: BiHelpCircle },
+]
+
+/** Sectioned list rendered by the menu (Browse / Create / Account). */
+export const getNavGroups = (isLoggedIn: boolean): NavGroup[] => {
+  if (!isLoggedIn) return [{ heading: 'Browse', items: browseItems }]
+  return [
+    { heading: 'Browse', items: browseItems },
+    { heading: 'Create', items: createItems },
+    { heading: 'Account', items: accountNavItems },
+  ]
+}

--- a/src/Components/Navbar/menu/types.ts
+++ b/src/Components/Navbar/menu/types.ts
@@ -1,6 +1,6 @@
 import { IconType } from 'react-icons'
 
-/** Data every mobile-nav variant needs, produced once by `useNavMenu`. */
+/** Auth/profile data the mobile nav menu needs, produced once by `useNavMenu`. */
 export type NavMenuData = {
   isLoggedIn: boolean
   authLoading: boolean
@@ -12,8 +12,8 @@ export type NavMenuData = {
   logout: () => void
 }
 
-/** Props shared by all variant components. */
-export type NavMenuVariantProps = NavMenuData & {
+/** Props for the mobile nav menu: profile data plus open/close control. */
+export type NavMenuProps = NavMenuData & {
   open: boolean
   onClose: () => void
 }

--- a/src/Components/Navbar/menu/types.ts
+++ b/src/Components/Navbar/menu/types.ts
@@ -1,0 +1,30 @@
+import { IconType } from 'react-icons'
+
+/** Data every mobile-nav variant needs, produced once by `useNavMenu`. */
+export type NavMenuData = {
+  isLoggedIn: boolean
+  authLoading: boolean
+  username: string
+  email: string
+  /** First letter of username (or email) for the avatar fallback. */
+  nameInitial: string
+  photoURL: string | null
+  logout: () => void
+}
+
+/** Props shared by all variant components. */
+export type NavMenuVariantProps = NavMenuData & {
+  open: boolean
+  onClose: () => void
+}
+
+export type NavItem = {
+  label: string
+  to: string
+  icon: IconType
+}
+
+export type NavGroup = {
+  heading: string
+  items: NavItem[]
+}

--- a/src/Components/Navbar/menu/useBodyScrollLock.ts
+++ b/src/Components/Navbar/menu/useBodyScrollLock.ts
@@ -1,23 +1,20 @@
 import { useEffect } from 'react'
 
-/** Locks `body` scroll (and preserves the scrollbar gutter) while `locked` is true. */
+/**
+ * Locks background scroll while `locked` is true. In this app the scroll
+ * container is `<body>` (html and #root are `overflow: hidden` — see
+ * index.scss), so freezing `body`'s overflow stops the page behind the menu.
+ */
 export const useBodyScrollLock = (locked: boolean): void => {
   useEffect(() => {
     if (!locked) return
 
     const { body } = document
     const prevOverflow = body.style.overflow
-    const prevPaddingRight = body.style.paddingRight
-    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
-
     body.style.overflow = 'hidden'
-    if (scrollbarWidth > 0) {
-      body.style.paddingRight = `${scrollbarWidth}px`
-    }
 
     return () => {
       body.style.overflow = prevOverflow
-      body.style.paddingRight = prevPaddingRight
     }
   }, [locked])
 }

--- a/src/Components/Navbar/menu/useBodyScrollLock.ts
+++ b/src/Components/Navbar/menu/useBodyScrollLock.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+
+/** Locks `body` scroll (and preserves the scrollbar gutter) while `locked` is true. */
+export const useBodyScrollLock = (locked: boolean): void => {
+  useEffect(() => {
+    if (!locked) return
+
+    const { body } = document
+    const prevOverflow = body.style.overflow
+    const prevPaddingRight = body.style.paddingRight
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
+
+    body.style.overflow = 'hidden'
+    if (scrollbarWidth > 0) {
+      body.style.paddingRight = `${scrollbarWidth}px`
+    }
+
+    return () => {
+      body.style.overflow = prevOverflow
+      body.style.paddingRight = prevPaddingRight
+    }
+  }, [locked])
+}

--- a/src/Components/Navbar/menu/useIsMobile.ts
+++ b/src/Components/Navbar/menu/useIsMobile.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+// Matches the mobile breakpoint where the hamburger menu is used (Navbar.scss).
+const MOBILE_QUERY = '(max-width: 725px)'
+
+const hasMatchMedia = (): boolean =>
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+
+/**
+ * True when the viewport is at the mobile nav breakpoint. Used to mount the
+ * mobile menu only where it's reachable, so its `SearchRecipesInput` (and the
+ * document listener it registers) isn't kept alive on desktop.
+ */
+export const useIsMobile = (): boolean => {
+  const [isMobile, setIsMobile] = useState(
+    () => hasMatchMedia() && window.matchMedia(MOBILE_QUERY).matches
+  )
+
+  useEffect(() => {
+    if (!hasMatchMedia()) return
+    const mql = window.matchMedia(MOBILE_QUERY)
+    const onChange = () => setIsMobile(mql.matches)
+    onChange() // sync in case it changed between render and effect
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [])
+
+  return isMobile
+}

--- a/src/Components/Navbar/menu/useNavMenu.ts
+++ b/src/Components/Navbar/menu/useNavMenu.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query'
+import { useAuth } from 'src/context/AuthContext'
+import AuthAPI from 'src/api/auth'
+import { NavMenuData } from './types'
+
+/**
+ * Centralizes the auth/profile data the mobile-nav variants need, so each
+ * variant renders from one source instead of re-running the username query.
+ */
+export const useNavMenu = (): NavMenuData => {
+  const authRes = useAuth()
+  const uid = AuthAPI.getUID()
+
+  const { data } = useQuery({
+    queryKey: ['username', uid],
+    queryFn: () => AuthAPI.getUsername(),
+    enabled: !!uid && !!authRes?.user,
+  })
+
+  const username = data ?? ''
+  const email = authRes?.user?.email ?? ''
+  const nameInitial = data
+    ? data.charAt(0).toUpperCase()
+    : data === null
+    ? email
+      ? email.charAt(0).toUpperCase()
+      : ''
+    : ''
+
+  return {
+    isLoggedIn: !!authRes?.user,
+    authLoading: !!authRes?.authLoading,
+    username,
+    email,
+    nameInitial,
+    photoURL: authRes?.user?.photoURL ?? null,
+    logout: () => authRes?.logout(),
+  }
+}

--- a/src/test/NavMenu.test.tsx
+++ b/src/test/NavMenu.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import NavMenu from 'src/Components/Navbar/menu/NavMenu'
+import { NavMenuProps } from 'src/Components/Navbar/menu/types'
+
+// The in-menu search pulls in RecipeAPI + autocomplete; stub it so these tests
+// focus on the menu's own structure/behavior.
+vi.mock('src/Components/SearchRecipesInput/SearchRecipesInput', () => ({
+  default: () => <div data-testid='search-stub' />,
+}))
+
+const createTestQueryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+const baseMenu = (
+  overrides: Partial<NavMenuProps> = {}
+): NavMenuProps => ({
+  open: true,
+  onClose: vi.fn(),
+  isLoggedIn: false,
+  authLoading: false,
+  username: '',
+  email: '',
+  nameInitial: '',
+  photoURL: null,
+  logout: vi.fn(),
+  ...overrides,
+})
+
+const renderMenu = (props: NavMenuProps) =>
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <MemoryRouter>
+        <NavMenu {...props} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+
+describe('NavMenu', () => {
+  it('logged out: shows Browse + Login/Signup CTAs, hides logged-in nav', () => {
+    renderMenu(baseMenu({ isLoggedIn: false }))
+
+    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Recipes' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Log in' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Sign up' })).toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('link', { name: 'Create Recipe' })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Account' })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /log out/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('logged in: shows all groups, account identity, and logout (no CTAs)', () => {
+    renderMenu(
+      baseMenu({
+        isLoggedIn: true,
+        username: 'chef',
+        email: 'chef@example.com',
+        nameInitial: 'C',
+      })
+    )
+
+    expect(screen.getByRole('link', { name: 'Create Recipe' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Account' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Help' })).toBeInTheDocument()
+    expect(screen.getByText('chef')).toBeInTheDocument()
+    expect(screen.getByText('chef@example.com')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument()
+
+    expect(screen.queryByRole('link', { name: 'Log in' })).not.toBeInTheDocument()
+  })
+
+  it('calls onClose when a nav link is clicked', () => {
+    const onClose = vi.fn()
+    renderMenu(baseMenu({ onClose }))
+    fireEvent.click(screen.getByRole('link', { name: 'Recipes' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    renderMenu(baseMenu({ onClose }))
+    // keydown bubbles from the dialog up to the window listener
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('logout button closes the menu and logs out', () => {
+    const onClose = vi.fn()
+    const logout = vi.fn()
+    renderMenu(baseMenu({ isLoggedIn: true, onClose, logout }))
+    fireEvent.click(screen.getByRole('button', { name: /log out/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(logout).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/test/navItems.test.ts
+++ b/src/test/navItems.test.ts
@@ -1,0 +1,25 @@
+import { getNavGroups } from 'src/Components/Navbar/menu/navItems'
+
+describe('getNavGroups', () => {
+  it('logged out: only the Browse group (Home, Recipes)', () => {
+    const groups = getNavGroups(false)
+    expect(groups.map(g => g.heading)).toEqual(['Browse'])
+    expect(groups[0].items.map(i => i.label)).toEqual(['Home', 'Recipes'])
+  })
+
+  it('logged in: Browse + Create + Account groups', () => {
+    const groups = getNavGroups(true)
+    expect(groups.map(g => g.heading)).toEqual(['Browse', 'Create', 'Account'])
+    expect(groups[1].items.map(i => i.label)).toEqual(['Create Recipe'])
+    expect(groups[2].items.map(i => i.label)).toEqual(['Account', 'Help'])
+  })
+
+  it('every item has a route and an icon', () => {
+    for (const group of getNavGroups(true)) {
+      for (const item of group.items) {
+        expect(item.to).toMatch(/^\//)
+        expect(item.icon).toBeTruthy()
+      }
+    }
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -14,3 +14,19 @@ configure({
 const rootEl = document.createElement('div')
 rootEl.id = 'root'
 document.body.appendChild(rootEl)
+
+// jsdom doesn't implement matchMedia; stub it (defaults to "not mobile" so the
+// mobile nav menu doesn't mount in component/app tests unless a test overrides).
+if (typeof window.matchMedia !== 'function') {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    } as unknown as MediaQueryList)
+}

--- a/src/test/useNavMenu.test.tsx
+++ b/src/test/useNavMenu.test.tsx
@@ -1,0 +1,77 @@
+import React, { ReactNode } from 'react'
+import { vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useNavMenu } from 'src/Components/Navbar/menu/useNavMenu'
+import AuthAPI from 'src/api/auth'
+import { useAuth } from 'src/context/AuthContext'
+
+vi.mock('src/api/auth', () => ({
+  default: { getUID: vi.fn(), getUsername: vi.fn() },
+}))
+vi.mock('src/context/AuthContext', () => ({ useAuth: vi.fn() }))
+
+const mockGetUID = AuthAPI.getUID as ReturnType<typeof vi.fn>
+const mockGetUsername = AuthAPI.getUsername as ReturnType<typeof vi.fn>
+const mockUseAuth = useAuth as ReturnType<typeof vi.fn>
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    {children}
+  </QueryClientProvider>
+)
+
+describe('useNavMenu', () => {
+  beforeEach(() => {
+    mockGetUID.mockReset()
+    mockGetUsername.mockReset()
+    mockUseAuth.mockReset()
+  })
+
+  it('logged out: empty profile data, isLoggedIn false', () => {
+    mockUseAuth.mockReturnValue({ user: null, authLoading: false, logout: vi.fn() })
+    mockGetUID.mockReturnValue(null)
+    mockGetUsername.mockResolvedValue(null)
+
+    const { result } = renderHook(() => useNavMenu(), { wrapper })
+
+    expect(result.current.isLoggedIn).toBe(false)
+    expect(result.current.username).toBe('')
+    expect(result.current.nameInitial).toBe('')
+    expect(result.current.photoURL).toBeNull()
+  })
+
+  it('logged in: derives the avatar initial from the username', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { email: 'chef@example.com', photoURL: 'https://img/x.png' },
+      authLoading: false,
+      logout: vi.fn(),
+    })
+    mockGetUID.mockReturnValue('uid-1')
+    mockGetUsername.mockResolvedValue('Chef')
+
+    const { result } = renderHook(() => useNavMenu(), { wrapper })
+
+    expect(result.current.isLoggedIn).toBe(true)
+    expect(result.current.photoURL).toBe('https://img/x.png')
+    await waitFor(() => expect(result.current.username).toBe('Chef'))
+    expect(result.current.nameInitial).toBe('C')
+  })
+
+  it('logged in without a username: falls back to the email initial', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { email: 'bob@example.com', photoURL: null },
+      authLoading: false,
+      logout: vi.fn(),
+    })
+    mockGetUID.mockReturnValue('uid-2')
+    mockGetUsername.mockResolvedValue(null) // no username set
+
+    const { result } = renderHook(() => useNavMenu(), { wrapper })
+
+    await waitFor(() => expect(result.current.nameInitial).toBe('B'))
+    expect(result.current.username).toBe('')
+  })
+})


### PR DESCRIPTION
## What

Replaces the legacy mobile nav — which just reflowed the desktop `nav-links` into a `.nav-content.show` overlay — with a dedicated mobile menu under `src/Components/Navbar/menu/`.

**The menu (≤725px):**
- Full-screen panel with a subtle brand gradient and frosted cards grouping the nav (Browse / Create / Account)
- In-menu recipe search (reuses `SearchRecipesInput`, widened to fill the column)
- Icon rows with active-route highlighting
- Account card: avatar + username + email + logout when signed in; prominent Login/Signup CTAs when signed out
- Body-scroll lock, Esc-to-close, safe-area padding, and modal focus handling (focus moves into the panel, is trapped, and restores on close)

Rendered as a sibling of `<nav>` so the bar (logo + hamburger/X) stays above the overlay and tappable. The legacy `.nav-content` overlay is disabled below 725px; **desktop nav is unchanged**. The menu mounts only at mobile widths (`useIsMobile`), so its `SearchRecipesInput` isn't kept alive on desktop and there's no duplicate search input in the DOM.

This was an exploration of 15 variants behind a dev switcher; the chosen design (B3c) was promoted and all scaffolding removed.

## Tests
New coverage (+11 tests): `NavMenu` (logged-in/out structure, link-click + Escape close, logout), `getNavGroups`, and `useNavMenu` (avatar-initial fallback). Full suite: 168 pass / 2 skipped. `matchMedia` stubbed in the test setup.

## Verification
Driven headless (run-prepify skill) at mobile + desktop:
- Opens/closes via hamburger and Esc; focus lands in the dialog; real wheel gesture confirms background scroll is locked while open and released on close.
- Desktop: `.nav-menu` absent from the DOM, single search input, inline nav unchanged.
- Zero console errors at both viewports.

## Docs
Updates `docs/RELEASE_PLAN.md`: marks the "Mobile Nav Bar redesign" blocker in progress and adds a "Search autocomplete redesign" follow-up item.