### PR TITLE
feat(admin): configurable support address in moderation emails

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -10,4 +10,7 @@ RESEND_API_KEY=
 EMAIL_FROM=Prepify <onboarding@resend.dev>
 # Base URL used for links/buttons in emails.
 APP_BASE_URL=http://localhost:3000
+# Address shown in moderation emails for appeals/support (the from-address is
+# no-reply). Leave empty to fall back to generic "contact Prepify support" wording.
+SUPPORT_EMAIL=
 # EMAIL_ENABLED=true   # optional kill switch; an empty RESEND_API_KEY already disables sending

--- a/server/__tests__/email-notifications.test.js
+++ b/server/__tests__/email-notifications.test.js
@@ -39,6 +39,7 @@ const TEST_UID = 'test-uid'
 beforeEach(() => {
   process.env.RESEND_API_KEY = 'test-key'
   delete process.env.EMAIL_ENABLED
+  delete process.env.SUPPORT_EMAIL
   sendMock.mockReset()
   // Resend's SDK resolves with { data, error } — it does not throw on API errors.
   sendMock.mockResolvedValue({ data: { id: 'email-1' }, error: null })
@@ -120,6 +121,19 @@ describe('per-event recipient resolution', () => {
     expect(sentArg().text).toContain('Reason: Posted spam $& scam <link>')
     // HTML escapes the angle brackets but keeps the literal text.
     expect(sentArg().html).toContain('Posted spam $&amp; scam &lt;link&gt;')
+  })
+
+  it('names SUPPORT_EMAIL in the appeal line when set, falls back when not', async () => {
+    admin.__setUsers([{ uid: 'owner', email: 'owner@example.dev' }])
+
+    process.env.SUPPORT_EMAIL = 'help@prepifymeals.com'
+    await notifyRecipeHidden('owner', 'Dish')
+    expect(sentArg().text).toContain('emailing us at help@prepifymeals.com')
+
+    sendMock.mockClear()
+    delete process.env.SUPPORT_EMAIL
+    await notifyRecipeHidden('owner', 'Dish')
+    expect(sentArg().text).toContain('contacting Prepify support')
   })
 
   it('recipeHidden mails the owner with the recipe title', async () => {

--- a/server/util/email.js
+++ b/server/util/email.js
@@ -158,7 +158,15 @@ function layout({ heading, paragraphs }) {
   return { html, text }
 }
 
-const APPEAL = 'If you believe this was a mistake, you can appeal by contacting Prepify support.'
+// The "how to appeal" line. If SUPPORT_EMAIL is configured it names a concrete
+// address (the from-address is no-reply, so replies go nowhere); otherwise it
+// falls back to generic wording so nothing reads as broken when it's unset.
+function appealLine() {
+  const support = process.env.SUPPORT_EMAIL
+  return support
+    ? `If you believe this was a mistake, you can appeal by emailing us at ${support}.`
+    : 'If you believe this was a mistake, you can appeal by contacting Prepify support.'
+}
 
 const templates = {
   reportResolved() {
@@ -189,7 +197,7 @@ const templates = {
         ? 'This decision is permanent and you can no longer post recipes or reviews.'
         : 'While suspended, you will not be able to post recipes or reviews.'
     )
-    paragraphs.push(APPEAL)
+    paragraphs.push(appealLine())
     return { subject, ...layout({ heading: subject, paragraphs }) }
   },
 
@@ -202,7 +210,7 @@ const templates = {
         heading: subject,
         paragraphs: [
           `Your recipe${titleBit} has been hidden by our moderation team because it may not meet our community guidelines, and is no longer visible to other users.`,
-          APPEAL,
+          appealLine(),
         ],
       }),
     }
@@ -217,7 +225,7 @@ const templates = {
         heading: subject,
         paragraphs: [
           `One of your reviews${onBit} has been removed by our moderation team because it may not meet our community guidelines.`,
-          APPEAL,
+          appealLine(),
         ],
       }),
     }


### PR DESCRIPTION
Small follow-up to #126. The appeal line in moderation emails said "contact Prepify support" with nowhere to go.

- Drive the line from a new **`SUPPORT_EMAIL`** env var: set ⇒ names a concrete address (the from-address is no-reply, so replies go nowhere); unset ⇒ falls back to the current generic wording, so nothing breaks until it's configured.
- Added to `server/.env.example` only.
- Test covers both the set and fallback paths. server 330 / tsc clean.

Set `SUPPORT_EMAIL` in the host env (Railway) once a support inbox exists — a free dedicated Gmail is fine for now; upgradable to `support@prepifymeals.com` later without code changes.