### PR TITLE
feat(help): make help form public and add email field

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,15 +164,15 @@ const App: FC = () => {
                   </Layout>
                 }
               />
-              <Route
-                path='/help'
-                element={
-                  <Layout darkNavLinks={true}>
-                    <Help />
-                  </Layout>
-                }
-              />
             </Route>
+            <Route
+              path='/help'
+              element={
+                <Layout darkNavLinks={true}>
+                  <Help />
+                </Layout>
+              }
+            />
             <Route path='/login' element={<Login />} />
             <Route path='/signup' element={<Signup />} />
             <Route path='/create-username' element={<CreateUsername />} />

--- a/src/pages/Help/Help.scss
+++ b/src/pages/Help/Help.scss
@@ -66,9 +66,11 @@
           width: 100%;
         }
       }
+      label.email-input-label,
       label.title-input-label {
         width: 100%;
 
+        input.email-input,
         input.title-input {
           width: 100%;
           height: 40px;

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -1,8 +1,9 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import Select, { SingleValue, StylesConfig } from 'react-select'
 import { useForm } from '@formspree/react'
 import './Help.scss'
 import { Helmet } from 'react-helmet-async'
+import { useAuth } from 'src/context/AuthContext'
 
 type OptionType = { value: string; label: string }
 
@@ -58,7 +59,10 @@ const customStyles: StylesConfig<OptionType> = {
 }
 
 const Help: FC = () => {
+  const user = useAuth()?.user
+
   const [selectOption, setSelectOption] = useState<OptionType | null>(null)
+  const [email, setEmail] = useState(user?.email ?? '')
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
 
@@ -66,11 +70,20 @@ const Help: FC = () => {
 
   const [formState, submitFormspree] = useForm('xknyboeq')
 
+  // Auth resolves async, so user is null on first render. Pre-fill the email
+  // once it loads, but don't clobber anything the visitor has already typed.
+  useEffect(() => {
+    if (user?.email) {
+      setEmail(prev => (prev === '' ? user.email ?? '' : prev))
+    }
+  }, [user])
+
   const handleSelectChange = (e: SingleValue<OptionType>) => {
     setSelectOption(e)
   }
   const clearForm = () => {
     setSelectOption(null)
+    setEmail(user?.email ?? '')
     setTitle('')
     setDescription('')
   }
@@ -126,6 +139,18 @@ const Help: FC = () => {
                   name='category'
                 />
               </div>
+              <label htmlFor='' className='email-input-label'>
+                <div className='text'>Email</div>
+                <input
+                  type='email'
+                  name='email'
+                  className='email-input'
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
+                  placeholder='Enter your email'
+                  required={true}
+                />
+              </label>
               <label htmlFor='' className='title-input-label'>
                 <div className='text'>Title</div>
                 <input


### PR DESCRIPTION
## Summary
- Move the `/help` route out of `PrivateRoute` so anyone can reach the support form. Previously the people most likely to need help (forgot password, broken signup, login issues) were locked out, and the page couldn't be indexed despite having a canonical URL + marketing meta description.
- Add a required **Email** field to the help form, pre-filled from the logged-in user's Firebase email and editable for anonymous visitors. Uses Formspree's `email` field name so submissions now have a reply-to address (previously there was no way to respond).
- Style the new email input to match the existing Title/Description inputs.

## Implementation notes
- Email is pre-filled via `useEffect` keyed on `user` because Firebase auth resolves async (the field would otherwise miss the value on a fresh page load). It won't clobber text the visitor has already typed.

## Testing
- `tsc --noEmit` clean
- Full frontend suite green (193 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)