### PR TITLE
fix(security): close NoSQL operator injection via query strings and JSON bodies

### DIFF
--- a/docs/SECURITY_AUDIT_2026-06-11.md
+++ b/docs/SECURITY_AUDIT_2026-06-11.md
@@ -1,0 +1,148 @@
+# Security & Auth Audit — 2026-06-11
+
+Full-codebase pass over the Express server (`server/`): per-route auth middleware
+coverage, ownership checks, CORS, rate limiting, input validation on the
+recipe/review endpoints, and Firebase token handling on both sides. Cross-checked
+against the older `docs/server-audit.md` for regressions. Branch: `development`.
+
+Regression tests for everything fixed here live in
+`server/__tests__/security.test.js`.
+
+---
+
+## 1. Cross-check vs. docs/server-audit.md — no regressions
+
+Every **high** item in the old audit is resolved in the current code:
+
+| Old finding | Status today |
+|---|---|
+| `addRecipe` trusts client `userId` | Fixed — server stamps `_id`, `userId`, and counters; client values discarded (`recipes.js`) |
+| `deleteRecipe` no ownership check | Fixed — fetch + `recipe.userId !== uid → 403`, deletion runs in a transaction |
+| `editReview` / `addRating` take `username` from query | Fixed — username is always looked up from `req.uid` via the `usernames` collection |
+| Unprotected `addRecipeTag` | Route no longer exists |
+| Dead `getSavedRecipes` shadowed route | Fixed — single implementation in `users.js`, mounted once |
+| Raw `$regex` from `q`/`cuisine`/`title` | Fixed — `escapeRegex()` applied everywhere |
+| Duplicate save / negative `numTimesSaved` | Fixed — already-saved 409 check; decrement clamped with `$max … 0` pipeline |
+| No axios auth interceptor | Fixed — `src/api/http-common.ts` attaches a fresh Firebase ID token per request |
+
+Still present from the old audit (carried forward below): `getReviews`
+`isCurrentUser` spoofing (§4.3) and the `newReview` upsert creating a
+rating-less doc (§4.8).
+
+`docs/server-audit.md` should now be treated as historical.
+
+---
+
+## 2. Findings fixed in this audit
+
+### 2.1 NoSQL operator injection via query strings — **High** — FIXED
+
+Express 4's default `extended` query parser turns `?recipeId[$ne]=x` into the
+object `{ $ne: 'x' }`, which several routes passed straight into MongoDB
+filters. Worst concrete case: `POST /api/addRating?recipeId[$gt]=&rating=1` —
+the ratings aggregation and the final `recipes.updateOne(recipeIdQuery(recipeId))`
+both ran with an operator filter, letting **any authenticated user overwrite an
+arbitrary recipe's stored rating** (integrity corruption). Lesser variants hit
+`getRecipe` (view-count pollution on an attacker-chosen doc) and `madeRecipe`.
+
+Fixes applied:
+- `app.set('query parser', 'simple')` in `server/app.js` — query values are now
+  always strings (or string arrays for repeated keys); bracket notation can no
+  longer produce operator objects anywhere.
+- `recipeIdQuery()` / `recipeIdInQuery()` (`server/util/recipeIdQuery.js`) now
+  return a match-nothing filter for any non-string id — a single choke point
+  covering every recipes-collection lookup, including repeated-key arrays.
+- `addRating` requires `recipeId` and `rating` to be strings.
+
+### 2.2 NoSQL operator injection via JSON body — **Medium** — FIXED
+
+`POST /newReview` read `recipeId`/`reviewText` from the JSON body, where the
+client fully controls types: `{ "recipeId": { "$ne": "" }, … }` reached the
+`ratings` upsert filter. Scope was limited to the caller's own username but
+could create malformed rating docs. Now both fields must be strings; same check
+added to `editReview`'s `text`.
+
+### 2.3 Non-string query params throwing unhandled 500s — **Low** — FIXED
+
+Repeated keys (`?q=a&q=b`) produced arrays that crashed `escapeRegex`,
+`username.toLowerCase()`, etc., returning 500s with internal error messages.
+`GET /recipes`, `searchAutoCompleteRecipes`, and `checkUsernameAvailability`
+now type-check before use.
+
+---
+
+## 3. Verified sound (no action)
+
+- **Auth coverage**: every write route and every user-scoped read carries
+  `verifyToken`. Public routes are read-only, intentionally anonymous browse/
+  review-display endpoints (`GET /recipes`, `searchAutoCompleteRecipes`,
+  `getTrendingRecipes`, `getRecipe`, `getReviews`, `getSingleUserReviews`,
+  `checkUsernameAvailability`, `/health`).
+- **Ownership**: `editRecipe`/`deleteRecipe` and all four owner-scoped draft
+  routes check `doc.userId !== req.uid → 403` after fetch (404 before 403, no
+  existence oracle for drafts). Reviews/ratings are keyed off the
+  server-resolved username, never a client-supplied one.
+- **Mass assignment**: recipe edits and drafts whitelist fields via
+  `EDITABLE_RECIPE_FIELDS` / `RECIPE_CONTENT_FIELDS` (`util/recipeFields.js`);
+  `addRecipe` stamps `_id`/`userId`/counters server-side. Counters, ratings,
+  and ownership are not client-writable.
+- **CORS** (`app.js`): exact-match allowlist from `FRONTEND_URLS`, a pinned
+  Netlify deploy-preview regex, and a localhost:3000–3010 pattern that is
+  disabled when `NODE_ENV=production`. No wildcard, no origin reflection.
+- **Firebase token handling**: server verifies ID tokens with the Admin SDK and
+  trusts only `decoded.uid`; service account comes from env. Client interceptor
+  calls `user.getIdToken()` per request (SDK handles refresh). The Cypress
+  `__cy_signIn__` hook is compiled in only when `VITE_CYPRESS=true` at build
+  time and still requires a valid Firebase custom token.
+- **Input bounds on recipes/drafts**: title/description/instruction lengths and
+  ingredient/instruction counts enforced server-side (`util/recipeLimits.js`);
+  rating clamped to 1–5 with NaN check; username validated server-side with a
+  unique index closing the set-username race.
+- **Storage deletion** (`util/firebaseStorage.js`): URL parsed with a strict
+  pattern; non-Firebase URLs are ignored, errors never fail the request.
+- **Admin claims**: not applicable on `development` — no admin routes exist on
+  this branch. The admin/reports system lives on the unmerged
+  `worktree-feat+admin-service` branch; its `requireAdmin` claims middleware
+  must be audited when that branch is merged.
+
+---
+
+## 4. Open findings — recommendations (not applied)
+
+Ordered by priority. None applied because each needs a product/design decision
+or has broad test impact.
+
+1. **No rate limiting anywhere** (*Medium*). Highest-value targets:
+   `POST /api/ingredients/parse` (each call spends paid Spoonacular quota with
+   attacker-chosen input; auth required but any signed-up user qualifies), and
+   the write endpoints (`addRecipe`, `newReview`, `setUsername`). Recommend
+   `express-rate-limit` with a tight per-uid limit on `/api/ingredients/parse`
+   and a generous global default. Decide thresholds first; Cypress E2E and the
+   autosaving drafts client must stay under them.
+2. **500 handlers echo `err.message` to clients** (*Low–Medium*, info
+   disclosure). Every route's catch block returns the raw message, which for
+   infrastructure failures can include internal hostnames (e.g. Mongo
+   `connect ECONNREFUSED <host>`). Recommend a shared error responder that logs
+   the real error and returns a generic message. Touches every route and some
+   test expectations, so left for a focused PR.
+3. **`GET /getReviews` `isCurrentUser` derived from a query param** (*Low*,
+   carried over from old audit). Anyone can pass `?username=victim` and get
+   `isCurrentUser: true` flags. Server-side edits remain protected, so this is
+   a UI-hint spoof only — but it should derive from the token when an
+   `Authorization` header is present.
+4. **`reviewText` has no length bound** (*Low*). Recipe fields are bounded;
+   reviews are not. Add a max length in `newReview`/`editReview` mirroring
+   `DESCRIPTION_MAX_LENGTH`.
+5. **Unbounded `recipesPerPage`/`reviewsPerPage`** (*Low*). A single request
+   can dump an entire collection. Cap like `getTrendingRecipes` does
+   (`Math.min(parsed, N)`).
+6. **No security headers** (*Low*). API-only server, so impact is limited, but
+   `helmet` is a one-liner worth adding alongside the rate-limit PR.
+7. **`verifyToken` doesn't pass `checkRevoked`** (*Info*). Revoked/disabled
+   users keep access until their ID token expires (≤1 h). Standard tradeoff
+   (checkRevoked costs a network call per request); acceptable as-is.
+8. **`newReview` upsert can create a doc without `rating` fields** (*Info*,
+   data integrity, carried over). A review posted before any rating yields a
+   ratings doc lacking `rating`/`ratingLastUpdated`; `addRating`'s averaging
+   then `parseFloat(undefined) → NaN`-guards only via the insert path. Worth
+   normalizing when reviews get their next pass.

--- a/docs/server-audit.md
+++ b/docs/server-audit.md
@@ -1,5 +1,9 @@
 # Prepify Error Handling & Auth Audit
 
+> **Historical document.** Every high-severity item below has since been fixed;
+> see `docs/SECURITY_AUDIT_2026-06-11.md` for the current audit, the
+> regression cross-check against this list, and the remaining open items.
+
 ---
 
 ### Backend Issues

--- a/server/__tests__/security.test.js
+++ b/server/__tests__/security.test.js
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for the 2026-06-11 security audit
+ * (docs/SECURITY_AUDIT_2026-06-11.md).
+ *
+ * Express's default 'extended' query parser turned ?id[$ne]=x into the object
+ * { $ne: 'x' }, which flowed into MongoDB filters as a query operator. The app
+ * now uses the 'simple' parser (app.js) and routes/utilities reject non-string
+ * values, so operator objects and repeated-key arrays can never reach a filter.
+ *
+ * Auth mocking follows the same approach as reviews.test.js: the automatic
+ * firebase-admin mock resolves verifyIdToken to { uid: 'test-uid' }.
+ */
+
+const request = require('supertest')
+const app = require('../app')
+const { getDB } = require('../db')
+const admin = require('firebase-admin')
+const { recipeIdQuery, recipeIdInQuery } = require('../util/recipeIdQuery')
+
+const TEST_UID = 'test-uid'
+const TEST_USERNAME = 'testuser'
+const RECIPE_ID = 'recipe-sec-001'
+const OTHER_RECIPE_ID = 'recipe-sec-002'
+const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
+
+beforeEach(async () => {
+  const db = getDB()
+  await db.collection('usernames').insertOne({
+    _id: TEST_UID,
+    username: TEST_USERNAME,
+    username_lower: TEST_USERNAME.toLowerCase(),
+  })
+  await db.collection('recipes').insertMany([
+    { _id: RECIPE_ID, title: 'Security Test Recipe', rating: { rateCount: 0, rateValue: 0 }, views: 0 },
+    { _id: OTHER_RECIPE_ID, title: 'Bystander Recipe', rating: { rateCount: 5, rateValue: 4.8 }, views: 0 },
+  ])
+  admin.auth.mockReset()
+  admin.auth.mockImplementation(() => ({
+    verifyIdToken: jest.fn().mockResolvedValue({ uid: TEST_UID }),
+  }))
+})
+
+afterEach(async () => {
+  const db = getDB()
+  await Promise.all([
+    db.collection('usernames').deleteMany({}),
+    db.collection('recipes').deleteMany({}),
+    db.collection('ratings').deleteMany({}),
+  ])
+})
+
+// ─── Query parser hardening ──────────────────────────────────────────────────
+
+describe('query-string operator injection', () => {
+  it('addRating rejects bracket-notation operator in recipeId (400)', async () => {
+    const res = await request(app)
+      .post('/api/addRating?recipeId[$ne]=x&rating=1')
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(400)
+    // The bystander recipe's rating must be untouched
+    const db = getDB()
+    const bystander = await db.collection('recipes').findOne({ _id: OTHER_RECIPE_ID })
+    expect(bystander.rating).toEqual({ rateCount: 5, rateValue: 4.8 })
+  })
+
+  it('addRating rejects repeated-key array recipeId (400)', async () => {
+    const res = await request(app)
+      .post(`/api/addRating?recipeId=${RECIPE_ID}&recipeId=${OTHER_RECIPE_ID}&rating=1`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(400)
+  })
+
+  it('getRecipe with operator in id returns 400, not another recipe', async () => {
+    const res = await request(app).get('/api/getRecipe?id[$ne]=x')
+    expect(res.status).toBe(400)
+  })
+
+  it('getRecipe with repeated id keys matches nothing (404)', async () => {
+    const res = await request(app).get(`/api/getRecipe?id=${RECIPE_ID}&id=${OTHER_RECIPE_ID}`)
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /recipes tolerates repeated q keys without a 500', async () => {
+    const res = await request(app).get('/api/recipes?q=a&q=b')
+    expect(res.status).toBe(200)
+  })
+
+  it('checkUsernameAvailability rejects operator-shaped username (400)', async () => {
+    const res = await request(app).get('/api/checkUsernameAvailability?username[$ne]=x')
+    expect(res.status).toBe(400)
+  })
+})
+
+// ─── JSON-body operator injection ────────────────────────────────────────────
+
+describe('JSON-body operator injection', () => {
+  it('newReview rejects object recipeId (400)', async () => {
+    const res = await request(app)
+      .post('/api/newReview')
+      .set(AUTH_HEADER)
+      .send({ recipeId: { $ne: '' }, reviewText: 'injected' })
+    expect(res.status).toBe(400)
+    const db = getDB()
+    expect(await db.collection('ratings').countDocuments({})).toBe(0)
+  })
+
+  it('newReview rejects non-string reviewText (400)', async () => {
+    const res = await request(app)
+      .post('/api/newReview')
+      .set(AUTH_HEADER)
+      .send({ recipeId: RECIPE_ID, reviewText: { $set: 'x' } })
+    expect(res.status).toBe(400)
+  })
+})
+
+// ─── recipeIdQuery non-string hardening ──────────────────────────────────────
+
+describe('recipeIdQuery non-string ids', () => {
+  it('returns a match-nothing filter for objects and arrays', () => {
+    expect(recipeIdQuery({ $ne: 'x' })).toEqual({ _id: { $in: [] } })
+    expect(recipeIdQuery(['a', 'b'])).toEqual({ _id: { $in: [] } })
+    expect(recipeIdQuery(undefined)).toEqual({ _id: { $in: [] } })
+  })
+
+  it('recipeIdInQuery drops non-string entries', () => {
+    const filter = recipeIdInQuery(['abc', { $ne: 'x' }, 42])
+    expect(filter._id.$in).toEqual(['abc'])
+  })
+})

--- a/server/app.js
+++ b/server/app.js
@@ -9,6 +9,11 @@ const draftRoutes = require('./routes/drafts')
 
 const app = express()
 
+// The default ('extended'/qs) parser turns ?id[$ne]=x into a nested object,
+// which would flow into MongoDB filters as a query operator. 'simple' keeps
+// every query value a plain string (or array of strings for repeated keys).
+app.set('query parser', 'simple')
+
 const allowedOrigins = (process.env.FRONTEND_URLS || 'http://localhost:3000')
   .split(',')
   .map(s => s.trim().replace(/\/$/, ''))

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -45,7 +45,9 @@ router.get('/getUsername', verifyToken, async (req, res) => {
 router.get('/checkUsernameAvailability', async (req, res) => {
   try {
     const { username } = req.query
-    if (!username) return res.status(400).json({ error: 'username is required' })
+    if (!username || typeof username !== 'string') {
+      return res.status(400).json({ error: 'username is required' })
+    }
     const db = getDB()
     const existing = await db
       .collection('usernames')

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -24,15 +24,15 @@ router.get('/recipes', async (req, res) => {
 
     const filter = {}
 
-    if (q) {
+    if (q && typeof q === 'string') {
       filter.title = { $regex: escapeRegex(q), $options: 'i' }
     }
 
-    if (cuisine && cuisine.trim()) {
+    if (cuisine && typeof cuisine === 'string' && cuisine.trim()) {
       filter.cuisine = { $regex: `^${escapeRegex(cuisine.trim())}$`, $options: 'i' }
     }
 
-    if (tags) {
+    if (tags && typeof tags === 'string') {
       const tagList = tags.split(',').map((t) => t.trim()).filter(Boolean)
       if (tagList.length > 0) {
         filter.$or = [
@@ -67,7 +67,7 @@ router.get('/searchAutoCompleteRecipes', async (req, res) => {
     const recipes = await db
       .collection('recipes')
       .find(
-        { title: { $regex: escapeRegex(title || ''), $options: 'i' } },
+        { title: { $regex: escapeRegex(typeof title === 'string' ? title : ''), $options: 'i' } },
         {
           projection: {
             _id: 1,

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -13,7 +13,7 @@ router.post('/addRating', verifyToken, async (req, res) => {
     const userDoc = await db.collection('usernames').findOne({ _id: req.uid })
     if (!userDoc) return res.status(400).json({ error: 'User not found' })
     const username = userDoc.username
-    if (!recipeId || !rating) {
+    if (!recipeId || typeof recipeId !== 'string' || !rating || typeof rating !== 'string') {
       return res.status(400).json({ error: 'recipeId and rating are required' })
     }
     const parsedRating = parseFloat(rating)
@@ -63,7 +63,7 @@ router.post('/newReview', verifyToken, async (req, res) => {
     const db = getDB()
     const { recipeId, reviewText } = req.body
     const userId = req.uid
-    if (!recipeId || reviewText == null) {
+    if (!recipeId || typeof recipeId !== 'string' || typeof reviewText !== 'string') {
       return res.status(400).json({ error: 'recipeId and reviewText are required' })
     }
 
@@ -116,7 +116,7 @@ router.post('/editReview', verifyToken, async (req, res) => {
     const userDoc = await db.collection('usernames').findOne({ _id: req.uid })
     if (!userDoc) return res.status(400).json({ error: 'User not found' })
     const username = userDoc.username
-    if (!recipeId || text == null) {
+    if (!recipeId || typeof recipeId !== 'string' || text == null || typeof text !== 'string') {
       return res.status(400).json({ error: 'recipeId and text are required' })
     }
     const editResult = await db.collection('ratings').updateOne(

--- a/server/util/recipeIdQuery.js
+++ b/server/util/recipeIdQuery.js
@@ -11,6 +11,9 @@ function isObjectIdHex(id) {
 // Once the one-time backfill runs, the $or branch becomes a no-op extra
 // clause — harmless to leave in place.
 function recipeIdQuery(id) {
+  // Non-string ids (arrays from repeated query keys, objects from JSON bodies)
+  // must never reach the filter — an object here would act as a query operator.
+  if (typeof id !== 'string') return { _id: { $in: [] } }
   if (isObjectIdHex(id)) {
     return { $or: [{ _id: new ObjectId(id) }, { _id: id }] }
   }
@@ -23,6 +26,7 @@ function recipeIdQuery(id) {
 function recipeIdInQuery(ids) {
   const variants = []
   for (const id of ids) {
+    if (typeof id !== 'string') continue
     variants.push(id)
     if (isObjectIdHex(id)) variants.push(new ObjectId(id))
   }


### PR DESCRIPTION
## Summary

Full server security audit (report: `docs/SECURITY_AUDIT_2026-06-11.md`) found one exploitable vulnerability, fixed here.

Express 4's default `extended` query parser turns `?id[$ne]=x` into an operator object that flowed into MongoDB filters. Worst concrete case: **any authenticated user could overwrite an arbitrary recipe's stored rating** via `POST /addRating?recipeId[$gt]=&rating=1`. Lesser variants hit `getRecipe` and `madeRecipe`. `POST /newReview` was independently injectable through its JSON body.

## Changes

- `server/app.js`: switch to the `simple` query parser — bracket notation can no longer produce operator objects anywhere
- `server/util/recipeIdQuery.js`: `recipeIdQuery`/`recipeIdInQuery` return a match-nothing filter for non-string ids (single choke point, also covers repeated-key arrays)
- `reviews.js`: require string `recipeId`/`rating`/`reviewText`/`text` in `addRating`, `newReview`, `editReview`
- `recipes.js` / `auth.js`: type-check `q`/`cuisine`/`tags`/`title`/`username` params that previously threw unhandled 500s on arrays
- New regression suite `server/__tests__/security.test.js` (10 tests) covering operator objects, repeated-key arrays, and body injection
- `docs/SECURITY_AUDIT_2026-06-11.md`: full audit report — cross-check vs the old `docs/server-audit.md` (all its high items verified fixed, no regressions; doc now marked historical) plus 6 open recommendations deliberately **not** included here (rate limiting, generic 500 messages, etc.) pending decisions and the worktree merge backlog

## Compatibility

All frontend API calls build flat query strings (verified across `src/api/`), so the parser change is behavior-neutral for the app. Cypress drives the same API modules.

## Test plan

- [x] Server suite green: 171/171 (includes the 10 new regression tests)
- [x] No frontend code changed