### PR TITLE
ci: add Fallow dead-code analysis (advisory, non-blocking)

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+
+  // Extra reachable files Fallow can't infer from imports alone.
+  // These are loaded by tooling/conventions, not by `import`, so without
+  // declaring them they show up as false-positive "unused files".
+  "entry": [
+    "server/scripts/*.js",          // operational CLI scripts (setAdmin, createModerationIndexes, etc.) run by hand
+    "server/__mocks__/*.js",        // Jest auto-mocks (e.g. firebase-admin), loaded by convention in __tests__
+    "src/test/setup.ts"             // Vitest setupFiles target (vite.config.ts -> test.setupFiles)
+  ],
+
+  // Build/tooling deps invoked via config, never `import`ed in source.
+  "ignoreDependencies": [
+    "sass",                         // used by Vite to compile .scss at build time
+    "@vitest/coverage-v8"           // used by `vitest --coverage`, not imported
+  ]
+
+  // Note: the remote Google Fonts @import in src/index.scss is suppressed
+  // inline (// fallow-ignore-next-line unresolved-import) — Fallow's glob
+  // matchers can't match the multiline token its SCSS parser captures.
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,3 +125,35 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
+
+  fallow:
+    name: Fallow (dead-code, advisory)
+    runs-on: ubuntu-latest
+    # Option B: advisory only — this job NEVER blocks merges (continue-on-error).
+    # Findings are posted to the run's Step Summary for visibility.
+    # TODO: once we trust the signal, flip to Option A (baseline-gated regression
+    # mode): commit a baseline of existing findings, fail only on NEW dead code,
+    # and drop `continue-on-error`. See the `regression` config in fallow docs.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      # node_modules must be present so Fallow can resolve imports/deps;
+      # without them it reports false "unresolved import" / "unused dependency" noise.
+      - name: Install root dependencies
+        run: npm ci --prefer-offline --no-audit
+      - name: Install server dependencies
+        run: npm ci --prefer-offline --no-audit
+        working-directory: server
+      # Version pinned for deterministic CI — Fallow releases very frequently and
+      # a new version could change findings and surprise a green PR.
+      - name: Run Fallow dead-code analysis
+        run: |
+          {
+            echo '## Fallow — dead-code (advisory, non-blocking)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          npx --yes fallow@2.95.0 dead-code | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,9 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so `fallow audit` can diff changed files against the base.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -156,4 +159,18 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           npx --yes fallow@2.95.0 dead-code | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+      # Changed-files audit: dead-code + complexity + duplication scoped to the
+      # PR diff. Default `--gate new-only` only counts findings the PR introduces
+      # (inherited backlog is reported but not failed). PR events only — needs a base.
+      - name: Run Fallow audit (changed files)
+        if: github.event_name == 'pull_request'
+        env:
+          FALLOW_AUDIT_BASE: origin/${{ github.base_ref }}
+        run: |
+          {
+            echo "## Fallow — audit: changed files vs ${{ github.base_ref }} (advisory)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          npx --yes fallow@2.95.0 audit | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,5 @@
 @use './helpers.scss' as s;
+// fallow-ignore-next-line unresolved-import
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,500;0,600;0,700;1,700&display=swap');
 
 * {


### PR DESCRIPTION
## What

Adds [Fallow](https://docs.fallow.tools) codebase-intelligence as an **advisory, non-blocking** CI check, plus the config needed to keep its findings accurate.

### Changes
- **`.github/workflows/test.yml`** — new `fallow` job (version-pinned `fallow@2.95.0`), `continue-on-error: true` so it **never blocks merges**. Two steps, both posting to the run's **Step Summary**:
  - `fallow dead-code` — repo-wide unused-code ledger (all events).
  - `fallow audit` — **changed-files** dead-code + complexity + duplication, **PR events only**. Default `--gate new-only` counts only findings the PR *introduces*; inherited backlog is reported but attributed, not failed. Checkout uses `fetch-depth: 0` to diff against the base.
- **`.fallowrc.json`** — declares tooling/convention entry points (server scripts, Jest `__mocks__`, Vitest setup) and build-time deps (`sass`, `@vitest/coverage-v8`) so they aren't false-flagged. Load-bearing for CI accuracy.
- **`src/index.scss`** — one-line inline suppression for the remote Google Fonts `@import` (Fallow's SCSS parser can't resolve the remote URL).

## Why
Option B from evaluation: start advisory to build trust before gating. Fallow found real cleanup signal (orphaned files, dead nav exports, an unused dep) in <0.1s. The `audit` step is the changed-files-scoped complexity/duplication signal without backlog noise.

## Follow-ups (not in this PR)
- Flip dead-code to **baseline-gated regression mode**, and/or drop `continue-on-error` on `audit` to make *new* findings blocking — once trusted. `TODO` noted in-workflow.
- Clean up the ~28 existing findings (2 dead files, dead nav exports, `react-collapse`, etc.).

## Note for reviewer
The `fallow` job shows a **green check with findings in the summary** — intended (advisory). It does not gate this or any PR.