### PR TITLE
feat(admin): P3b — analytics dashboard + saved filters

### DIFF
--- a/docs/ADMIN_FUNCTIONALITY.md
+++ b/docs/ADMIN_FUNCTIONALITY.md
@@ -250,6 +250,17 @@ recipes without a direct URL); optional functional split between suspend & ban
   enriched) + `/admin/audit` page & nav tab. Indexed in db.js (new collection).
 - `[x]` Bulk actions — `PATCH /reports/bulk` (resolve/dismiss many open reports, capped
   at 100, one audit entry each) + multi-select checkboxes & selection bar in the queue.
-- `[ ]` Admin analytics dashboard
-- `[ ]` Notifications/email (provider TBD)
-- `[ ]` Saved filters
+- `[x]` Admin analytics dashboard — `GET /admin/analytics` (server/routes/admin.js):
+  headline totals (users; recipes by status active/hidden/unpublished + featured,
+  legacy no-status counted active; written-review count; reports by status),
+  zero-filled date-bounded daily series (reports filed / new recipes / new signups,
+  `days` clamped 7–90), and a recent-admin-actions feed reusing the auditLog
+  (shared `enrichActors` helper). New `/admin/analytics` page is the admin landing
+  ("Overview" nav tab, `/admin` index redirects here): stat cards + dependency-free
+  bar charts + recent-actions list. **Caveat:** the signup series only counts
+  accounts created after this shipped — `setUsername` now stamps `createdAt`
+  (`$setOnInsert`); legacy `usernames` docs have no timestamp and are excluded.
+- `[x]` Saved filters — per-browser localStorage presets (`src/util/savedFilters.ts`
+  + reusable `SavedFilterBar`) wired into the Reports and Audit queues. No backend.
+- `[ ]` Notifications/email — **DEFERRED**: blocked on choosing a provider
+  (SendGrid / Postmark / SES). Not built.

--- a/server/__tests__/admin-analytics.test.js
+++ b/server/__tests__/admin-analytics.test.js
@@ -1,0 +1,138 @@
+/**
+ * Admin analytics overview: headline totals (with legacy-safe recipe status and
+ * written-review-only counts), zero-filled date-bounded over-time series, and the
+ * recent-actions feed enriched with actor usernames. Admin-gated.
+ */
+
+const request = require('supertest')
+const admin = require('firebase-admin') // auto-mocked
+const app = require('../app')
+const { getDB } = require('../db')
+const { seedRecipe, seedUser, seedRating } = require('./helpers/seed')
+
+const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
+
+// A Date `n` days before now (UTC), at midday so it lands squarely inside its day.
+function daysAgo(n) {
+  const d = new Date()
+  d.setUTCDate(d.getUTCDate() - n)
+  d.setUTCHours(12, 0, 0, 0)
+  return d
+}
+
+function todayUTC() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+afterEach(async () => {
+  admin.__resetClaims()
+  admin.__resetUsers()
+  const db = getDB()
+  await Promise.all([
+    db.collection('usernames').deleteMany({}),
+    db.collection('recipes').deleteMany({}),
+    db.collection('ratings').deleteMany({}),
+    db.collection('reports').deleteMany({}),
+    db.collection('auditLog').deleteMany({}),
+  ])
+})
+
+describe('GET /api/admin/analytics', () => {
+  it('requires admin', async () => {
+    const res = await request(app).get('/api/admin/analytics').set(AUTH_HEADER)
+    expect(res.status).toBe(403)
+  })
+
+  it('reports headline totals with legacy-safe recipe status + written-review counts', async () => {
+    admin.__setClaims({ admin: true })
+    await seedUser('u1', 'alice')
+    await seedUser('u2', 'bob')
+
+    // Recipe mix: one explicit active, one hidden, one unpublished, one featured,
+    // and one LEGACY recipe with no status field (must count as active).
+    await seedRecipe({ _id: 'r1', userId: 'u1', status: 'active', createdAt: daysAgo(1) })
+    await seedRecipe({ _id: 'r2', userId: 'u1', status: 'hidden', createdAt: daysAgo(1) })
+    await seedRecipe({ _id: 'r3', userId: 'u1', status: 'unpublished', createdAt: daysAgo(1) })
+    await seedRecipe({ _id: 'r4', userId: 'u1', status: 'active', featured: true, createdAt: daysAgo(1) })
+    await seedRecipe({ _id: 'r5', userId: 'u2', createdAt: daysAgo(1) }) // legacy: no status
+
+    // Reviews: two written, one bare star-only (must not count).
+    await seedRating({ username: 'alice', recipeId: 'r1', rating: 5, reviewText: 'great' })
+    await seedRating({ username: 'bob', recipeId: 'r1', rating: 4, reviewText: 'good' })
+    await seedRating({ username: 'bob', recipeId: 'r2', rating: 3, reviewText: '' })
+
+    await getDB().collection('reports').insertMany([
+      { targetType: 'recipe', recipeId: 'r1', status: 'open', createdAt: daysAgo(1) },
+      { targetType: 'recipe', recipeId: 'r2', status: 'open', createdAt: daysAgo(1) },
+      { targetType: 'recipe', recipeId: 'r3', status: 'resolved', createdAt: daysAgo(1) },
+      { targetType: 'recipe', recipeId: 'r4', status: 'dismissed', createdAt: daysAgo(1) },
+    ])
+
+    const res = await request(app).get('/api/admin/analytics').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    const { totals } = res.body
+    expect(totals.users).toBe(2)
+    expect(totals.recipes).toEqual({
+      total: 5,
+      active: 3, // r1, r4, and legacy r5
+      hidden: 1,
+      unpublished: 1,
+      featured: 1,
+    })
+    expect(totals.reviews).toBe(2) // bare star-only excluded
+    expect(totals.reports).toEqual({ open: 2, resolved: 1, dismissed: 1 })
+  })
+
+  it('returns a zero-filled, date-bounded daily series', async () => {
+    admin.__setClaims({ admin: true })
+    // Two recipes today, one inside the window (3 days ago), one OUTSIDE (40 days).
+    await seedRecipe({ _id: 'r1', userId: 'u1', createdAt: daysAgo(0) })
+    await seedRecipe({ _id: 'r2', userId: 'u1', createdAt: daysAgo(0) })
+    await seedRecipe({ _id: 'r3', userId: 'u1', createdAt: daysAgo(3) })
+    await seedRecipe({ _id: 'r4', userId: 'u1', createdAt: daysAgo(40) })
+
+    const res = await request(app).get('/api/admin/analytics?days=7').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.days).toBe(7)
+
+    const series = res.body.recipesOverTime
+    expect(series).toHaveLength(7) // one bucket per day, zero-filled
+    // Oldest first, contiguous, last bucket is today.
+    expect(series[series.length - 1].date).toBe(todayUTC())
+    const total = series.reduce((sum, b) => sum + b.count, 0)
+    expect(total).toBe(3) // the 40-day-old recipe is outside the window
+    expect(series.find((b) => b.date === todayUTC()).count).toBe(2)
+  })
+
+  it('clamps days to the allowed range', async () => {
+    admin.__setClaims({ admin: true })
+    const tooBig = await request(app).get('/api/admin/analytics?days=999').set(AUTH_HEADER)
+    expect(tooBig.body.days).toBe(90)
+    expect(tooBig.body.recipesOverTime).toHaveLength(90)
+
+    const tooSmall = await request(app).get('/api/admin/analytics?days=1').set(AUTH_HEADER)
+    expect(tooSmall.body.days).toBe(7)
+  })
+
+  it('surfaces recent admin actions newest-first with actor usernames', async () => {
+    admin.__setClaims({ admin: true })
+    await seedUser('admin-uid', 'mod')
+    await getDB().collection('auditLog').insertMany([
+      {
+        action: 'recipe.hide', actorUid: 'admin-uid', targetType: 'recipe',
+        targetId: 'r1', targetLabel: 'Soup', createdAt: daysAgo(2),
+      },
+      {
+        action: 'report.resolve', actorUid: 'admin-uid', targetType: 'report',
+        targetId: 'rep1', targetLabel: '@alice', createdAt: daysAgo(0),
+      },
+    ])
+
+    const res = await request(app).get('/api/admin/analytics').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    const actions = res.body.recentActions
+    expect(actions).toHaveLength(2)
+    expect(actions[0].action).toBe('report.resolve') // newest first
+    expect(actions[0].actorUsername).toBe('mod')
+  })
+})

--- a/server/db.js
+++ b/server/db.js
@@ -37,6 +37,16 @@ async function ensureIndexes() {
     )
   }
 
+  // Backs the admin analytics usersOverTime series (signup createdAt range
+  // bucketing). setUsername only began stamping createdAt in P3b, so this index
+  // covers the docs that have it; legacy docs without the field aren't counted in
+  // the signup series.
+  try {
+    await db.collection('usernames').createIndex({ createdAt: -1 })
+  } catch (err) {
+    console.error('Failed to create index on usernames.createdAt:', err.message)
+  }
+
   // Backs GET /api/drafts, which lists a user's drafts newest-updated first
   // (find({ userId }).sort({ updatedAt: -1 })). Without it that query is a full
   // collection scan plus an in-memory sort on every Drafts-tab load.
@@ -72,6 +82,8 @@ async function ensureIndexes() {
     await reports.createIndex({ status: 1, createdAt: -1 })
     await reports.createIndex({ reportedUsername: 1 })
     await reports.createIndex({ recipeId: 1 })
+    // Backs the admin analytics reportsOverTime series (createdAt range bucketing).
+    await reports.createIndex({ createdAt: -1 })
   } catch (err) {
     console.error('Failed to create indexes on reports:', err.message)
   }

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -11,8 +11,60 @@ const DEFAULT_PER_PAGE = 25
 const MAX_PER_PAGE = 50
 const MAX_REASON_LEN = 500
 
+// Analytics time-window bounds (days) for the over-time series, plus how many
+// recent admin actions the dashboard surfaces.
+const DEFAULT_DAYS = 30
+const MIN_DAYS = 7
+const MAX_DAYS = 90
+const RECENT_ACTIONS_LIMIT = 10
+
 function escapeRegex(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// Attach each audit entry's actor username in one batched lookup, so a page of
+// entries shows "@admin did X" without a per-row query. Shared by the audit
+// trail and the analytics "recent actions" feed.
+async function enrichActors(db, entries) {
+  const actorUids = [...new Set(entries.map((e) => e.actorUid).filter(Boolean))]
+  const actorDocs = actorUids.length
+    ? await db.collection('usernames').find({ _id: { $in: actorUids } }).toArray()
+    : []
+  const actorByUid = Object.fromEntries(actorDocs.map((d) => [d._id, d.username]))
+  return entries.map((e) => ({ ...e, actorUsername: actorByUid[e.actorUid] || null }))
+}
+
+// Build a complete, zero-filled daily time series for the last `days` days
+// (inclusive of today, oldest first) from a [{ _id: 'YYYY-MM-DD', count }]
+// aggregation result. Filling the gaps server-side means the client always
+// receives one bucket per day and never has to reason about missing dates.
+function buildDailySeries(aggRows, days, now = new Date()) {
+  const byDate = Object.fromEntries(aggRows.map((r) => [r._id, r.count]))
+  const series = []
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now)
+    d.setUTCDate(d.getUTCDate() - i)
+    const date = d.toISOString().slice(0, 10)
+    series.push({ date, count: byDate[date] || 0 })
+  }
+  return series
+}
+
+// One aggregation that buckets a collection's `createdAt` by UTC day since the
+// cutoff. Returns rows shaped for buildDailySeries.
+function dailyCreatedAgg(db, collection, cutoff) {
+  return db
+    .collection(collection)
+    .aggregate([
+      { $match: { createdAt: { $gte: cutoff } } },
+      {
+        $group: {
+          _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt', timezone: 'UTC' } },
+          count: { $sum: 1 },
+        },
+      },
+    ])
+    .toArray()
 }
 
 // There is no central user record (P2 introduces a `users` status doc, but it
@@ -290,18 +342,101 @@ router.get('/admin/audit', verifyToken, requireAdmin, async (req, res) => {
     ])
 
     // Batch-resolve actor usernames for this page.
-    const actorUids = [...new Set(entries.map((e) => e.actorUid).filter(Boolean))]
-    const actorDocs = actorUids.length
-      ? await db.collection('usernames').find({ _id: { $in: actorUids } }).toArray()
-      : []
-    const actorByUid = Object.fromEntries(actorDocs.map((d) => [d._id, d.username]))
-
-    const enriched = entries.map((e) => ({
-      ...e,
-      actorUsername: actorByUid[e.actorUid] || null,
-    }))
+    const enriched = await enrichActors(db, entries)
 
     res.json({ entries: enriched, totalCount })
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+
+// GET /admin/analytics?days= — single overview payload for the admin dashboard:
+// headline totals, daily over-time series (reports filed / recipes / signups),
+// and the most recent admin actions. `days` is clamped to [MIN_DAYS, MAX_DAYS].
+//
+// Caveat on usersOverTime: the `usernames` collection only started carrying a
+// `createdAt` with this change (setUsername $setOnInsert), so the signup series
+// only reflects accounts created from that point forward — older users have no
+// timestamp and are excluded. Recipe/report series are fully historical.
+router.get('/admin/analytics', verifyToken, requireAdmin, async (req, res) => {
+  try {
+    const db = getDB()
+    const days = Math.min(
+      Math.max(parseInt(req.query.days) || DEFAULT_DAYS, MIN_DAYS),
+      MAX_DAYS
+    )
+    const now = new Date()
+    const cutoff = new Date(now)
+    cutoff.setUTCDate(cutoff.getUTCDate() - (days - 1))
+    cutoff.setUTCHours(0, 0, 0, 0)
+
+    const [
+      userCount,
+      recipeStatusAgg,
+      featuredCount,
+      reviewCount,
+      reportStatusAgg,
+      reportsDaily,
+      recipesDaily,
+      usersDaily,
+      recentRaw,
+    ] = await Promise.all([
+      db.collection('usernames').countDocuments(),
+      // A missing status is a legacy 'active' recipe (legacy-safe — same rule the
+      // public read paths use via $nin).
+      db
+        .collection('recipes')
+        .aggregate([
+          { $group: { _id: { $ifNull: ['$status', 'active'] }, count: { $sum: 1 } } },
+        ])
+        .toArray(),
+      db.collection('recipes').countDocuments({ featured: true }),
+      // Count written reviews only, not bare star ratings (same rule as enrichUsers).
+      db.collection('ratings').countDocuments({ reviewText: { $exists: true, $nin: ['', null] } }),
+      db
+        .collection('reports')
+        .aggregate([{ $group: { _id: '$status', count: { $sum: 1 } } }])
+        .toArray(),
+      dailyCreatedAgg(db, 'reports', cutoff),
+      dailyCreatedAgg(db, 'recipes', cutoff),
+      dailyCreatedAgg(db, 'usernames', cutoff),
+      db
+        .collection('auditLog')
+        .find({})
+        .sort({ createdAt: -1 })
+        .limit(RECENT_ACTIONS_LIMIT)
+        .toArray(),
+    ])
+
+    const recipeByStatus = Object.fromEntries(recipeStatusAgg.map((r) => [r._id, r.count]))
+    const recipeTotal = recipeStatusAgg.reduce((sum, r) => sum + r.count, 0)
+    const reportByStatus = Object.fromEntries(reportStatusAgg.map((r) => [r._id, r.count]))
+
+    const recentActions = await enrichActors(db, recentRaw)
+
+    res.json({
+      days,
+      totals: {
+        users: userCount,
+        recipes: {
+          total: recipeTotal,
+          active: recipeByStatus.active || 0,
+          hidden: recipeByStatus.hidden || 0,
+          unpublished: recipeByStatus.unpublished || 0,
+          featured: featuredCount,
+        },
+        reviews: reviewCount,
+        reports: {
+          open: reportByStatus.open || 0,
+          resolved: reportByStatus.resolved || 0,
+          dismissed: reportByStatus.dismissed || 0,
+        },
+      },
+      reportsOverTime: buildDailySeries(reportsDaily, days, now),
+      recipesOverTime: buildDailySeries(recipesDaily, days, now),
+      usersOverTime: buildDailySeries(usersDaily, days, now),
+      recentActions,
+    })
   } catch (err) {
     res.status(500).json({ error: err.message })
   }

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -125,7 +125,13 @@ router.post('/setUsername', verifyToken, requireActive, async (req, res) => {
     try {
       await db.collection('usernames').updateOne(
         { _id: uid },
-        { $set: { username, username_lower: usernameLower } },
+        {
+          $set: { username, username_lower: usernameLower },
+          // Stamp the account's first-seen time once, so admin analytics can
+          // chart signups over time. Legacy docs created before this won't have
+          // it (and are excluded from the signup series) — see GET /admin/analytics.
+          $setOnInsert: { createdAt: new Date() },
+        },
         { upsert: true }
       )
     } catch (err) {

--- a/server/scripts/createModerationIndexes.js
+++ b/server/scripts/createModerationIndexes.js
@@ -47,6 +47,18 @@ const INDEXES = [
     name: 'featured_-1_views_-1',
     why: 'getTrendingRecipes homepage sort (featured picks first, then most-viewed)',
   },
+  // Analytics recipesOverTime (P3b, GET /admin/analytics) buckets recipes by a
+  // `createdAt` range; the existing {userId,createdAt} compound can't serve a
+  // createdAt-only range. recipes is the large collection, so it lives here in the
+  // deliberate migration. The small reports/usernames createdAt indexes auto-build
+  // at startup (db.js) alongside their siblings. Admin-only + low-frequency, so
+  // this is future-proofing, not a hot-path fix.
+  {
+    collection: 'recipes',
+    key: { createdAt: -1 },
+    name: 'createdAt_-1',
+    why: 'admin analytics recipesOverTime (createdAt range bucketing)',
+  },
 ]
 
 async function main() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import ForgotPassword from 'src/pages/ForgotPassword/ForgotPassword'
 import PrivateRoute from 'src/Components/PrivateRoute'
 import AdminRoute from 'src/Components/AdminRoute'
 import AdminLayout from 'src/pages/Admin/AdminLayout'
+import Analytics from 'src/pages/Admin/Analytics/Analytics'
 import Reports from 'src/pages/Admin/Reports/Reports'
 import Users from 'src/pages/Admin/Users/Users'
 import Audit from 'src/pages/Admin/Audit/Audit'
@@ -188,7 +189,8 @@ const App: FC = () => {
                 outside the public Layout (its own AdminLayout shell). */}
             <Route path='/admin' element={<AdminRoute />}>
               <Route element={<AdminLayout />}>
-                <Route index element={<Navigate to='/admin/reports' replace />} />
+                <Route index element={<Navigate to='/admin/analytics' replace />} />
+                <Route path='analytics' element={<Analytics />} />
                 <Route path='reports' element={<Reports />} />
                 <Route path='users' element={<Users />} />
                 <Route path='audit' element={<Audit />} />

--- a/src/Components/SavedFilters/SavedFilterBar.scss
+++ b/src/Components/SavedFilters/SavedFilterBar.scss
@@ -1,0 +1,64 @@
+.saved-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+
+  .preset-chips {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .preset-chip {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #d8dbe0;
+    background: #fff;
+    border-radius: 999px;
+    overflow: hidden;
+
+    .preset-apply {
+      border: none;
+      background: transparent;
+      color: #374151;
+      padding: 0.3rem 0.5rem 0.3rem 0.7rem;
+      font-size: 0.8rem;
+      cursor: pointer;
+
+      &:hover {
+        color: #111827;
+      }
+    }
+
+    .preset-delete {
+      border: none;
+      background: transparent;
+      color: #9ca3af;
+      padding: 0.3rem 0.55rem 0.3rem 0.2rem;
+      font-size: 0.95rem;
+      line-height: 1;
+      cursor: pointer;
+
+      &:hover {
+        color: #b91c1c;
+      }
+    }
+  }
+
+  .preset-save {
+    border: 1px dashed #cbd2da;
+    background: #fff;
+    color: #6b7280;
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    cursor: pointer;
+
+    &:hover {
+      border-color: #9ca3af;
+      color: #374151;
+    }
+  }
+}

--- a/src/Components/SavedFilters/SavedFilterBar.tsx
+++ b/src/Components/SavedFilters/SavedFilterBar.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react'
+import {
+  SavedFilter,
+  getSavedFilters,
+  saveFilter,
+  deleteFilter,
+} from 'src/util/savedFilters'
+import './SavedFilterBar.scss'
+
+interface SavedFilterBarProps<F> {
+  // Storage key for this queue ('reports' | 'audit').
+  page: string
+  // The page's current filter state, saved verbatim when the admin clicks Save.
+  current: F
+  // Apply a previously-saved preset back onto the page.
+  onApply: (filter: F) => void
+  // Whether the current state is the page's default (no point saving "nothing").
+  canSave?: boolean
+}
+
+// A compact row of saved filter presets for the admin queues. Clicking a chip
+// applies it; the × deletes it; "Save current" names and stores the live filter.
+// Generic over the page's filter shape — it only round-trips the value.
+function SavedFilterBar<F>({ page, current, onApply, canSave = true }: SavedFilterBarProps<F>) {
+  const [filters, setFilters] = useState<SavedFilter<F>[]>(() => getSavedFilters<F>(page))
+
+  const handleSave = () => {
+    const name = window.prompt('Name this filter preset:')
+    if (name === null) return
+    const trimmed = name.trim()
+    if (!trimmed) return
+    setFilters(saveFilter(page, trimmed, current))
+  }
+
+  const handleDelete = (name: string) => {
+    setFilters(deleteFilter<F>(page, name))
+  }
+
+  return (
+    <div className='saved-filter-bar'>
+      {filters.length > 0 && (
+        <div className='preset-chips'>
+          {filters.map(f => (
+            <span key={f.name} className='preset-chip'>
+              <button
+                type='button'
+                className='preset-apply'
+                onClick={() => onApply(f.filter)}
+              >
+                {f.name}
+              </button>
+              <button
+                type='button'
+                className='preset-delete'
+                aria-label={`Delete preset ${f.name}`}
+                onClick={() => handleDelete(f.name)}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      {canSave && (
+        <button type='button' className='preset-save' onClick={handleSave}>
+          + Save current
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default SavedFilterBar

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -5,6 +5,7 @@ import {
   AuditResponse,
   AuditAction,
   AuditTargetType,
+  AnalyticsResponse,
 } from 'types'
 import { http } from 'src/api/http-common'
 
@@ -77,6 +78,15 @@ class AdminAPIClass {
     perPage?: number
   }): Promise<AuditResponse> {
     const result = await http.get<AuditResponse>('api/admin/audit', { params })
+    return result.data
+  }
+
+  // Overview metrics for the admin dashboard. `days` bounds the over-time series
+  // (server clamps to 7–90).
+  async getAnalytics(params?: { days?: number }): Promise<AnalyticsResponse> {
+    const result = await http.get<AnalyticsResponse>('api/admin/analytics', {
+      params,
+    })
     return result.data
   }
 }

--- a/src/pages/Admin/AdminLayout.tsx
+++ b/src/pages/Admin/AdminLayout.tsx
@@ -6,6 +6,7 @@ import './AdminLayout.scss'
 // (no marketing navbar/footer) — this is an internal tool. P1 added the queue;
 // P2 adds Users; P3 adds the audit trail. Analytics will slot in alongside.
 const ADMIN_NAV = [
+  { to: '/admin/analytics', label: 'Overview' },
   { to: '/admin/reports', label: 'Reports' },
   { to: '/admin/users', label: 'Users' },
   { to: '/admin/audit', label: 'Audit log' },

--- a/src/pages/Admin/Analytics/Analytics.scss
+++ b/src/pages/Admin/Analytics/Analytics.scss
@@ -1,0 +1,245 @@
+.admin-analytics {
+  max-width: 960px;
+
+  .admin-analytics-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+
+    h1 {
+      margin: 0;
+      font-size: 1.6rem;
+    }
+
+    .range-toggle {
+      display: flex;
+      gap: 0.3rem;
+
+      .range {
+        border: 1px solid #d8dbe0;
+        background: #fff;
+        color: #4b5563;
+        padding: 0.35rem 0.75rem;
+        border-radius: 999px;
+        font-size: 0.82rem;
+        cursor: pointer;
+        transition: all 0.15s;
+
+        &:hover {
+          border-color: #9ca3af;
+        }
+
+        &.active {
+          background: #1f2430;
+          border-color: #1f2430;
+          color: #fff;
+        }
+      }
+    }
+  }
+
+  .analytics-state {
+    color: #6b7280;
+    font-size: 0.95rem;
+
+    &.error {
+      color: #b91c1c;
+    }
+  }
+
+  .stat-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.75rem;
+
+    .stat-card {
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      padding: 1rem 1.1rem;
+
+      .stat-value {
+        font-size: 1.9rem;
+        font-weight: 700;
+        color: #111827;
+        line-height: 1.1;
+
+        &.danger {
+          color: #b91c1c;
+        }
+      }
+
+      .stat-label {
+        font-size: 0.82rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        color: #6b7280;
+      }
+
+      .stat-sub {
+        margin-top: 0.3rem;
+        font-size: 0.78rem;
+        color: #9ca3af;
+      }
+    }
+  }
+
+  .trends {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.75rem;
+
+    .trend-card {
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      padding: 1rem 1.1rem;
+
+      h2 {
+        margin: 0 0 0.75rem;
+        font-size: 0.92rem;
+        font-weight: 600;
+        color: #374151;
+      }
+
+      .trend-note {
+        margin: 0.6rem 0 0;
+        font-size: 0.72rem;
+        color: #9ca3af;
+      }
+    }
+  }
+
+  .sparkbars {
+    .bars {
+      display: flex;
+      align-items: flex-end;
+      gap: 2px;
+      height: 80px;
+    }
+
+    .bar {
+      flex: 1;
+      min-width: 1px;
+      border-radius: 2px 2px 0 0;
+      background: #9ca3af;
+      transition: opacity 0.15s;
+
+      &:hover {
+        opacity: 0.7;
+      }
+
+      &.good {
+        background: #16a34a;
+      }
+      &.danger {
+        background: #dc2626;
+      }
+      &.warn {
+        background: #d97706;
+      }
+      &.neutral {
+        background: #6b7280;
+      }
+    }
+
+    .axis {
+      display: flex;
+      justify-content: space-between;
+      margin-top: 0.4rem;
+      font-size: 0.72rem;
+      color: #9ca3af;
+    }
+  }
+
+  .recent-actions {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+
+    h2 {
+      margin: 0 0 0.5rem;
+      font-size: 0.92rem;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    .action-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .action-row {
+      display: flex;
+      gap: 0.75rem;
+      padding: 0.7rem 0;
+      border-bottom: 1px solid #eef0f2;
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      .dot {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        margin-top: 0.35rem;
+        flex-shrink: 0;
+        background: #9ca3af;
+
+        &.good {
+          background: #16a34a;
+        }
+        &.warn {
+          background: #d97706;
+        }
+        &.danger {
+          background: #dc2626;
+        }
+        &.neutral {
+          background: #9ca3af;
+        }
+      }
+
+      .action-body {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .action-line {
+        margin: 0;
+        font-size: 0.9rem;
+        color: #374151;
+
+        .actor,
+        .target {
+          color: #111827;
+        }
+
+        .target {
+          font-weight: 600;
+          word-break: break-word;
+        }
+      }
+
+      .action-time {
+        margin: 0.2rem 0 0;
+        font-size: 0.74rem;
+        color: #9ca3af;
+      }
+    }
+  }
+}

--- a/src/pages/Admin/Analytics/Analytics.tsx
+++ b/src/pages/Admin/Analytics/Analytics.tsx
@@ -1,0 +1,150 @@
+import React, { FC, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { AuditEntryType, TimeBucket } from 'types'
+import AdminAPI from 'src/api/admin'
+import { ACTION_META } from 'src/pages/Admin/auditMeta'
+import './Analytics.scss'
+
+// Day windows offered by the toggle. Server clamps to 7–90 regardless.
+const DAY_OPTIONS = [7, 30, 90]
+
+// A dependency-free daily bar chart. Bars scale to the series max; the first and
+// last dates anchor the axis. Each bar carries its value as a title for hover.
+const Sparkbars: FC<{ data: TimeBucket[]; tone: string }> = ({ data, tone }) => {
+  const max = data.reduce((m, b) => Math.max(m, b.count), 0)
+  const total = data.reduce((sum, b) => sum + b.count, 0)
+  return (
+    <div className='sparkbars'>
+      <div className='bars' role='img' aria-label={`${total} over ${data.length} days`}>
+        {data.map(b => (
+          <div
+            key={b.date}
+            className={`bar ${tone}`}
+            style={{ height: max ? `${Math.max((b.count / max) * 100, b.count ? 4 : 0)}%` : '0%' }}
+            title={`${b.date}: ${b.count}`}
+          />
+        ))}
+      </div>
+      <div className='axis'>
+        <span>{data.length ? formatShort(data[0].date) : ''}</span>
+        <span>{data.length ? formatShort(data[data.length - 1].date) : ''}</span>
+      </div>
+    </div>
+  )
+}
+
+// 'YYYY-MM-DD' → 'Mon D' without pulling in a date library.
+function formatShort(date: string) {
+  const d = new Date(`${date}T00:00:00Z`)
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' })
+}
+
+const Analytics: FC = () => {
+  const [days, setDays] = useState(30)
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['admin-analytics', days],
+    queryFn: () => AdminAPI.getAnalytics({ days }),
+  })
+
+  return (
+    <div className='admin-analytics'>
+      <header className='admin-analytics-head'>
+        <h1>Overview</h1>
+        <div className='range-toggle' role='group' aria-label='Time range'>
+          {DAY_OPTIONS.map(d => (
+            <button
+              key={d}
+              className={days === d ? 'range active' : 'range'}
+              onClick={() => setDays(d)}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {isPending ? (
+        <p className='analytics-state'>Loading analytics…</p>
+      ) : isError ? (
+        <p className='analytics-state error'>Failed to load analytics.</p>
+      ) : (
+        <>
+          <section className='stat-cards'>
+            <div className='stat-card'>
+              <span className='stat-value'>{data.totals.users}</span>
+              <span className='stat-label'>Users</span>
+            </div>
+            <div className='stat-card'>
+              <span className='stat-value'>{data.totals.recipes.total}</span>
+              <span className='stat-label'>Recipes</span>
+              <span className='stat-sub'>
+                {data.totals.recipes.featured} featured · {data.totals.recipes.hidden} hidden ·{' '}
+                {data.totals.recipes.unpublished} unpublished
+              </span>
+            </div>
+            <div className='stat-card'>
+              <span className='stat-value'>{data.totals.reviews}</span>
+              <span className='stat-label'>Reviews</span>
+            </div>
+            <div className='stat-card'>
+              <span className='stat-value danger'>{data.totals.reports.open}</span>
+              <span className='stat-label'>Open reports</span>
+              <span className='stat-sub'>
+                {data.totals.reports.resolved} resolved · {data.totals.reports.dismissed} dismissed
+              </span>
+            </div>
+          </section>
+
+          <section className='trends'>
+            <div className='trend-card'>
+              <h2>Reports filed</h2>
+              <Sparkbars data={data.reportsOverTime} tone='danger' />
+            </div>
+            <div className='trend-card'>
+              <h2>New recipes</h2>
+              <Sparkbars data={data.recipesOverTime} tone='good' />
+            </div>
+            <div className='trend-card'>
+              <h2>New signups</h2>
+              <Sparkbars data={data.usersOverTime} tone='neutral' />
+              <p className='trend-note'>Counts accounts created since signup timestamps began.</p>
+            </div>
+          </section>
+
+          <section className='recent-actions'>
+            <h2>Recent admin actions</h2>
+            {data.recentActions.length === 0 ? (
+              <p className='analytics-state'>No admin actions recorded yet.</p>
+            ) : (
+              <ul className='action-list'>
+                {data.recentActions.map((entry: AuditEntryType) => {
+                  const meta = ACTION_META[entry.action]
+                  return (
+                    <li key={entry._id} className='action-row'>
+                      <span className={`dot ${meta?.tone || 'neutral'}`} aria-hidden='true' />
+                      <div className='action-body'>
+                        <p className='action-line'>
+                          <strong className='actor'>
+                            {entry.actorUsername ? `@${entry.actorUsername}` : 'An admin'}
+                          </strong>{' '}
+                          {meta?.label || entry.action}{' '}
+                          <span className='target'>{entry.targetLabel || entry.targetId}</span>
+                        </p>
+                        <p className='action-time'>
+                          {new Date(entry.createdAt).toLocaleString()}
+                        </p>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default Analytics

--- a/src/pages/Admin/Audit/Audit.tsx
+++ b/src/pages/Admin/Audit/Audit.tsx
@@ -2,7 +2,14 @@ import React, { FC, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { AuditAction, AuditEntryType, AuditTargetType } from 'types'
 import AdminAPI from 'src/api/admin'
+import { ACTION_META } from 'src/pages/Admin/auditMeta'
+import SavedFilterBar from 'src/Components/SavedFilters/SavedFilterBar'
 import './Audit.scss'
+
+type AuditFilter = {
+  action: AuditAction | 'all'
+  targetType: AuditTargetType | 'all'
+}
 
 const PER_PAGE = 25
 
@@ -23,23 +30,6 @@ const ACTION_FILTERS: { value: AuditAction | 'all'; label: string }[] = [
   { value: 'report.resolve', label: 'Report resolved' },
   { value: 'report.dismiss', label: 'Report dismissed' },
 ]
-
-// Short human phrasing + a colour family per action, for the row label.
-const ACTION_META: Record<AuditAction, { label: string; tone: string }> = {
-  'recipe.hide': { label: 'hid recipe', tone: 'danger' },
-  'recipe.unhide': { label: 'restored recipe', tone: 'good' },
-  'recipe.publish': { label: 'published recipe', tone: 'good' },
-  'recipe.unpublish': { label: 'unpublished recipe', tone: 'warn' },
-  'recipe.feature': { label: 'featured recipe', tone: 'good' },
-  'recipe.unfeature': { label: 'unfeatured recipe', tone: 'neutral' },
-  'review.takedown': { label: 'took down review by', tone: 'danger' },
-  'review.restore': { label: 'restored review by', tone: 'good' },
-  'user.suspend': { label: 'suspended', tone: 'warn' },
-  'user.ban': { label: 'banned', tone: 'danger' },
-  'user.activate': { label: 'reactivated', tone: 'good' },
-  'report.resolve': { label: 'resolved report', tone: 'good' },
-  'report.dismiss': { label: 'dismissed report', tone: 'neutral' },
-}
 
 const TARGET_TABS: { value: AuditTargetType | 'all'; label: string }[] = [
   { value: 'all', label: 'All targets' },
@@ -69,6 +59,12 @@ const Audit: FC = () => {
 
   const resetTo = <T,>(setter: (v: T) => void) => (value: T) => {
     setter(value)
+    setPage(1)
+  }
+
+  const applyPreset = (f: AuditFilter) => {
+    setAction(f.action)
+    setTargetType(f.targetType)
     setPage(1)
   }
 
@@ -105,6 +101,12 @@ const Audit: FC = () => {
           ))}
         </div>
       </div>
+
+      <SavedFilterBar<AuditFilter>
+        page='audit'
+        current={{ action, targetType }}
+        onApply={applyPreset}
+      />
 
       {isPending ? (
         <p className='audit-state'>Loading audit log…</p>

--- a/src/pages/Admin/Reports/Reports.tsx
+++ b/src/pages/Admin/Reports/Reports.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import { AdminReportType, ReportStatus } from 'types'
 import ReportAPI from 'src/api/reports'
+import SavedFilterBar from 'src/Components/SavedFilters/SavedFilterBar'
 import './Reports.scss'
 
 type StatusFilter = ReportStatus | 'all'
@@ -196,6 +197,12 @@ const Reports: FC = () => {
           </button>
         ))}
       </div>
+
+      <SavedFilterBar<{ status: StatusFilter }>
+        page='reports'
+        current={{ status: statusFilter }}
+        onApply={f => changeTab(f.status)}
+      />
 
       {openReports.length > 0 && (
         <div className='bulk-bar'>

--- a/src/pages/Admin/auditMeta.ts
+++ b/src/pages/Admin/auditMeta.ts
@@ -1,0 +1,21 @@
+import { AuditAction } from 'types'
+
+// Short human phrasing + a colour tone per audit action, used for the row label
+// in both the Audit log and the Analytics "recent actions" feed. Kept here so
+// the two views stay in sync. When a new AUDIT_ACTION is added on the server,
+// add it here too (TypeScript's Record makes a missing key a compile error).
+export const ACTION_META: Record<AuditAction, { label: string; tone: string }> = {
+  'recipe.hide': { label: 'hid recipe', tone: 'danger' },
+  'recipe.unhide': { label: 'restored recipe', tone: 'good' },
+  'recipe.publish': { label: 'published recipe', tone: 'good' },
+  'recipe.unpublish': { label: 'unpublished recipe', tone: 'warn' },
+  'recipe.feature': { label: 'featured recipe', tone: 'good' },
+  'recipe.unfeature': { label: 'unfeatured recipe', tone: 'neutral' },
+  'review.takedown': { label: 'took down review by', tone: 'danger' },
+  'review.restore': { label: 'restored review by', tone: 'good' },
+  'user.suspend': { label: 'suspended', tone: 'warn' },
+  'user.ban': { label: 'banned', tone: 'danger' },
+  'user.activate': { label: 'reactivated', tone: 'good' },
+  'report.resolve': { label: 'resolved report', tone: 'good' },
+  'report.dismiss': { label: 'dismissed report', tone: 'neutral' },
+}

--- a/src/test/AdminAnalytics.test.tsx
+++ b/src/test/AdminAnalytics.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Admin Analytics (Overview) page: renders headline totals + recent actions from
+ * AdminAPI.getAnalytics, and refetches when the day-range toggle changes. The API
+ * is mocked; react-query/router are real.
+ */
+
+import React from 'react'
+import { vi, Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import Analytics from 'src/pages/Admin/Analytics/Analytics'
+import AdminAPI from 'src/api/admin'
+
+vi.mock('src/api/admin', () => ({
+  __esModule: true,
+  default: { getAnalytics: vi.fn() },
+}))
+
+const mockedGet = AdminAPI.getAnalytics as unknown as Mock
+
+const series = (...counts: number[]) =>
+  counts.map((count, i) => ({ date: `2026-06-${String(i + 1).padStart(2, '0')}`, count }))
+
+const sample = {
+  days: 30,
+  totals: {
+    users: 42,
+    recipes: { total: 100, active: 90, hidden: 5, unpublished: 5, featured: 3 },
+    reviews: 17,
+    reports: { open: 4, resolved: 8, dismissed: 2 },
+  },
+  reportsOverTime: series(1, 0, 2),
+  recipesOverTime: series(3, 1, 0),
+  usersOverTime: series(0, 1, 1),
+  recentActions: [
+    {
+      _id: 'a1',
+      action: 'report.resolve' as const,
+      actorUid: 'admin-uid',
+      actorUsername: 'mod',
+      targetType: 'report' as const,
+      targetId: 'rep1',
+      targetLabel: '@alice',
+      reason: null,
+      metadata: null,
+      createdAt: new Date('2026-06-03T12:00:00Z').toISOString(),
+    },
+  ],
+}
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+    >
+      <MemoryRouter>
+        <Analytics />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+
+afterEach(() => vi.clearAllMocks())
+
+describe('Admin Analytics page', () => {
+  it('renders headline totals and a recent action', async () => {
+    mockedGet.mockResolvedValue(sample)
+    renderPage()
+
+    expect(await screen.findByText('42')).toBeInTheDocument() // users
+    expect(screen.getByText('100')).toBeInTheDocument() // recipes total
+    expect(screen.getByText('17')).toBeInTheDocument() // reviews
+    expect(screen.getByText('4')).toBeInTheDocument() // open reports
+    expect(screen.getByText(/3 featured/)).toBeInTheDocument()
+
+    // Recent action row reuses the audit phrasing.
+    expect(screen.getByText('@mod')).toBeInTheDocument()
+    expect(screen.getByText(/resolved report/)).toBeInTheDocument()
+    expect(screen.getByText('@alice')).toBeInTheDocument()
+  })
+
+  it('refetches when the day-range toggle changes', async () => {
+    mockedGet.mockResolvedValue(sample)
+    renderPage()
+    await screen.findByText('42')
+    expect(mockedGet).toHaveBeenCalledWith({ days: 30 })
+
+    fireEvent.click(screen.getByRole('button', { name: '7d' }))
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith({ days: 7 }))
+  })
+
+  it('shows an error state when the request fails', async () => {
+    mockedGet.mockRejectedValue(new Error('boom'))
+    renderPage()
+    expect(await screen.findByText(/failed to load analytics/i)).toBeInTheDocument()
+  })
+})

--- a/src/test/savedFilters.test.ts
+++ b/src/test/savedFilters.test.ts
@@ -1,0 +1,59 @@
+/**
+ * savedFilters localStorage store: save (with overwrite-by-name), list, and
+ * delete, plus graceful handling of corrupt storage.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  getSavedFilters,
+  saveFilter,
+  deleteFilter,
+} from 'src/util/savedFilters'
+
+type F = { status: string }
+
+beforeEach(() => localStorage.clear())
+
+describe('savedFilters', () => {
+  it('starts empty', () => {
+    expect(getSavedFilters<F>('reports')).toEqual([])
+  })
+
+  it('saves and lists a preset, round-tripping the filter payload', () => {
+    saveFilter<F>('reports', 'Open only', { status: 'open' })
+    const list = getSavedFilters<F>('reports')
+    expect(list).toEqual([{ name: 'Open only', filter: { status: 'open' } }])
+  })
+
+  it('overwrites a preset with the same name', () => {
+    saveFilter<F>('reports', 'preset', { status: 'open' })
+    saveFilter<F>('reports', 'preset', { status: 'resolved' })
+    const list = getSavedFilters<F>('reports')
+    expect(list).toHaveLength(1)
+    expect(list[0].filter).toEqual({ status: 'resolved' })
+  })
+
+  it('keeps each page id separate', () => {
+    saveFilter<F>('reports', 'r', { status: 'open' })
+    saveFilter<F>('audit', 'a', { status: 'x' })
+    expect(getSavedFilters<F>('reports')).toHaveLength(1)
+    expect(getSavedFilters<F>('audit')).toHaveLength(1)
+  })
+
+  it('ignores an empty name', () => {
+    saveFilter<F>('reports', '   ', { status: 'open' })
+    expect(getSavedFilters<F>('reports')).toEqual([])
+  })
+
+  it('deletes a preset by name', () => {
+    saveFilter<F>('reports', 'one', { status: 'open' })
+    saveFilter<F>('reports', 'two', { status: 'resolved' })
+    const after = deleteFilter<F>('reports', 'one')
+    expect(after.map(f => f.name)).toEqual(['two'])
+  })
+
+  it('degrades to empty on corrupt storage', () => {
+    localStorage.setItem('prepify.admin.savedFilters.reports', '{not json')
+    expect(getSavedFilters<F>('reports')).toEqual([])
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -304,6 +304,40 @@ export interface AuditResponse {
   totalCount: number
 }
 
+// Admin analytics dashboard (P3b). Mirrors GET /admin/analytics in
+// server/routes/admin.js.
+export interface AnalyticsTotals {
+  users: number
+  recipes: {
+    total: number
+    active: number
+    hidden: number
+    unpublished: number
+    featured: number
+  }
+  reviews: number
+  reports: {
+    open: number
+    resolved: number
+    dismissed: number
+  }
+}
+
+// One day of a zero-filled daily series (oldest first). `date` is 'YYYY-MM-DD'.
+export interface TimeBucket {
+  date: string
+  count: number
+}
+
+export interface AnalyticsResponse {
+  days: number
+  totals: AnalyticsTotals
+  reportsOverTime: TimeBucket[]
+  recipesOverTime: TimeBucket[]
+  usersOverTime: TimeBucket[]
+  recentActions: AuditEntryType[]
+}
+
 export interface AddRecipeErrorType {
   title: string
   image: string

--- a/src/util/savedFilters.ts
+++ b/src/util/savedFilters.ts
@@ -1,0 +1,51 @@
+// Tiny localStorage store for named admin filter presets. Per-browser only (no
+// backend) — presets don't follow an admin across devices, which is fine for a
+// small internal tool. Keyed by a page id ('reports' | 'audit') so each queue
+// keeps its own list. The filter payload is whatever JSON-serializable shape the
+// page uses for its filter state.
+
+export interface SavedFilter<F> {
+  name: string
+  filter: F
+}
+
+const KEY_PREFIX = 'prepify.admin.savedFilters.'
+
+// All reads/writes are defensive: a corrupt or unavailable localStorage (e.g.
+// privacy mode) degrades to "no saved filters" rather than throwing.
+export function getSavedFilters<F>(page: string): SavedFilter<F>[] {
+  try {
+    const raw = localStorage.getItem(KEY_PREFIX + page)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+// Save (or overwrite, by name) a preset and return the updated list. An empty
+// name is ignored.
+export function saveFilter<F>(page: string, name: string, filter: F): SavedFilter<F>[] {
+  const trimmed = name.trim()
+  if (!trimmed) return getSavedFilters<F>(page)
+  const others = getSavedFilters<F>(page).filter(f => f.name !== trimmed)
+  const next = [...others, { name: trimmed, filter }]
+  persist(page, next)
+  return next
+}
+
+export function deleteFilter<F>(page: string, name: string): SavedFilter<F>[] {
+  const next = getSavedFilters<F>(page).filter(f => f.name !== name)
+  persist(page, next)
+  return next
+}
+
+function persist<F>(page: string, filters: SavedFilter<F>[]) {
+  try {
+    localStorage.setItem(KEY_PREFIX + page, JSON.stringify(filters))
+  } catch {
+    // Best-effort: if we can't write (quota / privacy mode), the in-memory list
+    // the caller holds still reflects the change for this session.
+  }
+}


### PR DESCRIPTION
## P3b — Admin analytics dashboard + saved filters

Builds on merged admin P0–P2 (#121) and P3a (#124). Closes out the remaining P3 scope except email notifications (deferred — no provider chosen).

### Analytics dashboard (new admin landing)
- **`GET /admin/analytics?days=`** (`verifyToken` + `requireAdmin`): headline totals (users; recipes by status active/hidden/unpublished with legacy no-status counted active, + featured count; written-review count; reports by status), three **zero-filled, date-bounded daily series** (reports filed / new recipes / new signups; `days` clamped 7–90), and a recent-admin-actions feed.
- Extracted a shared **`enrichActors()`** helper (used by both the audit and analytics handlers) plus `buildDailySeries` / `dailyCreatedAgg`.
- New **`src/pages/Admin/Analytics`** page is now the admin landing ("Overview" first nav tab; `/admin` index redirects here): stat cards + **dependency-free CSS bar charts** + recent-actions list reusing `ACTION_META` (extracted to `auditMeta.ts`).
- `AnalyticsResponse` / `AnalyticsTotals` / `TimeBucket` types; `AdminAPI.getAnalytics`.

**Signup-series caveat:** `usernames` had no creation timestamp, so `setUsername` now stamps `createdAt` (`$setOnInsert`). The signup series is **forward-looking only** — legacy docs without the field are excluded; the users *total* still counts everyone.

### Saved filters (localStorage, no backend)
- `src/util/savedFilters.ts` (per-page-id named presets, defensive against corrupt/unavailable storage) + a reusable generic `SavedFilterBar`, wired into the **Reports** and **Audit** queues.

### Indexes
- `recipes.createdAt` → `createModerationIndexes.js` (large pre-existing collection, deliberate prod step).
- `reports.createdAt` + `usernames.createdAt` → auto-build at startup (`db.js`), alongside their siblings.

### Verification
- **Tests:** server **311**, frontend **263** (+2 skip), `tsc` clean.
- **Live smoke** (real Firebase + Mongo): admin → 200, regular → **403**; totals/status-breakdown/series-lengths/`days`-clamp/recent-actions all correct; confirmed `reports.createdAt` + `usernames.createdAt` built at startup on the live DB.

### Deferred
- Email notifications (provider TBD: SendGrid / Postmark / SES).
- Analytics "top lists" (most-reported / most-active).

### Prod step for maintainer
- Run `node server/scripts/createModerationIndexes.js` (now also builds `recipes.createdAt`). `reports`/`usernames` `createdAt` indexes auto-build at startup.