### PR TITLE
feat(admin): P3a — moderation audit log + bulk report actions

### DIFF
--- a/docs/ADMIN_FUNCTIONALITY.md
+++ b/docs/ADMIN_FUNCTIONALITY.md
@@ -243,7 +243,13 @@ recipes without a direct URL); optional functional split between suspend & ban
 (auto-expiry / Firebase-disable) — currently identical enforcement, semantic only.
 
 ### P3 — Polish
-- `[ ]` `auditLog` collection + writes on every admin action
+- `[x]` `auditLog` collection + writes on every admin action — `server/util/auditLog.js`
+  (`recordAudit`, best-effort/never breaks the action); wired into recipe
+  hide/publish/feature, review takedown/restore, user status, report resolve/dismiss.
+  `GET /admin/audit` (filter by action/targetType/actorUid, paginated, actor-username
+  enriched) + `/admin/audit` page & nav tab. Indexed in db.js (new collection).
+- `[x]` Bulk actions — `PATCH /reports/bulk` (resolve/dismiss many open reports, capped
+  at 100, one audit entry each) + multi-select checkboxes & selection bar in the queue.
 - `[ ]` Admin analytics dashboard
 - `[ ]` Notifications/email (provider TBD)
-- `[ ]` Bulk actions / saved filters
+- `[ ]` Saved filters

--- a/server/__tests__/audit-log.test.js
+++ b/server/__tests__/audit-log.test.js
@@ -1,0 +1,127 @@
+/**
+ * Audit log (server/util/auditLog.js + GET /admin/audit on server/routes/admin.js,
+ * and the recordAudit calls wired into the admin mutation endpoints).
+ *
+ * Auth: firebase-admin mock resolves verifyIdToken to { uid: 'test-uid' }.
+ * Admin routes require __setClaims({ admin: true }).
+ */
+
+const request = require('supertest')
+const admin = require('firebase-admin') // auto-mocked
+const { ObjectId } = require('mongodb')
+const app = require('../app')
+const { getDB } = require('../db')
+const { seedUser } = require('./helpers/seed')
+
+const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
+const TEST_UID = 'test-uid'
+
+afterEach(async () => {
+  admin.__resetClaims()
+  admin.__resetUsers()
+  const db = getDB()
+  await Promise.all([
+    db.collection('auditLog').deleteMany({}),
+    db.collection('usernames').deleteMany({}),
+    db.collection('users').deleteMany({}),
+  ])
+})
+
+async function seedAudit(entries) {
+  await getDB().collection('auditLog').insertMany(
+    entries.map((e) => ({
+      _id: new ObjectId(),
+      actorUid: TEST_UID,
+      targetType: 'recipe',
+      targetId: 'r1',
+      targetLabel: null,
+      reason: null,
+      metadata: null,
+      createdAt: new Date(),
+      ...e,
+    }))
+  )
+}
+
+describe('GET /api/admin/audit', () => {
+  it('requires admin (403 for a logged-in non-admin)', async () => {
+    const res = await request(app).get('/api/admin/audit').set(AUTH_HEADER)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns entries newest first, enriched with the actor username', async () => {
+    admin.__setClaims({ admin: true })
+    await seedUser(TEST_UID, 'adminuser')
+    await seedAudit([
+      { action: 'recipe.hide', createdAt: new Date('2026-01-01') },
+      { action: 'recipe.unhide', createdAt: new Date('2026-02-01') },
+    ])
+
+    const res = await request(app).get('/api/admin/audit').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.totalCount).toBe(2)
+    expect(res.body.entries[0].action).toBe('recipe.unhide') // newest first
+    expect(res.body.entries[0].actorUsername).toBe('adminuser')
+  })
+
+  it('filters by action and by targetType', async () => {
+    admin.__setClaims({ admin: true })
+    await seedAudit([
+      { action: 'recipe.hide', targetType: 'recipe' },
+      { action: 'user.ban', targetType: 'user' },
+      { action: 'report.resolve', targetType: 'report' },
+    ])
+
+    const byAction = await request(app).get('/api/admin/audit?action=user.ban').set(AUTH_HEADER)
+    expect(byAction.body.totalCount).toBe(1)
+    expect(byAction.body.entries[0].action).toBe('user.ban')
+
+    const byTarget = await request(app).get('/api/admin/audit?targetType=report').set(AUTH_HEADER)
+    expect(byTarget.body.totalCount).toBe(1)
+    expect(byTarget.body.entries[0].targetType).toBe('report')
+  })
+
+  it('ignores an unknown action filter rather than returning nothing', async () => {
+    admin.__setClaims({ admin: true })
+    await seedAudit([{ action: 'recipe.hide' }])
+    const res = await request(app).get('/api/admin/audit?action=bogus').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.totalCount).toBe(1)
+  })
+
+  it('paginates', async () => {
+    admin.__setClaims({ admin: true })
+    await seedAudit(Array.from({ length: 30 }, (_, i) => ({ action: 'recipe.hide', targetId: `r${i}` })))
+    const page1 = await request(app).get('/api/admin/audit?page=1&perPage=25').set(AUTH_HEADER)
+    expect(page1.body.entries).toHaveLength(25)
+    expect(page1.body.totalCount).toBe(30)
+    const page2 = await request(app).get('/api/admin/audit?page=2&perPage=25').set(AUTH_HEADER)
+    expect(page2.body.entries).toHaveLength(5)
+  })
+})
+
+describe('admin mutations write audit entries', () => {
+  it('user suspension writes a user.suspend entry with reason + label', async () => {
+    admin.__setClaims({ admin: true })
+    admin.__setUsers([
+      { uid: TEST_UID, email: 'admin@test.dev', admin: true },
+      { uid: 'target-uid', email: 'target@test.dev' },
+    ])
+    await seedUser('target-uid', 'targetuser')
+
+    const res = await request(app)
+      .patch('/api/admin/users/target-uid/status')
+      .set(AUTH_HEADER)
+      .send({ status: 'suspended', reason: 'spamming' })
+    expect(res.status).toBe(200)
+
+    const entries = await getDB().collection('auditLog').find({}).toArray()
+    expect(entries).toHaveLength(1)
+    expect(entries[0].action).toBe('user.suspend')
+    expect(entries[0].actorUid).toBe(TEST_UID)
+    expect(entries[0].targetType).toBe('user')
+    expect(entries[0].targetId).toBe('target-uid')
+    expect(entries[0].targetLabel).toBe('@targetuser')
+    expect(entries[0].reason).toBe('spamming')
+  })
+})

--- a/server/__tests__/reports.test.js
+++ b/server/__tests__/reports.test.js
@@ -23,6 +23,7 @@ afterEach(async () => {
     db.collection('reports').deleteMany({}),
     db.collection('recipes').deleteMany({}),
     db.collection('ratings').deleteMany({}),
+    db.collection('auditLog').deleteMany({}),
   ])
 })
 
@@ -204,5 +205,87 @@ describe('PATCH /api/reports/:id', () => {
     expect(missing.status).toBe(404)
     const malformed = await request(app).patch('/api/reports/not-an-id').set(AUTH_HEADER).send({ status: 'resolved' })
     expect(malformed.status).toBe(404)
+  })
+
+  it('writes an audit entry when a report is resolved', async () => {
+    admin.__setClaims({ admin: true })
+    const report = await seedReport({ reportedUsername: 'baduser', targetType: 'review' })
+    await request(app).patch(`/api/reports/${report._id}`).set(AUTH_HEADER).send({ status: 'dismissed' })
+    const entries = await getDB().collection('auditLog').find({}).toArray()
+    expect(entries).toHaveLength(1)
+    expect(entries[0].action).toBe('report.dismiss')
+    expect(entries[0].actorUid).toBe(TEST_UID)
+    expect(entries[0].targetType).toBe('report')
+  })
+})
+
+describe('PATCH /api/reports/bulk', () => {
+  async function seedReports(n, overrides = {}) {
+    const docs = Array.from({ length: n }, (_, i) => ({
+      _id: new ObjectId(),
+      targetType: 'recipe',
+      recipeId: `recipe-${i}`,
+      reporterUid: `u${i}`,
+      reason: 'spam',
+      status: 'open',
+      createdAt: new Date(),
+      ...overrides,
+    }))
+    await getDB().collection('reports').insertMany(docs)
+    return docs
+  }
+
+  it('requires admin', async () => {
+    const [a] = await seedReports(1)
+    const res = await request(app)
+      .patch('/api/reports/bulk')
+      .set(AUTH_HEADER)
+      .send({ ids: [String(a._id)], status: 'resolved' })
+    expect(res.status).toBe(403)
+  })
+
+  it('resolves many open reports and reports how many changed', async () => {
+    admin.__setClaims({ admin: true })
+    const docs = await seedReports(3)
+    const ids = docs.map((d) => String(d._id))
+    const res = await request(app)
+      .patch('/api/reports/bulk')
+      .set(AUTH_HEADER)
+      .send({ ids, status: 'resolved' })
+    expect(res.status).toBe(200)
+    expect(res.body.updated).toBe(3)
+    const remaining = await getDB().collection('reports').countDocuments({ status: 'open' })
+    expect(remaining).toBe(0)
+    // One audit entry per report actually closed.
+    const audits = await getDB().collection('auditLog').countDocuments({ action: 'report.resolve' })
+    expect(audits).toBe(3)
+  })
+
+  it('only touches open reports (skips already-closed ids in the batch)', async () => {
+    admin.__setClaims({ admin: true })
+    const open = await seedReports(2)
+    const closed = await seedReports(1, { status: 'dismissed' })
+    const ids = [...open, ...closed].map((d) => String(d._id))
+    const res = await request(app)
+      .patch('/api/reports/bulk')
+      .set(AUTH_HEADER)
+      .send({ ids, status: 'resolved' })
+    expect(res.status).toBe(200)
+    expect(res.body.updated).toBe(2)
+  })
+
+  it('rejects an empty id list and an invalid status', async () => {
+    admin.__setClaims({ admin: true })
+    const empty = await request(app).patch('/api/reports/bulk').set(AUTH_HEADER).send({ ids: [], status: 'resolved' })
+    expect(empty.status).toBe(400)
+    const badStatus = await request(app).patch('/api/reports/bulk').set(AUTH_HEADER).send({ ids: ['x'], status: 'open' })
+    expect(badStatus.status).toBe(400)
+  })
+
+  it('rejects a batch over the cap', async () => {
+    admin.__setClaims({ admin: true })
+    const ids = Array.from({ length: 101 }, () => String(new ObjectId()))
+    const res = await request(app).patch('/api/reports/bulk').set(AUTH_HEADER).send({ ids, status: 'resolved' })
+    expect(res.status).toBe(400)
   })
 })

--- a/server/db.js
+++ b/server/db.js
@@ -78,11 +78,15 @@ async function ensureIndexes() {
 
   // Admin audit log (P3). New collection, so these build instantly. Backs the
   // audit page (newest first), and filtering by actor or by a specific target.
+  // The action/targetType compounds end in createdAt:-1 so the page's filter
+  // dropdowns are served filter-then-sort by one index rather than an in-memory sort.
   try {
     const auditLog = db.collection('auditLog')
     await auditLog.createIndex({ createdAt: -1 })
     await auditLog.createIndex({ actorUid: 1, createdAt: -1 })
     await auditLog.createIndex({ targetType: 1, targetId: 1 })
+    await auditLog.createIndex({ action: 1, createdAt: -1 })
+    await auditLog.createIndex({ targetType: 1, createdAt: -1 })
   } catch (err) {
     console.error('Failed to create indexes on auditLog:', err.message)
   }

--- a/server/db.js
+++ b/server/db.js
@@ -75,6 +75,17 @@ async function ensureIndexes() {
   } catch (err) {
     console.error('Failed to create indexes on reports:', err.message)
   }
+
+  // Admin audit log (P3). New collection, so these build instantly. Backs the
+  // audit page (newest first), and filtering by actor or by a specific target.
+  try {
+    const auditLog = db.collection('auditLog')
+    await auditLog.createIndex({ createdAt: -1 })
+    await auditLog.createIndex({ actorUid: 1, createdAt: -1 })
+    await auditLog.createIndex({ targetType: 1, targetId: 1 })
+  } catch (err) {
+    console.error('Failed to create indexes on auditLog:', err.message)
+  }
 }
 
 async function closeDB() {

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -3,6 +3,7 @@ const admin = require('firebase-admin')
 const { getDB } = require('../db')
 const { verifyToken, requireAdmin } = require('../middleware/auth')
 const { USER_STATUSES } = require('../util/userStatus')
+const { recordAudit, AUDIT_ACTIONS, AUDIT_TARGET_TYPES } = require('../util/auditLog')
 
 const router = Router()
 
@@ -242,7 +243,65 @@ router.patch('/admin/users/:uid/status', verifyToken, requireAdmin, async (req, 
       { upsert: true }
     )
 
+    const targetUsernameDoc = await db.collection('usernames').findOne({ _id: uid })
+    const auditAction =
+      status === 'suspended' ? 'user.suspend' : status === 'banned' ? 'user.ban' : 'user.activate'
+    await recordAudit(db, {
+      action: auditAction,
+      actorUid: req.uid,
+      targetType: 'user',
+      targetId: uid,
+      targetLabel: targetUsernameDoc?.username ? `@${targetUsernameDoc.username}` : uid,
+      reason: status === 'active' ? null : reason || null,
+    })
+
     res.json({ uid, status })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /admin/audit?action=&targetType=&actorUid=&page=&perPage= — the moderation
+// audit trail, newest first. Each row is enriched with the actor's username so
+// the page can show "@admin did X" without a per-row lookup.
+router.get('/admin/audit', verifyToken, requireAdmin, async (req, res) => {
+  try {
+    const db = getDB()
+    const { action, targetType, actorUid } = req.query
+    const page = Math.max(parseInt(req.query.page) || 1, 1)
+    const perPage = Math.min(parseInt(req.query.perPage) || DEFAULT_PER_PAGE, MAX_PER_PAGE)
+
+    const filter = {}
+    if (typeof action === 'string' && AUDIT_ACTIONS.includes(action)) filter.action = action
+    if (typeof targetType === 'string' && AUDIT_TARGET_TYPES.includes(targetType)) {
+      filter.targetType = targetType
+    }
+    if (typeof actorUid === 'string' && actorUid) filter.actorUid = actorUid
+
+    const [entries, totalCount] = await Promise.all([
+      db
+        .collection('auditLog')
+        .find(filter)
+        .sort({ createdAt: -1 })
+        .skip((page - 1) * perPage)
+        .limit(perPage)
+        .toArray(),
+      db.collection('auditLog').countDocuments(filter),
+    ])
+
+    // Batch-resolve actor usernames for this page.
+    const actorUids = [...new Set(entries.map((e) => e.actorUid).filter(Boolean))]
+    const actorDocs = actorUids.length
+      ? await db.collection('usernames').find({ _id: { $in: actorUids } }).toArray()
+      : []
+    const actorByUid = Object.fromEntries(actorDocs.map((d) => [d._id, d.username]))
+
+    const enriched = entries.map((e) => ({
+      ...e,
+      actorUsername: actorByUid[e.actorUid] || null,
+    }))
+
+    res.json({ entries: enriched, totalCount })
   } catch (err) {
     res.status(500).json({ error: err.message })
   }

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -4,6 +4,7 @@ const { getDB, getClient } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { RECIPE_VISIBLE } = require('../util/moderation')
+const { recordAudit } = require('../util/auditLog')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
 const { EDITABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
@@ -396,6 +397,13 @@ router.patch('/admin/recipes/:id/moderation', verifyToken, requireAdmin, async (
       { returnDocument: 'after' }
     )
     if (!updated) return res.status(404).json({ error: 'Recipe not found' })
+    await recordAudit(db, {
+      action: status === 'hidden' ? 'recipe.hide' : 'recipe.unhide',
+      actorUid: req.uid,
+      targetType: 'recipe',
+      targetId: updated._id,
+      targetLabel: updated.title || null,
+    })
     res.json({ _id: updated._id, status: updated.status })
   } catch (err) {
     res.status(500).json({ error: err.message })
@@ -427,6 +435,13 @@ router.patch('/admin/recipes/:id/publish', verifyToken, requireAdmin, async (req
       { returnDocument: 'after' }
     )
     if (!updated) return res.status(404).json({ error: 'Recipe not found' })
+    await recordAudit(db, {
+      action: published ? 'recipe.publish' : 'recipe.unpublish',
+      actorUid: req.uid,
+      targetType: 'recipe',
+      targetId: updated._id,
+      targetLabel: updated.title || null,
+    })
     res.json({ _id: updated._id, status: updated.status })
   } catch (err) {
     res.status(500).json({ error: err.message })
@@ -455,6 +470,13 @@ router.patch('/admin/recipes/:id/feature', verifyToken, requireAdmin, async (req
       { returnDocument: 'after' }
     )
     if (!updated) return res.status(404).json({ error: 'Recipe not found' })
+    await recordAudit(db, {
+      action: featured ? 'recipe.feature' : 'recipe.unfeature',
+      actorUid: req.uid,
+      targetType: 'recipe',
+      targetId: updated._id,
+      targetLabel: updated.title || null,
+    })
     res.json({ _id: updated._id, featured: updated.featured === true })
   } catch (err) {
     res.status(500).json({ error: err.message })

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -3,7 +3,7 @@ const { ObjectId } = require('mongodb')
 const { getDB } = require('../db')
 const { verifyToken, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
-const { recordAudit } = require('../util/auditLog')
+const { recordAudit, recordAuditMany } = require('../util/auditLog')
 
 const router = Router()
 
@@ -127,7 +127,7 @@ router.get('/reports', verifyToken, requireAdmin, async (req, res) => {
 })
 
 // Most reports a single admin sweep would ever clear at once. Bounds the bulk
-// updateMany and the per-report audit fan-out.
+// updateMany and the audit insert.
 const MAX_BULK = 100
 
 // PATCH /reports/bulk — admin resolves/dismisses many reports in one sweep.
@@ -152,29 +152,34 @@ router.patch('/reports/bulk', verifyToken, requireAdmin, async (req, res) => {
       return res.status(400).json({ error: 'No valid report ids' })
     }
 
-    // Snapshot the open targets first so each closed report gets an audit entry
-    // with a readable label (updateMany can't return the docs).
-    const open = await db
-      .collection('reports')
-      .find({ _id: { $in: objectIds }, status: 'open' })
-      .toArray()
-
+    // Stamp every report this sweep closes with a single timestamp, then re-read
+    // exactly those docs by our own (actorUid, resolvedAt) stamp. updateMany
+    // can't return the modified docs, and re-reading by the stamp — rather than
+    // a pre-update snapshot — means a report closed concurrently by another
+    // admin can't slip into *our* audit trail.
+    const resolvedAt = new Date()
     const result = await db.collection('reports').updateMany(
       { _id: { $in: objectIds }, status: 'open' },
-      { $set: { status, resolvedBy: req.uid, resolvedAt: new Date() } }
+      { $set: { status, resolvedBy: req.uid, resolvedAt } }
     )
 
-    await Promise.all(
-      open.map((r) =>
-        recordAudit(db, {
-          action: status === 'resolved' ? 'report.resolve' : 'report.dismiss',
-          actorUid: req.uid,
-          targetType: 'report',
-          targetId: r._id,
-          targetLabel: r.reportedUsername ? `@${r.reportedUsername}` : r.recipeId,
-          metadata: { targetType: r.targetType, recipeId: r.recipeId, bulk: true },
-        })
-      )
+    const closed = result.modifiedCount
+      ? await db
+          .collection('reports')
+          .find({ _id: { $in: objectIds }, resolvedBy: req.uid, resolvedAt })
+          .toArray()
+      : []
+
+    await recordAuditMany(
+      db,
+      closed.map((r) => ({
+        action: status === 'resolved' ? 'report.resolve' : 'report.dismiss',
+        actorUid: req.uid,
+        targetType: 'report',
+        targetId: r._id,
+        targetLabel: r.reportedUsername ? `@${r.reportedUsername}` : r.recipeId,
+        metadata: { targetType: r.targetType, recipeId: r.recipeId, bulk: true },
+      }))
     )
 
     res.json({ updated: result.modifiedCount })

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -3,6 +3,7 @@ const { ObjectId } = require('mongodb')
 const { getDB } = require('../db')
 const { verifyToken, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
+const { recordAudit } = require('../util/auditLog')
 
 const router = Router()
 
@@ -125,6 +126,63 @@ router.get('/reports', verifyToken, requireAdmin, async (req, res) => {
   }
 })
 
+// Most reports a single admin sweep would ever clear at once. Bounds the bulk
+// updateMany and the per-report audit fan-out.
+const MAX_BULK = 100
+
+// PATCH /reports/bulk — admin resolves/dismisses many reports in one sweep.
+// Declared BEFORE /reports/:id so 'bulk' isn't captured as an :id. Only OPEN
+// reports are touched (already-closed ids in the batch are simply skipped), and
+// one audit entry is written per report actually closed.
+router.patch('/reports/bulk', verifyToken, requireAdmin, async (req, res) => {
+  try {
+    const db = getDB()
+    const { ids, status } = req.body
+    if (!RESOLUTIONS.includes(status)) {
+      return res.status(400).json({ error: "status must be 'resolved' or 'dismissed'" })
+    }
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return res.status(400).json({ error: 'ids must be a non-empty array' })
+    }
+    if (ids.length > MAX_BULK) {
+      return res.status(400).json({ error: `Cannot update more than ${MAX_BULK} reports at once` })
+    }
+    const objectIds = ids.filter((id) => typeof id === 'string' && ObjectId.isValid(id)).map((id) => new ObjectId(id))
+    if (objectIds.length === 0) {
+      return res.status(400).json({ error: 'No valid report ids' })
+    }
+
+    // Snapshot the open targets first so each closed report gets an audit entry
+    // with a readable label (updateMany can't return the docs).
+    const open = await db
+      .collection('reports')
+      .find({ _id: { $in: objectIds }, status: 'open' })
+      .toArray()
+
+    const result = await db.collection('reports').updateMany(
+      { _id: { $in: objectIds }, status: 'open' },
+      { $set: { status, resolvedBy: req.uid, resolvedAt: new Date() } }
+    )
+
+    await Promise.all(
+      open.map((r) =>
+        recordAudit(db, {
+          action: status === 'resolved' ? 'report.resolve' : 'report.dismiss',
+          actorUid: req.uid,
+          targetType: 'report',
+          targetId: r._id,
+          targetLabel: r.reportedUsername ? `@${r.reportedUsername}` : r.recipeId,
+          metadata: { targetType: r.targetType, recipeId: r.recipeId, bulk: true },
+        })
+      )
+    )
+
+    res.json({ updated: result.modifiedCount })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
 // PATCH /reports/:id — admin resolves or dismisses a report. Resolving does NOT
 // itself take content down; the admin takedown endpoints (on recipes/reviews)
 // do that. This just closes the queue item and stamps who/when.
@@ -144,6 +202,14 @@ router.patch('/reports/:id', verifyToken, requireAdmin, async (req, res) => {
       { returnDocument: 'after' }
     )
     if (!updated) return res.status(404).json({ error: 'Report not found' })
+    await recordAudit(db, {
+      action: status === 'resolved' ? 'report.resolve' : 'report.dismiss',
+      actorUid: req.uid,
+      targetType: 'report',
+      targetId: updated._id,
+      targetLabel: updated.reportedUsername ? `@${updated.reportedUsername}` : updated.recipeId,
+      metadata: { targetType: updated.targetType, recipeId: updated.recipeId },
+    })
     res.json(updated)
   } catch (err) {
     res.status(500).json({ error: err.message })

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -3,6 +3,7 @@ const { getDB } = require('../db')
 const { verifyToken, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { REVIEW_VISIBLE, RECIPE_VISIBLE } = require('../util/moderation')
+const { recordAudit } = require('../util/auditLog')
 const { recomputeRecipeRating } = require('../util/recipeRating')
 
 const router = Router()
@@ -260,6 +261,14 @@ router.patch('/admin/reviews/moderation', verifyToken, requireAdmin, async (req,
     }
     // A takedown/restore changes which ratings count toward the recipe's score.
     await recomputeRecipeRating(db, recipeId)
+    await recordAudit(db, {
+      action: moderationHidden ? 'review.takedown' : 'review.restore',
+      actorUid: req.uid,
+      targetType: 'review',
+      targetId: `${username}:${recipeId}`,
+      targetLabel: `@${username}`,
+      metadata: { recipeId, username },
+    })
     res.json({ recipeId, username, moderationHidden })
   } catch (err) {
     res.status(500).json({ error: err.message })

--- a/server/util/auditLog.js
+++ b/server/util/auditLog.js
@@ -55,4 +55,33 @@ async function recordAudit(db, entry) {
   }
 }
 
-module.exports = { recordAudit, AUDIT_ACTIONS, AUDIT_TARGET_TYPES }
+/**
+ * Append many audit entries in a single insertOne batch. Same best-effort
+ * contract as recordAudit (swallows its own errors, always resolves) — for
+ * bulk admin sweeps so we make one round-trip instead of one per entry.
+ *
+ * @param {import('mongodb').Db} db
+ * @param {object[]} entries  each shaped like the recordAudit `entry` arg
+ */
+async function recordAuditMany(db, entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return
+  try {
+    await db.collection('auditLog').insertMany(
+      entries.map((entry) => ({
+        _id: new ObjectId(),
+        action: entry.action,
+        actorUid: entry.actorUid,
+        targetType: entry.targetType,
+        targetId: entry.targetId != null ? String(entry.targetId) : null,
+        targetLabel: entry.targetLabel || null,
+        reason: entry.reason || null,
+        metadata: entry.metadata || null,
+        createdAt: new Date(),
+      }))
+    )
+  } catch (err) {
+    console.error('Failed to write audit log entries:', err.message)
+  }
+}
+
+module.exports = { recordAudit, recordAuditMany, AUDIT_ACTIONS, AUDIT_TARGET_TYPES }

--- a/server/util/auditLog.js
+++ b/server/util/auditLog.js
@@ -1,0 +1,58 @@
+const { ObjectId } = require('mongodb')
+
+// Canonical set of audit actions. Kept as a flat verb.noun list so the queue
+// and the audit page can filter on an exact value. New admin mutations should
+// add their action here rather than passing an ad-hoc string.
+const AUDIT_ACTIONS = [
+  'recipe.hide',
+  'recipe.unhide',
+  'recipe.publish',
+  'recipe.unpublish',
+  'recipe.feature',
+  'recipe.unfeature',
+  'review.takedown',
+  'review.restore',
+  'user.suspend',
+  'user.ban',
+  'user.activate',
+  'report.resolve',
+  'report.dismiss',
+]
+
+const AUDIT_TARGET_TYPES = ['recipe', 'review', 'user', 'report']
+
+/**
+ * Append one immutable entry to the `auditLog` collection describing an admin
+ * action. Deliberately best-effort: a logging failure must never break the
+ * action it is recording, so this swallows its own errors (and logs them) and
+ * always resolves. Callers should `await` it but need not guard it.
+ *
+ * @param {import('mongodb').Db} db
+ * @param {object} entry
+ * @param {string} entry.action       one of AUDIT_ACTIONS
+ * @param {string} entry.actorUid     admin uid performing the action
+ * @param {string} entry.targetType   one of AUDIT_TARGET_TYPES
+ * @param {string} entry.targetId     recipeId / uid / reportId (or username+recipeId for reviews)
+ * @param {string} [entry.targetLabel] human-readable label captured at action time (recipe title, @username)
+ * @param {string} [entry.reason]
+ * @param {object} [entry.metadata]   any extra structured context (e.g. { from, to })
+ */
+async function recordAudit(db, entry) {
+  try {
+    await db.collection('auditLog').insertOne({
+      _id: new ObjectId(),
+      action: entry.action,
+      actorUid: entry.actorUid,
+      targetType: entry.targetType,
+      targetId: entry.targetId != null ? String(entry.targetId) : null,
+      targetLabel: entry.targetLabel || null,
+      reason: entry.reason || null,
+      metadata: entry.metadata || null,
+      createdAt: new Date(),
+    })
+  } catch (err) {
+    console.error('Failed to write audit log entry:', err.message)
+  }
+}
+
+module.exports = { recordAudit, AUDIT_ACTIONS, AUDIT_TARGET_TYPES }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import AdminRoute from 'src/Components/AdminRoute'
 import AdminLayout from 'src/pages/Admin/AdminLayout'
 import Reports from 'src/pages/Admin/Reports/Reports'
 import Users from 'src/pages/Admin/Users/Users'
+import Audit from 'src/pages/Admin/Audit/Audit'
 import CreateUsername from 'src/pages/CreateUsername/CreateUsername'
 
 import Account from 'src/pages/Account/Account'
@@ -190,6 +191,7 @@ const App: FC = () => {
                 <Route index element={<Navigate to='/admin/reports' replace />} />
                 <Route path='reports' element={<Reports />} />
                 <Route path='users' element={<Users />} />
+                <Route path='audit' element={<Audit />} />
               </Route>
             </Route>
 

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -2,6 +2,9 @@ import {
   AdminUsersResponse,
   AdminUserDetailType,
   UserStatus,
+  AuditResponse,
+  AuditAction,
+  AuditTargetType,
 } from 'types'
 import { http } from 'src/api/http-common'
 
@@ -62,6 +65,18 @@ class AdminAPIClass {
       `api/admin/recipes/${recipeId}/publish`,
       { published }
     )
+    return result.data
+  }
+
+  // The moderation audit trail, newest first; optionally filtered.
+  async listAudit(params?: {
+    action?: AuditAction
+    targetType?: AuditTargetType
+    actorUid?: string
+    page?: number
+    perPage?: number
+  }): Promise<AuditResponse> {
+    const result = await http.get<AuditResponse>('api/admin/audit', { params })
     return result.data
   }
 }

--- a/src/api/reports.ts
+++ b/src/api/reports.ts
@@ -46,6 +46,19 @@ class ReportAPIClass {
     return result.data
   }
 
+  // Admin: close many reports at once. Returns how many were actually updated
+  // (already-closed ids in the batch are skipped server-side).
+  async bulkResolve(
+    ids: string[],
+    status: 'resolved' | 'dismissed'
+  ): Promise<{ updated: number }> {
+    const result = await http.patch<{ updated: number }>('api/reports/bulk', {
+      ids,
+      status,
+    })
+    return result.data
+  }
+
   // Admin: soft-hide / restore a recipe.
   async setRecipeModeration(
     recipeId: string,

--- a/src/pages/Admin/AdminLayout.tsx
+++ b/src/pages/Admin/AdminLayout.tsx
@@ -4,10 +4,11 @@ import './AdminLayout.scss'
 
 // Shell for the admin section. Deliberately separate from the public Layout
 // (no marketing navbar/footer) — this is an internal tool. P1 added the queue;
-// P2 adds Users. P3 will add Audit/analytics nav items alongside these.
+// P2 adds Users; P3 adds the audit trail. Analytics will slot in alongside.
 const ADMIN_NAV = [
   { to: '/admin/reports', label: 'Reports' },
   { to: '/admin/users', label: 'Users' },
+  { to: '/admin/audit', label: 'Audit log' },
 ]
 
 const AdminLayout: FC = () => {

--- a/src/pages/Admin/Audit/Audit.scss
+++ b/src/pages/Admin/Audit/Audit.scss
@@ -1,0 +1,172 @@
+.admin-audit {
+  max-width: 820px;
+
+  .admin-audit-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+
+    h1 {
+      margin: 0;
+      font-size: 1.6rem;
+    }
+
+    .total-count {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: #4b5563;
+      background: #f3f4f6;
+      padding: 0.2rem 0.55rem;
+      border-radius: 999px;
+    }
+  }
+
+  .audit-filters {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+
+    .action-select {
+      border: 1px solid #d8dbe0;
+      background: #fff;
+      color: #374151;
+      padding: 0.4rem 0.7rem;
+      border-radius: 8px;
+      font-size: 0.85rem;
+      cursor: pointer;
+    }
+
+    .target-tabs {
+      display: flex;
+      gap: 0.4rem;
+      flex-wrap: wrap;
+
+      .tab {
+        border: 1px solid #d8dbe0;
+        background: #fff;
+        color: #4b5563;
+        padding: 0.35rem 0.8rem;
+        border-radius: 999px;
+        font-size: 0.82rem;
+        cursor: pointer;
+        transition: all 0.15s;
+
+        &:hover {
+          border-color: #9ca3af;
+        }
+
+        &.active {
+          background: #1f2430;
+          border-color: #1f2430;
+          color: #fff;
+        }
+      }
+    }
+  }
+
+  .audit-state {
+    color: #6b7280;
+    font-size: 0.95rem;
+
+    &.error {
+      color: #b91c1c;
+    }
+  }
+
+  .audit-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .audit-row {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.85rem 0;
+    border-bottom: 1px solid #eef0f2;
+
+    .dot {
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      margin-top: 0.4rem;
+      flex-shrink: 0;
+      background: #9ca3af;
+
+      &.good {
+        background: #16a34a;
+      }
+      &.warn {
+        background: #d97706;
+      }
+      &.danger {
+        background: #dc2626;
+      }
+      &.neutral {
+        background: #9ca3af;
+      }
+    }
+
+    .audit-body {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .audit-line {
+      margin: 0;
+      font-size: 0.92rem;
+      color: #374151;
+
+      .actor {
+        color: #111827;
+      }
+
+      .target {
+        font-weight: 600;
+        color: #111827;
+        word-break: break-word;
+      }
+    }
+
+    .audit-reason {
+      margin: 0.25rem 0 0;
+      font-size: 0.85rem;
+      font-style: italic;
+      color: #6b7280;
+    }
+
+    .audit-time {
+      margin: 0.25rem 0 0;
+      font-size: 0.76rem;
+      color: #9ca3af;
+    }
+  }
+
+  .audit-pager {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 1.5rem;
+    font-size: 0.85rem;
+    color: #4b5563;
+
+    button {
+      border: 1px solid #d8dbe0;
+      background: #fff;
+      color: #374151;
+      padding: 0.4rem 0.9rem;
+      border-radius: 8px;
+      cursor: pointer;
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+    }
+  }
+}

--- a/src/pages/Admin/Audit/Audit.tsx
+++ b/src/pages/Admin/Audit/Audit.tsx
@@ -1,0 +1,165 @@
+import React, { FC, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { AuditAction, AuditEntryType, AuditTargetType } from 'types'
+import AdminAPI from 'src/api/admin'
+import './Audit.scss'
+
+const PER_PAGE = 25
+
+// Filter chips for the action column. `all` clears the filter.
+const ACTION_FILTERS: { value: AuditAction | 'all'; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'recipe.hide', label: 'Recipe hidden' },
+  { value: 'recipe.unhide', label: 'Recipe restored' },
+  { value: 'recipe.unpublish', label: 'Recipe unpublished' },
+  { value: 'recipe.publish', label: 'Recipe published' },
+  { value: 'recipe.feature', label: 'Recipe featured' },
+  { value: 'recipe.unfeature', label: 'Recipe unfeatured' },
+  { value: 'review.takedown', label: 'Review taken down' },
+  { value: 'review.restore', label: 'Review restored' },
+  { value: 'user.suspend', label: 'User suspended' },
+  { value: 'user.ban', label: 'User banned' },
+  { value: 'user.activate', label: 'User reactivated' },
+  { value: 'report.resolve', label: 'Report resolved' },
+  { value: 'report.dismiss', label: 'Report dismissed' },
+]
+
+// Short human phrasing + a colour family per action, for the row label.
+const ACTION_META: Record<AuditAction, { label: string; tone: string }> = {
+  'recipe.hide': { label: 'hid recipe', tone: 'danger' },
+  'recipe.unhide': { label: 'restored recipe', tone: 'good' },
+  'recipe.publish': { label: 'published recipe', tone: 'good' },
+  'recipe.unpublish': { label: 'unpublished recipe', tone: 'warn' },
+  'recipe.feature': { label: 'featured recipe', tone: 'good' },
+  'recipe.unfeature': { label: 'unfeatured recipe', tone: 'neutral' },
+  'review.takedown': { label: 'took down review by', tone: 'danger' },
+  'review.restore': { label: 'restored review by', tone: 'good' },
+  'user.suspend': { label: 'suspended', tone: 'warn' },
+  'user.ban': { label: 'banned', tone: 'danger' },
+  'user.activate': { label: 'reactivated', tone: 'good' },
+  'report.resolve': { label: 'resolved report', tone: 'good' },
+  'report.dismiss': { label: 'dismissed report', tone: 'neutral' },
+}
+
+const TARGET_TABS: { value: AuditTargetType | 'all'; label: string }[] = [
+  { value: 'all', label: 'All targets' },
+  { value: 'recipe', label: 'Recipes' },
+  { value: 'review', label: 'Reviews' },
+  { value: 'user', label: 'Users' },
+  { value: 'report', label: 'Reports' },
+]
+
+const Audit: FC = () => {
+  const [action, setAction] = useState<AuditAction | 'all'>('all')
+  const [targetType, setTargetType] = useState<AuditTargetType | 'all'>('all')
+  const [page, setPage] = useState(1)
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['admin-audit', action, targetType, page],
+    queryFn: () =>
+      AdminAPI.listAudit({
+        action: action === 'all' ? undefined : action,
+        targetType: targetType === 'all' ? undefined : targetType,
+        page,
+        perPage: PER_PAGE,
+      }),
+  })
+
+  const totalPages = data ? Math.max(Math.ceil(data.totalCount / PER_PAGE), 1) : 1
+
+  const resetTo = <T,>(setter: (v: T) => void) => (value: T) => {
+    setter(value)
+    setPage(1)
+  }
+
+  return (
+    <div className='admin-audit'>
+      <header className='admin-audit-head'>
+        <h1>Audit log</h1>
+        {data && <span className='total-count'>{data.totalCount} entries</span>}
+      </header>
+
+      <div className='audit-filters'>
+        <select
+          className='action-select'
+          value={action}
+          onChange={e => resetTo(setAction)(e.target.value as AuditAction | 'all')}
+          aria-label='Filter by action'
+        >
+          {ACTION_FILTERS.map(f => (
+            <option key={f.value} value={f.value}>
+              {f.label}
+            </option>
+          ))}
+        </select>
+
+        <div className='target-tabs'>
+          {TARGET_TABS.map(tab => (
+            <button
+              key={tab.value}
+              className={targetType === tab.value ? 'tab active' : 'tab'}
+              onClick={() => resetTo(setTargetType)(tab.value)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isPending ? (
+        <p className='audit-state'>Loading audit log…</p>
+      ) : isError ? (
+        <p className='audit-state error'>Failed to load the audit log.</p>
+      ) : data.entries.length === 0 ? (
+        <p className='audit-state'>No matching audit entries.</p>
+      ) : (
+        <>
+          <ul className='audit-list'>
+            {data.entries.map((entry: AuditEntryType) => {
+              const meta = ACTION_META[entry.action]
+              return (
+                <li key={entry._id} className='audit-row'>
+                  <span className={`dot ${meta?.tone || 'neutral'}`} aria-hidden='true' />
+                  <div className='audit-body'>
+                    <p className='audit-line'>
+                      <strong className='actor'>
+                        {entry.actorUsername ? `@${entry.actorUsername}` : 'An admin'}
+                      </strong>{' '}
+                      {meta?.label || entry.action}{' '}
+                      <span className='target'>{entry.targetLabel || entry.targetId}</span>
+                    </p>
+                    {entry.reason && (
+                      <p className='audit-reason'>“{entry.reason}”</p>
+                    )}
+                    <p className='audit-time'>
+                      {new Date(entry.createdAt).toLocaleString()}
+                    </p>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+
+          {totalPages > 1 && (
+            <div className='audit-pager'>
+              <button disabled={page <= 1} onClick={() => setPage(p => p - 1)}>
+                Prev
+              </button>
+              <span>
+                Page {page} of {totalPages}
+              </span>
+              <button
+                disabled={page >= totalPages}
+                onClick={() => setPage(p => p + 1)}
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+export default Audit

--- a/src/pages/Admin/Reports/Reports.scss
+++ b/src/pages/Admin/Reports/Reports.scss
@@ -138,6 +138,14 @@
     justify-content: space-between;
     gap: 1.25rem;
 
+    // Grow to fill the row between the (optional) select checkbox and the action
+    // column, so content stays left-aligned. Without this, space-between centres
+    // it and the slack reads as inconsistent whitespace that tracks title length.
+    .report-main {
+      flex: 1;
+      min-width: 0;
+    }
+
     .report-tags {
       display: flex;
       gap: 0.4rem;

--- a/src/pages/Admin/Reports/Reports.scss
+++ b/src/pages/Admin/Reports/Reports.scss
@@ -58,6 +58,68 @@
     }
   }
 
+  .bulk-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+    padding: 0.6rem 0.9rem;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+
+    .bulk-select-all {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+      color: #374151;
+      cursor: pointer;
+    }
+
+    .bulk-actions {
+      display: flex;
+      gap: 0.5rem;
+
+      .action {
+        cursor: pointer;
+        border-radius: 6px;
+        padding: 0.4rem 0.8rem;
+        font-size: 0.82rem;
+        font-weight: 600;
+        border: 1px solid transparent;
+        white-space: nowrap;
+
+        &:disabled {
+          opacity: 0.6;
+          cursor: default;
+        }
+
+        &.resolve {
+          background: #16a34a;
+          border-color: #16a34a;
+          color: #fff;
+        }
+
+        &.dismiss {
+          background: #fff;
+          border-color: #d1d5db;
+          color: #6b7280;
+        }
+      }
+    }
+  }
+
+  .report-select {
+    margin-top: 0.3rem;
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+  }
+
   .reports-list {
     list-style: none;
     margin: 0;

--- a/src/pages/Admin/Reports/Reports.tsx
+++ b/src/pages/Admin/Reports/Reports.tsx
@@ -17,6 +17,9 @@ const STATUS_TABS: { value: StatusFilter; label: string }[] = [
 
 const Reports: FC = () => {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('open')
+  // Ids of reports ticked for a bulk resolve/dismiss sweep. Only open reports
+  // are selectable; switching tabs clears the selection.
+  const [selected, setSelected] = useState<Set<string>>(new Set())
   const queryClient = useQueryClient()
 
   const { data, isPending, isError } = useQuery({
@@ -30,6 +33,40 @@ const Reports: FC = () => {
 
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: ['admin-reports'] })
+
+  const changeTab = (value: StatusFilter) => {
+    setStatusFilter(value)
+    setSelected(new Set())
+  }
+
+  const toggleSelect = (id: string) =>
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+
+  const openReports = (data?.reports || []).filter(r => r.status === 'open')
+  const allOpenSelected =
+    openReports.length > 0 && openReports.every(r => selected.has(r._id))
+
+  const toggleSelectAll = () =>
+    setSelected(
+      allOpenSelected ? new Set() : new Set(openReports.map(r => r._id))
+    )
+
+  // Resolve/dismiss every selected report in one request.
+  const bulkMutation = useMutation({
+    mutationFn: ({ status }: { status: 'resolved' | 'dismissed' }) =>
+      ReportAPI.bulkResolve(Array.from(selected), status),
+    onSuccess: (res, vars) => {
+      toast.success(`${res.updated} report${res.updated === 1 ? '' : 's'} ${vars.status}.`)
+      setSelected(new Set())
+      invalidate()
+    },
+    onError: () => toast.error('Could not update the selected reports.'),
+  })
 
   // Resolve / dismiss a report (does not itself change the content).
   const resolveMutation = useMutation({
@@ -92,7 +129,8 @@ const Reports: FC = () => {
   const busy =
     resolveMutation.isPending ||
     takedownMutation.isPending ||
-    restoreMutation.isPending
+    restoreMutation.isPending ||
+    bulkMutation.isPending
 
   const renderPreview = (report: AdminReportType) => {
     const { target } = report
@@ -152,12 +190,45 @@ const Reports: FC = () => {
           <button
             key={tab.value}
             className={statusFilter === tab.value ? 'tab active' : 'tab'}
-            onClick={() => setStatusFilter(tab.value)}
+            onClick={() => changeTab(tab.value)}
           >
             {tab.label}
           </button>
         ))}
       </div>
+
+      {openReports.length > 0 && (
+        <div className='bulk-bar'>
+          <label className='bulk-select-all'>
+            <input
+              type='checkbox'
+              checked={allOpenSelected}
+              onChange={toggleSelectAll}
+            />
+            {selected.size > 0
+              ? `${selected.size} selected`
+              : `Select all ${openReports.length} open`}
+          </label>
+          {selected.size > 0 && (
+            <div className='bulk-actions'>
+              <button
+                className='action resolve'
+                disabled={busy}
+                onClick={() => bulkMutation.mutate({ status: 'resolved' })}
+              >
+                Resolve selected
+              </button>
+              <button
+                className='action dismiss'
+                disabled={busy}
+                onClick={() => bulkMutation.mutate({ status: 'dismissed' })}
+              >
+                Dismiss selected
+              </button>
+            </div>
+          )}
+        </div>
+      )}
 
       {isPending ? (
         <p className='reports-state'>Loading reports…</p>
@@ -169,6 +240,15 @@ const Reports: FC = () => {
         <ul className='reports-list'>
           {data.reports.map(report => (
             <li key={report._id} className='report-card'>
+              {report.status === 'open' && (
+                <input
+                  type='checkbox'
+                  className='report-select'
+                  checked={selected.has(report._id)}
+                  onChange={() => toggleSelect(report._id)}
+                  aria-label='Select report for bulk action'
+                />
+              )}
               <div className='report-main'>
                 <div className='report-tags'>
                   <span className={`type-pill ${report.targetType}`}>

--- a/src/test/Audit.test.tsx
+++ b/src/test/Audit.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Admin Audit page: renders enriched audit entries and filters them through
+ * AdminAPI.listAudit. The API is mocked; react-query/router are real.
+ */
+
+import React from 'react'
+import { vi, Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import Audit from 'src/pages/Admin/Audit/Audit'
+import AdminAPI from 'src/api/admin'
+
+vi.mock('src/api/admin', () => ({
+  __esModule: true,
+  default: { listAudit: vi.fn() },
+}))
+
+const mockedList = AdminAPI.listAudit as unknown as Mock
+
+const sampleEntry = {
+  _id: 'a1',
+  action: 'user.ban' as const,
+  actorUid: 'admin-uid',
+  actorUsername: 'mod',
+  targetType: 'user' as const,
+  targetId: 'u9',
+  targetLabel: '@baduser',
+  reason: 'repeated abuse',
+  metadata: null,
+  createdAt: new Date('2026-06-01T12:00:00Z').toISOString(),
+}
+
+const renderAudit = () =>
+  render(
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+    >
+      <MemoryRouter>
+        <Audit />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+
+afterEach(() => vi.clearAllMocks())
+
+describe('Admin Audit page', () => {
+  it('renders an audit entry with actor, action phrasing, target and reason', async () => {
+    mockedList.mockResolvedValue({ entries: [sampleEntry], totalCount: 1 })
+    renderAudit()
+
+    expect(await screen.findByText('@mod')).toBeInTheDocument()
+    // The row label ("… banned …") — scoped to the audit line so it doesn't
+    // collide with the "User banned" option in the filter dropdown.
+    expect(screen.getByText(/banned/, { selector: '.audit-line' })).toBeInTheDocument()
+    expect(screen.getByText('@baduser')).toBeInTheDocument()
+    expect(screen.getByText(/repeated abuse/)).toBeInTheDocument()
+  })
+
+  it('filters by target type and refetches', async () => {
+    mockedList.mockResolvedValue({ entries: [sampleEntry], totalCount: 1 })
+    renderAudit()
+    await screen.findByText('@mod')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reports' }))
+
+    await waitFor(() =>
+      expect(mockedList).toHaveBeenCalledWith(
+        expect.objectContaining({ targetType: 'report', page: 1 })
+      )
+    )
+  })
+
+  it('shows an empty state when there are no entries', async () => {
+    mockedList.mockResolvedValue({ entries: [], totalCount: 0 })
+    renderAudit()
+    expect(await screen.findByText(/no matching audit entries/i)).toBeInTheDocument()
+  })
+})

--- a/src/test/Reports.test.tsx
+++ b/src/test/Reports.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Admin Reports queue — bulk select + bulk resolve/dismiss. The ReportAPI and
+ * toast are mocked; react-query/router are real.
+ */
+
+import React from 'react'
+import { vi, Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import Reports from 'src/pages/Admin/Reports/Reports'
+import ReportAPI from 'src/api/reports'
+
+vi.mock('src/api/reports', () => ({
+  __esModule: true,
+  default: {
+    listReports: vi.fn(),
+    resolveReport: vi.fn(),
+    bulkResolve: vi.fn().mockResolvedValue({ updated: 2 }),
+    setRecipeModeration: vi.fn(),
+    setReviewModeration: vi.fn(),
+  },
+}))
+vi.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: { success: vi.fn(), error: vi.fn() },
+}))
+
+const mockedList = ReportAPI.listReports as unknown as Mock
+const mockedBulk = ReportAPI.bulkResolve as unknown as Mock
+
+const openReport = (id: string, recipeId: string) => ({
+  _id: id,
+  targetType: 'recipe' as const,
+  recipeId,
+  reporterUid: 'u1',
+  reason: 'spam',
+  status: 'open' as const,
+  createdAt: new Date('2026-06-01').toISOString(),
+  target: { recipe: { title: `Dish ${id}`, recipeImage: '', status: 'active' }, review: null },
+})
+
+const renderReports = () =>
+  render(
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+    >
+      <MemoryRouter>
+        <Reports />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+
+afterEach(() => vi.clearAllMocks())
+
+describe('Admin Reports bulk actions', () => {
+  it('selects all open reports and bulk-resolves them', async () => {
+    mockedList.mockResolvedValue({
+      reports: [openReport('r1', 'rec1'), openReport('r2', 'rec2')],
+      totalCount: 2,
+      openCount: 2,
+    })
+    renderReports()
+    await screen.findByText('Dish r1')
+
+    // "Select all 2 open" toggle in the bulk bar.
+    fireEvent.click(screen.getByText(/select all 2 open/i))
+    expect(await screen.findByText(/2 selected/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /resolve selected/i }))
+
+    await waitFor(() => expect(mockedBulk).toHaveBeenCalledTimes(1))
+    const [ids, status] = mockedBulk.mock.calls[0]
+    expect(ids.sort()).toEqual(['r1', 'r2'])
+    expect(status).toBe('resolved')
+  })
+
+  it('does not show the bulk bar when there are no open reports', async () => {
+    mockedList.mockResolvedValue({
+      reports: [{ ...openReport('r1', 'rec1'), status: 'resolved' as const }],
+      totalCount: 1,
+      openCount: 0,
+    })
+    renderReports()
+    await screen.findByText('Dish r1')
+    expect(screen.queryByText(/select all/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -268,6 +268,42 @@ export interface AdminUsersResponse {
   totalCount: number
 }
 
+// Admin audit trail (P3). Mirrors server/util/auditLog.js.
+export type AuditAction =
+  | 'recipe.hide'
+  | 'recipe.unhide'
+  | 'recipe.publish'
+  | 'recipe.unpublish'
+  | 'recipe.feature'
+  | 'recipe.unfeature'
+  | 'review.takedown'
+  | 'review.restore'
+  | 'user.suspend'
+  | 'user.ban'
+  | 'user.activate'
+  | 'report.resolve'
+  | 'report.dismiss'
+
+export type AuditTargetType = 'recipe' | 'review' | 'user' | 'report'
+
+export interface AuditEntryType {
+  _id: string
+  action: AuditAction
+  actorUid: string
+  actorUsername: string | null
+  targetType: AuditTargetType
+  targetId: string | null
+  targetLabel: string | null
+  reason: string | null
+  metadata: Record<string, unknown> | null
+  createdAt: string
+}
+
+export interface AuditResponse {
+  entries: AuditEntryType[]
+  totalCount: number
+}
+
 export interface AddRecipeErrorType {
   title: string
   image: string


### PR DESCRIPTION
## Summary

Admin P3a: a **moderation audit trail** and **bulk report actions**. Builds on the P0–P2 admin work (PR #121).

### Audit log
- `server/util/auditLog.js` — `recordAudit()` / `recordAuditMany()` append immutable entries to a new `auditLog` collection. Best-effort by design: they swallow their own errors so a logging failure can never break the action being recorded.
- Wired into **every** admin mutation: recipe hide/unhide, publish/unpublish, feature/unfeature; review takedown/restore; user suspend/ban/activate; report resolve/dismiss. Each entry stores action, actor, target (+ human-readable label), reason, metadata, timestamp.
- `GET /admin/audit` (requireAdmin): newest-first, filterable by action/targetType/actorUid, paginated, enriched with the actor's username.
- New `/admin/audit` page + nav tab. `auditLog` indexes added in `db.js` (new collection → instant), including `{action:1,createdAt:-1}` and `{targetType:1,createdAt:-1}` so the UI's filters are served filter-then-sort.

### Bulk actions (report queue)
- `PATCH /reports/bulk` (requireAdmin): resolve/dismiss many open reports in one sweep (capped at 100, skips already-closed ids). Declared before `/reports/:id` so `bulk` isn't captured as an `:id`. Audits exactly the reports the sweep actually closed (re-read by its own stamp, so a concurrent close can't inflate the trail) via a single `insertMany`.
- Multi-select checkboxes on open reports + a selection bar (select-all, Resolve/Dismiss selected) in `Reports.tsx`.

## Commits
- `5e3c250` feat — audit log + bulk report actions
- `424c740` refactor — tighten bulk-report audit (no over-count under concurrency, single insertMany) + index audit filters (code-review follow-ups)
- `1d5d41f` fix — keep report-card content left-aligned with the select checkbox

## Testing
- **Unit:** server **306 pass**, frontend **253 pass / 2 skip**, `tsc` clean.
- **Live smoke test** (real Firebase + Mongo): authz gates (admin 200 / regular 403), bulk resolve of 3 → `updated:3`, re-bulk already-closed → `updated:0` (no over-count), single resolve/dismiss, recipe hide/unhide, edge cases (empty / bad status / over-cap → 400), action + targetType filters, and both admin pages driven in a headless browser (audit entries render with actor enrichment + tones; bulk select-all → Resolve/Dismiss selected works). No console errors.

## Deploy note (unchanged from P2)
On prod, run `node server/scripts/createModerationIndexes.js` and `node server/scripts/setAdmin.js <owner>` when enabling admin. The new `auditLog` indexes build automatically at startup.

## Out of scope (P3b)
Analytics dashboard, email notifications (provider TBD), saved filters.