### PR TITLE
feat(security): rate limiting, helmet, and page-size caps

### DIFF
--- a/docs/SECURITY_AUDIT_2026-06-11.md
+++ b/docs/SECURITY_AUDIT_2026-06-11.md
@@ -107,42 +107,108 @@ now type-check before use.
 
 ---
 
-## 4. Open findings — recommendations (not applied)
+## 4. Open findings — status checklist
 
-Ordered by priority. None applied because each needs a product/design decision
-or has broad test impact.
+Initial fixes from §2 merged via PR #117. The low-conflict hardening batch
+(items 1, 5, 6) was implemented 2026-06-11 in a follow-up PR. Items 2–4 are
+**deliberately deferred** until the three feature worktrees
+(recipes-page-refresh, account-page-redesign, admin-service) are merged — they
+touch the same files those branches change (see §5).
 
-1. **No rate limiting anywhere** (*Medium*). Highest-value targets:
-   `POST /api/ingredients/parse` (each call spends paid Spoonacular quota with
-   attacker-chosen input; auth required but any signed-up user qualifies), and
-   the write endpoints (`addRecipe`, `newReview`, `setUsername`). Recommend
-   `express-rate-limit` with a tight per-uid limit on `/api/ingredients/parse`
-   and a generous global default. Decide thresholds first; Cypress E2E and the
-   autosaving drafts client must stay under them.
-2. **500 handlers echo `err.message` to clients** (*Low–Medium*, info
-   disclosure). Every route's catch block returns the raw message, which for
-   infrastructure failures can include internal hostnames (e.g. Mongo
-   `connect ECONNREFUSED <host>`). Recommend a shared error responder that logs
-   the real error and returns a generic message. Touches every route and some
-   test expectations, so left for a focused PR.
-3. **`GET /getReviews` `isCurrentUser` derived from a query param** (*Low*,
-   carried over from old audit). Anyone can pass `?username=victim` and get
-   `isCurrentUser: true` flags. Server-side edits remain protected, so this is
-   a UI-hint spoof only — but it should derive from the token when an
-   `Authorization` header is present.
-4. **`reviewText` has no length bound** (*Low*). Recipe fields are bounded;
-   reviews are not. Add a max length in `newReview`/`editReview` mirroring
-   `DESCRIPTION_MAX_LENGTH`.
-5. **Unbounded `recipesPerPage`/`reviewsPerPage`** (*Low*). A single request
-   can dump an entire collection. Cap like `getTrendingRecipes` does
-   (`Math.min(parsed, N)`).
-6. **No security headers** (*Low*). API-only server, so impact is limited, but
-   `helmet` is a one-liner worth adding alongside the rate-limit PR.
-7. **`verifyToken` doesn't pass `checkRevoked`** (*Info*). Revoked/disabled
-   users keep access until their ID token expires (≤1 h). Standard tradeoff
-   (checkRevoked costs a network call per request); acceptable as-is.
-8. **`newReview` upsert can create a doc without `rating` fields** (*Info*,
-   data integrity, carried over). A review posted before any rating yields a
-   ratings doc lacking `rating`/`ratingLastUpdated`; `addRating`'s averaging
-   then `parseFloat(undefined) → NaN`-guards only via the insert path. Worth
-   normalizing when reviews get their next pass.
+1. [x] **No rate limiting anywhere** (*Medium*) — **DONE.**
+   `express-rate-limit` added: a generous global per-IP backstop on `/api`
+   (1000 req / 15 min, mounted after `/health` so health checks are never
+   throttled) and a tight per-uid limit on `POST /api/ingredients/parse`
+   (30/min — one parse per added ingredient, recipes cap at 50 ingredients).
+   `trust proxy = 1` only in production (one platform proxy); never in dev,
+   where `X-Forwarded-For` would be spoofable. Both limiters are skipped when
+   `NODE_ENV=test` because supertest fires hundreds of requests from one IP in
+   seconds — so the 429 path itself is intentionally untested by Jest. Cypress
+   CI runs with limiters active and stays well under the global cap.
+2. [ ] **500 handlers echo `err.message` to clients** (*Low–Medium*, info
+   disclosure) — **DEFERRED, see §5.** Every route's catch block returns the
+   raw message, which for infrastructure failures can include internal
+   hostnames (e.g. Mongo `connect ECONNREFUSED <host>`). Needs a shared error
+   responder that logs the real error and returns a generic message. Touches
+   every route file and some test expectations — maximal conflict with the
+   worktree backlog, so it must go last.
+3. [ ] **`GET /getReviews` `isCurrentUser` derived from a query param**
+   (*Low*, carried over from old audit) — **DEFERRED, see §5.** Anyone can
+   pass `?username=victim` and get `isCurrentUser: true` flags. UI-hint spoof
+   only (server-side edits remain protected); should derive from the token
+   when an `Authorization` header is present. Lives in `reviews.js`, which the
+   admin worktree's soft-hide moderation also changes.
+4. [ ] **`reviewText` has no length bound** (*Low*) — **DEFERRED, see §5.**
+   Recipe fields are bounded; reviews are not. Add a max length in
+   `newReview`/`editReview` mirroring `DESCRIPTION_MAX_LENGTH` (2000). Same
+   `reviews.js` conflict as item 3.
+5. [x] **Unbounded `recipesPerPage`/`reviewsPerPage`** (*Low*) — **DONE.**
+   All five paginated handlers (`GET /recipes`, `getReviews`,
+   `getSingleUserReviews`, `getCreatedRecipes`, `getSavedRecipes`) clamp the
+   page size to `MAX_PER_PAGE = 50` and coerce NaN page/size to defaults.
+   Regression tests in `security.test.js` ("pagination caps").
+6. [x] **No security headers** (*Low*) — **DONE.** `helmet()` with defaults on
+   every response.
+7. [x] **`verifyToken` doesn't pass `checkRevoked`** (*Info*) — **ACCEPTED
+   AS-IS.** Revoked/disabled users keep access until their ID token expires
+   (≤1 h). Standard tradeoff: `checkRevoked` costs a network round-trip per
+   request. Revisit only if account-ban semantics demand instant lockout.
+8. [ ] **`newReview` upsert can create a doc without `rating` fields**
+   (*Info*, data integrity, carried over) — **DEFERRED, see §5.** A review
+   posted before any rating yields a ratings doc lacking
+   `rating`/`ratingLastUpdated`. Normalize during the same `reviews.js` pass
+   as items 3–4.
+
+---
+
+## 5. Deferred follow-up — runbook for after the worktree merges
+
+**Preconditions:** the three worktree branches (recipes-page-refresh,
+account-page-redesign incl. its P6 teardown, admin-service) are merged into
+`development`, and CI is green. Do **not** start this while any of them is
+still open — items below edit `reviews.js` and every route's catch blocks,
+which those branches also touch.
+
+Ready-to-run prompt for a fresh session:
+
+> Work through §5 of docs/SECURITY_AUDIT_2026-06-11.md on a new branch off
+> development. Check items off in §4 as you complete them, run the server
+> suite after each step, and open a PR.
+
+Steps, in order:
+
+1. **`reviews.js` pass** (items 3, 4, 8 — one commit):
+   - `getReviews`: when an `Authorization` header is present, verify it and
+     derive `isCurrentUser` by resolving `req.uid → usernames` collection;
+     ignore the `username` query param for that flag (it can stay for other
+     uses). Keep the route anonymous-friendly: a missing/invalid header just
+     means `isCurrentUser: false` everywhere.
+   - `newReview`/`editReview`: reject `reviewText`/`text` longer than 2000
+     chars (mirror `DESCRIPTION_MAX_LENGTH` from `util/recipeLimits.js` —
+     import it, don't duplicate the constant).
+   - `newReview` upsert: on insert (`$setOnInsert`), default `rating: null`
+     and `ratingLastUpdated: ''` so no ratings doc ever lacks those keys; make
+     sure `addRating`'s averaging skips `rating: null` docs instead of
+     `parseFloat(null) → NaN`.
+   - Mind the merged admin soft-hide changes in this file: hidden-review
+     filtering must keep working; extend the existing tests rather than
+     replacing them.
+2. **Generic 500 responder** (item 2 — separate commit, largest diff):
+   - Add `server/util/respondServerError.js` (or similar): logs the real
+     error with route context via `console.error`, responds
+     `500 { error: 'Internal server error' }`.
+   - Replace every `res.status(500).json({ error: err.message })` across
+     `server/routes/*.js` (including any new admin/profile routes from the
+     merged worktrees — they were written before this rule).
+   - Keep 4xx validation messages as-is; only 500s change. Update any Jest
+     assertions that matched specific 500 messages.
+   - Exception: `ingredients.js` already logs rich context on purpose
+     (Phase A debugging) — keep its logging, change only the response body.
+3. **Re-audit the merged admin surface** (new since this audit): every
+   `/admin` route must chain `verifyToken` + the admin-claims check
+   (`requireAdmin`); verify report/moderation endpoints validate ids as
+   strings (the injection patterns from §2 — new code may not have inherited
+   them), and add those routes to the regression suite in
+   `security.test.js`.
+4. Update §4 checkboxes + this section, run `npm test` in `server/` (and the
+   frontend suite if `src/` was touched), open the PR.

--- a/server/__tests__/security.test.js
+++ b/server/__tests__/security.test.js
@@ -113,6 +113,29 @@ describe('JSON-body operator injection', () => {
   })
 })
 
+// ─── Page-size caps ──────────────────────────────────────────────────────────
+
+describe('pagination caps', () => {
+  it('GET /recipes caps recipesPerPage at 50 regardless of the requested size', async () => {
+    const db = getDB()
+    await db.collection('recipes').insertMany(
+      Array.from({ length: 55 }, (_, i) => ({
+        _id: `recipe-cap-${String(i).padStart(3, '0')}`,
+        title: `Cap Test ${i}`,
+      }))
+    )
+    const res = await request(app).get('/api/recipes?recipesPerPage=99999')
+    expect(res.status).toBe(200)
+    expect(res.body.recipeList).toHaveLength(50)
+    expect(res.body.total_results).toBe(57) // 55 + the 2 beforeEach fixtures
+  })
+
+  it('GET /recipes tolerates a non-numeric page size without a 500', async () => {
+    const res = await request(app).get('/api/recipes?recipesPerPage=abc&page=xyz')
+    expect(res.status).toBe(200)
+  })
+})
+
 // ─── recipeIdQuery non-string hardening ──────────────────────────────────────
 
 describe('recipeIdQuery non-string ids', () => {

--- a/server/app.js
+++ b/server/app.js
@@ -1,5 +1,7 @@
 const express = require('express')
 const cors = require('cors')
+const helmet = require('helmet')
+const { rateLimit } = require('express-rate-limit')
 const recipeRoutes = require('./routes/recipes')
 const reviewRoutes = require('./routes/reviews')
 const userRoutes = require('./routes/users')
@@ -42,8 +44,33 @@ app.use(cors({
   credentials: true,
 }))
 app.use(express.json())
+app.use(helmet())
 
+// In production the server sits behind exactly one reverse proxy (the hosting
+// platform's), so req.ip must come from X-Forwarded-For for per-IP rate
+// limiting to see real clients. Never trusted in dev, where the server is hit
+// directly and the header would be client-spoofable.
+if (isProduction) app.set('trust proxy', 1)
+
+// /health stays above the limiter so platform health checks and uptime
+// monitors can never be throttled into a false "down".
 app.get('/health', (req, res) => res.json({ status: 'ok' }))
+
+// Generous global per-IP backstop — normal browsing is tens of requests a
+// minute, so only scripted abuse approaches this. The tight per-user limit on
+// /api/ingredients/parse (paid Spoonacular quota) lives in routes/ingredients.js.
+// Skipped under Jest, where supertest fires hundreds of requests from one IP
+// in seconds; Cypress E2E in CI stays well under the cap.
+app.use(
+  '/api',
+  rateLimit({
+    windowMs: 15 * 60 * 1000,
+    limit: 1000,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: () => process.env.NODE_ENV === 'test',
+  })
+)
 
 app.use('/api', recipeRoutes)
 app.use('/api', reviewRoutes)

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,9 @@
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^4.18.2",
+        "express-rate-limit": "^8.5.2",
         "firebase-admin": "^13.8.0",
+        "helmet": "^8.2.0",
         "mongodb": "^6.0.0"
       },
       "devDependencies": {
@@ -3492,6 +3494,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4243,6 +4263,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -4458,6 +4490,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,9 @@
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^4.18.2",
+    "express-rate-limit": "^8.5.2",
     "firebase-admin": "^13.8.0",
+    "helmet": "^8.2.0",
     "mongodb": "^6.0.0"
   },
   "devDependencies": {

--- a/server/routes/ingredients.js
+++ b/server/routes/ingredients.js
@@ -1,10 +1,26 @@
 const { Router } = require('express')
+const { rateLimit } = require('express-rate-limit')
 const { ingredientParser } = require('@jclind/ingredient-parser')
 const { verifyToken } = require('../middleware/auth')
 
 const router = Router()
 
-router.post('/parse', verifyToken, async (req, res) => {
+// Every call spends paid Spoonacular quota, so this is the one route with a
+// tight per-user limit. Keyed by req.uid (set by verifyToken, which runs
+// first), not IP, so shared NATs don't collide. 30/min comfortably covers the
+// add-recipe flow — one parse per ingredient added, max 50 per recipe.
+// Skipped under Jest along with the global limiter (see app.js).
+const parseLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.uid,
+  skip: () => process.env.NODE_ENV === 'test',
+  message: { error: 'Too many ingredient lookups — wait a minute and try again.' },
+})
+
+router.post('/parse', verifyToken, parseLimiter, async (req, res) => {
   const { ingredientString, options } = req.body
   if (!ingredientString || typeof ingredientString !== 'string') {
     return res.status(400).json({ error: 'ingredientString must be a non-empty string' })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -9,6 +9,10 @@ const { deleteRecipeImage } = require('../util/firebaseStorage')
 
 const router = Router()
 
+// Hard ceiling on client-requested page sizes so a single request can never
+// dump a whole collection (audit §4.5). Shared by every paginated route here.
+const MAX_PER_PAGE = 50
+
 function escapeRegex(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
@@ -19,8 +23,8 @@ router.get('/recipes', async (req, res) => {
   try {
     const db = getDB()
     const { q, page = 0, recipesPerPage = 5, order, cuisine, tags } = req.query
-    const skip = parseInt(page) * parseInt(recipesPerPage)
-    const limit = parseInt(recipesPerPage)
+    const limit = Math.min(parseInt(recipesPerPage) || 5, MAX_PER_PAGE)
+    const skip = (parseInt(page) || 0) * limit
 
     const filter = {}
 

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -5,6 +5,9 @@ const { recipeIdQuery } = require('../util/recipeIdQuery')
 
 const router = Router()
 
+// Hard ceiling on client-requested page sizes (audit §4.5); mirrors recipes.js.
+const MAX_PER_PAGE = 50
+
 // POST /addRating
 router.post('/addRating', verifyToken, async (req, res) => {
   try {
@@ -165,8 +168,8 @@ router.get('/getReviews', async (req, res) => {
     const { username, recipeId, page = 0, reviewsPerPage = 5, filter } = req.query
     if (!recipeId) return res.status(400).json({ error: 'recipeId is required' })
 
-    const skip = parseInt(page) * parseInt(reviewsPerPage)
-    const limit = parseInt(reviewsPerPage)
+    const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
+    const skip = (parseInt(page) || 0) * limit
     const query = { recipeId, reviewText: { $exists: true, $ne: '' } }
 
     let sort = {}
@@ -196,8 +199,8 @@ router.get('/getSingleUserReviews', async (req, res) => {
     const { username, page = 0, reviewsPerPage = 5, filter, returnRecipeData } = req.query
     if (!username) return res.status(400).json({ error: 'username is required' })
 
-    const skip = parseInt(page) * parseInt(reviewsPerPage)
-    const limit = parseInt(reviewsPerPage)
+    const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
+    const skip = (parseInt(page) || 0) * limit
     const query = { username }
 
     let sort = {}

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -5,6 +5,9 @@ const { recipeIdInQuery } = require('../util/recipeIdQuery')
 
 const router = Router()
 
+// Hard ceiling on client-requested page sizes (audit §4.5); mirrors recipes.js.
+const MAX_PER_PAGE = 50
+
 // GET /getCreatedRecipes — recipes authored by the current user, with pagination
 router.get('/getCreatedRecipes', verifyToken, async (req, res) => {
   try {
@@ -14,8 +17,8 @@ router.get('/getCreatedRecipes', verifyToken, async (req, res) => {
 
     const sort = order === 'old' ? { createdAt: 1 } : { createdAt: -1 }
 
-    const pageNum = parseInt(page)
-    const perPage = parseInt(recipesPerPage)
+    const pageNum = parseInt(page) || 0
+    const perPage = Math.min(parseInt(recipesPerPage) || 6, MAX_PER_PAGE)
 
     const collection = db.collection('recipes')
     const filter = { userId: uid }
@@ -52,8 +55,8 @@ router.get('/getSavedRecipes', verifyToken, async (req, res) => {
       savedRecipes = [...savedRecipes].sort((a, b) => Number(a.dateSaved) - Number(b.dateSaved))
     }
 
-    const pageNum = parseInt(page)
-    const perPage = parseInt(recipesPerPage)
+    const pageNum = parseInt(page) || 0
+    const perPage = Math.min(parseInt(recipesPerPage) || 5, MAX_PER_PAGE)
     const pageSlice = savedRecipes.slice(pageNum * perPage, (pageNum + 1) * perPage)
     const recipeIds = pageSlice.map((entry) => entry.recipeId)
 


### PR DESCRIPTION
## Summary

Low-conflict hardening batch from the 2026-06-11 security audit — items 1, 5, and 6 of `docs/SECURITY_AUDIT_2026-06-11.md` §4. Deliberately scoped to avoid the files the three open feature worktrees are changing; the remaining audit items are deferred behind those merges with a runbook in §5 of the audit doc.

## Changes

**Rate limiting** (`express-rate-limit@8`)
- Global per-IP backstop on `/api`: 1000 req / 15 min — generous enough that only scripted abuse approaches it. Mounted **after** `/health` so platform health checks can never be throttled into a false "down".
- Tight per-uid limit on `POST /api/ingredients/parse`: 30/min, keyed by `req.uid` (runs after `verifyToken`), since every call spends paid Spoonacular quota. One parse per added ingredient and recipes cap at 50 ingredients, so legit use never approaches it.
- Both limiters skip `NODE_ENV=test` — supertest fires hundreds of requests from one IP in seconds. The Cypress CI job runs with limiters **active** and stays well under the global cap.
- `trust proxy = 1` in production only (one platform proxy ahead of the server), so `req.ip` resolves real clients; never trusted in dev where `X-Forwarded-For` would be client-spoofable. If prod ever runs behind more than one proxy hop, bump this value.

**Security headers**
- `helmet()` defaults on every response.

**Page-size caps**
- `MAX_PER_PAGE = 50` clamp on all five paginated handlers (`GET /recipes`, `getReviews`, `getSingleUserReviews`, `getCreatedRecipes`, `getSavedRecipes`) so a single request can no longer dump a whole collection; NaN-safe `page`/`perPage` parsing.

**Docs**
- Audit §4 converted to a status checklist (1, 5, 6 checked; 7 accepted as-is); new §5 is a self-contained runbook for the deferred items (reviews.js pass, generic 500 responder, admin-surface re-audit) to run after the worktree backlog merges.

## Test plan

- [x] Server suite green: 173/173 (includes 2 new pagination-cap regression tests in `security.test.js`)
- [x] No frontend code changed
- [x] Cypress CI exercises the live limiters end-to-end