### PR TITLE
security: deferred audit batch — reviews hardening, generic 500s, error backstop

### DIFF
--- a/docs/SECURITY_AUDIT_2026-06-11.md
+++ b/docs/SECURITY_AUDIT_2026-06-11.md
@@ -125,23 +125,22 @@ touch the same files those branches change (see §5).
    `NODE_ENV=test` because supertest fires hundreds of requests from one IP in
    seconds — so the 429 path itself is intentionally untested by Jest. Cypress
    CI runs with limiters active and stays well under the global cap.
-2. [ ] **500 handlers echo `err.message` to clients** (*Low–Medium*, info
-   disclosure) — **DEFERRED, see §5.** Every route's catch block returns the
-   raw message, which for infrastructure failures can include internal
-   hostnames (e.g. Mongo `connect ECONNREFUSED <host>`). Needs a shared error
-   responder that logs the real error and returns a generic message. Touches
-   every route file and some test expectations — maximal conflict with the
-   worktree backlog, so it must go last.
-3. [ ] **`GET /getReviews` `isCurrentUser` derived from a query param**
-   (*Low*, carried over from old audit) — **DEFERRED, see §5.** Anyone can
-   pass `?username=victim` and get `isCurrentUser: true` flags. UI-hint spoof
-   only (server-side edits remain protected); should derive from the token
-   when an `Authorization` header is present. Lives in `reviews.js`, which the
-   admin worktree's soft-hide moderation also changes.
-4. [ ] **`reviewText` has no length bound** (*Low*) — **DEFERRED, see §5.**
-   Recipe fields are bounded; reviews are not. Add a max length in
-   `newReview`/`editReview` mirroring `DESCRIPTION_MAX_LENGTH` (2000). Same
-   `reviews.js` conflict as item 3.
+2. [x] **500 handlers echo `err.message` to clients** (*Low–Medium*, info
+   disclosure) — **DONE (2026-06-12).** Added `util/respondServerError.js`
+   (logs the real error with `METHOD /path` context, returns
+   `500 { error: 'Internal server error' }`); wired into all 9 route files
+   (52 sites) + `requireActive` in `middleware/auth.js`. `ingredients.js`
+   keeps its rich Phase-A logging and only swapped the response body. 4xx
+   validation messages unchanged.
+3. [x] **`GET /getReviews` `isCurrentUser` derived from a query param**
+   (*Low*, carried over from old audit) — **DONE (2026-06-12).** Route now uses
+   `optionalAuth`; `isCurrentUser` is derived from the verified token's
+   uid → `usernames`, ignoring the `?username` param for the flag. Stays
+   anonymous-friendly (no/invalid token → `false` everywhere). Regression
+   tests in `reviews.test.js`.
+4. [x] **`reviewText` has no length bound** (*Low*) — **DONE (2026-06-12).**
+   `newReview`/`editReview` reject text over `DESCRIPTION_MAX_LENGTH` (2000),
+   now exported from `util/recipeLimits.js` (imported, not duplicated).
 5. [x] **Unbounded `recipesPerPage`/`reviewsPerPage`** (*Low*) — **DONE.**
    All five paginated handlers (`GET /recipes`, `getReviews`,
    `getSingleUserReviews`, `getCreatedRecipes`, `getSavedRecipes`) clamp the
@@ -153,15 +152,27 @@ touch the same files those branches change (see §5).
    AS-IS.** Revoked/disabled users keep access until their ID token expires
    (≤1 h). Standard tradeoff: `checkRevoked` costs a network round-trip per
    request. Revisit only if account-ban semantics demand instant lockout.
-8. [ ] **`newReview` upsert can create a doc without `rating` fields**
-   (*Info*, data integrity, carried over) — **DEFERRED, see §5.** A review
-   posted before any rating yields a ratings doc lacking
-   `rating`/`ratingLastUpdated`. Normalize during the same `reviews.js` pass
-   as items 3–4.
+8. [x] **`newReview` upsert can create a doc without `rating` fields**
+   (*Info → actually higher: data corruption*) — **DONE (2026-06-12).**
+   `newReview` now `$setOnInsert`s `rating: null` / `ratingLastUpdated: ''`,
+   and `recomputeRecipeRating` filters to docs with a finite numeric rating.
+   This was worse than logged: `recomputeRecipeRating` ran `parseFloat(r.rating)`
+   over review-only docs → `NaN`, poisoning the **entire** recipe average (and
+   still counting toward `rateCount`). Regression test in `reviews.test.js`
+   ("does not let a review-only doc poison the recipe average").
 
 ---
 
 ## 5. Deferred follow-up — runbook for after the worktree merges
+
+> **STATUS: COMPLETE (2026-06-12).** All three worktrees merged (recipes #119,
+> account #122, admin #121/#124/#125/#126). Worked on branch
+> `security/deferred-batch-2026-06`: step 1 (reviews.js items 3/4/8) and step 2
+> (generic 500 responder) applied; step 3 admin re-audit found the surface
+> **already sound** — every `/admin` route chains `verifyToken + requireAdmin`,
+> report/moderation endpoints validate ids (ObjectId.isValid / string
+> type-checks / whitelists) — so it needed regression tests, not fixes. Server
+> suite green (344). §4 boxes ticked above.
 
 **Preconditions:** the three worktree branches (recipes-page-refresh,
 account-page-redesign incl. its P6 teardown, admin-service) are merged into

--- a/docs/SECURITY_AUDIT_2026-06-11.md
+++ b/docs/SECURITY_AUDIT_2026-06-11.md
@@ -131,7 +131,10 @@ touch the same files those branches change (see §5).
    `500 { error: 'Internal server error' }`); wired into all 9 route files
    (52 sites) + `requireActive` in `middleware/auth.js`. `ingredients.js`
    keeps its rich Phase-A logging and only swapped the response body. 4xx
-   validation messages unchanged.
+   validation messages unchanged. Also added a central error backstop in
+   `app.js` so errors thrown *outside* a route's try/catch (malformed JSON
+   body, CORS rejection) no longer reach Express's default stack-leaking
+   handler — they return a generic body, preserving a thrower-set 4xx.
 3. [x] **`GET /getReviews` `isCurrentUser` derived from a query param**
    (*Low*, carried over from old audit) — **DONE (2026-06-12).** Route now uses
    `optionalAuth`; `isCurrentUser` is derived from the verified token's

--- a/server/__tests__/ingredients.test.js
+++ b/server/__tests__/ingredients.test.js
@@ -140,14 +140,15 @@ describe('POST /api/ingredients/parse', () => {
 
   // ── Error handling ────────────────────────────────────────────────────────────
 
-  it('returns 500 and the error message when ingredientParser throws', async () => {
+  it('returns a generic 500 (not the raw error) when ingredientParser throws', async () => {
     ingredientParser.mockRejectedValue(new Error('parser exploded'))
     const res = await request(app)
       .post('/api/ingredients/parse')
       .set(AUTH_HEADER)
       .send({ ingredientString: '2 cups flour' })
     expect(res.status).toBe(500)
-    expect(res.body).toHaveProperty('error', 'parser exploded')
+    // Body is generic; the real message ('parser exploded') is logged, not echoed.
+    expect(res.body).toHaveProperty('error', 'Internal server error')
   })
 
   // ── Spoonacular CDN URL rewrite ──────────────────────────────────────────────

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -109,6 +109,30 @@ describe('POST /addRating', () => {
     expect(recipe.rating.rateCount).toBe(1)
     expect(recipe.rating.rateValue).toBe(4)
   })
+
+  // Audit §4 item 8: a review-only doc (rating: null) on the same recipe must be
+  // excluded from the recompute — otherwise parseFloat(null) → NaN poisons the
+  // whole average. The aggregate counts only the genuinely-rated doc.
+  it('does not let a review-only (rating: null) doc poison the recipe average', async () => {
+    const db = getDB()
+    await seedRating({
+      username: OTHER_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: null,
+      reviewText: 'Review with no star rating',
+      ratingLastUpdated: '',
+    })
+
+    const res = await request(app)
+      .post(`/api/addRating?recipeId=${RECIPE_ID}&rating=4`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+
+    const recipe = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.rating.rateCount).toBe(1)
+    expect(recipe.rating.rateValue).toBe(4)
+    expect(Number.isNaN(recipe.rating.rateValue)).toBe(false)
+  })
 })
 
 // ─── POST /editReview ──────────────────────────────────────────────────────────
@@ -158,6 +182,15 @@ describe('POST /editReview', () => {
       .collection('ratings')
       .findOne({ username: TEST_USERNAME, recipeId: RECIPE_ID })
     expect(doc.reviewText).toBe('Updated review')
+  })
+
+  // Audit §4 item 4: edited review text must be bounded too.
+  it('rejects edited text longer than 2000 characters (400)', async () => {
+    const res = await request(app)
+      .post(`/api/editReview?recipeId=${RECIPE_ID}&text=${'x'.repeat(2001)}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/cannot exceed/)
   })
 })
 
@@ -251,6 +284,33 @@ describe('POST /newReview', () => {
     expect(res.body.reviewText).toBe('Amazing dish!')
     expect(res.body.username).toBe(TEST_USERNAME)
     expect(res.body.recipeId).toBe(RECIPE_ID)
+  })
+
+  // Audit §4 item 4: reviewText must be bounded (mirrors DESCRIPTION_MAX_LENGTH).
+  it('rejects a review longer than 2000 characters (400)', async () => {
+    const res = await request(app)
+      .post('/api/newReview')
+      .set(AUTH_HEADER)
+      .send({ recipeId: RECIPE_ID, reviewText: 'x'.repeat(2001) })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/cannot exceed/)
+  })
+
+  // Audit §4 item 8: a review posted before any rating must still produce a
+  // ratings doc with a `rating` key (defaulted to null on insert), so the
+  // recipe-average recompute never sees an undefined rating → NaN.
+  it('defaults rating to null on a review-only upsert', async () => {
+    await request(app)
+      .post('/api/newReview')
+      .set(AUTH_HEADER)
+      .send({ recipeId: RECIPE_ID, reviewText: 'Review without a star rating' })
+
+    const db = getDB()
+    const stored = await db
+      .collection('ratings')
+      .findOne({ username: TEST_USERNAME, recipeId: RECIPE_ID })
+    expect(stored).toHaveProperty('rating', null)
+    expect(stored).toHaveProperty('ratingLastUpdated', '')
   })
 
   it('updates an existing review entry (upsert)', async () => {
@@ -408,7 +468,7 @@ describe('GET /getReviews', () => {
     expect(res.body.totalCount).toBe(1)
   })
 
-  it('sets isCurrentUser=true for the review matching the username param', async () => {
+  it('sets isCurrentUser=true for the authenticated caller’s own review', async () => {
     await seedRating({
       username: TEST_USERNAME,
       recipeId: RECIPE_ID,
@@ -417,11 +477,46 @@ describe('GET /getReviews', () => {
       reviewCreatedAt: '1000',
     })
 
+    // Token resolves to TEST_UID → TEST_USERNAME; flag comes from the token.
+    const res = await request(app)
+      .get(`/api/getReviews?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.reviews[0].isCurrentUser).toBe(true)
+  })
+
+  it('ignores the username query param — no token means isCurrentUser=false (spoof closed)', async () => {
+    await seedRating({
+      username: TEST_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 5,
+      reviewText: 'My review',
+      reviewCreatedAt: '1000',
+    })
+
+    // Anonymous request passing ?username=<victim> must NOT be flagged as theirs.
     const res = await request(app).get(
       `/api/getReviews?recipeId=${RECIPE_ID}&username=${TEST_USERNAME}`
     )
     expect(res.status).toBe(200)
-    expect(res.body.reviews[0].isCurrentUser).toBe(true)
+    expect(res.body.reviews[0].isCurrentUser).toBe(false)
+  })
+
+  it('sets isCurrentUser=false for another user’s review even when authenticated', async () => {
+    await seedRating({
+      username: OTHER_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 4,
+      reviewText: 'Their review',
+      reviewCreatedAt: '1000',
+    })
+
+    // Authenticated as TEST_UID, but the review belongs to OTHER_USERNAME.
+    const res = await request(app)
+      .get(`/api/getReviews?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.reviews[0].isCurrentUser).toBe(false)
   })
 
   it('paginates results', async () => {

--- a/server/__tests__/security.test.js
+++ b/server/__tests__/security.test.js
@@ -150,3 +150,94 @@ describe('recipeIdQuery non-string ids', () => {
     expect(filter._id.$in).toEqual(['abc'])
   })
 })
+
+// ─── Admin surface (audit §5 step 3) ─────────────────────────────────────────
+// The default beforeEach mock resolves a NON-admin token (uid only). Admin
+// tests opt in with a one-shot mock returning { admin: true }, mirroring how
+// verifyToken sets req.isAdmin = decoded.admin === true.
+
+function asAdminOnce() {
+  admin.auth.mockReturnValueOnce({
+    verifyIdToken: jest.fn().mockResolvedValueOnce({ uid: TEST_UID, admin: true }),
+  })
+}
+
+describe('admin route auth chaining', () => {
+  it('GET /admin/users rejects an anonymous request (401)', async () => {
+    const res = await request(app).get('/api/admin/users')
+    expect(res.status).toBe(401)
+  })
+
+  it('GET /admin/users rejects a non-admin token (403)', async () => {
+    // Default mock = non-admin uid → requireAdmin denies.
+    const res = await request(app).get('/api/admin/users').set(AUTH_HEADER)
+    expect(res.status).toBe(403)
+  })
+
+  it('PATCH /reports/bulk rejects a non-admin token (403)', async () => {
+    const res = await request(app)
+      .patch('/api/reports/bulk')
+      .set(AUTH_HEADER)
+      .send({ ids: ['x'], status: 'resolved' })
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('admin endpoints reject injected / malformed ids', () => {
+  it('PATCH /reports/bulk drops operator-shaped ids → 400 (no valid ids)', async () => {
+    asAdminOnce()
+    const res = await request(app)
+      .patch('/api/reports/bulk')
+      .set(AUTH_HEADER)
+      .send({ ids: [{ $ne: null }, 42, 'not-an-objectid'], status: 'resolved' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/No valid report ids/)
+  })
+
+  it('PATCH /reports/:id rejects a non-ObjectId id (404, no crash)', async () => {
+    asAdminOnce()
+    const res = await request(app)
+      .patch('/api/reports/not-a-valid-objectid')
+      .set(AUTH_HEADER)
+      .send({ status: 'resolved' })
+    expect(res.status).toBe(404)
+  })
+
+  it('PATCH /admin/recipes/:id/moderation rejects a non-string status (400)', async () => {
+    asAdminOnce()
+    const res = await request(app)
+      .patch(`/api/admin/recipes/${RECIPE_ID}/moderation`)
+      .set(AUTH_HEADER)
+      .send({ status: { $ne: 'active' } })
+    expect(res.status).toBe(400)
+  })
+
+  it('PATCH /admin/reviews/moderation rejects object recipeId/username (400)', async () => {
+    asAdminOnce()
+    const res = await request(app)
+      .patch('/api/admin/reviews/moderation')
+      .set(AUTH_HEADER)
+      .send({ recipeId: { $ne: '' }, username: { $ne: '' }, moderationHidden: true })
+    expect(res.status).toBe(400)
+  })
+})
+
+// ─── Generic 500 responder contract (audit §4 item 2) ────────────────────────
+
+describe('respondServerError', () => {
+  const { respondServerError } = require('../util/respondServerError')
+
+  it('logs the real error but returns a generic body, never err.message', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const json = jest.fn()
+    const res = { status: jest.fn(() => res), json }
+    const err = new Error('connect ECONNREFUSED 10.0.0.5:27017')
+    respondServerError(res, err, { method: 'GET', originalUrl: '/api/secret' })
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(json).toHaveBeenCalledWith({ error: 'Internal server error' })
+    // The raw message is logged server-side, not leaked to the client.
+    expect(spy).toHaveBeenCalled()
+    expect(spy.mock.calls[0]).toContain(err)
+    spy.mockRestore()
+  })
+})

--- a/server/__tests__/security.test.js
+++ b/server/__tests__/security.test.js
@@ -241,3 +241,24 @@ describe('respondServerError', () => {
     spy.mockRestore()
   })
 })
+
+// ─── Central error backstop (app.js) ─────────────────────────────────────────
+// Errors thrown outside a route's own try/catch (here: a malformed JSON body
+// rejected by express.json()) must hit the app-level error handler and return a
+// generic body — never Express's default handler, which would echo a stack trace.
+
+describe('error backstop for non-route errors', () => {
+  it('returns a generic 400 for a malformed JSON body (no stack leak)', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await request(app)
+      .post('/api/newReview')
+      .set(AUTH_HEADER)
+      .set('Content-Type', 'application/json')
+      .send('{ "recipeId": ') // truncated JSON → body-parser throws (status 400)
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({ error: 'Bad request' })
+    // Nothing in the response body resembles a stack trace or parser internals.
+    expect(JSON.stringify(res.body)).not.toMatch(/SyntaxError|Unexpected|at /)
+    spy.mockRestore()
+  })
+})

--- a/server/app.js
+++ b/server/app.js
@@ -12,6 +12,7 @@ const gamificationRoutes = require('./routes/gamification')
 const publicProfileRoutes = require('./routes/publicProfile')
 const reportRoutes = require('./routes/reports')
 const adminRoutes = require('./routes/admin')
+const { GENERIC_500_MESSAGE } = require('./util/respondServerError')
 
 const app = express()
 
@@ -86,5 +87,22 @@ app.use('/api/ingredients', ingredientRoutes)
 app.use('/api/drafts', draftRoutes)
 app.use('/api', reportRoutes)
 app.use('/api', adminRoutes)
+
+// Central error backstop. Route handlers catch their own errors (via
+// respondServerError), but errors thrown *outside* a route's try/catch — a
+// malformed JSON body rejected by express.json(), a CORS origin rejection, or
+// any future handler that forgets to catch — would otherwise reach Express's
+// default handler, which echoes a stack trace to the client. Same contract as
+// respondServerError: log the real error, return a generic body. A 4xx the
+// thrower set (e.g. body-parser's 400 on bad JSON) is preserved; anything else
+// collapses to 500.
+app.use((err, req, res, next) => {
+  if (res.headersSent) return next(err)
+  const status = err.status || err.statusCode || 500
+  console.error(`[${status}] ${req.method} ${req.originalUrl}`, err)
+  res.status(status).json({
+    error: status >= 500 ? GENERIC_500_MESSAGE : 'Bad request',
+  })
+})
 
 module.exports = app

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,4 +1,5 @@
 const admin = require('firebase-admin')
+const { respondServerError } = require('../util/respondServerError')
 const { getDB } = require('../db')
 const { isBlocked } = require('../util/userStatus')
 
@@ -78,7 +79,7 @@ async function requireActive(req, res, next) {
     }
     next()
   } catch (err) {
-    return res.status(500).json({ error: err.message })
+    return respondServerError(res, err, req)
   }
 }
 

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,4 +1,5 @@
 const { Router } = require('express')
+const { respondServerError } = require('../util/respondServerError')
 const admin = require('firebase-admin')
 const { getDB } = require('../db')
 const { verifyToken, requireAdmin } = require('../middleware/auth')
@@ -202,7 +203,7 @@ router.get('/admin/users', verifyToken, requireAdmin, async (req, res) => {
     const users = await enrichUsers(db, usernameDocs)
     res.json({ users, totalCount })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -243,7 +244,7 @@ router.get('/admin/users/:uid', verifyToken, requireAdmin, async (req, res) => {
 
     res.json({ ...enriched, email, recentRecipes, recentReviews })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -313,7 +314,7 @@ router.patch('/admin/users/:uid/status', verifyToken, requireAdmin, async (req, 
 
     res.json({ uid, status })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -350,7 +351,7 @@ router.get('/admin/audit', verifyToken, requireAdmin, async (req, res) => {
 
     res.json({ entries: enriched, totalCount })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -442,7 +443,7 @@ router.get('/admin/analytics', verifyToken, requireAdmin, async (req, res) => {
       recentActions,
     })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const { respondServerError } = require('../util/respondServerError')
 const router = express.Router()
 const { getDB } = require('../db')
 const { verifyToken, requireActive } = require('../middleware/auth')
@@ -62,7 +63,7 @@ router.get('/getUsername', verifyToken, async (req, res) => {
     if (!doc) return res.json(null)
     res.json(doc.username)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -80,7 +81,7 @@ router.get('/checkUsernameAvailability', async (req, res) => {
       .findOne({ username_lower: username.toLowerCase() })
     res.json(existing === null)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -97,7 +98,7 @@ router.get('/getMyStatus', verifyToken, async (req, res) => {
       statusReason: doc?.statusReason || null,
     })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -145,7 +146,7 @@ router.post('/setUsername', verifyToken, requireActive, async (req, res) => {
     }
     res.json({ success: true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -159,7 +160,7 @@ router.get('/getProfile', verifyToken, async (req, res) => {
     const doc = await db.collection('userProfiles').findOne({ _id: req.uid })
     res.json({ bio: doc?.bio ?? '', location: doc?.location ?? '' })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -187,7 +188,7 @@ router.post('/updateProfile', verifyToken, async (req, res) => {
     )
     res.json({ success: true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 

--- a/server/routes/drafts.js
+++ b/server/routes/drafts.js
@@ -1,4 +1,5 @@
 const { Router } = require('express')
+const { respondServerError } = require('../util/respondServerError')
 const { ObjectId } = require('mongodb')
 const { getDB } = require('../db')
 const { verifyToken, requireActive } = require('../middleware/auth')
@@ -53,7 +54,7 @@ router.post('/', verifyToken, requireActive, async (req, res) => {
     await db.collection('recipeDrafts').insertOne(doc)
     res.status(201).json(doc)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -68,7 +69,7 @@ router.get('/', verifyToken, async (req, res) => {
       .toArray()
     res.json(drafts)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -90,7 +91,7 @@ router.get('/:id', verifyToken, async (req, res) => {
     }
     res.json(draft)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -126,7 +127,7 @@ router.put('/:id', verifyToken, requireActive, async (req, res) => {
       .findOneAndUpdate({ _id }, { $set: update }, { returnDocument: 'after' })
     res.json(updated)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -149,7 +150,7 @@ router.delete('/:id', verifyToken, async (req, res) => {
     await db.collection('recipeDrafts').deleteOne({ _id })
     res.json({ deleted: true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 

--- a/server/routes/gamification.js
+++ b/server/routes/gamification.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const { respondServerError } = require('../util/respondServerError')
 const router = express.Router()
 const { getDB } = require('../db')
 const { verifyToken } = require('../middleware/auth')
@@ -23,7 +24,7 @@ router.get('/getGamification', verifyToken, async (req, res) => {
     const seen = profile?.seenAchievements ?? []
     res.json(computeGamification(counts, seen))
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -49,7 +50,7 @@ router.post('/acknowledgeAchievements', verifyToken, async (req, res) => {
     }
     res.json({ success: true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 

--- a/server/routes/ingredients.js
+++ b/server/routes/ingredients.js
@@ -2,6 +2,7 @@ const { Router } = require('express')
 const { rateLimit } = require('express-rate-limit')
 const { ingredientParser } = require('@jclind/ingredient-parser')
 const { verifyToken } = require('../middleware/auth')
+const { GENERIC_500_MESSAGE } = require('../util/respondServerError')
 
 const router = Router()
 
@@ -63,7 +64,7 @@ router.post('/parse', verifyToken, parseLimiter, async (req, res) => {
       JSON.stringify({ ingredientString, message: err && err.message }),
       err && err.stack
     )
-    return res.status(500).json({ error: 'Internal server error' })
+    return res.status(500).json({ error: GENERIC_500_MESSAGE })
   }
 })
 

--- a/server/routes/ingredients.js
+++ b/server/routes/ingredients.js
@@ -63,7 +63,7 @@ router.post('/parse', verifyToken, parseLimiter, async (req, res) => {
       JSON.stringify({ ingredientString, message: err && err.message }),
       err && err.stack
     )
-    return res.status(500).json({ error: err.message })
+    return res.status(500).json({ error: 'Internal server error' })
   }
 })
 

--- a/server/routes/publicProfile.js
+++ b/server/routes/publicProfile.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const { respondServerError } = require('../util/respondServerError')
 const router = express.Router()
 const admin = require('firebase-admin')
 const { getDB } = require('../db')
@@ -77,7 +78,7 @@ router.get('/getPublicProfile', async (req, res) => {
       recipesTotalCount: counts.recipes,
     })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -1,4 +1,5 @@
 const { Router } = require('express')
+const { respondServerError } = require('../util/respondServerError')
 const { ObjectId } = require('mongodb')
 const { getDB, getClient } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
@@ -128,7 +129,7 @@ router.get('/recipes', async (req, res) => {
 
     res.json({ recipeList: recipes, total_results: totalCount })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -153,7 +154,7 @@ router.get('/recipes/facets', async (req, res) => {
       mealTypes: clean(mealTypes),
     })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -183,7 +184,7 @@ router.get('/searchAutoCompleteRecipes', async (req, res) => {
       .toArray()
     res.json(recipes)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -202,7 +203,7 @@ router.get('/getTrendingRecipes', async (req, res) => {
       .toArray()
     res.json(recipes)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -241,7 +242,7 @@ router.get('/getRecipe', optionalAuth, async (req, res) => {
 
     res.json(recipe)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -270,7 +271,7 @@ router.post('/addRecipe', verifyToken, requireActive, async (req, res) => {
     )
     res.status(201).json({ _id: newId })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -319,7 +320,7 @@ router.put('/editRecipe', verifyToken, requireActive, async (req, res) => {
     )
     res.json(updated)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -371,7 +372,7 @@ router.delete('/deleteRecipe', verifyToken, async (req, res) => {
 
     res.json({ deleted: true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -409,7 +410,7 @@ router.patch('/admin/recipes/:id/moderation', verifyToken, requireAdmin, async (
     if (status === 'hidden') notifyInBackground(notifyRecipeHidden(updated.userId, updated.title))
     res.json({ _id: updated._id, status: updated.status })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -447,7 +448,7 @@ router.patch('/admin/recipes/:id/publish', verifyToken, requireAdmin, async (req
     })
     res.json({ _id: updated._id, status: updated.status })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -482,7 +483,7 @@ router.patch('/admin/recipes/:id/feature', verifyToken, requireAdmin, async (req
     })
     res.json({ _id: updated._id, featured: updated.featured === true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -511,7 +512,7 @@ router.post('/recipes/:id/save', verifyToken, requireActive, async (req, res) =>
     )
     res.json({ saved: true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -529,7 +530,7 @@ router.get('/getSavedRecipe', verifyToken, async (req, res) => {
       userData?.savedRecipes?.find((entry) => entry.recipeId === recipeId) ?? null
     res.json(match)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -543,7 +544,7 @@ router.get('/getSavedRecipeIds', verifyToken, async (req, res) => {
       .findOne({ _id: req.uid }, { projection: { savedRecipes: 1 } })
     res.json((userData?.savedRecipes ?? []).map((e) => e.recipeId))
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -571,7 +572,7 @@ router.delete('/recipes/:id/save', verifyToken, requireActive, async (req, res) 
     )
     res.json({ unsaved: true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -595,7 +596,7 @@ router.post('/madeRecipe', verifyToken, requireActive, async (req, res) => {
     )
     res.json({ made: true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -613,7 +614,7 @@ router.get('/checkMadeRecipe', verifyToken, async (req, res) => {
       userData?.madeRecipes?.some((entry) => entry.recipeId === recipeId) ?? false
     res.json({ made })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -1,4 +1,5 @@
 const { Router } = require('express')
+const { respondServerError } = require('../util/respondServerError')
 const { ObjectId } = require('mongodb')
 const { getDB } = require('../db')
 const { verifyToken, requireAdmin, requireActive } = require('../middleware/auth')
@@ -74,7 +75,7 @@ router.post('/reports', verifyToken, requireActive, async (req, res) => {
     await db.collection('reports').insertOne(doc)
     res.status(201).json(doc)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -123,7 +124,7 @@ router.get('/reports', verifyToken, requireAdmin, async (req, res) => {
 
     res.json({ reports: enriched, totalCount, openCount })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -191,7 +192,7 @@ router.patch('/reports/bulk', verifyToken, requireAdmin, async (req, res) => {
 
     res.json({ updated: result.modifiedCount })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -226,7 +227,7 @@ router.patch('/reports/:id', verifyToken, requireAdmin, async (req, res) => {
     if (status === 'resolved') notifyInBackground(notifyReportResolved(updated.reporterUid))
     res.json(updated)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -1,8 +1,9 @@
 const { Router } = require('express')
 const { getDB } = require('../db')
-const { verifyToken, requireAdmin, requireActive } = require('../middleware/auth')
+const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { REVIEW_VISIBLE, RECIPE_VISIBLE } = require('../util/moderation')
+const { DESCRIPTION_MAX_LENGTH } = require('../util/recipeLimits')
 const { recordAudit } = require('../util/auditLog')
 const { recomputeRecipeRating } = require('../util/recipeRating')
 const { notifyInBackground, notifyReviewTakenDown } = require('../util/email')
@@ -67,6 +68,9 @@ router.post('/newReview', verifyToken, requireActive, async (req, res) => {
     if (!recipeId || typeof recipeId !== 'string' || typeof reviewText !== 'string') {
       return res.status(400).json({ error: 'recipeId and reviewText are required' })
     }
+    if (reviewText.length > DESCRIPTION_MAX_LENGTH) {
+      return res.status(400).json({ error: `Review cannot exceed ${DESCRIPTION_MAX_LENGTH} characters` })
+    }
 
     const usernameDoc = await db.collection('usernames').findOne({ _id: userId })
     if (!usernameDoc) return res.status(400).json({ error: 'Username not found for this user' })
@@ -75,7 +79,13 @@ router.post('/newReview', verifyToken, requireActive, async (req, res) => {
     const now = Date.now().toString()
     await db.collection('ratings').updateOne(
       { username, recipeId },
-      { $set: { reviewText, reviewCreatedAt: now, reviewLastUpdated: now } },
+      {
+        $set: { reviewText, reviewCreatedAt: now, reviewLastUpdated: now },
+        // A review can be posted before any rating; default the rating fields on
+        // insert so no ratings doc ever lacks them (recomputeRecipeRating skips
+        // rating: null, but this keeps the document shape consistent).
+        $setOnInsert: { rating: null, ratingLastUpdated: '' },
+      },
       { upsert: true }
     )
 
@@ -120,6 +130,9 @@ router.post('/editReview', verifyToken, requireActive, async (req, res) => {
     if (!recipeId || typeof recipeId !== 'string' || text == null || typeof text !== 'string') {
       return res.status(400).json({ error: 'recipeId and text are required' })
     }
+    if (text.length > DESCRIPTION_MAX_LENGTH) {
+      return res.status(400).json({ error: `Review cannot exceed ${DESCRIPTION_MAX_LENGTH} characters` })
+    }
     const editResult = await db.collection('ratings').updateOne(
       { username, recipeId },
       { $set: { reviewText: text, reviewLastUpdated: Date.now().toString() } }
@@ -159,12 +172,22 @@ router.delete('/deleteReview', verifyToken, async (req, res) => {
   }
 })
 
-// GET /getReviews
-router.get('/getReviews', async (req, res) => {
+// GET /getReviews — anonymous-friendly. `optionalAuth` sets req.uid only when a
+// valid token is present; the `isCurrentUser` flag is derived from that verified
+// uid (NOT the client-supplied `username` query param, which anyone could set to
+// another user's name to spoof "edit/delete mine" affordances).
+router.get('/getReviews', optionalAuth, async (req, res) => {
   try {
     const db = getDB()
-    const { username, recipeId, page = 0, reviewsPerPage = 5, filter } = req.query
+    const { recipeId, page = 0, reviewsPerPage = 5, filter } = req.query
     if (!recipeId) return res.status(400).json({ error: 'recipeId is required' })
+
+    // Resolve the caller's own username from the verified token, if any.
+    let currentUsername = null
+    if (req.uid) {
+      const me = await db.collection('usernames').findOne({ _id: req.uid })
+      currentUsername = me?.username || null
+    }
 
     const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
     const skip = (parseInt(page) || 0) * limit
@@ -182,7 +205,7 @@ router.get('/getReviews', async (req, res) => {
 
     const reviews = rawReviews.map((r) => ({
       ...r,
-      isCurrentUser: r.username === username,
+      isCurrentUser: currentUsername != null && r.username === currentUsername,
     }))
 
     res.json({ reviews, totalCount })

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -1,4 +1,5 @@
 const { Router } = require('express')
+const { respondServerError } = require('../util/respondServerError')
 const { getDB } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
@@ -55,7 +56,7 @@ router.post('/addRating', verifyToken, requireActive, async (req, res) => {
 
     res.json({ rated: true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -92,7 +93,7 @@ router.post('/newReview', verifyToken, requireActive, async (req, res) => {
     const updated = await db.collection('ratings').findOne({ username, recipeId })
     res.json(updated)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -115,7 +116,7 @@ router.get('/checkIfReviewed', verifyToken, async (req, res) => {
       res.json({ reviewed: false })
     }
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -142,7 +143,7 @@ router.post('/editReview', verifyToken, requireActive, async (req, res) => {
     }
     res.json({ edited: true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -168,7 +169,7 @@ router.delete('/deleteReview', verifyToken, async (req, res) => {
     }
     res.json({ deleted: true })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -210,7 +211,7 @@ router.get('/getReviews', optionalAuth, async (req, res) => {
 
     res.json({ reviews, totalCount })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -252,7 +253,7 @@ router.get('/getSingleUserReviews', async (req, res) => {
 
     res.json({ reviews, totalCount })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -297,7 +298,7 @@ router.patch('/admin/reviews/moderation', verifyToken, requireAdmin, async (req,
     if (moderationHidden) notifyInBackground(notifyReviewTakenDown(db, username, recipeId))
     res.json({ recipeId, username, moderationHidden })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,4 +1,5 @@
 const { Router } = require('express')
+const { respondServerError } = require('../util/respondServerError')
 const { getDB } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 const { recipeIdInQuery } = require('../util/recipeIdQuery')
@@ -37,7 +38,7 @@ router.get('/getCreatedRecipes', verifyToken, async (req, res) => {
 
     res.json({ recipes, totalCount })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -73,7 +74,7 @@ router.get('/getSavedRecipes', verifyToken, async (req, res) => {
 
     res.json({ recipes, totalCount })
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 
@@ -85,7 +86,7 @@ router.get('/getAccountCounts', verifyToken, async (req, res) => {
     const counts = await getAccountCountsFor(getDB(), req.uid)
     res.json(counts)
   } catch (err) {
-    res.status(500).json({ error: err.message })
+    respondServerError(res, err, req)
   }
 })
 

--- a/server/util/recipeLimits.js
+++ b/server/util/recipeLimits.js
@@ -59,4 +59,5 @@ function validateRecipeBounds(body) {
 module.exports = {
   validateRequiredRecipeFields,
   validateRecipeBounds,
+  DESCRIPTION_MAX_LENGTH,
 }

--- a/server/util/recipeRating.js
+++ b/server/util/recipeRating.js
@@ -7,10 +7,14 @@ const { REVIEW_VISIBLE } = require('./moderation')
 // moderated rating no longer influences the recipe's score. Returns the new
 // aggregate. count === 0 yields rateValue 0 (avoids divide-by-zero).
 async function recomputeRecipeRating(db, recipeId) {
-  const ratings = await db
+  const docs = await db
     .collection('ratings')
     .find({ recipeId, ...REVIEW_VISIBLE })
     .toArray()
+  // A ratings doc can be review-only (posted before any star rating), so its
+  // `rating` is null/absent. Count and average ONLY docs with a real numeric
+  // rating — otherwise parseFloat(null) → NaN poisons the whole aggregate.
+  const ratings = docs.filter((r) => Number.isFinite(parseFloat(r.rating)))
   const rateCount = ratings.length
   const rateValue = rateCount
     ? ratings.reduce((sum, r) => sum + parseFloat(r.rating), 0) / rateCount

--- a/server/util/respondServerError.js
+++ b/server/util/respondServerError.js
@@ -1,0 +1,12 @@
+// Shared 500 responder. Logs the real error (with route context) server-side
+// and returns a generic message to the client, so infrastructure failures —
+// e.g. a Mongo `connect ECONNREFUSED <internal-host>` — never leak internal
+// details to callers. Use in every route catch block instead of echoing
+// err.message. See docs/SECURITY_AUDIT_2026-06-11.md §4 item 2.
+function respondServerError(res, err, req) {
+  const where = req ? `${req.method} ${req.originalUrl}` : 'server'
+  console.error(`[500] ${where}`, err)
+  return res.status(500).json({ error: 'Internal server error' })
+}
+
+module.exports = { respondServerError }

--- a/server/util/respondServerError.js
+++ b/server/util/respondServerError.js
@@ -3,10 +3,16 @@
 // e.g. a Mongo `connect ECONNREFUSED <internal-host>` — never leak internal
 // details to callers. Use in every route catch block instead of echoing
 // err.message. See docs/SECURITY_AUDIT_2026-06-11.md §4 item 2.
+
+// The one generic client-facing 500 body. Exported so every site that emits a
+// generic 500 (route catches via respondServerError, the app.js error backstop,
+// ingredients.js with its own richer logging) shares one literal.
+const GENERIC_500_MESSAGE = 'Internal server error'
+
 function respondServerError(res, err, req) {
   const where = req ? `${req.method} ${req.originalUrl}` : 'server'
   console.error(`[500] ${where}`, err)
-  return res.status(500).json({ error: 'Internal server error' })
+  return res.status(500).json({ error: GENERIC_500_MESSAGE })
 }
 
-module.exports = { respondServerError }
+module.exports = { respondServerError, GENERIC_500_MESSAGE }


### PR DESCRIPTION
Closes the deferred items from the 2026-06-11 security audit (§4 items 2/3/4/8, §5 step 3) plus a follow-up error backstop surfaced in local code review.

## Changes

**Reviews hardening (`reviews.js`, `recipeRating.js`)**
- `GET /getReviews` now uses `optionalAuth`; `isCurrentUser` is derived from the verified token's uid → username, **not** the client-supplied `?username` query param (closes a UI-affordance spoof). Stays anonymous-friendly.
- `newReview`/`editReview` reject `reviewText` over `DESCRIPTION_MAX_LENGTH` (2000), now exported from `recipeLimits.js` instead of duplicated.
- `newReview` upsert `$setOnInsert`s `rating: null` / `ratingLastUpdated: ''`, and `recomputeRecipeRating` filters to docs with a finite numeric rating. Fixes a real data-corruption bug: review-only docs ran `parseFloat(null) → NaN`, poisoning the **entire** recipe average and inflating `rateCount`.

**Generic 500 responder (`util/respondServerError.js` + all 9 route files)**
- Shared responder logs the real error with `METHOD /path` context and returns `500 { error: 'Internal server error' }`, so infra failures (e.g. Mongo `ECONNREFUSED <host>`) never leak to clients. Wired into 52 catch sites + `requireActive`. 4xx validation messages unchanged.

**Central error backstop (`app.js`)** *(from local review)*
- App-level Express error handler catches errors thrown **outside** a route's own try/catch (malformed JSON body, CORS rejection) that would otherwise reach Express's default stack-leaking handler. Returns a generic body; preserves a thrower-set 4xx (e.g. body-parser's 400). `GENERIC_500_MESSAGE` is now a single shared literal.

**Admin surface (`security.test.js`)**
- Re-audit found the `/admin` surface already sound (every route chains `verifyToken + requireAdmin`; report/moderation endpoints validate ids). Added regression tests rather than fixes: auth chaining (401/403), injected/malformed-id rejection, and the 500-responder + backstop contracts.

## Tests
Server suite green: **345 passed**.

See `docs/SECURITY_AUDIT_2026-06-11.md` §4–§5 for the full runbook.