### PR TITLE
chore(server): allow localhost dev ports 3000-3010 in CORS (non-prod)

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -15,9 +15,20 @@ const allowedOrigins = (process.env.FRONTEND_URLS || 'http://localhost:3000')
 
 const netlifyPreviewPattern = /^https:\/\/deploy-preview-\d+--prepify\.netlify\.app$/
 
+// Outside production, allow any localhost/127.0.0.1 dev client on ports 3000-3010
+// so git worktrees (each Vite picks the next free port) reach the API without
+// editing FRONTEND_URLS each time. Never applied when NODE_ENV=production.
+const isProduction = process.env.NODE_ENV === 'production'
+const localhostDevPattern = /^http:\/\/(localhost|127\.0\.0\.1):30(0\d|10)$/
+
 app.use(cors({
   origin: (origin, callback) => {
-    if (!origin || allowedOrigins.includes(origin) || netlifyPreviewPattern.test(origin)) {
+    if (
+      !origin ||
+      allowedOrigins.includes(origin) ||
+      netlifyPreviewPattern.test(origin) ||
+      (!isProduction && localhostDevPattern.test(origin))
+    ) {
       callback(null, true)
     } else {
       callback(new Error('Not allowed by CORS'))


### PR DESCRIPTION
Local dev quality-of-life for working across **git worktrees**.

Each worktree runs its own Vite, which grabs the next free port (3001, 3007, …), but the server's CORS allow-list is a fixed `FRONTEND_URLS` (defaulting to `http://localhost:3000`). So every worktree except the first gets blocked and its API calls fail.

This allows `localhost`/`127.0.0.1` on ports **3000–3010** — but **only when `NODE_ENV !== 'production'`**. Deployed CORS (the `FRONTEND_URLS` list + the Netlify-preview pattern) is unchanged.

Verified at runtime against the running API:
- `http://localhost:3007` → `Access-Control-Allow-Origin: http://localhost:3007` ✅
- `http://localhost:3011`, `http://evil.com:3000` → blocked ✅