### PR TITLE
feat(admin): P3 — email notifications for moderation actions (Resend)

### DIFF
--- a/docs/ADMIN_FUNCTIONALITY.md
+++ b/docs/ADMIN_FUNCTIONALITY.md
@@ -54,7 +54,8 @@ Scoped **2026-06-10**. Single-developer estimate: **~3 weeks** for the full P0�
 3. **No central user record.** Identity is split across Firebase Auth + `usernames` +
    `userRecipeData`. "Ban a user" (P2) has no clean home today → plan to introduce a `users` status
    record when we reach P2.
-4. **No email provider exists yet.** P3 notifications require choosing one first.
+4. ~~**No email provider exists yet.** P3 notifications require choosing one first.~~
+   **RESOLVED (2026-06-12):** provider = **Resend**, behind `server/util/email.js`.
 
 ---
 
@@ -165,7 +166,8 @@ report = {
 
 - `[?]` **User-record source of truth for banning (P2).** Propose a `users` status record when we
   reach P2; revisit then.
-- `[?]` **Email provider for notifications (P3).** None exists; pick before P3 notifications.
+- `[x]` ~~**Email provider for notifications (P3).** None exists; pick before P3 notifications.~~
+  **Decided 2026-06-12: Resend** (free tier, simple SDK; wrapper keeps it swappable).
 
 ---
 
@@ -262,5 +264,23 @@ recipes without a direct URL); optional functional split between suspend & ban
   (`$setOnInsert`); legacy `usernames` docs have no timestamp and are excluded.
 - `[x]` Saved filters — per-browser localStorage presets (`src/util/savedFilters.ts`
   + reusable `SavedFilterBar`) wired into the Reports and Audit queues. No backend.
-- `[ ]` Notifications/email — **DEFERRED**: blocked on choosing a provider
-  (SendGrid / Postmark / SES). Not built.
+- `[x]` Notifications/email — **provider = Resend** (3k/mo free tier). Thin swappable
+  wrapper `server/util/email.js` (`sendEmail` + typed helpers), best-effort like
+  `recordAudit` (swallows errors, never breaks the moderation action) and **env-gated**:
+  with no `RESEND_API_KEY` (dev/CI/test) the module no-ops before any Firebase/DB lookup.
+  Sends run **in the background** (`notifyInBackground`) so the admin response never waits
+  on Firebase/Resend, with a 10s per-send timeout; bulk resolves are sent **serially** to
+  self-throttle under Resend's per-second rate limit.
+  Four **action-only** events wired alongside the audit writes:
+  report **resolved** → reporter (`reporterUid`; dismiss is silent; bulk resolve emails
+  each distinct reporter once), user **suspended/banned** → the user (`uid`; activate is
+  silent), recipe **hidden** → owner (`userId`; unhide silent), review **taken down** →
+  author (username→uid via `usernames`; restore silent). Env: `RESEND_API_KEY`,
+  `EMAIL_FROM`, `APP_BASE_URL` (+ optional `EMAIL_ENABLED=false` kill switch) — in
+  `server/.env.example`. Tests: `__tests__/email-notifications.test.js` (recipient per
+  event, no-op without key, failure-swallowed, route wiring incl. dismiss/unhide silence
+  + bulk dedupe). **Domain/DKIM:** works from Resend's test sender
+  `onboarding@resend.dev` out of the box; to send from a real domain, verify it in Resend
+  (DNS DKIM + SPF/MX) and point `EMAIL_FROM` at it. Firebase Auth's own emails (password
+  reset etc.) are untouched. **Deferred:** appeal flow has no support route yet (copy says
+  "contact Prepify support"); no reversal/"good news" emails.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,13 @@
 MONGO_URI=mongodb+srv://<user>:<password>@cluster0.xxxxx.mongodb.net/prepify?retryWrites=true&w=majority
 PORT=4000
 SPOONACULAR_API_KEY=<your-spoonacular-api-key>
+
+# Email notifications (Resend). Leave RESEND_API_KEY empty to disable email
+# entirely — the wrapper no-ops silently, so dev/CI without a key just skip sends.
+RESEND_API_KEY=
+# Sender. Works from Resend's test sender out of the box; swap to your own
+# verified domain once its DKIM/SPF DNS records are set up in Resend.
+EMAIL_FROM=Prepify <onboarding@resend.dev>
+# Base URL used for links/buttons in emails.
+APP_BASE_URL=http://localhost:3000
+# EMAIL_ENABLED=true   # optional kill switch; an empty RESEND_API_KEY already disables sending

--- a/server/__tests__/email-notifications.test.js
+++ b/server/__tests__/email-notifications.test.js
@@ -1,0 +1,353 @@
+/**
+ * Admin email notifications (server/util/email.js + the four moderation wirings).
+ *
+ * The `resend` package is mocked so no network call is made; `__send` is the
+ * shared spy behind the lazily-built Resend client. firebase-admin is auto-mocked
+ * — __setUsers([{ uid, email }]) supplies the addresses helpers resolve to.
+ *
+ * Contract under test: the right event mails the right recipient; dismiss/unhide
+ * stay silent; the whole thing no-ops without RESEND_API_KEY; and neither a
+ * recipient miss nor a provider failure ever throws into the moderation route.
+ */
+
+// Mocked Resend client. The factory returns the SAME `send` spy every time the
+// (lazily-cached) client is constructed, so assertions hold across calls.
+jest.mock('resend', () => {
+  const send = jest.fn()
+  return { Resend: jest.fn(() => ({ emails: { send } })), __send: send }
+})
+
+const request = require('supertest')
+const admin = require('firebase-admin') // auto-mocked
+const { ObjectId } = require('mongodb')
+const { __send: sendMock } = require('resend')
+const app = require('../app')
+const { getDB } = require('../db')
+const { seedRecipe, seedUser, seedRating } = require('./helpers/seed')
+const {
+  sendEmail,
+  flushNotifications,
+  notifyReportResolved,
+  notifyAccountStatus,
+  notifyRecipeHidden,
+  notifyReviewTakenDown,
+} = require('../util/email')
+
+const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
+const TEST_UID = 'test-uid'
+
+beforeEach(() => {
+  process.env.RESEND_API_KEY = 'test-key'
+  delete process.env.EMAIL_ENABLED
+  sendMock.mockReset()
+  // Resend's SDK resolves with { data, error } — it does not throw on API errors.
+  sendMock.mockResolvedValue({ data: { id: 'email-1' }, error: null })
+})
+
+afterEach(async () => {
+  await flushNotifications() // drain any background sends a test left in flight
+  admin.__resetClaims()
+  admin.__resetUsers()
+  const db = getDB()
+  await Promise.all([
+    db.collection('reports').deleteMany({}),
+    db.collection('recipes').deleteMany({}),
+    db.collection('ratings').deleteMany({}),
+    db.collection('usernames').deleteMany({}),
+    db.collection('users').deleteMany({}),
+    db.collection('auditLog').deleteMany({}),
+  ])
+})
+
+// Read the `to`/`subject` of the Nth (default first) send call.
+function sentArg(i = 0) {
+  return sendMock.mock.calls[i][0]
+}
+
+describe('email wrapper gating', () => {
+  it('no-ops (never calls the provider) when RESEND_API_KEY is absent', async () => {
+    delete process.env.RESEND_API_KEY
+    admin.__setUsers([{ uid: 'reporter', email: 'r@example.dev' }])
+    await notifyReportResolved('reporter')
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when EMAIL_ENABLED is explicitly false even with a key', async () => {
+    process.env.EMAIL_ENABLED = 'false'
+    admin.__setUsers([{ uid: 'reporter', email: 'r@example.dev' }])
+    await notifyReportResolved('reporter')
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('does not send when the recipient has no resolvable email', async () => {
+    admin.__setUsers([]) // getUser throws not-found ⇒ null email
+    await notifyReportResolved('ghost-uid')
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('per-event recipient resolution', () => {
+  it('reportResolved mails the reporter', async () => {
+    admin.__setUsers([{ uid: 'reporter', email: 'reporter@example.dev' }])
+    await notifyReportResolved('reporter')
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    expect(sentArg().to).toBe('reporter@example.dev')
+    expect(sentArg().subject).toMatch(/reported/i)
+  })
+
+  it('accountStatus mails the user on suspend and ban, but not on activate', async () => {
+    admin.__setUsers([{ uid: 'u1', email: 'u1@example.dev' }])
+
+    await notifyAccountStatus('u1', 'suspended', 'spamming')
+    expect(sentArg().to).toBe('u1@example.dev')
+    expect(sentArg().subject).toMatch(/suspended/i)
+    expect(sentArg().html).toMatch(/spamming/) // reason surfaced
+
+    sendMock.mockClear()
+    await notifyAccountStatus('u1', 'banned')
+    expect(sentArg().subject).toMatch(/banned/i)
+
+    sendMock.mockClear()
+    await notifyAccountStatus('u1', 'active')
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('renders the reason verbatim in the plain-text body, even with $-sequences', async () => {
+    // Regression: an earlier version reverse-replaced the escaped reason with
+    // String.replace, so `$&`/`$\``/`$'` in a reason corrupted the text body.
+    admin.__setUsers([{ uid: 'u1', email: 'u1@example.dev' }])
+    await notifyAccountStatus('u1', 'suspended', 'Posted spam $& scam <link>')
+    expect(sentArg().text).toContain('Reason: Posted spam $& scam <link>')
+    // HTML escapes the angle brackets but keeps the literal text.
+    expect(sentArg().html).toContain('Posted spam $&amp; scam &lt;link&gt;')
+  })
+
+  it('recipeHidden mails the owner with the recipe title', async () => {
+    admin.__setUsers([{ uid: 'owner', email: 'owner@example.dev' }])
+    await notifyRecipeHidden('owner', 'Spicy Noodles')
+    expect(sentArg().to).toBe('owner@example.dev')
+    expect(sentArg().html).toMatch(/Spicy Noodles/)
+  })
+
+  it('reviewTakenDown resolves the owner via the usernames collection', async () => {
+    const db = getDB()
+    await seedUser('chef-uid', 'chef')
+    await seedRecipe({ _id: 'r1', title: 'Pad Thai', userId: 'someone' })
+    admin.__setUsers([{ uid: 'chef-uid', email: 'chef@example.dev' }])
+
+    await notifyReviewTakenDown(db, 'chef', 'r1')
+    expect(sentArg().to).toBe('chef@example.dev')
+    expect(sentArg().html).toMatch(/Pad Thai/)
+  })
+})
+
+describe('failures never throw', () => {
+  it('resolves (does not reject) when the provider send throws', async () => {
+    admin.__setUsers([{ uid: 'reporter', email: 'reporter@example.dev' }])
+    sendMock.mockRejectedValueOnce(new Error('provider down'))
+    await expect(notifyReportResolved('reporter')).resolves.toBeUndefined()
+  })
+
+  it('treats a resolved { error } payload as a failure, not a success', async () => {
+    // Resend returns 4xx as { data: null, error } WITHOUT throwing — the wrapper
+    // must surface sent:false rather than reporting a phantom success.
+    admin.__setUsers([{ uid: 'reporter', email: 'reporter@example.dev' }])
+    sendMock.mockResolvedValueOnce({
+      data: null,
+      error: { statusCode: 403, message: 'You can only send testing emails to your own address' },
+    })
+    const res = await sendEmail({ to: 'reporter@example.dev', subject: 's', text: 't' })
+    expect(res.sent).toBe(false)
+    expect(res.error).toMatch(/testing emails/)
+  })
+
+  it('resolves when the recipient lookup itself throws', async () => {
+    // A db whose findOne rejects — emailForUsername must swallow it.
+    const brokenDb = { collection: () => ({ findOne: () => Promise.reject(new Error('db down')) }) }
+    await expect(notifyReviewTakenDown(brokenDb, 'chef', 'r1')).resolves.toBeUndefined()
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('moderation routes trigger the right sends', () => {
+  it('suspending a user emails them and returns 200', async () => {
+    admin.__setClaims({ admin: true })
+    admin.__setUsers([
+      { uid: TEST_UID, email: 'admin@test.dev', admin: true },
+      { uid: 'target', email: 'target@example.dev' },
+    ])
+    await seedUser('target', 'targetuser')
+
+    const res = await request(app)
+      .patch('/api/admin/users/target/status')
+      .set(AUTH_HEADER)
+      .send({ status: 'suspended', reason: 'abuse' })
+
+    expect(res.status).toBe(200)
+    await flushNotifications()
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    expect(sentArg().to).toBe('target@example.dev')
+  })
+
+  it('a failing send does not fail the suspend request', async () => {
+    admin.__setClaims({ admin: true })
+    admin.__setUsers([
+      { uid: TEST_UID, email: 'admin@test.dev', admin: true },
+      { uid: 'target', email: 'target@example.dev' },
+    ])
+    await seedUser('target', 'targetuser')
+    sendMock.mockRejectedValueOnce(new Error('provider down'))
+
+    const res = await request(app)
+      .patch('/api/admin/users/target/status')
+      .set(AUTH_HEADER)
+      .send({ status: 'banned', reason: 'abuse' })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('resolving a report emails the reporter; dismissing does not', async () => {
+    admin.__setClaims({ admin: true })
+    admin.__setUsers([
+      { uid: TEST_UID, email: 'admin@test.dev', admin: true },
+      { uid: 'reporter', email: 'reporter@example.dev' },
+    ])
+    const db = getDB()
+
+    const mkReport = async () => {
+      const _id = new ObjectId()
+      await db.collection('reports').insertOne({
+        _id,
+        targetType: 'recipe',
+        recipeId: 'recipe-1',
+        reporterUid: 'reporter',
+        reason: 'spam',
+        status: 'open',
+        createdAt: new Date(),
+      })
+      return _id
+    }
+
+    const resolveId = await mkReport()
+    await request(app)
+      .patch(`/api/reports/${resolveId}`)
+      .set(AUTH_HEADER)
+      .send({ status: 'resolved' })
+    await flushNotifications()
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    expect(sentArg().to).toBe('reporter@example.dev')
+
+    sendMock.mockClear()
+    const dismissId = await mkReport()
+    await request(app)
+      .patch(`/api/reports/${dismissId}`)
+      .set(AUTH_HEADER)
+      .send({ status: 'dismissed' })
+    await flushNotifications()
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('a bulk resolve emails each distinct reporter once', async () => {
+    admin.__setClaims({ admin: true })
+    admin.__setUsers([
+      { uid: TEST_UID, email: 'admin@test.dev', admin: true },
+      { uid: 'reporterA', email: 'a@example.dev' },
+      { uid: 'reporterB', email: 'b@example.dev' },
+    ])
+    const db = getDB()
+    const ids = [
+      { reporterUid: 'reporterA' },
+      { reporterUid: 'reporterA' }, // same reporter, two reports ⇒ one email
+      { reporterUid: 'reporterB' },
+    ].map((r) => {
+      const _id = new ObjectId()
+      return { ...r, _id }
+    })
+    await db.collection('reports').insertMany(
+      ids.map((r) => ({
+        _id: r._id,
+        targetType: 'recipe',
+        recipeId: 'recipe-1',
+        reporterUid: r.reporterUid,
+        reason: 'spam',
+        status: 'open',
+        createdAt: new Date(),
+      }))
+    )
+
+    const res = await request(app)
+      .patch('/api/reports/bulk')
+      .set(AUTH_HEADER)
+      .send({ ids: ids.map((r) => String(r._id)), status: 'resolved' })
+
+    expect(res.status).toBe(200)
+    await flushNotifications()
+    expect(sendMock).toHaveBeenCalledTimes(2) // deduped to A + B
+    const recipients = sendMock.mock.calls.map((c) => c[0].to).sort()
+    expect(recipients).toEqual(['a@example.dev', 'b@example.dev'])
+  })
+
+  it('unhiding a recipe does not email (only takedowns notify)', async () => {
+    admin.__setClaims({ admin: true })
+    admin.__setUsers([{ uid: TEST_UID, email: 'admin@test.dev', admin: true }])
+    await seedRecipe({ _id: 'r1', title: 'Dish', userId: 'owner', status: 'hidden' })
+
+    const res = await request(app)
+      .patch('/api/admin/recipes/r1/moderation')
+      .set(AUTH_HEADER)
+      .send({ status: 'active' })
+
+    expect(res.status).toBe(200)
+    await flushNotifications()
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('hiding a recipe emails the owner (resolved from updated.userId)', async () => {
+    admin.__setClaims({ admin: true })
+    admin.__setUsers([
+      { uid: TEST_UID, email: 'admin@test.dev', admin: true },
+      { uid: 'owner', email: 'owner@example.dev' },
+    ])
+    await seedRecipe({ _id: 'r1', title: 'Dish', userId: 'owner', status: 'active' })
+
+    const res = await request(app)
+      .patch('/api/admin/recipes/r1/moderation')
+      .set(AUTH_HEADER)
+      .send({ status: 'hidden' })
+
+    expect(res.status).toBe(200)
+    await flushNotifications()
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    expect(sentArg().to).toBe('owner@example.dev')
+  })
+
+  it('taking down a review emails the author; restoring does not', async () => {
+    admin.__setClaims({ admin: true })
+    admin.__setUsers([
+      { uid: TEST_UID, email: 'admin@test.dev', admin: true },
+      { uid: 'author-uid', email: 'author@example.dev' },
+    ])
+    const db = getDB()
+    await seedUser('author-uid', 'author')
+    await seedRecipe({ _id: 'r1', title: 'Dish', userId: 'someone' })
+    await seedRating({ username: 'author', recipeId: 'r1', rating: 4, reviewText: 'bad' })
+
+    const takedown = await request(app)
+      .patch('/api/admin/reviews/moderation')
+      .set(AUTH_HEADER)
+      .send({ recipeId: 'r1', username: 'author', moderationHidden: true })
+    expect(takedown.status).toBe(200)
+    await flushNotifications()
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    expect(sentArg().to).toBe('author@example.dev')
+
+    sendMock.mockClear()
+    const restore = await request(app)
+      .patch('/api/admin/reviews/moderation')
+      .set(AUTH_HEADER)
+      .send({ recipeId: 'r1', username: 'author', moderationHidden: false })
+    expect(restore.status).toBe(200)
+    await flushNotifications()
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+})

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,7 +15,8 @@
         "express-rate-limit": "^8.5.2",
         "firebase-admin": "^13.8.0",
         "helmet": "^8.2.0",
-        "mongodb": "^6.0.0"
+        "mongodb": "^6.0.0",
+        "resend": "^6.12.4"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -1555,6 +1556,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.1",
@@ -3553,6 +3560,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.9",
@@ -6613,6 +6626,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/pretty-format": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
@@ -6844,6 +6863,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
+      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve-cwd": {
@@ -7185,6 +7225,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,8 @@
     "express-rate-limit": "^8.5.2",
     "firebase-admin": "^13.8.0",
     "helmet": "^8.2.0",
-    "mongodb": "^6.0.0"
+    "mongodb": "^6.0.0",
+    "resend": "^6.12.4"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -4,6 +4,7 @@ const { getDB } = require('../db')
 const { verifyToken, requireAdmin } = require('../middleware/auth')
 const { USER_STATUSES } = require('../util/userStatus')
 const { recordAudit, AUDIT_ACTIONS, AUDIT_TARGET_TYPES } = require('../util/auditLog')
+const { notifyInBackground, notifyAccountStatus } = require('../util/email')
 
 const router = Router()
 
@@ -306,6 +307,9 @@ router.patch('/admin/users/:uid/status', verifyToken, requireAdmin, async (req, 
       targetLabel: targetUsernameDoc?.username ? `@${targetUsernameDoc.username}` : uid,
       reason: status === 'active' ? null : reason || null,
     })
+
+    // Notify the affected user on suspend/ban (background). Activation is silent.
+    notifyInBackground(notifyAccountStatus(uid, status, reason))
 
     res.json({ uid, status })
   } catch (err) {

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -5,6 +5,7 @@ const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../m
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { RECIPE_VISIBLE } = require('../util/moderation')
 const { recordAudit } = require('../util/auditLog')
+const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
 const { EDITABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
@@ -404,6 +405,8 @@ router.patch('/admin/recipes/:id/moderation', verifyToken, requireAdmin, async (
       targetId: updated._id,
       targetLabel: updated.title || null,
     })
+    // Notify the owner on a takedown (background). Unhide is silent.
+    if (status === 'hidden') notifyInBackground(notifyRecipeHidden(updated.userId, updated.title))
     res.json({ _id: updated._id, status: updated.status })
   } catch (err) {
     res.status(500).json({ error: err.message })

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -4,6 +4,7 @@ const { getDB } = require('../db')
 const { verifyToken, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { recordAudit, recordAuditMany } = require('../util/auditLog')
+const { notifyInBackground, notifyReportResolved, notifyReportResolvedMany } = require('../util/email')
 
 const router = Router()
 
@@ -182,6 +183,12 @@ router.patch('/reports/bulk', verifyToken, requireAdmin, async (req, res) => {
       }))
     )
 
+    // Email each affected reporter once per sweep (resolve only; dismiss is
+    // silent), in the background so a large sweep never blocks the response.
+    if (status === 'resolved') {
+      notifyInBackground(notifyReportResolvedMany(closed.map((r) => r.reporterUid)))
+    }
+
     res.json({ updated: result.modifiedCount })
   } catch (err) {
     res.status(500).json({ error: err.message })
@@ -215,6 +222,8 @@ router.patch('/reports/:id', verifyToken, requireAdmin, async (req, res) => {
       targetLabel: updated.reportedUsername ? `@${updated.reportedUsername}` : updated.recipeId,
       metadata: { targetType: updated.targetType, recipeId: updated.recipeId },
     })
+    // Notify the reporter that action was taken. Dismiss is intentionally silent.
+    if (status === 'resolved') notifyInBackground(notifyReportResolved(updated.reporterUid))
     res.json(updated)
   } catch (err) {
     res.status(500).json({ error: err.message })

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -5,6 +5,7 @@ const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { REVIEW_VISIBLE, RECIPE_VISIBLE } = require('../util/moderation')
 const { recordAudit } = require('../util/auditLog')
 const { recomputeRecipeRating } = require('../util/recipeRating')
+const { notifyInBackground, notifyReviewTakenDown } = require('../util/email')
 
 const router = Router()
 
@@ -269,6 +270,8 @@ router.patch('/admin/reviews/moderation', verifyToken, requireAdmin, async (req,
       targetLabel: `@${username}`,
       metadata: { recipeId, username },
     })
+    // Notify the review author on a takedown (background). Restore is silent.
+    if (moderationHidden) notifyInBackground(notifyReviewTakenDown(db, username, recipeId))
     res.json({ recipeId, username, moderationHidden })
   } catch (err) {
     res.status(500).json({ error: err.message })

--- a/server/util/email.js
+++ b/server/util/email.js
@@ -1,0 +1,326 @@
+const admin = require('firebase-admin')
+const { recipeIdQuery } = require('./recipeIdQuery')
+
+// Transactional email for moderation outcomes, behind one thin Resend wrapper so
+// the provider can be swapped (SES/Postmark) without touching the call sites.
+//
+// Deliberately best-effort, exactly like util/auditLog.recordAudit: a send (or
+// recipient-lookup) failure must NEVER break the moderation action that triggered
+// it, so every public helper swallows its own errors and always resolves. Callers
+// `await` it alongside recordAudit but need not guard it.
+//
+// Env-gated: with no RESEND_API_KEY (dev/CI/test default) the whole module
+// no-ops before any Firebase/DB lookup, so it adds zero behavior when disabled.
+
+// Lazily-constructed Resend client. Kept module-local so a single client is
+// reused across sends; built on first use only when email is enabled.
+let _client = null
+
+// Email is on only when a key is present AND not explicitly killed. Read from
+// the environment on every call (not cached at import) so tests can toggle it
+// and a missing key in CI cleanly disables sending.
+function emailEnabled() {
+  if (process.env.EMAIL_ENABLED === 'false') return false
+  return !!process.env.RESEND_API_KEY
+}
+
+function getClient() {
+  if (!emailEnabled()) return null
+  if (!_client) {
+    // Required lazily so the `resend` package is never loaded when disabled.
+    const { Resend } = require('resend')
+    _client = new Resend(process.env.RESEND_API_KEY)
+  }
+  return _client
+}
+
+function fromAddress() {
+  return process.env.EMAIL_FROM || 'Prepify <onboarding@resend.dev>'
+}
+
+function appBaseUrl() {
+  return (process.env.APP_BASE_URL || 'http://localhost:3000').replace(/\/$/, '')
+}
+
+// Hard cap on a single provider send. Even though notifications run in the
+// background (see notifyInBackground), a hung connection would otherwise keep a
+// promise — and its closure — alive indefinitely; this bounds it.
+const SEND_TIMEOUT_MS = 10000
+
+// Promise.race against a timer, clearing the timer when `promise` settles so we
+// never leak an open handle (important under Jest and for clean shutdown).
+function withTimeout(promise, ms, label) {
+  let timer
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+  })
+  return Promise.race([
+    Promise.resolve(promise).finally(() => clearTimeout(timer)),
+    timeout,
+  ])
+}
+
+/**
+ * Send one email, best-effort. No-ops (returns `{ skipped: true }`) when email is
+ * disabled or there is no recipient; on a provider error it logs and returns
+ * `{ sent: false, error }` rather than throwing.
+ *
+ * @param {object} msg
+ * @param {string} msg.to       recipient email (falsy ⇒ skipped)
+ * @param {string} msg.subject
+ * @param {string} msg.html
+ * @param {string} msg.text     plain-text fallback
+ */
+async function sendEmail({ to, subject, html, text }) {
+  try {
+    const client = getClient()
+    if (!client || !to) return { sent: false, skipped: true }
+    // The Resend SDK does NOT throw on API errors — it resolves with
+    // { data, error }. So a 403/validation failure must be read off `error`,
+    // not caught; the try/catch only guards transport-level throws.
+    const { data, error } = await withTimeout(
+      client.emails.send({ from: fromAddress(), to, subject, html, text }),
+      SEND_TIMEOUT_MS,
+      'email send'
+    )
+    if (error) {
+      console.error('Failed to send email:', error.message)
+      return { sent: false, error: error.message }
+    }
+    return { sent: true, id: data?.id }
+  } catch (err) {
+    console.error('Failed to send email:', err.message)
+    return { sent: false, error: err.message }
+  }
+}
+
+// --- Recipient resolution ---------------------------------------------------
+
+// Look up a Firebase user's email by uid. Returns null if the user is gone or the
+// lookup fails — a missing address just means "nobody to notify", never an error.
+async function emailForUid(uid) {
+  try {
+    const user = await admin.auth().getUser(uid)
+    return user.email || null
+  } catch (err) {
+    return null
+  }
+}
+
+// Reviews are keyed by username (no uid on the doc); the usernames collection is
+// _id=uid → username. Look up by the indexed, canonical `username_lower` (the same
+// field auth.js/publicProfile.js query) so the match is case-insensitive and hits
+// the index instead of scanning.
+async function emailForUsername(db, username) {
+  try {
+    const doc = await db
+      .collection('usernames')
+      .findOne({ username_lower: String(username).toLowerCase() })
+    if (!doc) return null
+    return emailForUid(doc._id)
+  } catch (err) {
+    return null
+  }
+}
+
+// --- Templates --------------------------------------------------------------
+
+const TEAM = 'The Prepify Team'
+
+// Minimal HTML-escape for user-supplied values interpolated into template HTML
+// (recipe titles, moderation reasons).
+function esc(str) {
+  return String(str == null ? '' : str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+// Shared inline-styled shell (no external CSS — email clients strip <style>) plus
+// a plain-text fallback. Callers pass ONE array of RAW paragraphs; escaping for
+// the HTML branch happens here, so a single source of truth backs both bodies
+// and no caller has to hand-maintain a parallel text copy (or reverse an escape).
+function layout({ heading, paragraphs }) {
+  const url = appBaseUrl()
+  const htmlParas = paragraphs
+    .map((p) => `<p style="margin:0 0 16px;color:#374151;line-height:1.55;">${esc(p)}</p>`)
+    .join('')
+  const html = `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:520px;margin:0 auto;padding:24px;">
+  <h1 style="font-size:20px;color:#111827;margin:0 0 20px;">${esc(heading)}</h1>
+  ${htmlParas}
+  <p style="margin:24px 0 8px;">
+    <a href="${url}" style="display:inline-block;background:#16a34a;color:#fff;text-decoration:none;padding:10px 18px;border-radius:8px;font-weight:600;">Go to Prepify</a>
+  </p>
+  <p style="margin:24px 0 0;color:#6b7280;font-size:13px;">— ${TEAM}</p>
+</div>`
+  const text = `${heading}\n\n${paragraphs.join('\n\n')}\n\n${url}\n\n— ${TEAM}`
+  return { html, text }
+}
+
+const APPEAL = 'If you believe this was a mistake, you can appeal by contacting Prepify support.'
+
+const templates = {
+  reportResolved() {
+    const subject = 'Update on the content you reported'
+    return {
+      subject,
+      ...layout({
+        heading: subject,
+        paragraphs: [
+          'Thanks for helping keep Prepify safe.',
+          'We reviewed the content you reported and have taken action in line with our community guidelines. No further action is needed on your part.',
+        ],
+      }),
+    }
+  },
+
+  accountStatus({ status, reason }) {
+    const banned = status === 'banned'
+    const subject = banned
+      ? 'Your Prepify account has been banned'
+      : 'Your Prepify account has been suspended'
+    const paragraphs = [
+      `Your Prepify account has been ${banned ? 'banned' : 'suspended'} following a review of activity that violates our community guidelines.`,
+    ]
+    if (reason) paragraphs.push(`Reason: ${reason}`)
+    paragraphs.push(
+      banned
+        ? 'This decision is permanent and you can no longer post recipes or reviews.'
+        : 'While suspended, you will not be able to post recipes or reviews.'
+    )
+    paragraphs.push(APPEAL)
+    return { subject, ...layout({ heading: subject, paragraphs }) }
+  },
+
+  recipeHidden({ recipeTitle }) {
+    const subject = 'Your recipe was removed from Prepify'
+    const titleBit = recipeTitle ? ` "${recipeTitle}"` : ''
+    return {
+      subject,
+      ...layout({
+        heading: subject,
+        paragraphs: [
+          `Your recipe${titleBit} has been hidden by our moderation team because it may not meet our community guidelines, and is no longer visible to other users.`,
+          APPEAL,
+        ],
+      }),
+    }
+  },
+
+  reviewTakenDown({ recipeTitle }) {
+    const subject = 'Your review was removed from Prepify'
+    const onBit = recipeTitle ? ` on "${recipeTitle}"` : ''
+    return {
+      subject,
+      ...layout({
+        heading: subject,
+        paragraphs: [
+          `One of your reviews${onBit} has been removed by our moderation team because it may not meet our community guidelines.`,
+          APPEAL,
+        ],
+      }),
+    }
+  },
+}
+
+// --- Per-event helpers ------------------------------------------------------
+
+// Shared delivery shell: resolve a recipient, build the template, send — all
+// best-effort (swallows its own errors, never throws). Every event helper is just
+// this plus its own precondition + resolver + template, so adding a 5th event
+// doesn't re-introduce the guard/try/catch boilerplate. `buildTemplate` may be
+// async (the review event fetches a recipe title first).
+async function deliver(resolveRecipient, buildTemplate) {
+  try {
+    const to = await resolveRecipient()
+    if (!to) return // nobody to notify — skip the template build + send
+    await sendEmail({ to, ...(await buildTemplate()) })
+  } catch (err) {
+    console.error('Email notification failed:', err.message)
+  }
+}
+
+// Best-effort recipe-title lookup for nicer copy; null on any miss/failure.
+async function fetchRecipeTitle(db, recipeId) {
+  try {
+    const recipe = await db
+      .collection('recipes')
+      .findOne(recipeIdQuery(recipeId), { projection: { title: 1 } })
+    return recipe?.title || null
+  } catch (e) {
+    return null
+  }
+}
+
+// Report resolved → email the reporter. (Dismiss is intentionally silent.)
+function notifyReportResolved(reporterUid) {
+  if (!emailEnabled() || !reporterUid) return Promise.resolve()
+  return deliver(() => emailForUid(reporterUid), () => templates.reportResolved())
+}
+
+// Bulk resolve → email each DISTINCT reporter once, sent serially so a large
+// sweep self-throttles under the provider's per-second rate limit instead of
+// firing the whole batch at once.
+async function notifyReportResolvedMany(reporterUids) {
+  if (!emailEnabled()) return
+  const unique = [...new Set((reporterUids || []).filter(Boolean))]
+  for (const uid of unique) {
+    await notifyReportResolved(uid)
+  }
+}
+
+// Account suspended/banned → email the affected user. Activation is silent.
+function notifyAccountStatus(uid, status, reason) {
+  if (!emailEnabled() || (status !== 'suspended' && status !== 'banned')) return Promise.resolve()
+  return deliver(() => emailForUid(uid), () => templates.accountStatus({ status, reason }))
+}
+
+// Recipe hidden → email the owner. Unhide is silent.
+function notifyRecipeHidden(ownerUid, recipeTitle) {
+  if (!emailEnabled() || !ownerUid) return Promise.resolve()
+  return deliver(() => emailForUid(ownerUid), () => templates.recipeHidden({ recipeTitle }))
+}
+
+// Review taken down → email the author. Restore is silent.
+function notifyReviewTakenDown(db, ownerUsername, recipeId) {
+  if (!emailEnabled() || !ownerUsername) return Promise.resolve()
+  return deliver(
+    () => emailForUsername(db, ownerUsername),
+    async () => templates.reviewTakenDown({ recipeTitle: await fetchRecipeTitle(db, recipeId) })
+  )
+}
+
+// --- Background dispatch -----------------------------------------------------
+// Moderation routes fire notifications WITHOUT awaiting them, so the admin's
+// HTTP response never waits on Firebase + the email provider (the action has
+// already committed). The promise is tracked so tests — and a future graceful
+// shutdown — can await in-flight sends; it can never reject (the helpers swallow
+// their own errors, and we attach a catch as a backstop).
+const _pending = new Set()
+
+function notifyInBackground(promise) {
+  const tracked = Promise.resolve(promise).catch((err) => {
+    console.error('Background notification failed:', err && err.message)
+  })
+  _pending.add(tracked)
+  tracked.finally(() => _pending.delete(tracked))
+  return tracked
+}
+
+// Await all in-flight background notifications (used by tests).
+function flushNotifications() {
+  return Promise.all([..._pending])
+}
+
+module.exports = {
+  emailEnabled,
+  sendEmail,
+  notifyInBackground,
+  flushNotifications,
+  notifyReportResolved,
+  notifyReportResolvedMany,
+  notifyAccountStatus,
+  notifyRecipeHidden,
+  notifyReviewTakenDown,
+}


### PR DESCRIPTION
Completes the last open P3 item in `docs/ADMIN_FUNCTIONALITY.md`: transactional email so moderation outcomes reach the affected person.

## What
Provider = **Resend** (3k/mo free tier), behind one swappable wrapper so SES/Postmark could replace it later. Mirrors the best-effort `recordAudit` pattern — a send failure never breaks the moderation action.

Four **action-only** events, wired alongside the existing audit writes:

| Event | Recipient |
|-------|-----------|
| report **resolved** | reporter (bulk resolves email each distinct reporter once; dismiss is silent) |
| user **suspended/banned** | the user (activate is silent) |
| recipe **hidden** | owner (unhide silent) |
| review **taken down** | author (restore silent) |

## How
- `server/util/email.js` — `sendEmail` + typed helpers behind a shared `deliver()` shell.
- **Env-gated:** with no `RESEND_API_KEY` (dev/CI/test) the module no-ops *before* any Firebase/DB lookup, so existing suites are unaffected.
- Sends run **in the background** (`notifyInBackground`) so the admin response never waits on Firebase/Resend, with a **10s per-send timeout**; **bulk resolves are sent serially** to self-throttle under Resend's per-second rate limit.
- The Resend SDK resolves `{ data, error }` (it does *not* throw on API errors) — the wrapper reads the error off the resolved value.

## Env (added to `server/.env.example` only)
`RESEND_API_KEY` (empty = disabled), `EMAIL_FROM`, `APP_BASE_URL`, optional `EMAIL_ENABLED=false` kill switch. Firebase Auth's own emails (password reset etc.) are untouched.

## Tests
`server/__tests__/email-notifications.test.js` — recipient per event, no-op without key, failure-swallowed, resolved-`{error}` payload, and route wiring incl. dismiss/unhide silence + bulk dedupe. **server 329 / FE 263 / tsc clean.** Live send verified end-to-end from a verified domain (Resend).

## Deploy notes
- Set `RESEND_API_KEY`, `EMAIL_FROM`, `APP_BASE_URL` in the host env (without them, email simply no-ops).
- To send from a custom domain, verify it in Resend (DKIM + SPF/MX) and point `EMAIL_FROM` at it.

## Deferred
- Appeal flow has no support route yet (copy says "contact Prepify support").
- No reversal / "good news" emails.