### PR TITLE
refactor(server): asyncHandler replaces per-route try/catch boilerplate

### DIFF
--- a/server/__tests__/security.test.js
+++ b/server/__tests__/security.test.js
@@ -242,6 +242,32 @@ describe('respondServerError', () => {
   })
 })
 
+// ─── asyncHandler (util/asyncHandler) ────────────────────────────────────────
+// Wrapped handlers no longer carry their own try/catch; a rejected handler
+// promise must reach Express's error chain via next(err) so the backstop turns
+// it into a generic 500.
+
+describe('asyncHandler', () => {
+  const { asyncHandler } = require('../util/asyncHandler')
+
+  it('forwards a rejected handler promise to next(err)', async () => {
+    const boom = new Error('handler blew up')
+    const next = jest.fn()
+    await asyncHandler(async () => {
+      throw boom
+    })({}, {}, next)
+    expect(next).toHaveBeenCalledWith(boom)
+  })
+
+  it('does not call next when the handler resolves', async () => {
+    const next = jest.fn()
+    await asyncHandler(async (req, res) => {
+      res.json({ ok: true })
+    })({}, { json: jest.fn() }, next)
+    expect(next).not.toHaveBeenCalled()
+  })
+})
+
 // ─── Central error backstop (app.js) ─────────────────────────────────────────
 // Errors thrown outside a route's own try/catch (here: a malformed JSON body
 // rejected by express.json()) must hit the app-level error handler and return a

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,5 +1,5 @@
 const { Router } = require('express')
-const { respondServerError } = require('../util/respondServerError')
+const { asyncHandler } = require('../util/asyncHandler')
 const admin = require('firebase-admin')
 const { getDB } = require('../db')
 const { verifyToken, requireAdmin } = require('../middleware/auth')
@@ -156,204 +156,188 @@ async function enrichUsers(db, usernameDocs) {
 // Primary search is a username prefix (case-insensitive). A query containing '@'
 // is treated as an email and resolved through Firebase Auth; an exact uid match
 // is also honored. Empty query lists all users alphabetically.
-router.get('/admin/users', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    const query = (req.query.query || '').trim()
-    const page = Math.max(parseInt(req.query.page) || 1, 1)
-    const perPage = Math.min(
-      parseInt(req.query.perPage) || DEFAULT_PER_PAGE,
-      MAX_PER_PAGE
-    )
+router.get('/admin/users', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const query = (req.query.query || '').trim()
+  const page = Math.max(parseInt(req.query.page) || 1, 1)
+  const perPage = Math.min(
+    parseInt(req.query.perPage) || DEFAULT_PER_PAGE,
+    MAX_PER_PAGE
+  )
 
-    // Email lookup: resolve to a uid via Firebase, then surface that one user.
-    if (query.includes('@')) {
-      try {
-        const fbUser = await admin.auth().getUserByEmail(query)
-        const usernameDoc =
-          (await db.collection('usernames').findOne({ _id: fbUser.uid })) || {
-            _id: fbUser.uid,
-            username: null,
-          }
-        const [enriched] = await enrichUsers(db, [usernameDoc])
-        return res.json({ users: [{ ...enriched, email: fbUser.email }], totalCount: 1 })
-      } catch (e) {
-        return res.json({ users: [], totalCount: 0 })
-      }
-    }
-
-    const filter = query
-      ? {
-          $or: [
-            { username_lower: { $regex: '^' + escapeRegex(query.toLowerCase()) } },
-            { _id: query },
-          ],
+  // Email lookup: resolve to a uid via Firebase, then surface that one user.
+  if (query.includes('@')) {
+    try {
+      const fbUser = await admin.auth().getUserByEmail(query)
+      const usernameDoc =
+        (await db.collection('usernames').findOne({ _id: fbUser.uid })) || {
+          _id: fbUser.uid,
+          username: null,
         }
-      : {}
-
-    const totalCount = await db.collection('usernames').countDocuments(filter)
-    const usernameDocs = await db
-      .collection('usernames')
-      .find(filter)
-      .sort({ username_lower: 1 })
-      .skip((page - 1) * perPage)
-      .limit(perPage)
-      .toArray()
-
-    const users = await enrichUsers(db, usernameDocs)
-    res.json({ users, totalCount })
-  } catch (err) {
-    respondServerError(res, err, req)
+      const [enriched] = await enrichUsers(db, [usernameDoc])
+      return res.json({ users: [{ ...enriched, email: fbUser.email }], totalCount: 1 })
+    } catch (e) {
+      return res.json({ users: [], totalCount: 0 })
+    }
   }
-})
+
+  const filter = query
+    ? {
+        $or: [
+          { username_lower: { $regex: '^' + escapeRegex(query.toLowerCase()) } },
+          { _id: query },
+        ],
+      }
+    : {}
+
+  const totalCount = await db.collection('usernames').countDocuments(filter)
+  const usernameDocs = await db
+    .collection('usernames')
+    .find(filter)
+    .sort({ username_lower: 1 })
+    .skip((page - 1) * perPage)
+    .limit(perPage)
+    .toArray()
+
+  const users = await enrichUsers(db, usernameDocs)
+  res.json({ users, totalCount })
+}))
 
 // GET /admin/users/:uid — single-user detail (adds email + recent content).
-router.get('/admin/users/:uid', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    const uid = req.params.uid
-    const usernameDoc =
-      (await db.collection('usernames').findOne({ _id: uid })) || {
-        _id: uid,
-        username: null,
-      }
-    const [enriched] = await enrichUsers(db, [usernameDoc])
-
-    let email = null
-    try {
-      const fbUser = await admin.auth().getUser(uid)
-      email = fbUser.email || null
-    } catch (e) {
-      // No Firebase user (or lookup failed) — detail still renders without email.
+router.get('/admin/users/:uid', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const uid = req.params.uid
+  const usernameDoc =
+    (await db.collection('usernames').findOne({ _id: uid })) || {
+      _id: uid,
+      username: null,
     }
+  const [enriched] = await enrichUsers(db, [usernameDoc])
 
-    const [recentRecipes, recentReviews] = await Promise.all([
-      db
-        .collection('recipes')
-        .find({ userId: uid }, { projection: { title: 1, recipeImage: 1, status: 1 } })
-        .limit(5)
-        .toArray(),
-      usernameDoc.username
-        ? db
-            .collection('ratings')
-            .find({ username: usernameDoc.username })
-            .limit(5)
-            .toArray()
-        : Promise.resolve([]),
-    ])
-
-    res.json({ ...enriched, email, recentRecipes, recentReviews })
-  } catch (err) {
-    respondServerError(res, err, req)
+  let email = null
+  try {
+    const fbUser = await admin.auth().getUser(uid)
+    email = fbUser.email || null
+  } catch (e) {
+    // No Firebase user (or lookup failed) — detail still renders without email.
   }
-})
+
+  const [recentRecipes, recentReviews] = await Promise.all([
+    db
+      .collection('recipes')
+      .find({ userId: uid }, { projection: { title: 1, recipeImage: 1, status: 1 } })
+      .limit(5)
+      .toArray(),
+    usernameDoc.username
+      ? db
+          .collection('ratings')
+          .find({ username: usernameDoc.username })
+          .limit(5)
+          .toArray()
+      : Promise.resolve([]),
+  ])
+
+  res.json({ ...enriched, email, recentRecipes, recentReviews })
+}))
 
 // PATCH /admin/users/:uid/status — set an account's moderation status.
 // Guards: an admin can't change their own status, and can't suspend/ban another
 // admin. Status is stored in the `users` collection (upserted), the single
 // source of truth read by requireActive.
-router.patch('/admin/users/:uid/status', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    const uid = req.params.uid
-    const { status, reason } = req.body
+router.patch('/admin/users/:uid/status', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const uid = req.params.uid
+  const { status, reason } = req.body
 
-    if (!USER_STATUSES.includes(status)) {
-      return res
-        .status(400)
-        .json({ error: `status must be one of: ${USER_STATUSES.join(', ')}` })
-    }
-    if (typeof reason === 'string' && reason.length > MAX_REASON_LEN) {
-      return res
-        .status(400)
-        .json({ error: `reason must be at most ${MAX_REASON_LEN} characters` })
-    }
-    if (uid === req.uid) {
-      return res.status(400).json({ error: 'You cannot change your own status.' })
-    }
-
-    // An admin cannot suspend/ban a fellow admin.
-    try {
-      const target = await admin.auth().getUser(uid)
-      if (target.customClaims?.admin === true) {
-        return res
-          .status(403)
-          .json({ error: 'Cannot change the status of another admin.' })
-      }
-    } catch (e) {
-      return res.status(404).json({ error: 'User not found' })
-    }
-
-    await db.collection('users').updateOne(
-      { _id: uid },
-      {
-        $set: {
-          status,
-          statusReason: status === 'active' ? null : reason || null,
-          statusUpdatedBy: req.uid,
-          statusUpdatedAt: new Date(),
-        },
-      },
-      { upsert: true }
-    )
-
-    const targetUsernameDoc = await db.collection('usernames').findOne({ _id: uid })
-    const auditAction =
-      status === 'suspended' ? 'user.suspend' : status === 'banned' ? 'user.ban' : 'user.activate'
-    await recordAudit(db, {
-      action: auditAction,
-      actorUid: req.uid,
-      targetType: 'user',
-      targetId: uid,
-      targetLabel: targetUsernameDoc?.username ? `@${targetUsernameDoc.username}` : uid,
-      reason: status === 'active' ? null : reason || null,
-    })
-
-    // Notify the affected user on suspend/ban (background). Activation is silent.
-    notifyInBackground(notifyAccountStatus(uid, status, reason))
-
-    res.json({ uid, status })
-  } catch (err) {
-    respondServerError(res, err, req)
+  if (!USER_STATUSES.includes(status)) {
+    return res
+      .status(400)
+      .json({ error: `status must be one of: ${USER_STATUSES.join(', ')}` })
   }
-})
+  if (typeof reason === 'string' && reason.length > MAX_REASON_LEN) {
+    return res
+      .status(400)
+      .json({ error: `reason must be at most ${MAX_REASON_LEN} characters` })
+  }
+  if (uid === req.uid) {
+    return res.status(400).json({ error: 'You cannot change your own status.' })
+  }
+
+  // An admin cannot suspend/ban a fellow admin.
+  try {
+    const target = await admin.auth().getUser(uid)
+    if (target.customClaims?.admin === true) {
+      return res
+        .status(403)
+        .json({ error: 'Cannot change the status of another admin.' })
+    }
+  } catch (e) {
+    return res.status(404).json({ error: 'User not found' })
+  }
+
+  await db.collection('users').updateOne(
+    { _id: uid },
+    {
+      $set: {
+        status,
+        statusReason: status === 'active' ? null : reason || null,
+        statusUpdatedBy: req.uid,
+        statusUpdatedAt: new Date(),
+      },
+    },
+    { upsert: true }
+  )
+
+  const targetUsernameDoc = await db.collection('usernames').findOne({ _id: uid })
+  const auditAction =
+    status === 'suspended' ? 'user.suspend' : status === 'banned' ? 'user.ban' : 'user.activate'
+  await recordAudit(db, {
+    action: auditAction,
+    actorUid: req.uid,
+    targetType: 'user',
+    targetId: uid,
+    targetLabel: targetUsernameDoc?.username ? `@${targetUsernameDoc.username}` : uid,
+    reason: status === 'active' ? null : reason || null,
+  })
+
+  // Notify the affected user on suspend/ban (background). Activation is silent.
+  notifyInBackground(notifyAccountStatus(uid, status, reason))
+
+  res.json({ uid, status })
+}))
 
 // GET /admin/audit?action=&targetType=&actorUid=&page=&perPage= — the moderation
 // audit trail, newest first. Each row is enriched with the actor's username so
 // the page can show "@admin did X" without a per-row lookup.
-router.get('/admin/audit', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    const { action, targetType, actorUid } = req.query
-    const page = Math.max(parseInt(req.query.page) || 1, 1)
-    const perPage = Math.min(parseInt(req.query.perPage) || DEFAULT_PER_PAGE, MAX_PER_PAGE)
+router.get('/admin/audit', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { action, targetType, actorUid } = req.query
+  const page = Math.max(parseInt(req.query.page) || 1, 1)
+  const perPage = Math.min(parseInt(req.query.perPage) || DEFAULT_PER_PAGE, MAX_PER_PAGE)
 
-    const filter = {}
-    if (typeof action === 'string' && AUDIT_ACTIONS.includes(action)) filter.action = action
-    if (typeof targetType === 'string' && AUDIT_TARGET_TYPES.includes(targetType)) {
-      filter.targetType = targetType
-    }
-    if (typeof actorUid === 'string' && actorUid) filter.actorUid = actorUid
-
-    const [entries, totalCount] = await Promise.all([
-      db
-        .collection('auditLog')
-        .find(filter)
-        .sort({ createdAt: -1 })
-        .skip((page - 1) * perPage)
-        .limit(perPage)
-        .toArray(),
-      db.collection('auditLog').countDocuments(filter),
-    ])
-
-    // Batch-resolve actor usernames for this page.
-    const enriched = await enrichActors(db, entries)
-
-    res.json({ entries: enriched, totalCount })
-  } catch (err) {
-    respondServerError(res, err, req)
+  const filter = {}
+  if (typeof action === 'string' && AUDIT_ACTIONS.includes(action)) filter.action = action
+  if (typeof targetType === 'string' && AUDIT_TARGET_TYPES.includes(targetType)) {
+    filter.targetType = targetType
   }
-})
+  if (typeof actorUid === 'string' && actorUid) filter.actorUid = actorUid
+
+  const [entries, totalCount] = await Promise.all([
+    db
+      .collection('auditLog')
+      .find(filter)
+      .sort({ createdAt: -1 })
+      .skip((page - 1) * perPage)
+      .limit(perPage)
+      .toArray(),
+    db.collection('auditLog').countDocuments(filter),
+  ])
+
+  // Batch-resolve actor usernames for this page.
+  const enriched = await enrichActors(db, entries)
+
+  res.json({ entries: enriched, totalCount })
+}))
 
 // GET /admin/analytics?days= — single overview payload for the admin dashboard:
 // headline totals, daily over-time series (reports filed / recipes / signups),
@@ -363,88 +347,84 @@ router.get('/admin/audit', verifyToken, requireAdmin, async (req, res) => {
 // `createdAt` with this change (setUsername $setOnInsert), so the signup series
 // only reflects accounts created from that point forward — older users have no
 // timestamp and are excluded. Recipe/report series are fully historical.
-router.get('/admin/analytics', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    const days = Math.min(
-      Math.max(parseInt(req.query.days) || DEFAULT_DAYS, MIN_DAYS),
-      MAX_DAYS
-    )
-    const now = new Date()
-    const cutoff = new Date(now)
-    cutoff.setUTCDate(cutoff.getUTCDate() - (days - 1))
-    cutoff.setUTCHours(0, 0, 0, 0)
+router.get('/admin/analytics', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const days = Math.min(
+    Math.max(parseInt(req.query.days) || DEFAULT_DAYS, MIN_DAYS),
+    MAX_DAYS
+  )
+  const now = new Date()
+  const cutoff = new Date(now)
+  cutoff.setUTCDate(cutoff.getUTCDate() - (days - 1))
+  cutoff.setUTCHours(0, 0, 0, 0)
 
-    const [
-      userCount,
-      recipeStatusAgg,
-      featuredCount,
-      reviewCount,
-      reportStatusAgg,
-      reportsDaily,
-      recipesDaily,
-      usersDaily,
-      recentRaw,
-    ] = await Promise.all([
-      db.collection('usernames').countDocuments(),
-      // A missing status is a legacy 'active' recipe (legacy-safe — same rule the
-      // public read paths use via $nin).
-      db
-        .collection('recipes')
-        .aggregate([
-          { $group: { _id: { $ifNull: ['$status', 'active'] }, count: { $sum: 1 } } },
-        ])
-        .toArray(),
-      db.collection('recipes').countDocuments({ featured: true }),
-      // Count written reviews only, not bare star ratings (same rule as enrichUsers).
-      db.collection('ratings').countDocuments({ reviewText: { $exists: true, $nin: ['', null] } }),
-      db
-        .collection('reports')
-        .aggregate([{ $group: { _id: '$status', count: { $sum: 1 } } }])
-        .toArray(),
-      dailyCreatedAgg(db, 'reports', cutoff),
-      dailyCreatedAgg(db, 'recipes', cutoff),
-      dailyCreatedAgg(db, 'usernames', cutoff),
-      db
-        .collection('auditLog')
-        .find({})
-        .sort({ createdAt: -1 })
-        .limit(RECENT_ACTIONS_LIMIT)
-        .toArray(),
-    ])
+  const [
+    userCount,
+    recipeStatusAgg,
+    featuredCount,
+    reviewCount,
+    reportStatusAgg,
+    reportsDaily,
+    recipesDaily,
+    usersDaily,
+    recentRaw,
+  ] = await Promise.all([
+    db.collection('usernames').countDocuments(),
+    // A missing status is a legacy 'active' recipe (legacy-safe — same rule the
+    // public read paths use via $nin).
+    db
+      .collection('recipes')
+      .aggregate([
+        { $group: { _id: { $ifNull: ['$status', 'active'] }, count: { $sum: 1 } } },
+      ])
+      .toArray(),
+    db.collection('recipes').countDocuments({ featured: true }),
+    // Count written reviews only, not bare star ratings (same rule as enrichUsers).
+    db.collection('ratings').countDocuments({ reviewText: { $exists: true, $nin: ['', null] } }),
+    db
+      .collection('reports')
+      .aggregate([{ $group: { _id: '$status', count: { $sum: 1 } } }])
+      .toArray(),
+    dailyCreatedAgg(db, 'reports', cutoff),
+    dailyCreatedAgg(db, 'recipes', cutoff),
+    dailyCreatedAgg(db, 'usernames', cutoff),
+    db
+      .collection('auditLog')
+      .find({})
+      .sort({ createdAt: -1 })
+      .limit(RECENT_ACTIONS_LIMIT)
+      .toArray(),
+  ])
 
-    const recipeByStatus = Object.fromEntries(recipeStatusAgg.map((r) => [r._id, r.count]))
-    const recipeTotal = recipeStatusAgg.reduce((sum, r) => sum + r.count, 0)
-    const reportByStatus = Object.fromEntries(reportStatusAgg.map((r) => [r._id, r.count]))
+  const recipeByStatus = Object.fromEntries(recipeStatusAgg.map((r) => [r._id, r.count]))
+  const recipeTotal = recipeStatusAgg.reduce((sum, r) => sum + r.count, 0)
+  const reportByStatus = Object.fromEntries(reportStatusAgg.map((r) => [r._id, r.count]))
 
-    const recentActions = await enrichActors(db, recentRaw)
+  const recentActions = await enrichActors(db, recentRaw)
 
-    res.json({
-      days,
-      totals: {
-        users: userCount,
-        recipes: {
-          total: recipeTotal,
-          active: recipeByStatus.active || 0,
-          hidden: recipeByStatus.hidden || 0,
-          unpublished: recipeByStatus.unpublished || 0,
-          featured: featuredCount,
-        },
-        reviews: reviewCount,
-        reports: {
-          open: reportByStatus.open || 0,
-          resolved: reportByStatus.resolved || 0,
-          dismissed: reportByStatus.dismissed || 0,
-        },
+  res.json({
+    days,
+    totals: {
+      users: userCount,
+      recipes: {
+        total: recipeTotal,
+        active: recipeByStatus.active || 0,
+        hidden: recipeByStatus.hidden || 0,
+        unpublished: recipeByStatus.unpublished || 0,
+        featured: featuredCount,
       },
-      reportsOverTime: buildDailySeries(reportsDaily, days, now),
-      recipesOverTime: buildDailySeries(recipesDaily, days, now),
-      usersOverTime: buildDailySeries(usersDaily, days, now),
-      recentActions,
-    })
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+      reviews: reviewCount,
+      reports: {
+        open: reportByStatus.open || 0,
+        resolved: reportByStatus.resolved || 0,
+        dismissed: reportByStatus.dismissed || 0,
+      },
+    },
+    reportsOverTime: buildDailySeries(reportsDaily, days, now),
+    recipesOverTime: buildDailySeries(recipesDaily, days, now),
+    usersOverTime: buildDailySeries(usersDaily, days, now),
+    recentActions,
+  })
+}))
 
 module.exports = router

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,5 +1,5 @@
 const express = require('express')
-const { respondServerError } = require('../util/respondServerError')
+const { asyncHandler } = require('../util/asyncHandler')
 const router = express.Router()
 const { getDB } = require('../db')
 const { verifyToken, requireActive } = require('../middleware/auth')
@@ -56,140 +56,116 @@ function validateUsername(username) {
 // Returns the authenticated user's own username, or null if not set yet.
 // Scoped to req.uid so a user can't enumerate other users' usernames by id;
 // other users' usernames are surfaced through the reviews endpoints instead.
-router.get('/getUsername', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const doc = await db.collection('usernames').findOne({ _id: req.uid })
-    if (!doc) return res.json(null)
-    res.json(doc.username)
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+router.get('/getUsername', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const doc = await db.collection('usernames').findOne({ _id: req.uid })
+  if (!doc) return res.json(null)
+  res.json(doc.username)
+}))
 
 // GET /checkUsernameAvailability?username=...
 // Returns true if username is available, false if taken
-router.get('/checkUsernameAvailability', async (req, res) => {
-  try {
-    const { username } = req.query
-    if (!username || typeof username !== 'string') {
-      return res.status(400).json({ error: 'username is required' })
-    }
-    const db = getDB()
-    const existing = await db
-      .collection('usernames')
-      .findOne({ username_lower: username.toLowerCase() })
-    res.json(existing === null)
-  } catch (err) {
-    respondServerError(res, err, req)
+router.get('/checkUsernameAvailability', asyncHandler(async (req, res) => {
+  const { username } = req.query
+  if (!username || typeof username !== 'string') {
+    return res.status(400).json({ error: 'username is required' })
   }
-})
+  const db = getDB()
+  const existing = await db
+    .collection('usernames')
+    .findOne({ username_lower: username.toLowerCase() })
+  res.json(existing === null)
+}))
 
 // GET /getMyStatus — the authenticated user's own moderation status, so the
 // client can show a persistent "account suspended/banned" banner up front
 // instead of only failing on a write. NOT behind requireActive: a suspended
 // user must be able to read their own status.
-router.get('/getMyStatus', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const doc = await db.collection('users').findOne({ _id: req.uid })
-    res.json({
-      status: doc?.status || 'active',
-      statusReason: doc?.statusReason || null,
-    })
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+router.get('/getMyStatus', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const doc = await db.collection('users').findOne({ _id: req.uid })
+  res.json({
+    status: doc?.status || 'active',
+    statusReason: doc?.statusReason || null,
+  })
+}))
 
 // POST /setUsername?username=...
 // Creates or updates the username for the authenticated user
-router.post('/setUsername', verifyToken, requireActive, async (req, res) => {
-  try {
-    const { username } = req.query
-    const validationError = validateUsername(username)
-    if (validationError) {
-      return res.status(400).json({ error: validationError })
-    }
-    const usernameLower = username.toLowerCase()
-    const uid = req.uid
-    const db = getDB()
+router.post('/setUsername', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const { username } = req.query
+  const validationError = validateUsername(username)
+  if (validationError) {
+    return res.status(400).json({ error: validationError })
+  }
+  const usernameLower = username.toLowerCase()
+  const uid = req.uid
+  const db = getDB()
 
-    // Check the name isn't already taken by someone else (case-insensitive).
-    const existing = await db
-      .collection('usernames')
-      .findOne({ username_lower: usernameLower })
-    if (existing && existing._id !== uid) {
+  // Check the name isn't already taken by someone else (case-insensitive).
+  const existing = await db
+    .collection('usernames')
+    .findOne({ username_lower: usernameLower })
+  if (existing && existing._id !== uid) {
+    return res.status(409).json({ error: 'Username already taken' })
+  }
+
+  try {
+    await db.collection('usernames').updateOne(
+      { _id: uid },
+      {
+        $set: { username, username_lower: usernameLower },
+        // Stamp the account's first-seen time once, so admin analytics can
+        // chart signups over time. Legacy docs created before this won't have
+        // it (and are excluded from the signup series) — see GET /admin/analytics.
+        $setOnInsert: { createdAt: new Date() },
+      },
+      { upsert: true }
+    )
+  } catch (err) {
+    // The unique index on username_lower is the source of truth: it closes
+    // the race between the check above and this write, where two concurrent
+    // requests could both pass the findOne.
+    if (err.code === 11000) {
       return res.status(409).json({ error: 'Username already taken' })
     }
-
-    try {
-      await db.collection('usernames').updateOne(
-        { _id: uid },
-        {
-          $set: { username, username_lower: usernameLower },
-          // Stamp the account's first-seen time once, so admin analytics can
-          // chart signups over time. Legacy docs created before this won't have
-          // it (and are excluded from the signup series) — see GET /admin/analytics.
-          $setOnInsert: { createdAt: new Date() },
-        },
-        { upsert: true }
-      )
-    } catch (err) {
-      // The unique index on username_lower is the source of truth: it closes
-      // the race between the check above and this write, where two concurrent
-      // requests could both pass the findOne.
-      if (err.code === 11000) {
-        return res.status(409).json({ error: 'Username already taken' })
-      }
-      throw err
-    }
-    res.json({ success: true })
-  } catch (err) {
-    respondServerError(res, err, req)
+    throw err
   }
-})
+  res.json({ success: true })
+}))
 
 // GET /getProfile
 // Returns the authenticated user's own profile fields (bio + location), or
 // empty strings when nothing has been saved yet. Scoped to req.uid like
 // /getUsername so a user only ever reads their own profile.
-router.get('/getProfile', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const doc = await db.collection('userProfiles').findOne({ _id: req.uid })
-    res.json({ bio: doc?.bio ?? '', location: doc?.location ?? '' })
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+router.get('/getProfile', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const doc = await db.collection('userProfiles').findOne({ _id: req.uid })
+  res.json({ bio: doc?.bio ?? '', location: doc?.location ?? '' })
+}))
 
 // POST /updateProfile
 // Upserts the authenticated user's bio + location. Empty strings are allowed
 // and clear the field. Values are trimmed before storage.
-router.post('/updateProfile', verifyToken, async (req, res) => {
-  try {
-    const { bio, location } = req.body || {}
-    const validationError = validateProfile(bio, location)
-    if (validationError) {
-      return res.status(400).json({ error: validationError })
-    }
-    const db = getDB()
-    await db.collection('userProfiles').updateOne(
-      { _id: req.uid },
-      {
-        $set: {
-          bio: typeof bio === 'string' ? bio.trim() : '',
-          location: typeof location === 'string' ? location.trim() : '',
-          updatedAt: new Date(),
-        },
-      },
-      { upsert: true }
-    )
-    res.json({ success: true })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.post('/updateProfile', verifyToken, asyncHandler(async (req, res) => {
+  const { bio, location } = req.body || {}
+  const validationError = validateProfile(bio, location)
+  if (validationError) {
+    return res.status(400).json({ error: validationError })
   }
-})
+  const db = getDB()
+  await db.collection('userProfiles').updateOne(
+    { _id: req.uid },
+    {
+      $set: {
+        bio: typeof bio === 'string' ? bio.trim() : '',
+        location: typeof location === 'string' ? location.trim() : '',
+        updatedAt: new Date(),
+      },
+    },
+    { upsert: true }
+  )
+  res.json({ success: true })
+}))
 
 module.exports = router

--- a/server/routes/drafts.js
+++ b/server/routes/drafts.js
@@ -1,5 +1,5 @@
 const { Router } = require('express')
-const { respondServerError } = require('../util/respondServerError')
+const { asyncHandler } = require('../util/asyncHandler')
 const { ObjectId } = require('mongodb')
 const { getDB } = require('../db')
 const { verifyToken, requireActive } = require('../middleware/auth')
@@ -25,133 +25,113 @@ const MAX_DRAFTS_PER_USER = 25
 
 // POST /drafts — create a new draft for the current user. Returns the new _id
 // so the client can switch to update-on-autosave from then on.
-router.post('/', verifyToken, requireActive, async (req, res) => {
-  try {
-    const db = getDB()
-    const boundsError = validateRecipeBounds(req.body)
-    if (boundsError) {
-      return res.status(400).json({ error: boundsError })
-    }
-    // Cap the number of drafts per user. 409 + a machine-readable code so the
-    // client can show a specific "delete some drafts" message and stop retrying.
-    const draftCount = await db
-      .collection('recipeDrafts')
-      .countDocuments({ userId: req.uid })
-    if (draftCount >= MAX_DRAFTS_PER_USER) {
-      return res.status(409).json({
-        code: 'DRAFT_LIMIT',
-        error: `You've reached the maximum of ${MAX_DRAFTS_PER_USER} saved drafts. Delete some from your Drafts to start a new one.`,
-      })
-    }
-    const now = Date.now().toString()
-    const doc = {
-      _id: new ObjectId(),
-      userId: req.uid,
-      ...pickFields(req.body, RECIPE_CONTENT_FIELDS),
-      createdAt: now,
-      updatedAt: now,
-    }
-    await db.collection('recipeDrafts').insertOne(doc)
-    res.status(201).json(doc)
-  } catch (err) {
-    respondServerError(res, err, req)
+router.post('/', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const boundsError = validateRecipeBounds(req.body)
+  if (boundsError) {
+    return res.status(400).json({ error: boundsError })
   }
-})
+  // Cap the number of drafts per user. 409 + a machine-readable code so the
+  // client can show a specific "delete some drafts" message and stop retrying.
+  const draftCount = await db
+    .collection('recipeDrafts')
+    .countDocuments({ userId: req.uid })
+  if (draftCount >= MAX_DRAFTS_PER_USER) {
+    return res.status(409).json({
+      code: 'DRAFT_LIMIT',
+      error: `You've reached the maximum of ${MAX_DRAFTS_PER_USER} saved drafts. Delete some from your Drafts to start a new one.`,
+    })
+  }
+  const now = Date.now().toString()
+  const doc = {
+    _id: new ObjectId(),
+    userId: req.uid,
+    ...pickFields(req.body, RECIPE_CONTENT_FIELDS),
+    createdAt: now,
+    updatedAt: now,
+  }
+  await db.collection('recipeDrafts').insertOne(doc)
+  res.status(201).json(doc)
+}))
 
 // GET /drafts — list the current user's drafts, newest-updated first.
-router.get('/', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const drafts = await db
-      .collection('recipeDrafts')
-      .find({ userId: req.uid })
-      .sort({ updatedAt: -1 })
-      .toArray()
-    res.json(drafts)
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+router.get('/', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const drafts = await db
+    .collection('recipeDrafts')
+    .find({ userId: req.uid })
+    .sort({ updatedAt: -1 })
+    .toArray()
+  res.json(drafts)
+}))
 
 // GET /drafts/:id — fetch a single draft (used when resuming). Owner-only.
-router.get('/:id', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    if (!ObjectId.isValid(req.params.id)) {
-      return res.status(404).json({ error: 'Draft not found' })
-    }
-    const draft = await db
-      .collection('recipeDrafts')
-      .findOne({ _id: new ObjectId(req.params.id) })
-    if (!draft) {
-      return res.status(404).json({ error: 'Draft not found' })
-    }
-    if (draft.userId !== req.uid) {
-      return res.status(403).json({ error: 'Forbidden' })
-    }
-    res.json(draft)
-  } catch (err) {
-    respondServerError(res, err, req)
+router.get('/:id', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  if (!ObjectId.isValid(req.params.id)) {
+    return res.status(404).json({ error: 'Draft not found' })
   }
-})
+  const draft = await db
+    .collection('recipeDrafts')
+    .findOne({ _id: new ObjectId(req.params.id) })
+  if (!draft) {
+    return res.status(404).json({ error: 'Draft not found' })
+  }
+  if (draft.userId !== req.uid) {
+    return res.status(403).json({ error: 'Forbidden' })
+  }
+  res.json(draft)
+}))
 
 // PUT /drafts/:id — overwrite a draft's content (autosave). Owner-only. Only
 // whitelisted content fields are written; userId/createdAt/_id are immutable.
-router.put('/:id', verifyToken, requireActive, async (req, res) => {
-  try {
-    const db = getDB()
-    if (!ObjectId.isValid(req.params.id)) {
-      return res.status(404).json({ error: 'Draft not found' })
-    }
-    const _id = new ObjectId(req.params.id)
-    // Check existence and ownership before validating the payload, so a caller
-    // can't probe bounds-validity for a draft they don't own or that doesn't
-    // exist (matches the editRecipe route's ordering).
-    const draft = await db.collection('recipeDrafts').findOne({ _id })
-    if (!draft) {
-      return res.status(404).json({ error: 'Draft not found' })
-    }
-    if (draft.userId !== req.uid) {
-      return res.status(403).json({ error: 'Forbidden' })
-    }
-    const boundsError = validateRecipeBounds(req.body)
-    if (boundsError) {
-      return res.status(400).json({ error: boundsError })
-    }
-    const update = {
-      ...pickFields(req.body, RECIPE_CONTENT_FIELDS),
-      updatedAt: Date.now().toString(),
-    }
-    const updated = await db
-      .collection('recipeDrafts')
-      .findOneAndUpdate({ _id }, { $set: update }, { returnDocument: 'after' })
-    res.json(updated)
-  } catch (err) {
-    respondServerError(res, err, req)
+router.put('/:id', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const db = getDB()
+  if (!ObjectId.isValid(req.params.id)) {
+    return res.status(404).json({ error: 'Draft not found' })
   }
-})
+  const _id = new ObjectId(req.params.id)
+  // Check existence and ownership before validating the payload, so a caller
+  // can't probe bounds-validity for a draft they don't own or that doesn't
+  // exist (matches the editRecipe route's ordering).
+  const draft = await db.collection('recipeDrafts').findOne({ _id })
+  if (!draft) {
+    return res.status(404).json({ error: 'Draft not found' })
+  }
+  if (draft.userId !== req.uid) {
+    return res.status(403).json({ error: 'Forbidden' })
+  }
+  const boundsError = validateRecipeBounds(req.body)
+  if (boundsError) {
+    return res.status(400).json({ error: boundsError })
+  }
+  const update = {
+    ...pickFields(req.body, RECIPE_CONTENT_FIELDS),
+    updatedAt: Date.now().toString(),
+  }
+  const updated = await db
+    .collection('recipeDrafts')
+    .findOneAndUpdate({ _id }, { $set: update }, { returnDocument: 'after' })
+  res.json(updated)
+}))
 
 // DELETE /drafts/:id — remove a draft (manual delete, or cleanup after the
 // recipe is published). Owner-only.
-router.delete('/:id', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    if (!ObjectId.isValid(req.params.id)) {
-      return res.status(404).json({ error: 'Draft not found' })
-    }
-    const _id = new ObjectId(req.params.id)
-    const draft = await db.collection('recipeDrafts').findOne({ _id })
-    if (!draft) {
-      return res.status(404).json({ error: 'Draft not found' })
-    }
-    if (draft.userId !== req.uid) {
-      return res.status(403).json({ error: 'Forbidden' })
-    }
-    await db.collection('recipeDrafts').deleteOne({ _id })
-    res.json({ deleted: true })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.delete('/:id', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  if (!ObjectId.isValid(req.params.id)) {
+    return res.status(404).json({ error: 'Draft not found' })
   }
-})
+  const _id = new ObjectId(req.params.id)
+  const draft = await db.collection('recipeDrafts').findOne({ _id })
+  if (!draft) {
+    return res.status(404).json({ error: 'Draft not found' })
+  }
+  if (draft.userId !== req.uid) {
+    return res.status(403).json({ error: 'Forbidden' })
+  }
+  await db.collection('recipeDrafts').deleteOne({ _id })
+  res.json({ deleted: true })
+}))
 
 module.exports = router

--- a/server/routes/gamification.js
+++ b/server/routes/gamification.js
@@ -1,5 +1,5 @@
 const express = require('express')
-const { respondServerError } = require('../util/respondServerError')
+const { asyncHandler } = require('../util/asyncHandler')
 const router = express.Router()
 const { getDB } = require('../db')
 const { verifyToken } = require('../middleware/auth')
@@ -14,44 +14,36 @@ const VALID_ACHIEVEMENT_IDS = new Set(ACHIEVEMENTS.map(a => a.id))
 // are earned but not yet acknowledged, so the client can fire the unlock toast.
 // Read-only — acknowledging is a separate POST so the toast isn't silently
 // consumed if it never gets shown.
-router.get('/getGamification', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const [counts, profile] = await Promise.all([
-      getAccountCountsFor(db, req.uid),
-      db.collection('userProfiles').findOne({ _id: req.uid }),
-    ])
-    const seen = profile?.seenAchievements ?? []
-    res.json(computeGamification(counts, seen))
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+router.get('/getGamification', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const [counts, profile] = await Promise.all([
+    getAccountCountsFor(db, req.uid),
+    db.collection('userProfiles').findOne({ _id: req.uid }),
+  ])
+  const seen = profile?.seenAchievements ?? []
+  res.json(computeGamification(counts, seen))
+}))
 
 // POST /acknowledgeAchievements
 // Records that the given achievement ids have been shown to the user, so the
 // unlock toast won't fire again. Body: { ids: string[] }. Unknown ids are
 // ignored; $addToSet makes it idempotent.
-router.post('/acknowledgeAchievements', verifyToken, async (req, res) => {
-  try {
-    const { ids } = req.body || {}
-    if (!Array.isArray(ids)) {
-      return res.status(400).json({ error: 'ids must be an array' })
-    }
-    const cleanIds = ids.filter(id => VALID_ACHIEVEMENT_IDS.has(id))
-    if (cleanIds.length > 0) {
-      await getDB()
-        .collection('userProfiles')
-        .updateOne(
-          { _id: req.uid },
-          { $addToSet: { seenAchievements: { $each: cleanIds } } },
-          { upsert: true }
-        )
-    }
-    res.json({ success: true })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.post('/acknowledgeAchievements', verifyToken, asyncHandler(async (req, res) => {
+  const { ids } = req.body || {}
+  if (!Array.isArray(ids)) {
+    return res.status(400).json({ error: 'ids must be an array' })
   }
-})
+  const cleanIds = ids.filter(id => VALID_ACHIEVEMENT_IDS.has(id))
+  if (cleanIds.length > 0) {
+    await getDB()
+      .collection('userProfiles')
+      .updateOne(
+        { _id: req.uid },
+        { $addToSet: { seenAchievements: { $each: cleanIds } } },
+        { upsert: true }
+      )
+  }
+  res.json({ success: true })
+}))
 
 module.exports = router

--- a/server/routes/publicProfile.js
+++ b/server/routes/publicProfile.js
@@ -1,5 +1,5 @@
 const express = require('express')
-const { respondServerError } = require('../util/respondServerError')
+const { asyncHandler } = require('../util/asyncHandler')
 const router = express.Router()
 const admin = require('firebase-admin')
 const { getDB } = require('../db')
@@ -14,72 +14,68 @@ const PROFILE_RECIPE_LIMIT = 12
 // username to a uid via the usernames collection (404 if not found). Avatar and
 // display name come from Firebase Auth via the Admin SDK; on failure we fall
 // back to the username so the profile still renders.
-router.get('/getPublicProfile', async (req, res) => {
-  try {
-    const { username } = req.query
-    if (!username) {
-      return res.status(400).json({ error: 'username is required' })
-    }
-
-    const db = getDB()
-    const usernameDoc = await db
-      .collection('usernames')
-      .findOne({ username_lower: String(username).toLowerCase() })
-    if (!usernameDoc) {
-      return res.status(404).json({ error: 'Profile not found' })
-    }
-    const uid = usernameDoc._id
-
-    // Avatar + display name live in Firebase Auth; fetch via the Admin SDK in
-    // parallel with the DB reads. On failure fall back to the username so the
-    // profile still renders (deleted user / transient error).
-    const fetchAuthRecord = async () => {
-      try {
-        const r = await admin.auth().getUser(uid)
-        return {
-          displayName: r.displayName || usernameDoc.username,
-          photoURL: r.photoURL || null,
-        }
-      } catch (err) {
-        return { displayName: usernameDoc.username, photoURL: null }
-      }
-    }
-
-    const [profile, counts, recipes, authRecord] = await Promise.all([
-      db.collection('userProfiles').findOne({ _id: uid }),
-      // We already resolved the username to find the uid — pass it so the counts
-      // helper doesn't look it up again.
-      getAccountCountsFor(db, uid, usernameDoc.username),
-      db
-        .collection('recipes')
-        .find({ userId: uid })
-        .sort({ createdAt: -1 })
-        .limit(PROFILE_RECIPE_LIMIT)
-        .toArray(),
-      fetchAuthRecord(),
-    ])
-
-    const gamification = computeGamification(counts, [])
-    const earnedAchievements = gamification.achievements.filter(a => a.earned)
-
-    res.json({
-      username: usernameDoc.username,
-      displayName: authRecord.displayName,
-      photoURL: authRecord.photoURL,
-      bio: profile?.bio ?? '',
-      location: profile?.location ?? '',
-      level: gamification.level,
-      rank: gamification.rank,
-      xp: gamification.xp,
-      xpNext: gamification.xpNext,
-      pct: gamification.pct,
-      achievements: earnedAchievements,
-      recipes,
-      recipesTotalCount: counts.recipes,
-    })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.get('/getPublicProfile', asyncHandler(async (req, res) => {
+  const { username } = req.query
+  if (!username) {
+    return res.status(400).json({ error: 'username is required' })
   }
-})
+
+  const db = getDB()
+  const usernameDoc = await db
+    .collection('usernames')
+    .findOne({ username_lower: String(username).toLowerCase() })
+  if (!usernameDoc) {
+    return res.status(404).json({ error: 'Profile not found' })
+  }
+  const uid = usernameDoc._id
+
+  // Avatar + display name live in Firebase Auth; fetch via the Admin SDK in
+  // parallel with the DB reads. On failure fall back to the username so the
+  // profile still renders (deleted user / transient error).
+  const fetchAuthRecord = async () => {
+    try {
+      const r = await admin.auth().getUser(uid)
+      return {
+        displayName: r.displayName || usernameDoc.username,
+        photoURL: r.photoURL || null,
+      }
+    } catch (err) {
+      return { displayName: usernameDoc.username, photoURL: null }
+    }
+  }
+
+  const [profile, counts, recipes, authRecord] = await Promise.all([
+    db.collection('userProfiles').findOne({ _id: uid }),
+    // We already resolved the username to find the uid — pass it so the counts
+    // helper doesn't look it up again.
+    getAccountCountsFor(db, uid, usernameDoc.username),
+    db
+      .collection('recipes')
+      .find({ userId: uid })
+      .sort({ createdAt: -1 })
+      .limit(PROFILE_RECIPE_LIMIT)
+      .toArray(),
+    fetchAuthRecord(),
+  ])
+
+  const gamification = computeGamification(counts, [])
+  const earnedAchievements = gamification.achievements.filter(a => a.earned)
+
+  res.json({
+    username: usernameDoc.username,
+    displayName: authRecord.displayName,
+    photoURL: authRecord.photoURL,
+    bio: profile?.bio ?? '',
+    location: profile?.location ?? '',
+    level: gamification.level,
+    rank: gamification.rank,
+    xp: gamification.xp,
+    xpNext: gamification.xpNext,
+    pct: gamification.pct,
+    achievements: earnedAchievements,
+    recipes,
+    recipesTotalCount: counts.recipes,
+  })
+}))
 
 module.exports = router

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -1,5 +1,5 @@
 const { Router } = require('express')
-const { respondServerError } = require('../util/respondServerError')
+const { asyncHandler } = require('../util/asyncHandler')
 const { ObjectId } = require('mongodb')
 const { getDB, getClient } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
@@ -22,600 +22,532 @@ function escapeRegex(str) {
 }
 
 // GET /recipes — browse/filter with pagination
-router.get('/recipes', async (req, res) => {
-  // TODO: no auth required for browse; individual write routes below need auth
-  try {
-    const db = getDB()
-    const {
-      q,
-      page = 0,
-      recipesPerPage = 5,
-      order,
-      cuisine,
-      tags,
-      mealTypes,
-      diets,
-    } = req.query
-    // Page-size cap (audit §4.5): a single request can never dump the whole
-    // collection. The 'simple' query parser (app.js) guarantees every value is
-    // a string or string[] — never a `{$ne:…}` operator object — so the helpers
-    // below only have to coerce those two shapes.
-    const limit = Math.min(parseInt(recipesPerPage) || 5, MAX_PER_PAGE)
-    const skip = (parseInt(page) || 0) * limit
+// No auth required for browse; individual write routes below need auth.
+router.get('/recipes', asyncHandler(async (req, res) => {
+  const db = getDB()
+  const {
+    q,
+    page = 0,
+    recipesPerPage = 5,
+    order,
+    cuisine,
+    tags,
+    mealTypes,
+    diets,
+  } = req.query
+  // Page-size cap (audit §4.5): a single request can never dump the whole
+  // collection. The 'simple' query parser (app.js) guarantees every value is
+  // a string or string[] — never a `{$ne:…}` operator object — so the helpers
+  // below only have to coerce those two shapes.
+  const limit = Math.min(parseInt(recipesPerPage) || 5, MAX_PER_PAGE)
+  const skip = (parseInt(page) || 0) * limit
 
-    // Soft-hidden recipes never surface in public browse.
-    const filter = { ...RECIPE_VISIBLE }
+  // Soft-hidden recipes never surface in public browse.
+  const filter = { ...RECIPE_VISIBLE }
 
-    // Query params can arrive as arrays (?x=a&x=b) — coerce so string ops below
-    // can't throw on malformed/repeated params.
-    const asText = (v) => (Array.isArray(v) ? v[0] : v) ?? ''
-    const parseList = (v) =>
-      (Array.isArray(v) ? v : String(v).split(','))
-        .map((s) => s.trim())
-        .filter(Boolean)
+  // Query params can arrive as arrays (?x=a&x=b) — coerce so string ops below
+  // can't throw on malformed/repeated params.
+  const asText = (v) => (Array.isArray(v) ? v[0] : v) ?? ''
+  const parseList = (v) =>
+    (Array.isArray(v) ? v : String(v).split(','))
+      .map((s) => s.trim())
+      .filter(Boolean)
 
-    const qText = asText(q)
-    if (qText) {
-      filter.title = { $regex: escapeRegex(qText), $options: 'i' }
-    }
-
-    const cuisineText = asText(cuisine).trim()
-    if (cuisineText) {
-      filter.cuisine = { $regex: `^${escapeRegex(cuisineText)}$`, $options: 'i' }
-    }
-
-    if (tags) {
-      const tagList = parseList(tags)
-      if (tagList.length > 0) {
-        filter.$or = [
-          { mealTypes: { $in: tagList } },
-          { nutritionLabels: { $in: tagList } },
-        ]
-      }
-    }
-
-    // Separate meal-type filter (AND'd with the rest): recipes matching any of
-    // the selected meal types.
-    if (mealTypes) {
-      const mealList = parseList(mealTypes)
-      if (mealList.length > 0) {
-        filter.mealTypes = { $in: mealList }
-      }
-    }
-
-    // Dietary filter — conjunctive ($all): a recipe must carry EVERY selected
-    // diet label (e.g. Vegan AND Gluten-Free), since these are restrictions.
-    // (The shared `tags`/$or above stays OR-based for the Home meal lookup.)
-    if (diets) {
-      const dietList = parseList(diets)
-      if (dietList.length > 0) {
-        filter.nutritionLabels = { $all: dietList }
-      }
-    }
-
-    // Sort options exposed by the browse UI. `createdAt` is a millisecond-epoch
-    // string of fixed (13-digit) width, so a lexicographic sort matches
-    // chronological order. `_id` is a final tiebreak so pagination is stable
-    // when the primary key ties (e.g. many recipes with 0 saves / same price).
-    const SORTS = {
-      popular: { numTimesSaved: -1, views: -1, _id: -1 },
-      new: { createdAt: -1, _id: -1 },
-      old: { createdAt: 1, _id: 1 },
-      // Price/time sorts assume every recipe has servingPrice/totalTime (all
-      // current docs do). If null/missing values ever appear, Mongo sorts them
-      // first in ascending order, so "cheapest"/"quickest" would lead with
-      // unpriced/untimed recipes — switch to an aggregation with $ifNull→Infinity
-      // (nulls-last) at that point rather than papering over it here.
-      cheapest: { servingPrice: 1, _id: 1 },
-      expensive: { servingPrice: -1, _id: -1 },
-      shortest: { totalTime: 1, _id: 1 },
-      longest: { totalTime: -1, _id: -1 },
-      // Retained for any non-UI callers.
-      top: { 'rating.rateValue': -1, _id: -1 },
-      trending: { views: -1, _id: -1 },
-    }
-    // Own-property lookup only — `order` is client-controlled, so a bare
-    // `SORTS[order]` would resolve inherited members (`constructor`, `__proto__`)
-    // to a function/object and break the Mongo sort.
-    const sort = Object.prototype.hasOwnProperty.call(SORTS, order)
-      ? SORTS[order]
-      : SORTS.popular
-
-    const collection = db.collection('recipes')
-    const [recipes, totalCount] = await Promise.all([
-      collection.find(filter).sort(sort).skip(skip).limit(limit).toArray(),
-      collection.countDocuments(filter),
-    ])
-
-    res.json({ recipeList: recipes, total_results: totalCount })
-  } catch (err) {
-    respondServerError(res, err, req)
+  const qText = asText(q)
+  if (qText) {
+    filter.title = { $regex: escapeRegex(qText), $options: 'i' }
   }
-})
+
+  const cuisineText = asText(cuisine).trim()
+  if (cuisineText) {
+    filter.cuisine = { $regex: `^${escapeRegex(cuisineText)}$`, $options: 'i' }
+  }
+
+  if (tags) {
+    const tagList = parseList(tags)
+    if (tagList.length > 0) {
+      filter.$or = [
+        { mealTypes: { $in: tagList } },
+        { nutritionLabels: { $in: tagList } },
+      ]
+    }
+  }
+
+  // Separate meal-type filter (AND'd with the rest): recipes matching any of
+  // the selected meal types.
+  if (mealTypes) {
+    const mealList = parseList(mealTypes)
+    if (mealList.length > 0) {
+      filter.mealTypes = { $in: mealList }
+    }
+  }
+
+  // Dietary filter — conjunctive ($all): a recipe must carry EVERY selected
+  // diet label (e.g. Vegan AND Gluten-Free), since these are restrictions.
+  // (The shared `tags`/$or above stays OR-based for the Home meal lookup.)
+  if (diets) {
+    const dietList = parseList(diets)
+    if (dietList.length > 0) {
+      filter.nutritionLabels = { $all: dietList }
+    }
+  }
+
+  // Sort options exposed by the browse UI. `createdAt` is a millisecond-epoch
+  // string of fixed (13-digit) width, so a lexicographic sort matches
+  // chronological order. `_id` is a final tiebreak so pagination is stable
+  // when the primary key ties (e.g. many recipes with 0 saves / same price).
+  const SORTS = {
+    popular: { numTimesSaved: -1, views: -1, _id: -1 },
+    new: { createdAt: -1, _id: -1 },
+    old: { createdAt: 1, _id: 1 },
+    // Price/time sorts assume every recipe has servingPrice/totalTime (all
+    // current docs do). If null/missing values ever appear, Mongo sorts them
+    // first in ascending order, so "cheapest"/"quickest" would lead with
+    // unpriced/untimed recipes — switch to an aggregation with $ifNull→Infinity
+    // (nulls-last) at that point rather than papering over it here.
+    cheapest: { servingPrice: 1, _id: 1 },
+    expensive: { servingPrice: -1, _id: -1 },
+    shortest: { totalTime: 1, _id: 1 },
+    longest: { totalTime: -1, _id: -1 },
+    // Retained for any non-UI callers.
+    top: { 'rating.rateValue': -1, _id: -1 },
+    trending: { views: -1, _id: -1 },
+  }
+  // Own-property lookup only — `order` is client-controlled, so a bare
+  // `SORTS[order]` would resolve inherited members (`constructor`, `__proto__`)
+  // to a function/object and break the Mongo sort.
+  const sort = Object.prototype.hasOwnProperty.call(SORTS, order)
+    ? SORTS[order]
+    : SORTS.popular
+
+  const collection = db.collection('recipes')
+  const [recipes, totalCount] = await Promise.all([
+    collection.find(filter).sort(sort).skip(skip).limit(limit).toArray(),
+    collection.countDocuments(filter),
+  ])
+
+  res.json({ recipeList: recipes, total_results: totalCount })
+}))
 
 // GET /recipes/facets — distinct filter values that actually exist in the
 // catalog, so the browse UI can hide filters with zero recipes (e.g. don't
 // offer "Jamaican" when nothing is tagged Jamaican). `distinct` returns raw
 // stored values including null/'' — drop the empties; the client maps the rest
 // back to its curated label lists.
-router.get('/recipes/facets', async (req, res) => {
-  try {
-    const collection = getDB().collection('recipes')
-    const clean = (arr) =>
-      arr.filter((v) => typeof v === 'string' && v.trim() !== '')
-    const [cuisines, diets, mealTypes] = await Promise.all([
-      collection.distinct('cuisine'),
-      collection.distinct('nutritionLabels'),
-      collection.distinct('mealTypes'),
-    ])
-    res.json({
-      cuisines: clean(cuisines),
-      diets: clean(diets),
-      mealTypes: clean(mealTypes),
-    })
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+router.get('/recipes/facets', asyncHandler(async (req, res) => {
+  const collection = getDB().collection('recipes')
+  const clean = (arr) =>
+    arr.filter((v) => typeof v === 'string' && v.trim() !== '')
+  const [cuisines, diets, mealTypes] = await Promise.all([
+    collection.distinct('cuisine'),
+    collection.distinct('nutritionLabels'),
+    collection.distinct('mealTypes'),
+  ])
+  res.json({
+    cuisines: clean(cuisines),
+    diets: clean(diets),
+    mealTypes: clean(mealTypes),
+  })
+}))
 
 // GET /searchAutoCompleteRecipes — quick title search for autocomplete
-router.get('/searchAutoCompleteRecipes', async (req, res) => {
-  try {
-    const db = getDB()
-    const { title } = req.query
-    const recipes = await db
-      .collection('recipes')
-      .find(
-        { title: { $regex: escapeRegex(typeof title === 'string' ? title : ''), $options: 'i' }, ...RECIPE_VISIBLE },
-        {
-          projection: {
-            _id: 1,
-            title: 1,
-            recipeImage: 1,
-            totalTime: 1,
-            servings: 1,
-            rating: 1,
-            nutritionLabels: 1,
-            servingPrice: 1,
-          },
-        }
-      )
-      .limit(8)
-      .toArray()
-    res.json(recipes)
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+router.get('/searchAutoCompleteRecipes', asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { title } = req.query
+  const recipes = await db
+    .collection('recipes')
+    .find(
+      { title: { $regex: escapeRegex(typeof title === 'string' ? title : ''), $options: 'i' }, ...RECIPE_VISIBLE },
+      {
+        projection: {
+          _id: 1,
+          title: 1,
+          recipeImage: 1,
+          totalTime: 1,
+          servings: 1,
+          rating: 1,
+          nutritionLabels: 1,
+          servingPrice: 1,
+        },
+      }
+    )
+    .limit(8)
+    .toArray()
+  res.json(recipes)
+}))
 
 // GET /getTrendingRecipes
-router.get('/getTrendingRecipes', async (req, res) => {
-  try {
-    const db = getDB()
-    const limit = Math.min(parseInt(req.query.limit) || 4, 20)
-    // Admin-curated `featured` picks are pinned to the front of the row, then
-    // the usual most-viewed ordering fills the rest.
-    const recipes = await db
-      .collection('recipes')
-      .find({ ...RECIPE_VISIBLE })
-      .sort({ featured: -1, views: -1 })
-      .limit(limit)
-      .toArray()
-    res.json(recipes)
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+router.get('/getTrendingRecipes', asyncHandler(async (req, res) => {
+  const db = getDB()
+  const limit = Math.min(parseInt(req.query.limit) || 4, 20)
+  // Admin-curated `featured` picks are pinned to the front of the row, then
+  // the usual most-viewed ordering fills the rest.
+  const recipes = await db
+    .collection('recipes')
+    .find({ ...RECIPE_VISIBLE })
+    .sort({ featured: -1, views: -1 })
+    .limit(limit)
+    .toArray()
+  res.json(recipes)
+}))
 
 // GET /getRecipe — fetch single recipe and increment view count.
 // optionalAuth so an admin keeps access to hidden/unpublished recipes (to review
 // + restore them); for everyone else a moderated recipe is treated as not found.
-router.get('/getRecipe', optionalAuth, async (req, res) => {
-  try {
-    const db = getDB()
-    const { id } = req.query
-    if (!id) return res.status(400).json({ error: 'id is required' })
+router.get('/getRecipe', optionalAuth, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { id } = req.query
+  if (!id) return res.status(400).json({ error: 'id is required' })
 
-    // Admin: load the recipe regardless of moderation state, WITHOUT inflating
-    // its view count (this is a moderation preview, not a real visit).
-    if (req.isAdmin) {
-      const recipe = await db.collection('recipes').findOne(recipeIdQuery(id))
-      if (!recipe) return res.status(404).json({ error: 'Not found' })
-      return res.json(recipe)
-    }
-
-    // Public: a soft-hidden/unpublished recipe is "not found" — and the
-    // non-match means views aren't incremented either.
-    const recipe = await db.collection('recipes').findOneAndUpdate(
-      { ...recipeIdQuery(id), ...RECIPE_VISIBLE },
-      { $inc: { views: 1 } },
-      { returnDocument: 'after' }
-    )
-
+  // Admin: load the recipe regardless of moderation state, WITHOUT inflating
+  // its view count (this is a moderation preview, not a real visit).
+  if (req.isAdmin) {
+    const recipe = await db.collection('recipes').findOne(recipeIdQuery(id))
     if (!recipe) return res.status(404).json({ error: 'Not found' })
-
-    // Fire-and-forget global stats increment
-    db.collection('stats').updateOne(
-      { _id: 'globalStats' },
-      { $inc: { totalRecipeViews: 1 } }
-    )
-
-    res.json(recipe)
-  } catch (err) {
-    respondServerError(res, err, req)
+    return res.json(recipe)
   }
-})
+
+  // Public: a soft-hidden/unpublished recipe is "not found" — and the
+  // non-match means views aren't incremented either.
+  const recipe = await db.collection('recipes').findOneAndUpdate(
+    { ...recipeIdQuery(id), ...RECIPE_VISIBLE },
+    { $inc: { views: 1 } },
+    { returnDocument: 'after' }
+  )
+
+  if (!recipe) return res.status(404).json({ error: 'Not found' })
+
+  // Fire-and-forget global stats increment
+  db.collection('stats').updateOne(
+    { _id: 'globalStats' },
+    { $inc: { totalRecipeViews: 1 } }
+  )
+
+  res.json(recipe)
+}))
 
 // POST /addRecipe
-router.post('/addRecipe', verifyToken, requireActive, async (req, res) => {
-  try {
-    const db = getDB()
-    const body = req.body
-    const uid = req.uid
-    const requiredError = validateRequiredRecipeFields(body)
-    if (requiredError) {
-      return res.status(400).json({ error: requiredError })
-    }
-    const boundsError = validateRecipeBounds(body)
-    if (boundsError) {
-      return res.status(400).json({ error: boundsError })
-    }
-    // Server stamps _id, userId, and counters — client-supplied values are discarded
-    const newId = new ObjectId()
-    const docToInsert = { ...body, _id: newId, userId: uid, numTimesSaved: 0, numTimesMade: 0, views: 0 }
-    await db.collection('recipes').insertOne(docToInsert)
-    await db.collection('userRecipeData').updateOne(
-      { _id: uid },
-      { $push: { userRecipes: { recipeId: newId } } },
-      { upsert: true }
-    )
-    res.status(201).json({ _id: newId })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.post('/addRecipe', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const body = req.body
+  const uid = req.uid
+  const requiredError = validateRequiredRecipeFields(body)
+  if (requiredError) {
+    return res.status(400).json({ error: requiredError })
   }
-})
+  const boundsError = validateRecipeBounds(body)
+  if (boundsError) {
+    return res.status(400).json({ error: boundsError })
+  }
+  // Server stamps _id, userId, and counters — client-supplied values are discarded
+  const newId = new ObjectId()
+  const docToInsert = { ...body, _id: newId, userId: uid, numTimesSaved: 0, numTimesMade: 0, views: 0 }
+  await db.collection('recipes').insertOne(docToInsert)
+  await db.collection('userRecipeData').updateOne(
+    { _id: uid },
+    { $push: { userRecipes: { recipeId: newId } } },
+    { upsert: true }
+  )
+  res.status(201).json({ _id: newId })
+}))
 
 // PUT /editRecipe — owner-only edit. Social/derived counters and immutable
 // metadata are never writable here (only EDITABLE_RECIPE_FIELDS are copied), so
 // an edit can never reset a recipe's ratings, saves, or made-count. editedAt is
 // stamped so the UI can surface that the recipe changed after people saved it.
-router.put('/editRecipe', verifyToken, requireActive, async (req, res) => {
-  try {
-    const db = getDB()
-    const { recipeId } = req.query
-    if (!recipeId) {
-      return res.status(400).json({ error: 'recipeId is required' })
-    }
-    const uid = req.uid
-    const recipe = await db.collection('recipes').findOne(recipeIdQuery(recipeId))
-    if (!recipe) {
-      return res.status(404).json({ error: 'Recipe not found' })
-    }
-    if (recipe.userId !== uid) {
-      return res.status(403).json({ error: 'Forbidden' })
-    }
-
-    const body = req.body
-    const requiredError = validateRequiredRecipeFields(body)
-    if (requiredError) {
-      return res.status(400).json({ error: requiredError })
-    }
-    const boundsError = validateRecipeBounds(body)
-    if (boundsError) {
-      return res.status(400).json({ error: boundsError })
-    }
-
-    // Whitelist: copy only editable fields from the client payload. Anything
-    // else the client sends (rating, numTimesSaved, views, userId, _id, …) is
-    // ignored.
-    const update = {
-      ...pickFields(body, EDITABLE_RECIPE_FIELDS),
-      editedAt: Date.now().toString(),
-    }
-
-    const updated = await db.collection('recipes').findOneAndUpdate(
-      recipeIdQuery(recipeId),
-      { $set: update },
-      { returnDocument: 'after' }
-    )
-    res.json(updated)
-  } catch (err) {
-    respondServerError(res, err, req)
+router.put('/editRecipe', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { recipeId } = req.query
+  if (!recipeId) {
+    return res.status(400).json({ error: 'recipeId is required' })
   }
-})
+  const uid = req.uid
+  const recipe = await db.collection('recipes').findOne(recipeIdQuery(recipeId))
+  if (!recipe) {
+    return res.status(404).json({ error: 'Recipe not found' })
+  }
+  if (recipe.userId !== uid) {
+    return res.status(403).json({ error: 'Forbidden' })
+  }
+
+  const body = req.body
+  const requiredError = validateRequiredRecipeFields(body)
+  if (requiredError) {
+    return res.status(400).json({ error: requiredError })
+  }
+  const boundsError = validateRecipeBounds(body)
+  if (boundsError) {
+    return res.status(400).json({ error: boundsError })
+  }
+
+  // Whitelist: copy only editable fields from the client payload. Anything
+  // else the client sends (rating, numTimesSaved, views, userId, _id, …) is
+  // ignored.
+  const update = {
+    ...pickFields(body, EDITABLE_RECIPE_FIELDS),
+    editedAt: Date.now().toString(),
+  }
+
+  const updated = await db.collection('recipes').findOneAndUpdate(
+    recipeIdQuery(recipeId),
+    { $set: update },
+    { returnDocument: 'after' }
+  )
+  res.json(updated)
+}))
 
 // DELETE /deleteRecipe
-router.delete('/deleteRecipe', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const { recipeId } = req.query
-    if (!recipeId) {
-      return res.status(400).json({ error: 'recipeId is required' })
-    }
-    const uid = req.uid
-    const recipe = await db.collection('recipes').findOne(recipeIdQuery(recipeId))
-    if (!recipe) {
-      return res.status(404).json({ error: 'Recipe not found' })
-    }
-    if (recipe.userId !== uid) {
-      return res.status(403).json({ error: 'Forbidden' })
-    }
-
-    // Remove the recipe and every reference to it atomically: its ratings/
-    // reviews, and the recipeId entry from any user's saved/made/created lists.
-    // userRecipes only ever lives on the owner's doc, but pulling it across all
-    // docs in the same updateMany is harmless and keeps this to one write.
-    const session = getClient().startSession()
-    try {
-      await session.withTransaction(async () => {
-        await db.collection('recipes').deleteOne(recipeIdQuery(recipeId), { session })
-        await db.collection('ratings').deleteMany({ recipeId }, { session })
-        await db.collection('userRecipeData').updateMany(
-          {},
-          {
-            $pull: {
-              savedRecipes: { recipeId },
-              madeRecipes: { recipeId },
-              userRecipes: { recipeId },
-            },
-          },
-          { session }
-        )
-      })
-    } finally {
-      await session.endSession()
-    }
-
-    // External side effect — runs after the transaction commits and never
-    // fails the request (an orphaned image is preferable to a 500 here).
-    await deleteRecipeImage(recipe.recipeImage)
-
-    res.json({ deleted: true })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.delete('/deleteRecipe', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { recipeId } = req.query
+  if (!recipeId) {
+    return res.status(400).json({ error: 'recipeId is required' })
   }
-})
+  const uid = req.uid
+  const recipe = await db.collection('recipes').findOne(recipeIdQuery(recipeId))
+  if (!recipe) {
+    return res.status(404).json({ error: 'Recipe not found' })
+  }
+  if (recipe.userId !== uid) {
+    return res.status(403).json({ error: 'Forbidden' })
+  }
+
+  // Remove the recipe and every reference to it atomically: its ratings/
+  // reviews, and the recipeId entry from any user's saved/made/created lists.
+  // userRecipes only ever lives on the owner's doc, but pulling it across all
+  // docs in the same updateMany is harmless and keeps this to one write.
+  const session = getClient().startSession()
+  try {
+    await session.withTransaction(async () => {
+      await db.collection('recipes').deleteOne(recipeIdQuery(recipeId), { session })
+      await db.collection('ratings').deleteMany({ recipeId }, { session })
+      await db.collection('userRecipeData').updateMany(
+        {},
+        {
+          $pull: {
+            savedRecipes: { recipeId },
+            madeRecipes: { recipeId },
+            userRecipes: { recipeId },
+          },
+        },
+        { session }
+      )
+    })
+  } finally {
+    await session.endSession()
+  }
+
+  // External side effect — runs after the transaction commits and never
+  // fails the request (an orphaned image is preferable to a 500 here).
+  await deleteRecipeImage(recipe.recipeImage)
+
+  res.json({ deleted: true })
+}))
 
 // PATCH /admin/recipes/:id/moderation — admin soft-hide / unhide.
 // Bypasses the owner check (admin authority). Reversible: flips `status`
 // between 'hidden' and 'active'.
-router.patch('/admin/recipes/:id/moderation', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    const recipeId = req.params.id
-    const { status } = req.body
-    if (status !== 'hidden' && status !== 'active') {
-      return res.status(400).json({ error: "status must be 'hidden' or 'active'" })
-    }
-    const updated = await db.collection('recipes').findOneAndUpdate(
-      recipeIdQuery(recipeId),
-      {
-        $set: {
-          status,
-          moderatedBy: req.uid,
-          moderatedAt: new Date(),
-        },
-      },
-      { returnDocument: 'after' }
-    )
-    if (!updated) return res.status(404).json({ error: 'Recipe not found' })
-    await recordAudit(db, {
-      action: status === 'hidden' ? 'recipe.hide' : 'recipe.unhide',
-      actorUid: req.uid,
-      targetType: 'recipe',
-      targetId: updated._id,
-      targetLabel: updated.title || null,
-    })
-    // Notify the owner on a takedown (background). Unhide is silent.
-    if (status === 'hidden') notifyInBackground(notifyRecipeHidden(updated.userId, updated.title))
-    res.json({ _id: updated._id, status: updated.status })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.patch('/admin/recipes/:id/moderation', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const recipeId = req.params.id
+  const { status } = req.body
+  if (status !== 'hidden' && status !== 'active') {
+    return res.status(400).json({ error: "status must be 'hidden' or 'active'" })
   }
-})
+  const updated = await db.collection('recipes').findOneAndUpdate(
+    recipeIdQuery(recipeId),
+    {
+      $set: {
+        status,
+        moderatedBy: req.uid,
+        moderatedAt: new Date(),
+      },
+    },
+    { returnDocument: 'after' }
+  )
+  if (!updated) return res.status(404).json({ error: 'Recipe not found' })
+  await recordAudit(db, {
+    action: status === 'hidden' ? 'recipe.hide' : 'recipe.unhide',
+    actorUid: req.uid,
+    targetType: 'recipe',
+    targetId: updated._id,
+    targetLabel: updated.title || null,
+  })
+  // Notify the owner on a takedown (background). Unhide is silent.
+  if (status === 'hidden') notifyInBackground(notifyRecipeHidden(updated.userId, updated.title))
+  res.json({ _id: updated._id, status: updated.status })
+}))
 
 // PATCH /admin/recipes/:id/publish — admin de-publish / re-publish.
 // Distinct from /moderation on purpose: this flips `status` between
 // 'unpublished' and 'active' and stamps `publishUpdatedBy/At` (NOT `moderatedBy`)
 // so an editorial de-publish never reads as a moderation takedown. Both states
 // are filtered from public reads identically (util/moderation RECIPE_VISIBLE).
-router.patch('/admin/recipes/:id/publish', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    const recipeId = req.params.id
-    const { published } = req.body
-    if (typeof published !== 'boolean') {
-      return res.status(400).json({ error: 'published must be a boolean' })
-    }
-    const updated = await db.collection('recipes').findOneAndUpdate(
-      recipeIdQuery(recipeId),
-      {
-        $set: {
-          status: published ? 'active' : 'unpublished',
-          publishUpdatedBy: req.uid,
-          publishUpdatedAt: new Date(),
-        },
-      },
-      { returnDocument: 'after' }
-    )
-    if (!updated) return res.status(404).json({ error: 'Recipe not found' })
-    await recordAudit(db, {
-      action: published ? 'recipe.publish' : 'recipe.unpublish',
-      actorUid: req.uid,
-      targetType: 'recipe',
-      targetId: updated._id,
-      targetLabel: updated.title || null,
-    })
-    res.json({ _id: updated._id, status: updated.status })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.patch('/admin/recipes/:id/publish', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const recipeId = req.params.id
+  const { published } = req.body
+  if (typeof published !== 'boolean') {
+    return res.status(400).json({ error: 'published must be a boolean' })
   }
-})
+  const updated = await db.collection('recipes').findOneAndUpdate(
+    recipeIdQuery(recipeId),
+    {
+      $set: {
+        status: published ? 'active' : 'unpublished',
+        publishUpdatedBy: req.uid,
+        publishUpdatedAt: new Date(),
+      },
+    },
+    { returnDocument: 'after' }
+  )
+  if (!updated) return res.status(404).json({ error: 'Recipe not found' })
+  await recordAudit(db, {
+    action: published ? 'recipe.publish' : 'recipe.unpublish',
+    actorUid: req.uid,
+    targetType: 'recipe',
+    targetId: updated._id,
+    targetLabel: updated.title || null,
+  })
+  res.json({ _id: updated._id, status: updated.status })
+}))
 
 // PATCH /admin/recipes/:id/feature — admin curation. `featured` recipes are
 // pinned to the front of the home trending row (see getTrendingRecipes).
-router.patch('/admin/recipes/:id/feature', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    const recipeId = req.params.id
-    const { featured } = req.body
-    if (typeof featured !== 'boolean') {
-      return res.status(400).json({ error: 'featured must be a boolean' })
-    }
-    const updated = await db.collection('recipes').findOneAndUpdate(
-      recipeIdQuery(recipeId),
-      {
-        $set: {
-          featured,
-          featuredBy: req.uid,
-          featuredAt: new Date(),
-        },
-      },
-      { returnDocument: 'after' }
-    )
-    if (!updated) return res.status(404).json({ error: 'Recipe not found' })
-    await recordAudit(db, {
-      action: featured ? 'recipe.feature' : 'recipe.unfeature',
-      actorUid: req.uid,
-      targetType: 'recipe',
-      targetId: updated._id,
-      targetLabel: updated.title || null,
-    })
-    res.json({ _id: updated._id, featured: updated.featured === true })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.patch('/admin/recipes/:id/feature', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const recipeId = req.params.id
+  const { featured } = req.body
+  if (typeof featured !== 'boolean') {
+    return res.status(400).json({ error: 'featured must be a boolean' })
   }
-})
+  const updated = await db.collection('recipes').findOneAndUpdate(
+    recipeIdQuery(recipeId),
+    {
+      $set: {
+        featured,
+        featuredBy: req.uid,
+        featuredAt: new Date(),
+      },
+    },
+    { returnDocument: 'after' }
+  )
+  if (!updated) return res.status(404).json({ error: 'Recipe not found' })
+  await recordAudit(db, {
+    action: featured ? 'recipe.feature' : 'recipe.unfeature',
+    actorUid: req.uid,
+    targetType: 'recipe',
+    targetId: updated._id,
+    targetLabel: updated.title || null,
+  })
+  res.json({ _id: updated._id, featured: updated.featured === true })
+}))
 
 // POST /recipes/:id/save
-router.post('/recipes/:id/save', verifyToken, requireActive, async (req, res) => {
-  try {
-    const db = getDB()
-    const recipeId = req.params.id
-    if (!recipeId) {
-      return res.status(400).json({ error: 'recipeId is required' })
-    }
-    const uid = req.uid
-    const existingData = await db.collection('userRecipeData').findOne({ _id: uid })
-    const alreadySaved = existingData?.savedRecipes?.some(e => e.recipeId === recipeId) ?? false
-    if (alreadySaved) {
-      return res.status(409).json({ error: 'Recipe already saved' })
-    }
-    await db.collection('userRecipeData').updateOne(
-      { _id: uid },
-      { $push: { savedRecipes: { recipeId, dateSaved: Date.now().toString() } } },
-      { upsert: true }
-    )
-    await db.collection('recipes').updateOne(
-      recipeIdQuery(recipeId),
-      { $inc: { numTimesSaved: 1 } }
-    )
-    res.json({ saved: true })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.post('/recipes/:id/save', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const recipeId = req.params.id
+  if (!recipeId) {
+    return res.status(400).json({ error: 'recipeId is required' })
   }
-})
+  const uid = req.uid
+  const existingData = await db.collection('userRecipeData').findOne({ _id: uid })
+  const alreadySaved = existingData?.savedRecipes?.some(e => e.recipeId === recipeId) ?? false
+  if (alreadySaved) {
+    return res.status(409).json({ error: 'Recipe already saved' })
+  }
+  await db.collection('userRecipeData').updateOne(
+    { _id: uid },
+    { $push: { savedRecipes: { recipeId, dateSaved: Date.now().toString() } } },
+    { upsert: true }
+  )
+  await db.collection('recipes').updateOne(
+    recipeIdQuery(recipeId),
+    { $inc: { numTimesSaved: 1 } }
+  )
+  res.json({ saved: true })
+}))
 
 // GET /getSavedRecipe
-router.get('/getSavedRecipe', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const { recipeId } = req.query
-    if (!recipeId) {
-      return res.status(400).json({ error: 'recipeId is required' })
-    }
-    const uid = req.uid
-    const userData = await db.collection('userRecipeData').findOne({ _id: uid })
-    const match =
-      userData?.savedRecipes?.find((entry) => entry.recipeId === recipeId) ?? null
-    res.json(match)
-  } catch (err) {
-    respondServerError(res, err, req)
+router.get('/getSavedRecipe', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { recipeId } = req.query
+  if (!recipeId) {
+    return res.status(400).json({ error: 'recipeId is required' })
   }
-})
+  const uid = req.uid
+  const userData = await db.collection('userRecipeData').findOne({ _id: uid })
+  const match =
+    userData?.savedRecipes?.find((entry) => entry.recipeId === recipeId) ?? null
+  res.json(match)
+}))
 
 // GET /getSavedRecipeIds — just the current user's saved recipe ids, so a grid
 // can resolve every card's saved state from one request instead of N.
-router.get('/getSavedRecipeIds', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const userData = await db
-      .collection('userRecipeData')
-      .findOne({ _id: req.uid }, { projection: { savedRecipes: 1 } })
-    res.json((userData?.savedRecipes ?? []).map((e) => e.recipeId))
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+router.get('/getSavedRecipeIds', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const userData = await db
+    .collection('userRecipeData')
+    .findOne({ _id: req.uid }, { projection: { savedRecipes: 1 } })
+  res.json((userData?.savedRecipes ?? []).map((e) => e.recipeId))
+}))
 
 // DELETE /recipes/:id/save
-router.delete('/recipes/:id/save', verifyToken, requireActive, async (req, res) => {
-  try {
-    const db = getDB()
-    const recipeId = req.params.id
-    if (!recipeId) {
-      return res.status(400).json({ error: 'recipeId is required' })
-    }
-    const uid = req.uid
-    const savedData = await db.collection('userRecipeData').findOne({ _id: uid })
-    const isSaved = savedData?.savedRecipes?.some(e => e.recipeId === recipeId) ?? false
-    if (!isSaved) {
-      return res.status(404).json({ error: 'Recipe not in saved list' })
-    }
-    await db.collection('userRecipeData').updateOne(
-      { _id: uid },
-      { $pull: { savedRecipes: { recipeId } } }
-    )
-    await db.collection('recipes').updateOne(
-      recipeIdQuery(recipeId),
-      [{ $set: { numTimesSaved: { $max: [{ $subtract: ['$numTimesSaved', 1] }, 0] } } }]
-    )
-    res.json({ unsaved: true })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.delete('/recipes/:id/save', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const recipeId = req.params.id
+  if (!recipeId) {
+    return res.status(400).json({ error: 'recipeId is required' })
   }
-})
+  const uid = req.uid
+  const savedData = await db.collection('userRecipeData').findOne({ _id: uid })
+  const isSaved = savedData?.savedRecipes?.some(e => e.recipeId === recipeId) ?? false
+  if (!isSaved) {
+    return res.status(404).json({ error: 'Recipe not in saved list' })
+  }
+  await db.collection('userRecipeData').updateOne(
+    { _id: uid },
+    { $pull: { savedRecipes: { recipeId } } }
+  )
+  await db.collection('recipes').updateOne(
+    recipeIdQuery(recipeId),
+    [{ $set: { numTimesSaved: { $max: [{ $subtract: ['$numTimesSaved', 1] }, 0] } } }]
+  )
+  res.json({ unsaved: true })
+}))
 
 // POST /madeRecipe
-router.post('/madeRecipe', verifyToken, requireActive, async (req, res) => {
-  try {
-    const db = getDB()
-    const { recipeId } = req.query
-    if (!recipeId) {
-      return res.status(400).json({ error: 'recipeId is required' })
-    }
-    const uid = req.uid
-    await db.collection('recipes').updateOne(
-      recipeIdQuery(recipeId),
-      { $inc: { numTimesMade: 1 } }
-    )
-    await db.collection('userRecipeData').updateOne(
-      { _id: uid },
-      { $addToSet: { madeRecipes: { recipeId } } },
-      { upsert: true }
-    )
-    res.json({ made: true })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.post('/madeRecipe', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { recipeId } = req.query
+  if (!recipeId) {
+    return res.status(400).json({ error: 'recipeId is required' })
   }
-})
+  const uid = req.uid
+  await db.collection('recipes').updateOne(
+    recipeIdQuery(recipeId),
+    { $inc: { numTimesMade: 1 } }
+  )
+  await db.collection('userRecipeData').updateOne(
+    { _id: uid },
+    { $addToSet: { madeRecipes: { recipeId } } },
+    { upsert: true }
+  )
+  res.json({ made: true })
+}))
 
 // GET /checkMadeRecipe
-router.get('/checkMadeRecipe', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const { recipeId } = req.query
-    if (!recipeId) {
-      return res.status(400).json({ error: 'recipeId is required' })
-    }
-    const uid = req.uid
-    const userData = await db.collection('userRecipeData').findOne({ _id: uid })
-    const made =
-      userData?.madeRecipes?.some((entry) => entry.recipeId === recipeId) ?? false
-    res.json({ made })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.get('/checkMadeRecipe', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { recipeId } = req.query
+  if (!recipeId) {
+    return res.status(400).json({ error: 'recipeId is required' })
   }
-})
+  const uid = req.uid
+  const userData = await db.collection('userRecipeData').findOne({ _id: uid })
+  const made =
+    userData?.madeRecipes?.some((entry) => entry.recipeId === recipeId) ?? false
+  res.json({ made })
+}))
 
 module.exports = router

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -1,5 +1,5 @@
 const { Router } = require('express')
-const { respondServerError } = require('../util/respondServerError')
+const { asyncHandler } = require('../util/asyncHandler')
 const { ObjectId } = require('mongodb')
 const { getDB } = require('../db')
 const { verifyToken, requireAdmin, requireActive } = require('../middleware/auth')
@@ -27,106 +27,98 @@ function targetMatch({ targetType, recipeId, reportedUsername }) {
 
 // POST /reports — any logged-in user files a report. Rate-limited to one OPEN
 // report per (reporter, target) so a single user can't flood the queue.
-router.post('/reports', verifyToken, requireActive, async (req, res) => {
-  try {
-    const db = getDB()
-    const { targetType, recipeId, reportedUsername, reason, details } = req.body
+router.post('/reports', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { targetType, recipeId, reportedUsername, reason, details } = req.body
 
-    if (!TARGET_TYPES.includes(targetType)) {
-      return res.status(400).json({ error: "targetType must be 'recipe' or 'review'" })
-    }
-    if (!recipeId || typeof recipeId !== 'string') {
-      return res.status(400).json({ error: 'recipeId is required' })
-    }
-    if (targetType === 'review' && (!reportedUsername || typeof reportedUsername !== 'string')) {
-      return res.status(400).json({ error: 'reportedUsername is required for review reports' })
-    }
-    if (!REASONS.includes(reason)) {
-      return res.status(400).json({ error: 'Invalid reason' })
-    }
-    if (details != null && (typeof details !== 'string' || details.length > MAX_DETAILS_LEN)) {
-      return res.status(400).json({ error: `details must be a string under ${MAX_DETAILS_LEN} chars` })
-    }
-
-    const match = targetMatch({ targetType, recipeId, reportedUsername })
-    const existing = await db.collection('reports').findOne({
-      ...match,
-      reporterUid: req.uid,
-      status: 'open',
-    })
-    if (existing) {
-      return res.status(409).json({
-        code: 'ALREADY_REPORTED',
-        error: 'You already have an open report for this content.',
-      })
-    }
-
-    const doc = {
-      _id: new ObjectId(),
-      targetType,
-      recipeId,
-      ...(targetType === 'review' ? { reportedUsername } : {}),
-      reporterUid: req.uid,
-      reason,
-      details: details || '',
-      status: 'open',
-      createdAt: new Date(),
-    }
-    await db.collection('reports').insertOne(doc)
-    res.status(201).json(doc)
-  } catch (err) {
-    respondServerError(res, err, req)
+  if (!TARGET_TYPES.includes(targetType)) {
+    return res.status(400).json({ error: "targetType must be 'recipe' or 'review'" })
   }
-})
+  if (!recipeId || typeof recipeId !== 'string') {
+    return res.status(400).json({ error: 'recipeId is required' })
+  }
+  if (targetType === 'review' && (!reportedUsername || typeof reportedUsername !== 'string')) {
+    return res.status(400).json({ error: 'reportedUsername is required for review reports' })
+  }
+  if (!REASONS.includes(reason)) {
+    return res.status(400).json({ error: 'Invalid reason' })
+  }
+  if (details != null && (typeof details !== 'string' || details.length > MAX_DETAILS_LEN)) {
+    return res.status(400).json({ error: `details must be a string under ${MAX_DETAILS_LEN} chars` })
+  }
+
+  const match = targetMatch({ targetType, recipeId, reportedUsername })
+  const existing = await db.collection('reports').findOne({
+    ...match,
+    reporterUid: req.uid,
+    status: 'open',
+  })
+  if (existing) {
+    return res.status(409).json({
+      code: 'ALREADY_REPORTED',
+      error: 'You already have an open report for this content.',
+    })
+  }
+
+  const doc = {
+    _id: new ObjectId(),
+    targetType,
+    recipeId,
+    ...(targetType === 'review' ? { reportedUsername } : {}),
+    reporterUid: req.uid,
+    reason,
+    details: details || '',
+    status: 'open',
+    createdAt: new Date(),
+  }
+  await db.collection('reports').insertOne(doc)
+  res.status(201).json(doc)
+}))
 
 // GET /reports — admin queue. Filters by status/targetType, paginates, and
 // enriches each report with a snapshot of the reported content for inline
 // preview (recipe title/image, or the review text).
-router.get('/reports', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    const { status, targetType, page = 0, perPage = 20 } = req.query
+router.get('/reports', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { status, targetType, page = 0, perPage = 20 } = req.query
 
-    const filter = {}
-    if (status && ['open', ...RESOLUTIONS].includes(status)) filter.status = status
-    if (targetType && TARGET_TYPES.includes(targetType)) filter.targetType = targetType
+  const filter = {}
+  if (status && ['open', ...RESOLUTIONS].includes(status)) filter.status = status
+  if (targetType && TARGET_TYPES.includes(targetType)) filter.targetType = targetType
 
-    const skip = parseInt(page) * parseInt(perPage)
-    const limit = parseInt(perPage)
+  const skip = parseInt(page) * parseInt(perPage)
+  const limit = parseInt(perPage)
 
-    const [reports, totalCount, openCount] = await Promise.all([
-      db.collection('reports').find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit).toArray(),
-      db.collection('reports').countDocuments(filter),
-      db.collection('reports').countDocuments({ status: 'open' }),
-    ])
+  const [reports, totalCount, openCount] = await Promise.all([
+    db.collection('reports').find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit).toArray(),
+    db.collection('reports').countDocuments(filter),
+    db.collection('reports').countDocuments({ status: 'open' }),
+  ])
 
-    // Attach a lightweight snapshot of the target so the queue can render a
-    // preview without a second round trip per row.
-    const enriched = await Promise.all(
-      reports.map(async (r) => {
-        const recipe = await db
-          .collection('recipes')
-          .findOne(recipeIdQuery(r.recipeId), {
-            projection: { title: 1, recipeImage: 1, status: 1, userId: 1 },
-          })
-        let review = null
-        if (r.targetType === 'review') {
-          review = await db
-            .collection('ratings')
-            .findOne(
-              { username: r.reportedUsername, recipeId: r.recipeId },
-              { projection: { reviewText: 1, rating: 1, moderationHidden: 1 } }
-            )
-        }
-        return { ...r, target: { recipe, review } }
-      })
-    )
+  // Attach a lightweight snapshot of the target so the queue can render a
+  // preview without a second round trip per row.
+  const enriched = await Promise.all(
+    reports.map(async (r) => {
+      const recipe = await db
+        .collection('recipes')
+        .findOne(recipeIdQuery(r.recipeId), {
+          projection: { title: 1, recipeImage: 1, status: 1, userId: 1 },
+        })
+      let review = null
+      if (r.targetType === 'review') {
+        review = await db
+          .collection('ratings')
+          .findOne(
+            { username: r.reportedUsername, recipeId: r.recipeId },
+            { projection: { reviewText: 1, rating: 1, moderationHidden: 1 } }
+          )
+      }
+      return { ...r, target: { recipe, review } }
+    })
+  )
 
-    res.json({ reports: enriched, totalCount, openCount })
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+  res.json({ reports: enriched, totalCount, openCount })
+}))
 
 // Most reports a single admin sweep would ever clear at once. Bounds the bulk
 // updateMany and the audit insert.
@@ -136,99 +128,91 @@ const MAX_BULK = 100
 // Declared BEFORE /reports/:id so 'bulk' isn't captured as an :id. Only OPEN
 // reports are touched (already-closed ids in the batch are simply skipped), and
 // one audit entry is written per report actually closed.
-router.patch('/reports/bulk', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    const { ids, status } = req.body
-    if (!RESOLUTIONS.includes(status)) {
-      return res.status(400).json({ error: "status must be 'resolved' or 'dismissed'" })
-    }
-    if (!Array.isArray(ids) || ids.length === 0) {
-      return res.status(400).json({ error: 'ids must be a non-empty array' })
-    }
-    if (ids.length > MAX_BULK) {
-      return res.status(400).json({ error: `Cannot update more than ${MAX_BULK} reports at once` })
-    }
-    const objectIds = ids.filter((id) => typeof id === 'string' && ObjectId.isValid(id)).map((id) => new ObjectId(id))
-    if (objectIds.length === 0) {
-      return res.status(400).json({ error: 'No valid report ids' })
-    }
-
-    // Stamp every report this sweep closes with a single timestamp, then re-read
-    // exactly those docs by our own (actorUid, resolvedAt) stamp. updateMany
-    // can't return the modified docs, and re-reading by the stamp — rather than
-    // a pre-update snapshot — means a report closed concurrently by another
-    // admin can't slip into *our* audit trail.
-    const resolvedAt = new Date()
-    const result = await db.collection('reports').updateMany(
-      { _id: { $in: objectIds }, status: 'open' },
-      { $set: { status, resolvedBy: req.uid, resolvedAt } }
-    )
-
-    const closed = result.modifiedCount
-      ? await db
-          .collection('reports')
-          .find({ _id: { $in: objectIds }, resolvedBy: req.uid, resolvedAt })
-          .toArray()
-      : []
-
-    await recordAuditMany(
-      db,
-      closed.map((r) => ({
-        action: status === 'resolved' ? 'report.resolve' : 'report.dismiss',
-        actorUid: req.uid,
-        targetType: 'report',
-        targetId: r._id,
-        targetLabel: r.reportedUsername ? `@${r.reportedUsername}` : r.recipeId,
-        metadata: { targetType: r.targetType, recipeId: r.recipeId, bulk: true },
-      }))
-    )
-
-    // Email each affected reporter once per sweep (resolve only; dismiss is
-    // silent), in the background so a large sweep never blocks the response.
-    if (status === 'resolved') {
-      notifyInBackground(notifyReportResolvedMany(closed.map((r) => r.reporterUid)))
-    }
-
-    res.json({ updated: result.modifiedCount })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.patch('/reports/bulk', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { ids, status } = req.body
+  if (!RESOLUTIONS.includes(status)) {
+    return res.status(400).json({ error: "status must be 'resolved' or 'dismissed'" })
   }
-})
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return res.status(400).json({ error: 'ids must be a non-empty array' })
+  }
+  if (ids.length > MAX_BULK) {
+    return res.status(400).json({ error: `Cannot update more than ${MAX_BULK} reports at once` })
+  }
+  const objectIds = ids.filter((id) => typeof id === 'string' && ObjectId.isValid(id)).map((id) => new ObjectId(id))
+  if (objectIds.length === 0) {
+    return res.status(400).json({ error: 'No valid report ids' })
+  }
+
+  // Stamp every report this sweep closes with a single timestamp, then re-read
+  // exactly those docs by our own (actorUid, resolvedAt) stamp. updateMany
+  // can't return the modified docs, and re-reading by the stamp — rather than
+  // a pre-update snapshot — means a report closed concurrently by another
+  // admin can't slip into *our* audit trail.
+  const resolvedAt = new Date()
+  const result = await db.collection('reports').updateMany(
+    { _id: { $in: objectIds }, status: 'open' },
+    { $set: { status, resolvedBy: req.uid, resolvedAt } }
+  )
+
+  const closed = result.modifiedCount
+    ? await db
+        .collection('reports')
+        .find({ _id: { $in: objectIds }, resolvedBy: req.uid, resolvedAt })
+        .toArray()
+    : []
+
+  await recordAuditMany(
+    db,
+    closed.map((r) => ({
+      action: status === 'resolved' ? 'report.resolve' : 'report.dismiss',
+      actorUid: req.uid,
+      targetType: 'report',
+      targetId: r._id,
+      targetLabel: r.reportedUsername ? `@${r.reportedUsername}` : r.recipeId,
+      metadata: { targetType: r.targetType, recipeId: r.recipeId, bulk: true },
+    }))
+  )
+
+  // Email each affected reporter once per sweep (resolve only; dismiss is
+  // silent), in the background so a large sweep never blocks the response.
+  if (status === 'resolved') {
+    notifyInBackground(notifyReportResolvedMany(closed.map((r) => r.reporterUid)))
+  }
+
+  res.json({ updated: result.modifiedCount })
+}))
 
 // PATCH /reports/:id — admin resolves or dismisses a report. Resolving does NOT
 // itself take content down; the admin takedown endpoints (on recipes/reviews)
 // do that. This just closes the queue item and stamps who/when.
-router.patch('/reports/:id', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    if (!ObjectId.isValid(req.params.id)) {
-      return res.status(404).json({ error: 'Report not found' })
-    }
-    const { status } = req.body
-    if (!RESOLUTIONS.includes(status)) {
-      return res.status(400).json({ error: "status must be 'resolved' or 'dismissed'" })
-    }
-    const updated = await db.collection('reports').findOneAndUpdate(
-      { _id: new ObjectId(req.params.id) },
-      { $set: { status, resolvedBy: req.uid, resolvedAt: new Date() } },
-      { returnDocument: 'after' }
-    )
-    if (!updated) return res.status(404).json({ error: 'Report not found' })
-    await recordAudit(db, {
-      action: status === 'resolved' ? 'report.resolve' : 'report.dismiss',
-      actorUid: req.uid,
-      targetType: 'report',
-      targetId: updated._id,
-      targetLabel: updated.reportedUsername ? `@${updated.reportedUsername}` : updated.recipeId,
-      metadata: { targetType: updated.targetType, recipeId: updated.recipeId },
-    })
-    // Notify the reporter that action was taken. Dismiss is intentionally silent.
-    if (status === 'resolved') notifyInBackground(notifyReportResolved(updated.reporterUid))
-    res.json(updated)
-  } catch (err) {
-    respondServerError(res, err, req)
+router.patch('/reports/:id', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  if (!ObjectId.isValid(req.params.id)) {
+    return res.status(404).json({ error: 'Report not found' })
   }
-})
+  const { status } = req.body
+  if (!RESOLUTIONS.includes(status)) {
+    return res.status(400).json({ error: "status must be 'resolved' or 'dismissed'" })
+  }
+  const updated = await db.collection('reports').findOneAndUpdate(
+    { _id: new ObjectId(req.params.id) },
+    { $set: { status, resolvedBy: req.uid, resolvedAt: new Date() } },
+    { returnDocument: 'after' }
+  )
+  if (!updated) return res.status(404).json({ error: 'Report not found' })
+  await recordAudit(db, {
+    action: status === 'resolved' ? 'report.resolve' : 'report.dismiss',
+    actorUid: req.uid,
+    targetType: 'report',
+    targetId: updated._id,
+    targetLabel: updated.reportedUsername ? `@${updated.reportedUsername}` : updated.recipeId,
+    metadata: { targetType: updated.targetType, recipeId: updated.recipeId },
+  })
+  // Notify the reporter that action was taken. Dismiss is intentionally silent.
+  if (status === 'resolved') notifyInBackground(notifyReportResolved(updated.reporterUid))
+  res.json(updated)
+}))
 
 module.exports = router

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -1,5 +1,5 @@
 const { Router } = require('express')
-const { respondServerError } = require('../util/respondServerError')
+const { asyncHandler } = require('../util/asyncHandler')
 const { getDB } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
@@ -15,291 +15,259 @@ const router = Router()
 const MAX_PER_PAGE = 50
 
 // POST /addRating
-router.post('/addRating', verifyToken, requireActive, async (req, res) => {
-  try {
-    const { recipeId, rating } = req.query
-    const db = getDB()
-    const userDoc = await db.collection('usernames').findOne({ _id: req.uid })
-    if (!userDoc) return res.status(400).json({ error: 'User not found' })
-    const username = userDoc.username
-    if (!recipeId || typeof recipeId !== 'string' || !rating || typeof rating !== 'string') {
-      return res.status(400).json({ error: 'recipeId and rating are required' })
-    }
-    const parsedRating = parseFloat(rating)
-    if (isNaN(parsedRating)) {
-      return res.status(400).json({ error: 'Invalid rating' })
-    }
-    if (parsedRating < 1 || parsedRating > 5) {
-      return res.status(400).json({ error: 'Rating must be between 1 and 5' })
-    }
-
-    const existing = await db.collection('ratings').findOne({ username, recipeId })
-    if (existing) {
-      await db.collection('ratings').updateOne(
-        { username, recipeId },
-        { $set: { rating: parsedRating, ratingLastUpdated: new Date() } }
-      )
-    } else {
-      await db.collection('ratings').insertOne({
-        username,
-        recipeId,
-        rating: parsedRating,
-        ratingLastUpdated: new Date(),
-        reviewCreatedAt: '',
-        reviewLastUpdated: '',
-        reviewText: '',
-      })
-    }
-
-    // Recompute the aggregate (excludes moderated ratings).
-    await recomputeRecipeRating(db, recipeId)
-
-    res.json({ rated: true })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.post('/addRating', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const { recipeId, rating } = req.query
+  const db = getDB()
+  const userDoc = await db.collection('usernames').findOne({ _id: req.uid })
+  if (!userDoc) return res.status(400).json({ error: 'User not found' })
+  const username = userDoc.username
+  if (!recipeId || typeof recipeId !== 'string' || !rating || typeof rating !== 'string') {
+    return res.status(400).json({ error: 'recipeId and rating are required' })
   }
-})
+  const parsedRating = parseFloat(rating)
+  if (isNaN(parsedRating)) {
+    return res.status(400).json({ error: 'Invalid rating' })
+  }
+  if (parsedRating < 1 || parsedRating > 5) {
+    return res.status(400).json({ error: 'Rating must be between 1 and 5' })
+  }
 
-// POST /newReview
-router.post('/newReview', verifyToken, requireActive, async (req, res) => {
-  try {
-    const db = getDB()
-    const { recipeId, reviewText } = req.body
-    const userId = req.uid
-    if (!recipeId || typeof recipeId !== 'string' || typeof reviewText !== 'string') {
-      return res.status(400).json({ error: 'recipeId and reviewText are required' })
-    }
-    if (reviewText.length > DESCRIPTION_MAX_LENGTH) {
-      return res.status(400).json({ error: `Review cannot exceed ${DESCRIPTION_MAX_LENGTH} characters` })
-    }
-
-    const usernameDoc = await db.collection('usernames').findOne({ _id: userId })
-    if (!usernameDoc) return res.status(400).json({ error: 'Username not found for this user' })
-    const { username } = usernameDoc
-
-    const now = Date.now().toString()
+  const existing = await db.collection('ratings').findOne({ username, recipeId })
+  if (existing) {
     await db.collection('ratings').updateOne(
       { username, recipeId },
-      {
-        $set: { reviewText, reviewCreatedAt: now, reviewLastUpdated: now },
-        // A review can be posted before any rating; default the rating fields on
-        // insert so no ratings doc ever lacks them (recomputeRecipeRating skips
-        // rating: null, but this keeps the document shape consistent).
-        $setOnInsert: { rating: null, ratingLastUpdated: '' },
-      },
-      { upsert: true }
+      { $set: { rating: parsedRating, ratingLastUpdated: new Date() } }
     )
-
-    const updated = await db.collection('ratings').findOne({ username, recipeId })
-    res.json(updated)
-  } catch (err) {
-    respondServerError(res, err, req)
+  } else {
+    await db.collection('ratings').insertOne({
+      username,
+      recipeId,
+      rating: parsedRating,
+      ratingLastUpdated: new Date(),
+      reviewCreatedAt: '',
+      reviewLastUpdated: '',
+      reviewText: '',
+    })
   }
-})
+
+  // Recompute the aggregate (excludes moderated ratings).
+  await recomputeRecipeRating(db, recipeId)
+
+  res.json({ rated: true })
+}))
+
+// POST /newReview
+router.post('/newReview', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { recipeId, reviewText } = req.body
+  const userId = req.uid
+  if (!recipeId || typeof recipeId !== 'string' || typeof reviewText !== 'string') {
+    return res.status(400).json({ error: 'recipeId and reviewText are required' })
+  }
+  if (reviewText.length > DESCRIPTION_MAX_LENGTH) {
+    return res.status(400).json({ error: `Review cannot exceed ${DESCRIPTION_MAX_LENGTH} characters` })
+  }
+
+  const usernameDoc = await db.collection('usernames').findOne({ _id: userId })
+  if (!usernameDoc) return res.status(400).json({ error: 'Username not found for this user' })
+  const { username } = usernameDoc
+
+  const now = Date.now().toString()
+  await db.collection('ratings').updateOne(
+    { username, recipeId },
+    {
+      $set: { reviewText, reviewCreatedAt: now, reviewLastUpdated: now },
+      // A review can be posted before any rating; default the rating fields on
+      // insert so no ratings doc ever lacks them (recomputeRecipeRating skips
+      // rating: null, but this keeps the document shape consistent).
+      $setOnInsert: { rating: null, ratingLastUpdated: '' },
+    },
+    { upsert: true }
+  )
+
+  const updated = await db.collection('ratings').findOne({ username, recipeId })
+  res.json(updated)
+}))
 
 // GET /checkIfReviewed — scoped to the authenticated user
-router.get('/checkIfReviewed', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const { recipeId } = req.query
-    if (!recipeId) {
-      return res.status(400).json({ error: 'recipeId is required' })
-    }
-    const userDoc = await db.collection('usernames').findOne({ _id: req.uid })
-    if (!userDoc) return res.status(400).json({ error: 'Username not found for this user' })
-    const { username } = userDoc
-
-    const doc = await db.collection('ratings').findOne({ username, recipeId })
-    if (doc) {
-      res.json({ reviewed: true, ...doc })
-    } else {
-      res.json({ reviewed: false })
-    }
-  } catch (err) {
-    respondServerError(res, err, req)
+router.get('/checkIfReviewed', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { recipeId } = req.query
+  if (!recipeId) {
+    return res.status(400).json({ error: 'recipeId is required' })
   }
-})
+  const userDoc = await db.collection('usernames').findOne({ _id: req.uid })
+  if (!userDoc) return res.status(400).json({ error: 'Username not found for this user' })
+  const { username } = userDoc
+
+  const doc = await db.collection('ratings').findOne({ username, recipeId })
+  if (doc) {
+    res.json({ reviewed: true, ...doc })
+  } else {
+    res.json({ reviewed: false })
+  }
+}))
 
 // POST /editReview
-router.post('/editReview', verifyToken, requireActive, async (req, res) => {
-  try {
-    const { recipeId, text } = req.query
-    const db = getDB()
-    const userDoc = await db.collection('usernames').findOne({ _id: req.uid })
-    if (!userDoc) return res.status(400).json({ error: 'User not found' })
-    const username = userDoc.username
-    if (!recipeId || typeof recipeId !== 'string' || text == null || typeof text !== 'string') {
-      return res.status(400).json({ error: 'recipeId and text are required' })
-    }
-    if (text.length > DESCRIPTION_MAX_LENGTH) {
-      return res.status(400).json({ error: `Review cannot exceed ${DESCRIPTION_MAX_LENGTH} characters` })
-    }
-    const editResult = await db.collection('ratings').updateOne(
-      { username, recipeId },
-      { $set: { reviewText: text, reviewLastUpdated: Date.now().toString() } }
-    )
-    if (editResult.matchedCount === 0) {
-      return res.status(403).json({ error: 'Review not found or not authorized' })
-    }
-    res.json({ edited: true })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.post('/editReview', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const { recipeId, text } = req.query
+  const db = getDB()
+  const userDoc = await db.collection('usernames').findOne({ _id: req.uid })
+  if (!userDoc) return res.status(400).json({ error: 'User not found' })
+  const username = userDoc.username
+  if (!recipeId || typeof recipeId !== 'string' || text == null || typeof text !== 'string') {
+    return res.status(400).json({ error: 'recipeId and text are required' })
   }
-})
+  if (text.length > DESCRIPTION_MAX_LENGTH) {
+    return res.status(400).json({ error: `Review cannot exceed ${DESCRIPTION_MAX_LENGTH} characters` })
+  }
+  const editResult = await db.collection('ratings').updateOne(
+    { username, recipeId },
+    { $set: { reviewText: text, reviewLastUpdated: Date.now().toString() } }
+  )
+  if (editResult.matchedCount === 0) {
+    return res.status(403).json({ error: 'Review not found or not authorized' })
+  }
+  res.json({ edited: true })
+}))
 
 // DELETE /deleteReview
-router.delete('/deleteReview', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const { recipeId } = req.query
-    const userId = req.uid
-    if (!recipeId) {
-      return res.status(400).json({ error: 'recipeId is required' })
-    }
-    const usernameDoc = await db.collection('usernames').findOne({ _id: userId })
-    if (!usernameDoc) return res.status(400).json({ error: 'Username not found for this user' })
-    const { username } = usernameDoc
-
-    const deleteResult = await db.collection('ratings').updateOne(
-      { username, recipeId },
-      { $set: { reviewText: '', reviewLastUpdated: '' } }
-    )
-    if (deleteResult.matchedCount === 0) {
-      return res.status(403).json({ error: 'Review not found or not authorized' })
-    }
-    res.json({ deleted: true })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.delete('/deleteReview', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { recipeId } = req.query
+  const userId = req.uid
+  if (!recipeId) {
+    return res.status(400).json({ error: 'recipeId is required' })
   }
-})
+  const usernameDoc = await db.collection('usernames').findOne({ _id: userId })
+  if (!usernameDoc) return res.status(400).json({ error: 'Username not found for this user' })
+  const { username } = usernameDoc
+
+  const deleteResult = await db.collection('ratings').updateOne(
+    { username, recipeId },
+    { $set: { reviewText: '', reviewLastUpdated: '' } }
+  )
+  if (deleteResult.matchedCount === 0) {
+    return res.status(403).json({ error: 'Review not found or not authorized' })
+  }
+  res.json({ deleted: true })
+}))
 
 // GET /getReviews — anonymous-friendly. `optionalAuth` sets req.uid only when a
 // valid token is present; the `isCurrentUser` flag is derived from that verified
 // uid (NOT the client-supplied `username` query param, which anyone could set to
 // another user's name to spoof "edit/delete mine" affordances).
-router.get('/getReviews', optionalAuth, async (req, res) => {
-  try {
-    const db = getDB()
-    const { recipeId, page = 0, reviewsPerPage = 5, filter } = req.query
-    if (!recipeId) return res.status(400).json({ error: 'recipeId is required' })
+router.get('/getReviews', optionalAuth, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { recipeId, page = 0, reviewsPerPage = 5, filter } = req.query
+  if (!recipeId) return res.status(400).json({ error: 'recipeId is required' })
 
-    // Resolve the caller's own username from the verified token, if any.
-    let currentUsername = null
-    if (req.uid) {
-      const me = await db.collection('usernames').findOne({ _id: req.uid })
-      currentUsername = me?.username || null
-    }
-
-    const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
-    const skip = (parseInt(page) || 0) * limit
-    // Exclude admin-taken-down reviews from the public list.
-    const query = { recipeId, reviewText: { $exists: true, $ne: '' }, ...REVIEW_VISIBLE }
-
-    let sort = {}
-    if (filter === 'new') sort = { reviewCreatedAt: -1 }
-    else if (filter === 'top') sort = { rating: -1 }
-
-    const [rawReviews, totalCount] = await Promise.all([
-      db.collection('ratings').find(query).sort(sort).skip(skip).limit(limit).toArray(),
-      db.collection('ratings').countDocuments(query),
-    ])
-
-    const reviews = rawReviews.map((r) => ({
-      ...r,
-      isCurrentUser: currentUsername != null && r.username === currentUsername,
-    }))
-
-    res.json({ reviews, totalCount })
-  } catch (err) {
-    respondServerError(res, err, req)
+  // Resolve the caller's own username from the verified token, if any.
+  let currentUsername = null
+  if (req.uid) {
+    const me = await db.collection('usernames').findOne({ _id: req.uid })
+    currentUsername = me?.username || null
   }
-})
+
+  const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
+  const skip = (parseInt(page) || 0) * limit
+  // Exclude admin-taken-down reviews from the public list.
+  const query = { recipeId, reviewText: { $exists: true, $ne: '' }, ...REVIEW_VISIBLE }
+
+  let sort = {}
+  if (filter === 'new') sort = { reviewCreatedAt: -1 }
+  else if (filter === 'top') sort = { rating: -1 }
+
+  const [rawReviews, totalCount] = await Promise.all([
+    db.collection('ratings').find(query).sort(sort).skip(skip).limit(limit).toArray(),
+    db.collection('ratings').countDocuments(query),
+  ])
+
+  const reviews = rawReviews.map((r) => ({
+    ...r,
+    isCurrentUser: currentUsername != null && r.username === currentUsername,
+  }))
+
+  res.json({ reviews, totalCount })
+}))
 
 // GET /getSingleUserReviews
-router.get('/getSingleUserReviews', async (req, res) => {
-  try {
-    const db = getDB()
-    const { username, page = 0, reviewsPerPage = 5, filter, returnRecipeData } = req.query
-    if (!username) return res.status(400).json({ error: 'username is required' })
+router.get('/getSingleUserReviews', asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { username, page = 0, reviewsPerPage = 5, filter, returnRecipeData } = req.query
+  if (!username) return res.status(400).json({ error: 'username is required' })
 
-    const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
-    const skip = (parseInt(page) || 0) * limit
-    // Suppress admin-taken-down reviews from a user's public review list too.
-    const query = { username, ...REVIEW_VISIBLE }
+  const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
+  const skip = (parseInt(page) || 0) * limit
+  // Suppress admin-taken-down reviews from a user's public review list too.
+  const query = { username, ...REVIEW_VISIBLE }
 
-    let sort = {}
-    if (filter === 'new') sort = { reviewCreatedAt: -1 }
-    else if (filter === 'top') sort = { rating: -1 }
+  let sort = {}
+  if (filter === 'new') sort = { reviewCreatedAt: -1 }
+  else if (filter === 'top') sort = { rating: -1 }
 
-    const [rawReviews, totalCount] = await Promise.all([
-      db.collection('ratings').find(query).sort(sort).skip(skip).limit(limit).toArray(),
-      db.collection('ratings').countDocuments(query),
-    ])
+  const [rawReviews, totalCount] = await Promise.all([
+    db.collection('ratings').find(query).sort(sort).skip(skip).limit(limit).toArray(),
+    db.collection('ratings').countDocuments(query),
+  ])
 
-    let reviews = rawReviews
-    if (returnRecipeData === 'true') {
-      // Only attach (and keep) ratings whose recipe is still publicly visible —
-      // a rating for a soft-hidden recipe shouldn't surface in the user's list.
-      const withRecipe = await Promise.all(
-        rawReviews.map(async (r) => {
-          const recipeData = await db
-            .collection('recipes')
-            .findOne({ ...recipeIdQuery(r.recipeId), ...RECIPE_VISIBLE })
-          return recipeData ? { ...r, recipeData } : null
-        })
-      )
-      reviews = withRecipe.filter(Boolean)
-    }
-
-    res.json({ reviews, totalCount })
-  } catch (err) {
-    respondServerError(res, err, req)
+  let reviews = rawReviews
+  if (returnRecipeData === 'true') {
+    // Only attach (and keep) ratings whose recipe is still publicly visible —
+    // a rating for a soft-hidden recipe shouldn't surface in the user's list.
+    const withRecipe = await Promise.all(
+      rawReviews.map(async (r) => {
+        const recipeData = await db
+          .collection('recipes')
+          .findOne({ ...recipeIdQuery(r.recipeId), ...RECIPE_VISIBLE })
+        return recipeData ? { ...r, recipeData } : null
+      })
+    )
+    reviews = withRecipe.filter(Boolean)
   }
-})
+
+  res.json({ reviews, totalCount })
+}))
 
 // PATCH /admin/reviews/moderation — admin take down / restore a review.
 // Reviews have no stable id; identity is the (username, recipeId) pair. Uses a
 // distinct `moderationHidden` flag rather than blanking reviewText, so the
 // takedown is reversible and the original text is preserved for audit/appeal.
-router.patch('/admin/reviews/moderation', verifyToken, requireAdmin, async (req, res) => {
-  try {
-    const db = getDB()
-    const { recipeId, username, moderationHidden } = req.body
-    if (!recipeId || typeof recipeId !== 'string' || !username || typeof username !== 'string') {
-      return res.status(400).json({ error: 'recipeId and username are required' })
-    }
-    if (typeof moderationHidden !== 'boolean') {
-      return res.status(400).json({ error: 'moderationHidden must be a boolean' })
-    }
-    const result = await db.collection('ratings').updateOne(
-      { username, recipeId },
-      {
-        $set: {
-          moderationHidden,
-          moderatedBy: req.uid,
-          moderatedAt: new Date(),
-        },
-      }
-    )
-    if (result.matchedCount === 0) {
-      return res.status(404).json({ error: 'Review not found' })
-    }
-    // A takedown/restore changes which ratings count toward the recipe's score.
-    await recomputeRecipeRating(db, recipeId)
-    await recordAudit(db, {
-      action: moderationHidden ? 'review.takedown' : 'review.restore',
-      actorUid: req.uid,
-      targetType: 'review',
-      targetId: `${username}:${recipeId}`,
-      targetLabel: `@${username}`,
-      metadata: { recipeId, username },
-    })
-    // Notify the review author on a takedown (background). Restore is silent.
-    if (moderationHidden) notifyInBackground(notifyReviewTakenDown(db, username, recipeId))
-    res.json({ recipeId, username, moderationHidden })
-  } catch (err) {
-    respondServerError(res, err, req)
+router.patch('/admin/reviews/moderation', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { recipeId, username, moderationHidden } = req.body
+  if (!recipeId || typeof recipeId !== 'string' || !username || typeof username !== 'string') {
+    return res.status(400).json({ error: 'recipeId and username are required' })
   }
-})
+  if (typeof moderationHidden !== 'boolean') {
+    return res.status(400).json({ error: 'moderationHidden must be a boolean' })
+  }
+  const result = await db.collection('ratings').updateOne(
+    { username, recipeId },
+    {
+      $set: {
+        moderationHidden,
+        moderatedBy: req.uid,
+        moderatedAt: new Date(),
+      },
+    }
+  )
+  if (result.matchedCount === 0) {
+    return res.status(404).json({ error: 'Review not found' })
+  }
+  // A takedown/restore changes which ratings count toward the recipe's score.
+  await recomputeRecipeRating(db, recipeId)
+  await recordAudit(db, {
+    action: moderationHidden ? 'review.takedown' : 'review.restore',
+    actorUid: req.uid,
+    targetType: 'review',
+    targetId: `${username}:${recipeId}`,
+    targetLabel: `@${username}`,
+    metadata: { recipeId, username },
+  })
+  // Notify the review author on a takedown (background). Restore is silent.
+  if (moderationHidden) notifyInBackground(notifyReviewTakenDown(db, username, recipeId))
+  res.json({ recipeId, username, moderationHidden })
+}))
 
 module.exports = router

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,5 +1,5 @@
 const { Router } = require('express')
-const { respondServerError } = require('../util/respondServerError')
+const { asyncHandler } = require('../util/asyncHandler')
 const { getDB } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 const { recipeIdInQuery } = require('../util/recipeIdQuery')
@@ -12,82 +12,70 @@ const router = Router()
 const MAX_PER_PAGE = 50
 
 // GET /getCreatedRecipes — recipes authored by the current user, with pagination
-router.get('/getCreatedRecipes', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const { page = 0, recipesPerPage = 6, order } = req.query
-    const uid = req.uid
+router.get('/getCreatedRecipes', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { page = 0, recipesPerPage = 6, order } = req.query
+  const uid = req.uid
 
-    const sort = order === 'old' ? { createdAt: 1 } : { createdAt: -1 }
+  const sort = order === 'old' ? { createdAt: 1 } : { createdAt: -1 }
 
-    const pageNum = parseInt(page) || 0
-    const perPage = Math.min(parseInt(recipesPerPage) || 6, MAX_PER_PAGE)
+  const pageNum = parseInt(page) || 0
+  const perPage = Math.min(parseInt(recipesPerPage) || 6, MAX_PER_PAGE)
 
-    const collection = db.collection('recipes')
-    // Don't surface soft-hidden recipes in the author's own created list.
-    const filter = { userId: uid, ...RECIPE_VISIBLE }
-    const [recipes, totalCount] = await Promise.all([
-      collection
-        .find(filter)
-        .sort(sort)
-        .skip(pageNum * perPage)
-        .limit(perPage)
-        .toArray(),
-      collection.countDocuments(filter),
-    ])
+  const collection = db.collection('recipes')
+  // Don't surface soft-hidden recipes in the author's own created list.
+  const filter = { userId: uid, ...RECIPE_VISIBLE }
+  const [recipes, totalCount] = await Promise.all([
+    collection
+      .find(filter)
+      .sort(sort)
+      .skip(pageNum * perPage)
+      .limit(perPage)
+      .toArray(),
+    collection.countDocuments(filter),
+  ])
 
-    res.json({ recipes, totalCount })
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+  res.json({ recipes, totalCount })
+}))
 
 // GET /getSavedRecipes — with dateSaved sorting
-router.get('/getSavedRecipes', verifyToken, async (req, res) => {
-  try {
-    const db = getDB()
-    const { page = 0, recipesPerPage = 5, order } = req.query
-    const uid = req.uid
+router.get('/getSavedRecipes', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { page = 0, recipesPerPage = 5, order } = req.query
+  const uid = req.uid
 
-    const userData = await db.collection('userRecipeData').findOne({ _id: uid })
-    let savedRecipes = userData?.savedRecipes ?? []
-    const totalCount = savedRecipes.length
+  const userData = await db.collection('userRecipeData').findOne({ _id: uid })
+  let savedRecipes = userData?.savedRecipes ?? []
+  const totalCount = savedRecipes.length
 
-    if (order === 'new') {
-      savedRecipes = [...savedRecipes].sort((a, b) => Number(b.dateSaved) - Number(a.dateSaved))
-    } else if (order === 'old') {
-      savedRecipes = [...savedRecipes].sort((a, b) => Number(a.dateSaved) - Number(b.dateSaved))
-    }
-
-    const pageNum = parseInt(page) || 0
-    const perPage = Math.min(parseInt(recipesPerPage) || 5, MAX_PER_PAGE)
-    const pageSlice = savedRecipes.slice(pageNum * perPage, (pageNum + 1) * perPage)
-    const recipeIds = pageSlice.map((entry) => entry.recipeId)
-
-    const recipes =
-      recipeIds.length > 0
-        ? await db
-            .collection('recipes')
-            .find({ ...recipeIdInQuery(recipeIds), ...RECIPE_VISIBLE })
-            .toArray()
-        : []
-
-    res.json({ recipes, totalCount })
-  } catch (err) {
-    respondServerError(res, err, req)
+  if (order === 'new') {
+    savedRecipes = [...savedRecipes].sort((a, b) => Number(b.dateSaved) - Number(a.dateSaved))
+  } else if (order === 'old') {
+    savedRecipes = [...savedRecipes].sort((a, b) => Number(a.dateSaved) - Number(b.dateSaved))
   }
-})
+
+  const pageNum = parseInt(page) || 0
+  const perPage = Math.min(parseInt(recipesPerPage) || 5, MAX_PER_PAGE)
+  const pageSlice = savedRecipes.slice(pageNum * perPage, (pageNum + 1) * perPage)
+  const recipeIds = pageSlice.map((entry) => entry.recipeId)
+
+  const recipes =
+    recipeIds.length > 0
+      ? await db
+          .collection('recipes')
+          .find({ ...recipeIdInQuery(recipeIds), ...RECIPE_VISIBLE })
+          .toArray()
+      : []
+
+  res.json({ recipes, totalCount })
+}))
 
 // GET /getAccountCounts — aggregate item counts for the account-page tabs
 // (saved, ratings, recipes, drafts) for the authenticated user, in one round
 // trip so the nav doesn't need four separate list requests.
-router.get('/getAccountCounts', verifyToken, async (req, res) => {
-  try {
-    const counts = await getAccountCountsFor(getDB(), req.uid)
-    res.json(counts)
-  } catch (err) {
-    respondServerError(res, err, req)
-  }
-})
+router.get('/getAccountCounts', verifyToken, asyncHandler(async (req, res) => {
+  const counts = await getAccountCountsFor(getDB(), req.uid)
+  res.json(counts)
+}))
 
 module.exports = router

--- a/server/util/asyncHandler.js
+++ b/server/util/asyncHandler.js
@@ -1,0 +1,9 @@
+// Wraps an async Express route handler so a rejected promise is forwarded to
+// the central error-handling middleware (the backstop in app.js) via next(err),
+// instead of every handler repeating the same try/catch + respondServerError.
+// The backstop logs the real error and returns a generic body, so wrapped
+// handlers can `throw`/reject freely and still never leak internals.
+const asyncHandler = (fn) => (req, res, next) =>
+  Promise.resolve(fn(req, res, next)).catch(next)
+
+module.exports = { asyncHandler }

--- a/server/util/respondServerError.js
+++ b/server/util/respondServerError.js
@@ -5,8 +5,10 @@
 // err.message. See docs/SECURITY_AUDIT_2026-06-11.md §4 item 2.
 
 // The one generic client-facing 500 body. Exported so every site that emits a
-// generic 500 (route catches via respondServerError, the app.js error backstop,
-// ingredients.js with its own richer logging) shares one literal.
+// generic 500 (the app.js error backstop, `requireActive` in middleware/auth.js,
+// ingredients.js with its own richer logging) shares one literal. Route handlers
+// reach this body indirectly: util/asyncHandler forwards their rejections to the
+// backstop, so they no longer call respondServerError directly.
 const GENERIC_500_MESSAGE = 'Internal server error'
 
 function respondServerError(res, err, req) {


### PR DESCRIPTION
Follow-up to #129. The generic-500 work there left every route handler with an identical `catch (err) { respondServerError(res, err, req) }`. Now that #129 added a central error backstop in `app.js`, those per-route catches are redundant.

## Change
- New `util/asyncHandler.js` — wraps a handler so a rejected promise forwards to the backstop via `next(err)`.
- Removed the ~52 identical try/catch blocks across 9 route files (`recipes`, `reviews`, `auth`, `admin`, `reports`, `drafts`, `users`, `gamification`, `publicProfile`). Handlers now read straight through.

## Deliberately preserved
- `ingredients.js` keeps its own rich Phase-A logging catch (untouched).
- `middleware/auth.js` keeps its intentional `verifyToken` 401 / `optionalAuth` ignore control flow; `requireActive` still uses `respondServerError`.
- Inner try/catch blocks that handle locally and rethrow are kept, so a genuine failure still reaches the backstop:
  - `setUsername` — 11000 duplicate-key → 409 (rethrows others)
  - `publicProfile` — `fetchAuthRecord` avatar fallback
  - `deleteRecipe` — session `try/finally`
  - `admin.js` — per-lookup Firebase `catch (e)` guards

## Behaviour
No external behaviour change: a thrown handler error still logs server-side and returns `500 { error: 'Internal server error' }`, now via the backstop instead of each catch. 4xx responses are unaffected (handlers still `return res.status(4xx)`).

## Tests
- New `asyncHandler` unit tests (forwards rejection to `next`; no `next` on resolve).
- Full server suite green: **347 passed**.

Large line counts are dedent churn from un-nesting the try blocks, not logic changes.