### PR TITLE
test(e2e): fix Cypress selectors after desktop navbar redesign

### DIFF
--- a/cypress/e2e/addRecipe.cy.ts
+++ b/cypress/e2e/addRecipe.cy.ts
@@ -143,7 +143,7 @@ const loginAndVisitAddRecipe = () => {
   // same-origin visits, so the second visit is authenticated.
   cy.visit('/')
   cy.login()
-  cy.contains('a.nav-link', 'Create Recipe', { timeout: 10000 }).should('be.visible')
+  cy.get('.dnav__create', { timeout: 10000 }).should('be.visible')
   cy.visit('/add-recipe')
 }
 

--- a/cypress/e2e/auth.cy.ts
+++ b/cypress/e2e/auth.cy.ts
@@ -11,18 +11,20 @@ describe('Auth', () => {
   it('login flow completes and nav shows username', () => {
     cy.visit('/')
     cy.login()
-    cy.contains('a.nav-link', 'Create Recipe', { timeout: 10000 }).should('be.visible')
-    // .signed-in-as lives inside a CSS hover-only dropdown so be.visible would always fail.
+    // The desktop "Create Recipe" link only renders when logged in — a reliable login gate.
+    cy.get('.dnav__create', { timeout: 10000 }).should('be.visible')
+    // The username lives inside the account-menu disclosure panel (hidden until opened).
     // Asserting text content is the meaningful check: username was fetched and rendered correctly.
-    cy.get('.signed-in-as strong', { timeout: 10000 }).should('contain.text', 'testinguser')
+    cy.get('.dnav-account__profile-name', { timeout: 10000 }).should('contain.text', 'testinguser')
   })
 
   it('logout works', () => {
     cy.visit('/')
     cy.login()
-    cy.contains('a.nav-link', 'Create Recipe', { timeout: 10000 }).should('be.visible')
-    // The logout button lives inside a CSS hover-dropdown — force bypasses visibility
-    cy.get('button.logout', { timeout: 5000 }).click({ force: true })
-    cy.contains('a.nav-link', 'login', { timeout: 5000 }).should('be.visible')
+    cy.get('.dnav__create', { timeout: 10000 }).should('be.visible')
+    // Account menu is a click-disclosure: open it, then click Log out inside the panel.
+    cy.get('button.dnav-account__btn', { timeout: 5000 }).click()
+    cy.get('button.dnav-account__logout-btn', { timeout: 5000 }).should('be.visible').click()
+    cy.contains('a.dnav__cta--login', 'Log in', { timeout: 5000 }).should('be.visible')
   })
 })

--- a/cypress/e2e/browse.cy.ts
+++ b/cypress/e2e/browse.cy.ts
@@ -20,8 +20,9 @@ describe('Browse', () => {
   it('search input filters results', () => {
     cy.visit('/recipes')
     cy.wait('@getRecipes')
-    cy.get('input.search-recipes-input', { timeout: 10000 }).should('be.visible').type('Tuscan')
-    cy.get('.search-recipes-btn', { timeout: 5000 }).should('be.visible').click().and('be.visible')
+    // The navbar also renders a SearchRecipesInput, so scope to the page's input/button.
+    cy.get('.recipes-page input.search-recipes-input', { timeout: 10000 }).should('be.visible').type('Tuscan')
+    cy.get('.recipes-page .search-recipes-btn', { timeout: 5000 }).should('be.visible').click().and('be.visible')
     // App navigates to /recipes?q=Tuscan and fires a new getRecipes call
     cy.wait('@getRecipes')
     cy.url().should('include', 'q=Tuscan')

--- a/cypress/e2e/recipe.cy.ts
+++ b/cypress/e2e/recipe.cy.ts
@@ -37,7 +37,7 @@ describe('Single Recipe', () => {
     // so navigating directly to the recipe page after login works without React Router tricks.
     cy.visit('/')
     cy.login()
-    cy.contains('a.nav-link', 'Create Recipe', { timeout: 10000 }).should('be.visible')
+    cy.get('.dnav__create', { timeout: 10000 }).should('be.visible')
 
     cy.visit(`/recipes/${recipeId}`)
     cy.wait('@getRecipe')


### PR DESCRIPTION
## Why

The desktop navbar redesign (PR #109 — Quiet skin + Profile Card) replaced the old `a.nav-link` markup and turned the account menu from a CSS hover-dropdown into a **click-disclosure**. The Cypress specs were never updated, so **13 of 17 tests** failed on stale selectors (e.g. `Expected to find 'Create Recipe' within 'a.nav-link' but never did`, and `cy.type() ... subject contained 2 elements` because the navbar now renders its own search input).

These were test-vs-markup drift, **not app bugs**.

## What changed

Selector-only updates across the four specs (no app code touched):

| Spec | Old | New |
|------|-----|-----|
| auth, addRecipe, recipe | `a.nav-link` "Create Recipe" login gate | `.dnav__create` |
| auth (username) | `.signed-in-as strong` | `.dnav-account__profile-name` |
| auth (logout) | force-click `button.logout` | open `.dnav-account__btn` → click `.dnav-account__logout-btn` |
| auth (logged-out CTA) | `a.nav-link` "login" | `a.dnav__cta--login` |
| browse (search) | ambiguous `input.search-recipes-input` | scoped to `.recipes-page …` |

The logout test also needed a behavioral update (open the disclosure before clicking Log out), since the menu is no longer hover-driven.

## Verification

Ran the full suite locally against a `--mode test` Vite + live API:

`All specs passed — 17 tests, 16 passing, 1 pending (pre-existing .skip), 0 failing.`

> Note: the CI **E2e (Cypress)** job may still be red for the separate, pre-existing test-mode/login reason; this PR removes the navbar-redesign drift that was masking it.