### PR TITLE
feat(auth): soft-glass redesign of login/signup/forgot + onboarding

### DIFF
--- a/src/Components/Form/FormInput.scss
+++ b/src/Components/Form/FormInput.scss
@@ -1,48 +1,91 @@
 @use '../../helpers.scss' as s;
 
 .form-input {
-  position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  height: 80px;
   width: 100%;
+  text-align: left;
 
   .label-title {
-    padding-bottom: 0.5rem;
+    margin-bottom: 0.3rem;
     font-weight: 600;
-    font-size: 0.875rem;
+    font-size: 0.78rem;
+    color: s.$primary-text;
     text-transform: capitalize;
   }
 
   .input-container {
+    position: relative;
     display: flex;
     align-items: center;
     width: 100%;
-    height: 55px;
 
     .icon {
+      position: absolute;
+      left: 0.85rem;
       display: flex;
       justify-content: center;
       align-items: center;
-      position: absolute;
-      height: 25px;
-      width: 25px;
-      color: s.$primary-text;
-      left: 0.75rem;
+      height: 22px;
+      width: 22px;
+      color: s.$tertiary-text;
+      pointer-events: none;
     }
+
     input {
-      outline: none;
-      border: none;
-      background: none;
-      padding-left: 3rem;
-      padding-right: 1rem;
       width: 100%;
-      height: 100%;
-      font-size: 1rem;
+      height: 48px;
+      box-sizing: border-box;
+      padding: 0 2.75rem;
+      font-family: inherit;
+      font-size: 0.95rem;
       font-weight: 500;
-      background: s.$secondary-background;
+      color: s.$primary-text;
+      border: 1.5px solid s.$gray-300;
       border-radius: s.$border-radius;
+      background: s.$white;
+      outline: none;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+      &:focus {
+        border-color: s.$secondary;
+        box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.15);
+      }
+      &::placeholder {
+        color: s.$tertiary-text;
+        font-weight: 400;
+      }
+    }
+
+    .toggle-visibility {
+      position: absolute;
+      right: 0.6rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.25rem;
+      border: none;
+      background: transparent;
+      color: s.$tertiary-text;
+      font-size: 1.3rem;
+      cursor: pointer;
+      transition: color 0.15s ease;
+
+      &:hover {
+        color: s.$primary-text;
+      }
+    }
+  }
+
+  .input-hint {
+    margin-top: 0.35rem;
+    font-size: 0.75rem;
+
+    &--error {
+      color: s.$error-red;
+    }
+    &--ok {
+      color: s.$tertiary-text;
     }
   }
 }

--- a/src/Components/Form/FormInput.tsx
+++ b/src/Components/Form/FormInput.tsx
@@ -1,44 +1,84 @@
-import React, { ChangeEvent, FC, ReactElement } from 'react'
+import React, { ChangeEvent, FC, ReactElement, useState } from 'react'
+import { MdOutlineVisibility, MdOutlineVisibilityOff } from 'react-icons/md'
 import './FormInput.scss'
 
-interface LoginInputProps {
+interface FormInputProps {
   icon: ReactElement
   type: string
   placeholder: string
   name: string
   val: string
   setVal: (value: string) => void
+  /** Visible label above the field. Defaults to a capitalized `name`. */
+  label?: string
+  /** Small helper / validation line below the field. */
+  hint?: string
+  hintTone?: 'error' | 'ok'
+  autoComplete?: string
+  required?: boolean
+  maxLength?: number
 }
 
-const LoginInput: FC<LoginInputProps> = ({
+const FormInput: FC<FormInputProps> = ({
   icon,
   type,
   placeholder,
   name,
   val,
   setVal,
+  label,
+  hint,
+  hintTone = 'ok',
+  autoComplete = 'on',
+  required = true,
+  maxLength,
 }) => {
+  // Password fields render a show/hide toggle and swap their input type.
+  const [show, setShow] = useState(false)
+  const isPassword = type === 'password'
+  const resolvedType = isPassword ? (show ? 'text' : 'password') : type
+
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setVal(e.target.value)
   }
 
   return (
     <label className='form-input'>
-      <div className='label-title'>{name}</div>
+      <span className='label-title'>{label ?? name}</span>
       <div className='input-container'>
         {icon}
         <input
-          type={type}
+          type={resolvedType}
           name={name}
           placeholder={placeholder}
           value={val}
           onChange={handleChange}
-          autoComplete='on'
-          required
+          autoComplete={autoComplete}
+          required={required}
+          maxLength={maxLength}
         />
+        {isPassword && (
+          <button
+            type='button'
+            className='toggle-visibility'
+            aria-label={show ? 'Hide password' : 'Show password'}
+            onClick={() => setShow(s => !s)}
+            tabIndex={-1}
+          >
+            {show ? <MdOutlineVisibilityOff /> : <MdOutlineVisibility />}
+          </button>
+        )}
       </div>
+      {hint && (
+        <span
+          className={`input-hint input-hint--${hintTone}`}
+          role={hintTone === 'error' ? 'alert' : undefined}
+        >
+          {hint}
+        </span>
+      )}
     </label>
   )
 }
 
-export default LoginInput
+export default FormInput

--- a/src/Components/Form/FormStyles.scss
+++ b/src/Components/Form/FormStyles.scss
@@ -1,83 +1,205 @@
 @use '../../helpers.scss' as s;
 
+// Shared layout for the auth pages (login / signup / create-username /
+// forgot-password). These routes render OUTSIDE <Layout> (which owns the app's
+// scroll container) and the app's `html`/`#root` use `overflow: hidden`, so
+// `.form-format` owns its own full-height, centered, scrollable context.
+// Design: "P2 · Minimal" soft-glass — a frosted card centered on a calm pastel
+// peach→teal wash, a teal "P" brand mark, one short title, and grouped spacing.
 .form-format {
+  position: relative;
   box-sizing: border-box;
+  min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  // Own scroll context for the auth pages (login / signup / create-username /
-  // forgot-password): the app's `html`/`#root` use `overflow: hidden` and these
-  // routes aren't wrapped in <Layout> (which owns the app's scroll container),
-  // so a form taller than the viewport would otherwise be clipped with no way
-  // to scroll. border-box keeps the height inclusive of the padding. `dvh`
-  // tracks the *visible* viewport so the form's bottom (e.g. the signup consent
-  // notice) isn't trapped under the mobile browser toolbar; `vh` is the fallback
-  // for browsers without dvh support. Top padding replaces the old 8rem margin.
-  height: 100vh;
-  height: 100dvh;
+  justify-content: center;
+  padding: 2.5rem 1rem;
   overflow-y: auto;
-  // Top padding clears the absolute .abs-logo (≈ nav height); keep it modest so
-  // the forms don't sit too low. Deeper layout polish is deferred to a planned
-  // login/signup audit.
-  padding: 5rem 1rem 2rem;
-  .form-container {
-    max-width: 350px;
-    width: 95%;
-    .form {
+  // Calm pastel peach→teal wash.
+  background: radial-gradient(55% 75% at 18% 20%, #ffe0cf, transparent),
+    radial-gradient(60% 80% at 85% 82%, #c8edef, transparent),
+    linear-gradient(135deg, #ffc4ab, #8fd6db);
+
+  // Both card class names in use across the auth pages.
+  .form-container,
+  .login-form-container {
+    width: 100%;
+    max-width: 400px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+    padding: 2.5rem 2rem;
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.7);
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(18px);
+    box-shadow: 0 22px 55px rgba(40, 30, 20, 0.18);
+  }
+
+  // Brand mark — teal rounded square with a thin, cursive-leaning white "P"
+  // (Montserrat thin italic) to echo the favicon.
+  .brand-mark {
+    align-self: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 52px;
+    height: 52px;
+    border-radius: 16px;
+    font-size: 2.3rem;
+    font-weight: 300;
+    font-style: italic;
+    line-height: 1;
+    letter-spacing: 0;
+    color: s.$white;
+    background: linear-gradient(135deg, #2ec0c8, s.$secondary);
+    box-shadow: 0 8px 18px rgba(0, 173, 181, 0.3);
+    margin-bottom: 1rem;
+  }
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    text-align: center;
+
+    .title {
+      font-size: 1.55rem;
+      font-weight: 800;
+      color: s.$primary-text;
+      margin-bottom: 1.5rem;
+    }
+    // Supporting line under the title (forgot-password / onboarding).
+    .prompt {
+      margin-top: -1.1rem;
+      margin-bottom: 1.5rem;
+      font-weight: 500;
+      font-size: 0.9rem;
+      line-height: 1.45;
+      color: s.$secondary-text;
+      .prompt-btn {
+        color: s.$secondary;
+        font-weight: 700;
+        text-decoration: none;
+      }
+    }
+    .input-fields {
+      width: 100%;
       display: flex;
       flex-direction: column;
-      width: 100%;
-      margin: 0 auto;
-      .title {
-        padding-bottom: 1rem;
-      }
-      .prompt {
-        padding-bottom: 2rem;
-        font-weight: 500;
-        font-size: 1rem;
+      gap: 0.85rem;
+      text-align: left;
+    }
+    // Remember-me / forgot-password row beneath the fields (login).
+    .form-meta {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      margin-top: 0.9rem;
+      font-size: 0.82rem;
+
+      .remember {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
         color: s.$secondary-text;
-        .prompt-btn {
-          color: s.$secondary;
-          font-weight: 700;
+        font-weight: 500;
+        cursor: pointer;
+
+        // Custom checkbox: matches the inputs when empty, fills teal with a
+        // crisp white check when on — consistent across browsers.
+        input[type='checkbox'] {
+          appearance: none;
+          -webkit-appearance: none;
+          flex-shrink: 0;
+          margin: 0;
+          width: 18px;
+          height: 18px;
+          border: 1.5px solid s.$gray-300;
+          border-radius: 5px;
+          background: s.$white;
+          cursor: pointer;
+          transition: background 0.15s ease, border-color 0.15s ease;
+
+          &:hover {
+            border-color: s.$secondary;
+          }
+          &:checked {
+            border-color: s.$secondary;
+            background-color: s.$secondary;
+            background-repeat: no-repeat;
+            background-position: center;
+            background-size: 11px;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='3.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E");
+          }
+          &:focus-visible {
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.2);
+          }
         }
       }
-      .input-fields {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-
-        .forgot-password-prompt {
-          text-decoration: none;
-          font-weight: 500;
-          font-size: 0.875rem;
-          color: s.$secondary-text;
-          width: fit-content;
+      .forgot-password-prompt {
+        margin-left: auto;
+        color: s.$secondary;
+        font-weight: 600;
+        text-decoration: none;
+        &:hover {
+          text-decoration: underline;
         }
       }
     }
   }
 
-  .btn {
-    height: 55px;
-    width: 100%;
+  // Terms/Privacy consent (signup) — sits between the fields and the CTA.
+  .terms-consent {
+    margin-top: 1rem;
+    font-size: 0.75rem;
+    line-height: 1.45;
+    color: s.$tertiary-text;
+    text-align: center;
+    .terms-consent-link {
+      color: s.$secondary;
+      font-weight: 600;
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  // Alert banners (errors + success). aria-live handled in the pages. Scoped
+  // overrides of the global .error/.success (which carry a large margin).
+  .error,
+  .success {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 500;
+    margin: 0 0 0.4rem;
+    padding: 0.65rem 0.85rem;
     border-radius: s.$border-radius;
-    font-weight: 600;
+    text-align: left;
+  }
+  .error {
+    background: s.$alert-error-red;
+    border: 1px solid s.$alert-error-red-border;
+    color: s.$alert-error-red-text;
+  }
+  .success {
+    background: s.$alert-success-green;
+    border: 1px solid s.$alert-success-green-border;
+    color: s.$alert-success-green-text;
   }
 
-  .form-action-btn {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-top: 1.5rem;
-
-    color: s.$primary-background;
-    background: s.$secondary;
-  }
+  // Username availability hints (UsernameInput).
   .available,
   .not-available {
+    margin-top: -0.55rem;
     font-weight: 600;
-    font-size: 1rem;
+    font-size: 0.75rem;
+    text-align: left;
   }
   .available {
     color: s.$success-green;
@@ -85,18 +207,84 @@
   .not-available {
     color: s.$error-red;
   }
+
+  .btn {
+    height: 48px;
+    width: 100%;
+    border-radius: s.$border-radius;
+    font-weight: 700;
+    font-size: 1rem;
+    cursor: pointer;
+  }
+
+  .form-action-btn {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 1.25rem;
+    border: none;
+    color: s.$white;
+    background: s.$secondary;
+    transition: filter 0.15s ease;
+    &:hover:not(:disabled) {
+      filter: brightness(0.95);
+    }
+    &:disabled {
+      opacity: 0.65;
+      cursor: default;
+    }
+  }
+
+  // "or" divider between the email form and the Google button.
+  .divider {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 1.1rem 0;
+    color: s.$tertiary-text;
+    font-size: 0.8rem;
+    font-weight: 500;
+    &::before,
+    &::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: s.$gray-300;
+    }
+  }
+
   .google-btn {
-    margin-top: 1rem;
-    border: 1px solid s.$secondary-background;
+    border: 1.5px solid s.$gray-300;
+    background: s.$white;
+    color: s.$primary-text;
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
-    font-size: 1.125rem;
+    gap: 0.6rem;
+    transition: background 0.15s ease;
+    &:hover {
+      background: s.$gray-50;
+    }
     .icon {
-      height: 40px;
-      width: 40px;
+      height: 24px;
+      width: 24px;
       color: s.$secondary;
+    }
+  }
+
+  // Bottom switch link ("Don't have an account? Sign up").
+  .switch-prompt {
+    margin-top: 1.4rem;
+    font-size: 0.88rem;
+    text-align: center;
+    color: s.$secondary-text;
+    .prompt-btn {
+      color: s.$secondary;
+      font-weight: 700;
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 }

--- a/src/Components/Form/UsernameInput.tsx
+++ b/src/Components/Form/UsernameInput.tsx
@@ -57,8 +57,10 @@ const UsernameInput: FC<UsernameInputProps> = ({
     <>
       <FormInput
         icon={<MdAlternateEmail className='icon' />}
-        type='username'
+        type='text'
         name='username'
+        label='Username'
+        autoComplete='username'
         val={username}
         setVal={setUsername}
         placeholder='johnsmith'

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -7,6 +7,9 @@ import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
   sendPasswordResetEmail,
+  setPersistence,
+  browserLocalPersistence,
+  browserSessionPersistence,
   UserCredential,
   updateProfile,
   updateEmail,
@@ -20,6 +23,7 @@ import AuthAPI from 'src/api/auth'
 import { TailSpin } from 'react-loader-spinner'
 import { getDownloadURL, getStorage, ref, uploadBytes } from 'firebase/storage'
 import { ErrorWithData } from 'src/util/ErrorWithData'
+import { authErrorMessage } from 'src/util/authErrors'
 
 export function useAuth() {
   return useContext(AuthContext)
@@ -33,19 +37,19 @@ type AuthContextValueType = {
   signInDefault: (
     email: string,
     password: string,
+    remember: boolean,
+    setLoading: (val: boolean) => void,
     setError: (val: string) => void
   ) => void
   signUp: (
     email: string,
     password: string,
-    username: string,
-    displayName: string,
     setLoading: (val: boolean) => void,
-    setSuccess: (val: string) => void,
     setError: (val: string) => void
   ) => void
   forgotPassword: (
     email: string,
+    setLoading: (val: boolean) => void,
     setSuccess: (val: string) => void,
     setError: (val: string) => void
   ) => void
@@ -95,99 +99,93 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
         navigate('/')
       })
       .catch(err => {
-        setError(err.code)
+        // authErrorMessage returns '' for benign cases (e.g. the user closing
+        // the popup), so only surface a banner when there's something to say.
+        const message = authErrorMessage(err.code)
+        if (message) setError(message)
       })
   }
   const signInDefault = (
     email: string,
     password: string,
+    remember: boolean,
+    setLoading: (val: boolean) => void,
     setError: (val: string) => void
   ) => {
     if (!email) {
-      return setError('Must enter email')
+      return setError('Please enter your email.')
     } else if (!password) {
-      return setError('Must enter password')
+      return setError('Please enter your password.')
     }
-    signInWithEmailAndPassword(auth, email, password)
+    setLoading(true)
+    // "Remember me" → keep the session across browser restarts (local), else
+    // drop it when the tab/window closes (session). Local matches Firebase's
+    // default, so leaving the box checked preserves prior behavior.
+    setPersistence(
+      auth,
+      remember ? browserLocalPersistence : browserSessionPersistence
+    )
+      .then(() => signInWithEmailAndPassword(auth, email, password))
       .then(userCredential => {
         setUser(userCredential.user)
         navigate('/')
       })
       .catch(err => {
-        const errCode = err.code
-
-        switch (errCode) {
-          case 'auth/user-not-found':
-            return setError(
-              'User not found in database, try creating an account.'
-            )
-          default:
-            return setError('Error, try refreshing your page.')
-        }
+        setLoading(false)
+        setError(authErrorMessage(err.code))
       })
   }
   const signUp = (
     email: string,
     password: string,
-    username: string,
-    displayName: string,
+    setLoading: (val: boolean) => void,
+    setError: (val: string) => void
+  ) => {
+    if (!email) {
+      return setError('Please enter your email.')
+    } else if (!password) {
+      return setError('Please enter your password.')
+    }
+    setLoading(true)
+    createUserWithEmailAndPassword(auth, email, password)
+      .then(cred => {
+        setUser(cred.user)
+        setLoading(false)
+        // Username + optional profile details (display name, bio, location) are
+        // collected on the onboarding step. The post-auth redirect also funnels
+        // username-less Google sign-ins here, so both paths share one page.
+        navigate('/create-username')
+      })
+      .catch(err => {
+        setLoading(false)
+        setError(authErrorMessage(err.code))
+      })
+  }
+  const forgotPassword = (
+    email: string,
     setLoading: (val: boolean) => void,
     setSuccess: (val: string) => void,
     setError: (val: string) => void
   ) => {
-    setLoading(true)
-    if (!username) {
-      setLoading(false)
-      return setError('Must enter username')
-    } else if (!email) {
-      setLoading(false)
-      return setError('Must enter email')
-    } else if (!password) {
-      setLoading(false)
-      return setError('Must enter password')
+    if (!email) {
+      return setError('Please enter your email.')
     }
-
-    AuthAPI.checkUsernameAvailability(username).then(isAvailable => {
-      if (!isAvailable) {
-        setLoading(false)
-        return setError(`${username} has already been taken`)
-      }
-      createUserWithEmailAndPassword(auth, email, password)
-        .then(cred => {
-          AuthAPI.setUsername(username).then(() => {
-            setLoading(false)
-            setSuccess('Username successfully created!')
-            return navigate('/')
-          })
-          updateProfile(cred.user, {
-            displayName: displayName,
-          })
-        })
-        .catch(err => {
-          const errCode = err.code
-          if (err.code === 'auth/weak-password') {
-            setError('Password must be 6 characters or more')
-          } else if (err.code === 'auth/email-already-in-use') {
-            setError('Email is already in use')
-          } else {
-            setError(errCode)
-          }
-          setLoading(false)
-        })
-    })
-  }
-  const forgotPassword = (
-    email: string,
-    setSuccess: (val: string) => void,
-    setError: (val: string) => void
-  ) => {
+    setLoading(true)
     sendPasswordResetEmail(auth, email)
       .then(() => {
+        setLoading(false)
         setSuccess('Email sent! Check your inbox for instructions.')
       })
       .catch(err => {
-        console.log(err)
-        setError(err.code)
+        setLoading(false)
+        // Don't reveal whether an email is registered: a missing account still
+        // shows the same "email sent" confirmation. Only genuinely actionable
+        // problems (bad email format, network, rate-limit) surface an error.
+        if (err.code === 'auth/user-not-found') {
+          setSuccess('Email sent! Check your inbox for instructions.')
+        } else {
+          setError(authErrorMessage(err.code))
+        }
       })
   }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,6 +1,6 @@
 @use './helpers.scss' as s;
 // fallow-ignore-next-line unresolved-import
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,500;0,600;0,700;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,700&display=swap');
 
 * {
   font-family: s.$font-family;
@@ -119,19 +119,6 @@ a {
   gap: 2rem;
   height: 90vh;
   width: 100%;
-}
-
-.abs-logo {
-  top: 0;
-  left: 0;
-  right: 0;
-  margin: 0 auto;
-  height: s.$nav-height;
-  display: flex;
-  align-items: center;
-  position: absolute;
-  width: 90%;
-  max-width: s.$max-width;
 }
 
 .error,

--- a/src/pages/CreateUsername/CreateUsername.scss
+++ b/src/pages/CreateUsername/CreateUsername.scss
@@ -20,4 +20,56 @@
     width: fit-content;
     align-self: center;
   }
+
+  // Quiet separator between the required username and the optional details.
+  .optional-divider {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin: 0.15rem 0;
+    color: s.$tertiary-text;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    &::before,
+    &::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: s.$gray-300;
+    }
+  }
+
+  // Multi-line bio field, styled to match the single-line inputs.
+  .form-textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.65rem 0.85rem;
+    font-family: inherit;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: s.$primary-text;
+    border: 1.5px solid s.$gray-300;
+    border-radius: s.$border-radius;
+    background: s.$white;
+    outline: none;
+    resize: vertical;
+    min-height: 70px;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+    &:focus {
+      border-color: s.$secondary;
+      box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.15);
+    }
+    &::placeholder {
+      color: s.$tertiary-text;
+      font-weight: 400;
+    }
+  }
+
+  // Right-align the bio character counter under the textarea.
+  .form-input .input-hint {
+    align-self: flex-end;
+  }
 }

--- a/src/pages/CreateUsername/CreateUsername.tsx
+++ b/src/pages/CreateUsername/CreateUsername.tsx
@@ -3,16 +3,28 @@ import '../../Components/Form/FormStyles.scss'
 import './CreateUsername.scss'
 import { TailSpin } from 'react-loader-spinner'
 import { useNavigate } from 'react-router-dom'
+import { updateProfile } from 'firebase/auth'
 import toast from 'react-hot-toast'
+import { AiOutlineUser } from 'react-icons/ai'
+import { MdOutlineLocationOn } from 'react-icons/md'
 import UsernameInput from 'src/Components/Form/UsernameInput'
+import FormInput from 'src/Components/Form/FormInput'
 import AuthAPI from 'src/api/auth'
 import { useAuth } from 'src/context/AuthContext'
+
+const BIO_MAX = 300
+const LOCATION_MAX = 80
 
 const CreateUsername: FC = () => {
   const [currUsername, setCurrUsername] = useState('')
   const [isUsernameAvailable, setIsUsernameAvailable] = useState<
     boolean | null
   >(null)
+
+  // Optional profile details — username is the only required field.
+  const [displayName, setDisplayName] = useState('')
+  const [bio, setBio] = useState('')
+  const [location, setLocation] = useState('')
 
   const [loadingCreateUsername, setLoadingCreateUsername] = useState(false)
   // Block rendering the form until we've confirmed the user actually needs it,
@@ -52,12 +64,11 @@ const CreateUsername: FC = () => {
     }
   }, [authLoading, user, navigate])
 
-  const handleCreateUsernameForm = (e: ChangeEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: ChangeEvent<HTMLFormElement>) => {
     e.preventDefault()
 
-    const uid = user?.uid
-    if (!uid) {
-      setError('You must be signed in to create a username.')
+    if (!user?.uid) {
+      setError('You must be signed in to continue.')
       return
     }
     if (!isUsernameAvailable) return
@@ -65,18 +76,30 @@ const CreateUsername: FC = () => {
     setLoadingCreateUsername(true)
     setError('')
 
-    AuthAPI.setUsername(currUsername)
-      .then(() => {
+    // Username first (the required identity); optional details only when filled.
+    // Each step is independent so a failure surfaces its own message.
+    ;(async () => {
+      try {
+        await AuthAPI.setUsername(currUsername)
+        if (displayName.trim()) {
+          await updateProfile(user, { displayName: displayName.trim() })
+        }
+        if (bio.trim() || location.trim()) {
+          await AuthAPI.updateProfile({
+            bio: bio.trim(),
+            location: location.trim(),
+          })
+        }
         setLoadingCreateUsername(false)
         // A toast (rendered at the app root) survives the redirect, unlike an
         // inline message on a page we immediately navigate away from.
-        toast.success('Username created successfully!')
+        toast.success('Welcome to Prepify!')
         navigate('/')
-      })
-      .catch((error: unknown) => {
+      } catch (err: unknown) {
         setLoadingCreateUsername(false)
-        setError(error instanceof Error ? error.message : String(error))
-      })
+        setError(err instanceof Error ? err.message : String(err))
+      }
+    })()
   }
 
   if (authLoading || checkingExisting) {
@@ -92,12 +115,16 @@ const CreateUsername: FC = () => {
   return (
     <div className='create-username-page form-format'>
       <div className='login-form-container'>
-        <form onSubmit={handleCreateUsernameForm} className='form'>
-          <h1 className='title'>One last step...</h1>
+        <div className='brand-mark'>P</div>
+        <form onSubmit={handleSubmit} className='form'>
+          <h1 className='title'>Finish your profile</h1>
           <p className='prompt'>
-            Create a unique username to identify yourself with.
+            Pick a username to get started — everything else is optional and you
+            can change it anytime.
           </p>
-          {error ? <div className='error'>{error}</div> : null}
+          <div aria-live='polite'>
+            {error ? <div className='error'>{error}</div> : null}
+          </div>
           <div className='input-fields'>
             <UsernameInput
               username={currUsername}
@@ -107,20 +134,62 @@ const CreateUsername: FC = () => {
               isUsernameAvailable={isUsernameAvailable}
               setIsUsernameAvailable={setIsUsernameAvailable}
             />
+
+            <div className='optional-divider'>
+              <span>Optional</span>
+            </div>
+
+            <FormInput
+              icon={<AiOutlineUser className='icon' />}
+              type='text'
+              name='display-name'
+              label='Display name'
+              autoComplete='name'
+              required={false}
+              val={displayName}
+              setVal={setDisplayName}
+              placeholder='John Smith'
+            />
+            <FormInput
+              icon={<MdOutlineLocationOn className='icon' />}
+              type='text'
+              name='location'
+              label='Location'
+              autoComplete='off'
+              required={false}
+              maxLength={LOCATION_MAX}
+              val={location}
+              setVal={setLocation}
+              placeholder='Toronto, Canada'
+            />
+            <label className='form-input'>
+              <span className='label-title'>Bio</span>
+              <textarea
+                className='form-textarea'
+                value={bio}
+                onChange={e => setBio(e.target.value)}
+                placeholder='Tell others a little about yourself'
+                maxLength={BIO_MAX}
+                rows={3}
+              />
+              <span className='input-hint input-hint--ok'>
+                {bio.length}/{BIO_MAX}
+              </span>
+            </label>
           </div>
           <button
             className='form-action-btn btn'
-            disabled={loadingCreateUsername}
+            disabled={loadingCreateUsername || !isUsernameAvailable}
           >
             {loadingCreateUsername ? (
               <TailSpin
-                height='30'
-                width='30'
+                height='28'
+                width='28'
                 color='white'
                 ariaLabel='loading'
               />
             ) : (
-              'Create Username'
+              'Continue'
             )}
           </button>
           <button

--- a/src/pages/ForgotPassword/ForgotPassword.scss
+++ b/src/pages/ForgotPassword/ForgotPassword.scss
@@ -1,11 +1,4 @@
 @use '../../helpers.scss' as s;
 
-.forgot-password-page {
-  .back-to-login {
-    margin-top: 1rem;
-    font-weight: 600;
-    display: flex;
-    justify-content: center;
-    color: s.$tertiary-text;
-  }
-}
+// Layout + the "Back to login" switch link come from the shared `.form-format`
+// (FormStyles.scss). No forgot-password-specific overrides are needed.

--- a/src/pages/ForgotPassword/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword/ForgotPassword.tsx
@@ -5,7 +5,7 @@ import '../../Components/Form/FormStyles.scss'
 import FormInput from 'src/Components/Form/FormInput'
 import { MdOutlineEmail } from 'react-icons/md'
 import { useAuth } from 'src/context/AuthContext'
-import PrepifyLogo from 'src/Components/Navbar/PrepifyLogo'
+import { TailSpin } from 'react-loader-spinner'
 import { Helmet } from 'react-helmet-async'
 
 const ForgotPassword: FC = () => {
@@ -15,12 +15,15 @@ const ForgotPassword: FC = () => {
 
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
+  const [loading, setLoading] = useState(false)
 
-  const handleChangePasswordFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleChangePasswordFormSubmit = (
+    e: React.FormEvent<HTMLFormElement>
+  ) => {
     e.preventDefault()
     setError('')
     setSuccess('')
-    authRes?.forgotPassword(email, setSuccess, setError)
+    authRes?.forgotPassword(email, setLoading, setSuccess, setError)
   }
 
   return (
@@ -29,33 +32,49 @@ const ForgotPassword: FC = () => {
         <meta charSet='utf-8' />
         <title>Prepify | Forgot Password</title>
       </Helmet>
-      <div className='abs-logo'>
-        <PrepifyLogo />
-      </div>
       <div className='forgot-password-page form-format'>
         <div className='login-form-container'>
+          <div className='brand-mark'>P</div>
           <form onSubmit={handleChangePasswordFormSubmit} className='form'>
-            <h1 className='title'>Forgot Password?</h1>
+            <h1 className='title'>Reset your password</h1>
             <p className='prompt'>
-              Enter your email to receive a link to reset your password.
+              Enter your email and we'll send you a link to get back in.
             </p>
-            {error ? <div className='error'>{error}</div> : null}
-            {success ? <div className='success'>{success}</div> : null}
+            <div aria-live='polite'>
+              {error ? <div className='error'>{error}</div> : null}
+              {success ? <div className='success'>{success}</div> : null}
+            </div>
             <div className='input-fields'>
               <FormInput
                 icon={<MdOutlineEmail className='icon' />}
                 type='email'
                 name='email'
+                label='Email'
+                autoComplete='email'
                 val={email}
                 setVal={setEmail}
                 placeholder='name@example.com'
               />
             </div>
-            <button className='form-action-btn btn'>Send Email</button>
+            <button className='form-action-btn btn' disabled={loading}>
+              {loading ? (
+                <TailSpin
+                  height='28'
+                  width='28'
+                  color='white'
+                  ariaLabel='loading'
+                />
+              ) : (
+                'Send reset link'
+              )}
+            </button>
           </form>
-          <Link to='/login' className='back-to-login'>
-            Return to Login
-          </Link>
+          <p className='switch-prompt'>
+            Remembered it?{' '}
+            <Link to='/login' className='prompt-btn'>
+              Back to login
+            </Link>
+          </p>
         </div>
       </div>
     </>

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -6,21 +6,25 @@ import FormInput from 'src/Components/Form/FormInput'
 import { useAuth } from 'src/context/AuthContext'
 import { AiOutlineGoogle } from 'react-icons/ai'
 import { MdOutlineEmail, MdOutlineLock } from 'react-icons/md'
-import PrepifyLogo from 'src/Components/Navbar/PrepifyLogo'
+import { TailSpin } from 'react-loader-spinner'
 import { Helmet } from 'react-helmet-async'
 
 const Login: FC = () => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [remember, setRemember] = useState(true)
 
   const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
 
   const authRes = useAuth()
 
-  const handleEmailAndPasswordFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleEmailAndPasswordFormSubmit = (
+    e: React.FormEvent<HTMLFormElement>
+  ) => {
     e.preventDefault()
     setError('')
-    authRes?.signInDefault(email, password, setError)
+    authRes?.signInDefault(email, password, remember, setLoading, setError)
   }
 
   return authRes?.user ? (
@@ -31,25 +35,21 @@ const Login: FC = () => {
         <meta charSet='utf-8' />
         <title>Prepify | Login</title>
       </Helmet>
-      <div className='abs-logo'>
-        <PrepifyLogo />
-      </div>
       <div className='login-page form-format'>
         <div className='form-container'>
+          <div className='brand-mark'>P</div>
           <form onSubmit={handleEmailAndPasswordFormSubmit} className='form'>
-            <h1 className='title'>Login</h1>
-            <p className='prompt'>
-              Don't have an account yet?{' '}
-              <Link to='/signup' className='prompt-btn'>
-                Sign Up
-              </Link>{' '}
-            </p>
-            {error ? <div className='error'>{error}</div> : null}
+            <h1 className='title'>Welcome back</h1>
+            <div aria-live='polite'>
+              {error ? <div className='error'>{error}</div> : null}
+            </div>
             <div className='input-fields'>
               <FormInput
                 icon={<MdOutlineEmail className='icon' />}
                 type='email'
                 name='email'
+                label='Email'
+                autoComplete='email'
                 val={email}
                 setVal={setEmail}
                 placeholder='name@example.com'
@@ -58,26 +58,59 @@ const Login: FC = () => {
                 icon={<MdOutlineLock className='icon' />}
                 type='password'
                 name='password'
+                label='Password'
+                autoComplete='current-password'
                 val={password}
                 setVal={setPassword}
-                placeholder='6+ Characters'
+                placeholder='Your password'
               />
+            </div>
+            <div className='form-meta'>
+              <label className='remember'>
+                <input
+                  type='checkbox'
+                  checked={remember}
+                  onChange={e => setRemember(e.target.checked)}
+                />
+                Remember me
+              </label>
               <Link to='/forgot-password' className='forgot-password-prompt'>
-                Forgot Password
+                Forgot password?
               </Link>
             </div>
-            <button className='form-action-btn btn'>Login</button>
+            <button className='form-action-btn btn' disabled={loading}>
+              {loading ? (
+                <TailSpin
+                  height='28'
+                  width='28'
+                  color='white'
+                  ariaLabel='loading'
+                />
+              ) : (
+                'Log in'
+              )}
+            </button>
           </form>
+          <div className='divider'>or</div>
           <button
             className='google-btn btn'
-            onClick={() => authRes?.signInWithGoogle(setError)}
+            onClick={() => {
+              setError('')
+              authRes?.signInWithGoogle(setError)
+            }}
           >
-            <AiOutlineGoogle className='icon' /> Log In With Google
+            <AiOutlineGoogle className='icon' /> Continue with Google
           </button>
+          <p className='switch-prompt'>
+            New to Prepify?{' '}
+            <Link to='/signup' className='prompt-btn'>
+              Sign up
+            </Link>
+          </p>
         </div>
       </div>
     </>
   )
 }
-// Work on functionality for all log in, sign up, and forgot password forms
+
 export default Login

--- a/src/pages/Signup/Signup.scss
+++ b/src/pages/Signup/Signup.scss
@@ -1,26 +1,5 @@
 @use '../../helpers.scss' as s;
 
-// The full-height scroll container + top padding live on the shared
-// `.form-format` (FormStyles.scss), so all three auth pages get them. Only
-// signup-specific tweaks live here.
-.signup-page {
-  // Consent notice below both signup buttons. Use secondary (not tertiary) text
-  // so it's legible, and give it a little separation from the buttons.
-  .terms-consent {
-    margin-top: 1.75rem;
-    text-align: center;
-    font-size: 0.8125rem;
-    line-height: 1.5;
-    color: s.$secondary-text;
-
-    .terms-consent-link {
-      color: s.$secondary;
-      font-weight: 600;
-      text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-  }
-}
+// The card layout, brand mark, consent line, and spacing all live on the shared
+// `.form-format` (FormStyles.scss) so the auth pages stay consistent. No
+// signup-specific overrides are needed at the moment.

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -1,52 +1,40 @@
 import React, { ChangeEvent, FC, useState } from 'react'
 import { Link, Navigate } from 'react-router-dom'
-import { AiOutlineGoogle, AiOutlineUser } from 'react-icons/ai'
+import { AiOutlineGoogle } from 'react-icons/ai'
 import { MdOutlineEmail, MdOutlineLock } from 'react-icons/md'
 import { useAuth } from 'src/context/AuthContext'
 import { TailSpin } from 'react-loader-spinner'
 import { Helmet } from 'react-helmet-async'
 
-import UsernameInput from 'src/Components/Form/UsernameInput'
-
 import './Signup.scss'
 import '../../Components/Form/FormStyles.scss'
 
-import PrepifyLogo from 'src/Components/Navbar/PrepifyLogo'
 import FormInput from 'src/Components/Form/FormInput'
 
 const Signup: FC = () => {
-  const [name, setName] = useState('')
-  const [username, setUsername] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
 
-  const [success, setSuccess] = useState('')
   const [error, setError] = useState('')
-
   const [loading, setLoading] = useState(false)
-
-  const [isUsernameAvailable, setIsUsernameAvailable] = useState<
-    boolean | null
-  >(null)
 
   const authRes = useAuth()
 
-  const handleEmailAndPasswordFormSubmit = async (
+  const handleEmailAndPasswordFormSubmit = (
     e: ChangeEvent<HTMLFormElement>
   ) => {
-    setError('')
-    setSuccess('')
     e.preventDefault()
+    setError('')
 
-    authRes?.signUp(
-      email,
-      password,
-      username,
-      name,
-      setLoading,
-      setSuccess,
-      setError
-    )
+    // Catch typos before hitting Firebase — a mismatched confirm is the most
+    // common signup mistake and otherwise can't be detected after the fact.
+    if (password !== confirmPassword) {
+      return setError('Passwords do not match.')
+    }
+
+    // Username + optional profile details are collected on the next step.
+    authRes?.signUp(email, password, setLoading, setError)
   }
 
   return authRes?.user ? (
@@ -57,42 +45,21 @@ const Signup: FC = () => {
         <meta charSet='utf-8' />
         <title>Prepify | Sign Up</title>
       </Helmet>
-      <div className='abs-logo'>
-        <PrepifyLogo />
-      </div>
       <div className='signup-page form-format'>
         <div className='form-container'>
+          <div className='brand-mark'>P</div>
           <form onSubmit={handleEmailAndPasswordFormSubmit} className='form'>
-            <h1 className='title'>Sign Up</h1>
-            <p className='prompt'>
-              Already have an account?{' '}
-              <Link to='/login' className='prompt-btn'>
-                Login
-              </Link>{' '}
-            </p>
-            {success ? <div className='success'>{success}</div> : null}
-            {error ? <div className='error'>{error}</div> : null}
+            <h1 className='title'>Create your account</h1>
+            <div aria-live='polite'>
+              {error ? <div className='error'>{error}</div> : null}
+            </div>
             <div className='input-fields'>
-              <FormInput
-                icon={<AiOutlineUser className='icon' />}
-                type='text'
-                name='name'
-                val={name}
-                setVal={setName}
-                placeholder={'John Smith'}
-              />
-              <UsernameInput
-                isUsernameAvailable={isUsernameAvailable}
-                setIsUsernameAvailable={setIsUsernameAvailable}
-                username={username}
-                setUsername={setUsername}
-                setSuccess={setSuccess}
-                setError={setError}
-              />
               <FormInput
                 icon={<MdOutlineEmail className='icon' />}
                 type='email'
                 name='email'
+                label='Email'
+                autoComplete='email'
                 val={email}
                 setVal={setEmail}
                 placeholder='name@example.com'
@@ -101,42 +68,64 @@ const Signup: FC = () => {
                 icon={<MdOutlineLock className='icon' />}
                 type='password'
                 name='password'
+                label='Password'
+                autoComplete='new-password'
                 val={password}
                 setVal={setPassword}
-                placeholder='6+ Characters'
+                placeholder='6+ characters'
+              />
+              <FormInput
+                icon={<MdOutlineLock className='icon' />}
+                type='password'
+                name='confirm-password'
+                label='Confirm password'
+                autoComplete='new-password'
+                val={confirmPassword}
+                setVal={setConfirmPassword}
+                placeholder='Re-enter password'
               />
             </div>
-            <button className='form-action-btn btn'>
+            {/* Consent applies to account creation by any method (email or
+                Google) — placed by the primary CTA. */}
+            <p className='terms-consent'>
+              By creating an account, you agree to our{' '}
+              <Link to='/terms' className='terms-consent-link'>
+                Terms of Service
+              </Link>{' '}
+              and{' '}
+              <Link to='/privacy' className='terms-consent-link'>
+                Privacy Policy
+              </Link>
+              .
+            </p>
+            <button className='form-action-btn btn' disabled={loading}>
               {loading ? (
                 <TailSpin
-                  height='30'
-                  width='30'
+                  height='28'
+                  width='28'
                   color='white'
                   ariaLabel='loading'
                 />
               ) : (
-                'Create Username'
+                'Create account'
               )}
             </button>
           </form>
+          <div className='divider'>or</div>
           <button
             className='google-btn btn'
-            onClick={() => authRes?.signInWithGoogle(setError)}
+            onClick={() => {
+              setError('')
+              authRes?.signInWithGoogle(setError)
+            }}
           >
-            <AiOutlineGoogle className='icon' /> Sign Up With Google
+            <AiOutlineGoogle className='icon' /> Sign up with Google
           </button>
-          {/* Consent notice covers both signup paths (email form + Google),
-              so it sits below both buttons. */}
-          <p className='terms-consent'>
-            By creating an account, you agree to our{' '}
-            <Link to='/terms' className='terms-consent-link'>
-              Terms of Service
-            </Link>{' '}
-            and{' '}
-            <Link to='/privacy' className='terms-consent-link'>
-              Privacy Policy
+          <p className='switch-prompt'>
+            Already have an account?{' '}
+            <Link to='/login' className='prompt-btn'>
+              Log in
             </Link>
-            .
           </p>
         </div>
       </div>

--- a/src/test/CreateUsername.test.tsx
+++ b/src/test/CreateUsername.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import CreateUsername from 'src/pages/CreateUsername/CreateUsername'
+
+const {
+  getUsernameMock,
+  checkAvailMock,
+  setUsernameMock,
+  updateProfileApiMock,
+  updateProfileFbMock,
+  toastSuccessMock,
+  navigateMock,
+} = vi.hoisted(() => ({
+  getUsernameMock: vi.fn(),
+  checkAvailMock: vi.fn(),
+  setUsernameMock: vi.fn(),
+  updateProfileApiMock: vi.fn(),
+  updateProfileFbMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  navigateMock: vi.fn(),
+}))
+
+vi.mock('src/api/auth', () => ({
+  default: {
+    getUsername: getUsernameMock,
+    checkUsernameAvailability: checkAvailMock,
+    setUsername: setUsernameMock,
+    updateProfile: updateProfileApiMock,
+  },
+}))
+vi.mock('firebase/auth', () => ({ updateProfile: updateProfileFbMock }))
+vi.mock('react-hot-toast', () => ({
+  default: { success: toastSuccessMock, error: vi.fn() },
+}))
+vi.mock('react-router-dom', async orig => ({
+  ...(await orig<typeof import('react-router-dom')>()),
+  useNavigate: () => navigateMock,
+}))
+vi.mock('src/context/AuthContext', () => ({
+  useAuth: () => ({ user: { uid: 'u1' }, authLoading: false, logout: vi.fn() }),
+}))
+
+const renderOnboarding = () =>
+  render(
+    <MemoryRouter>
+      <CreateUsername />
+    </MemoryRouter>
+  )
+
+// Type a valid username and wait for the availability check to enable Continue.
+const pickAvailableUsername = async (name = 'validuser') => {
+  fireEvent.change(screen.getByLabelText('Username'), { target: { value: name } })
+  const cont = screen.getByRole('button', { name: /continue/i })
+  await waitFor(() => expect(cont).toBeEnabled(), { timeout: 2500 })
+  return cont
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getUsernameMock.mockResolvedValue(null) // brand-new user -> show the form
+  checkAvailMock.mockResolvedValue(true)
+  setUsernameMock.mockResolvedValue(undefined)
+  updateProfileApiMock.mockResolvedValue(undefined)
+  updateProfileFbMock.mockResolvedValue(undefined)
+})
+
+describe('CreateUsername (onboarding)', () => {
+  it('disables Continue until a username is available', async () => {
+    renderOnboarding()
+    await screen.findByText('Finish your profile')
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled()
+    await pickAvailableUsername()
+    expect(screen.getByRole('button', { name: /continue/i })).toBeEnabled()
+  })
+
+  it('saves username + the optional details that were filled in', async () => {
+    renderOnboarding()
+    await screen.findByText('Finish your profile')
+    const cont = await pickAvailableUsername()
+    fireEvent.change(screen.getByLabelText('Display name'), {
+      target: { value: 'John Smith' },
+    })
+    fireEvent.change(screen.getByLabelText('Location'), {
+      target: { value: 'Toronto' },
+    })
+    fireEvent.change(
+      screen.getByPlaceholderText('Tell others a little about yourself'),
+      { target: { value: 'I cook.' } }
+    )
+    fireEvent.click(cont)
+
+    await waitFor(() =>
+      expect(setUsernameMock).toHaveBeenCalledWith('validuser')
+    )
+    expect(updateProfileFbMock).toHaveBeenCalledWith(
+      { uid: 'u1' },
+      { displayName: 'John Smith' }
+    )
+    expect(updateProfileApiMock).toHaveBeenCalledWith({
+      bio: 'I cook.',
+      location: 'Toronto',
+    })
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/'))
+    expect(toastSuccessMock).toHaveBeenCalled()
+  })
+
+  it('skips the optional saves when those fields are left blank', async () => {
+    renderOnboarding()
+    await screen.findByText('Finish your profile')
+    const cont = await pickAvailableUsername()
+    fireEvent.click(cont)
+
+    await waitFor(() =>
+      expect(setUsernameMock).toHaveBeenCalledWith('validuser')
+    )
+    expect(updateProfileFbMock).not.toHaveBeenCalled()
+    expect(updateProfileApiMock).not.toHaveBeenCalled()
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/'))
+  })
+})

--- a/src/test/ForgotPassword.test.tsx
+++ b/src/test/ForgotPassword.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import ForgotPassword from 'src/pages/ForgotPassword/ForgotPassword'
+
+const { forgotPasswordMock } = vi.hoisted(() => ({
+  forgotPasswordMock: vi.fn(),
+}))
+
+vi.mock('src/context/AuthContext', () => ({
+  useAuth: () => ({ forgotPassword: forgotPasswordMock }),
+}))
+
+const renderForgot = () =>
+  render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <ForgotPassword />
+      </MemoryRouter>
+    </HelmetProvider>
+  )
+
+beforeEach(() => forgotPasswordMock.mockReset())
+
+describe('ForgotPassword', () => {
+  it('calls forgotPassword with the email and the state setters', () => {
+    renderForgot()
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'a@b.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }))
+    expect(forgotPasswordMock).toHaveBeenCalledWith(
+      'a@b.com',
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    )
+  })
+
+  it('renders the success message the auth layer reports', () => {
+    renderForgot()
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'a@b.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    // The page hands its own setSuccess to the auth layer (3rd arg). Drive it
+    // the way a successful send would and confirm the banner renders.
+    const setSuccess = forgotPasswordMock.mock.calls[0][2]
+    act(() => setSuccess('Email sent! Check your inbox for instructions.'))
+    expect(
+      screen.getByText('Email sent! Check your inbox for instructions.')
+    ).toBeInTheDocument()
+  })
+})

--- a/src/test/FormInput.test.tsx
+++ b/src/test/FormInput.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import FormInput from 'src/Components/Form/FormInput'
+
+const renderInput = (props: Partial<React.ComponentProps<typeof FormInput>> = {}) =>
+  render(
+    <FormInput
+      icon={<span data-testid='icon' />}
+      type='password'
+      name='password'
+      label='Password'
+      val='secret'
+      setVal={() => {}}
+      placeholder='Your password'
+      {...props}
+    />
+  )
+
+describe('FormInput password toggle', () => {
+  it('starts hidden and flips type + aria-label when toggled', () => {
+    renderInput()
+    const input = screen.getByLabelText('Password') as HTMLInputElement
+    expect(input.type).toBe('password')
+
+    const toggle = screen.getByRole('button', { name: 'Show password' })
+    fireEvent.click(toggle)
+    expect(input.type).toBe('text')
+    expect(
+      screen.getByRole('button', { name: 'Hide password' })
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide password' }))
+    expect(input.type).toBe('password')
+  })
+
+  it('renders no toggle for non-password inputs', () => {
+    renderInput({ type: 'email', name: 'email', label: 'Email' })
+    expect(
+      screen.queryByRole('button', { name: /password/i })
+    ).not.toBeInTheDocument()
+    expect((screen.getByLabelText('Email') as HTMLInputElement).type).toBe(
+      'email'
+    )
+  })
+
+  it('uses the label text for the field and reflects typing', () => {
+    const setVal = vi.fn()
+    renderInput({ setVal, val: '' })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'hunter2' },
+    })
+    expect(setVal).toHaveBeenCalledWith('hunter2')
+  })
+})

--- a/src/test/Login.test.tsx
+++ b/src/test/Login.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import Login from 'src/pages/Login/Login'
+
+const { signInDefaultMock, signInWithGoogleMock } = vi.hoisted(() => ({
+  signInDefaultMock: vi.fn(),
+  signInWithGoogleMock: vi.fn(),
+}))
+
+vi.mock('src/context/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+    signInDefault: signInDefaultMock,
+    signInWithGoogle: signInWithGoogleMock,
+  }),
+}))
+
+const renderLogin = () =>
+  render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    </HelmetProvider>
+  )
+
+const fillCreds = () => {
+  fireEvent.change(screen.getByLabelText('Email'), {
+    target: { value: 'a@b.com' },
+  })
+  fireEvent.change(screen.getByLabelText('Password'), {
+    target: { value: 'pw123456' },
+  })
+}
+
+beforeEach(() => {
+  signInDefaultMock.mockReset()
+  signInWithGoogleMock.mockReset()
+})
+
+describe('Login', () => {
+  it('submits with remember=true by default', () => {
+    renderLogin()
+    fillCreds()
+    fireEvent.click(screen.getByRole('button', { name: /log in/i }))
+    expect(signInDefaultMock).toHaveBeenCalledWith(
+      'a@b.com',
+      'pw123456',
+      true,
+      expect.any(Function),
+      expect.any(Function)
+    )
+  })
+
+  it('passes remember=false when the box is unchecked', () => {
+    renderLogin()
+    fillCreds()
+    fireEvent.click(screen.getByRole('checkbox')) // default checked -> off
+    fireEvent.click(screen.getByRole('button', { name: /log in/i }))
+    expect(signInDefaultMock).toHaveBeenCalledWith(
+      'a@b.com',
+      'pw123456',
+      false,
+      expect.any(Function),
+      expect.any(Function)
+    )
+  })
+
+  it('renders the friendly error the auth layer reports', () => {
+    signInDefaultMock.mockImplementation(
+      (_e, _p, _r, _setLoading, setError) =>
+        setError('Incorrect email or password. Please try again.')
+    )
+    renderLogin()
+    fillCreds()
+    fireEvent.click(screen.getByRole('button', { name: /log in/i }))
+    expect(
+      screen.getByText('Incorrect email or password. Please try again.')
+    ).toBeInTheDocument()
+  })
+
+  it('routes the Google button through signInWithGoogle', () => {
+    renderLogin()
+    fireEvent.click(
+      screen.getByRole('button', { name: /continue with google/i })
+    )
+    expect(signInWithGoogleMock).toHaveBeenCalled()
+  })
+})

--- a/src/test/Signup.test.tsx
+++ b/src/test/Signup.test.tsx
@@ -1,24 +1,20 @@
 import React from 'react'
 import { vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import Signup from 'src/pages/Signup/Signup'
+
+// Hoisted so the mocked useAuth and the assertions share one spy.
+const { signUpMock } = vi.hoisted(() => ({ signUpMock: vi.fn() }))
 
 // Stub auth so the page renders signed-out chrome without booting Firebase.
 vi.mock('src/context/AuthContext', () => ({
   useAuth: () => ({
     user: null,
-    signUp: vi.fn(),
+    signUp: signUpMock,
     signInWithGoogle: vi.fn(),
   }),
-}))
-
-// UsernameInput imports AuthAPI (→ axios/Firebase) at module scope; mock it so
-// the import graph stays out of these presentational tests. (The availability
-// check only fires for usernames ≥ 3 chars, which this test never types.)
-vi.mock('src/api/auth', () => ({
-  default: { checkUsernameAvailability: vi.fn() },
 }))
 
 const renderSignup = () =>
@@ -29,6 +25,10 @@ const renderSignup = () =>
       </MemoryRouter>
     </HelmetProvider>
   )
+
+beforeEach(() => {
+  signUpMock.mockClear()
+})
 
 describe('Signup terms-of-service consent', () => {
   it('shows a consent notice linking to the Terms and Privacy pages', () => {
@@ -42,5 +42,45 @@ describe('Signup terms-of-service consent', () => {
     expect(
       screen.getByRole('link', { name: 'Privacy Policy' })
     ).toHaveAttribute('href', '/privacy')
+  })
+})
+
+describe('Signup confirm-password validation', () => {
+  it('blocks submit and shows an error when the passwords do not match', () => {
+    renderSignup()
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'a@b.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'abc123' },
+    })
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'xyz789' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    expect(screen.getByText('Passwords do not match.')).toBeInTheDocument()
+    expect(signUpMock).not.toHaveBeenCalled()
+  })
+
+  it('calls signUp with email + password when the passwords match', () => {
+    renderSignup()
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'a@b.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'abc123' },
+    })
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'abc123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    expect(signUpMock).toHaveBeenCalledWith(
+      'a@b.com',
+      'abc123',
+      expect.any(Function),
+      expect.any(Function)
+    )
   })
 })

--- a/src/test/authErrors.test.ts
+++ b/src/test/authErrors.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { authErrorMessage } from 'src/util/authErrors'
+
+describe('authErrorMessage', () => {
+  it('collapses all credential failures into one non-leaky message', () => {
+    const expected = 'Incorrect email or password. Please try again.'
+    expect(authErrorMessage('auth/invalid-credential')).toBe(expected)
+    expect(authErrorMessage('auth/wrong-password')).toBe(expected)
+    // user-not-found must read the same so we never reveal which emails exist.
+    expect(authErrorMessage('auth/user-not-found')).toBe(expected)
+  })
+
+  it('returns empty string for benign popup dismissals (no banner)', () => {
+    expect(authErrorMessage('auth/popup-closed-by-user')).toBe('')
+    expect(authErrorMessage('auth/cancelled-popup-request')).toBe('')
+  })
+
+  it('maps the common specific cases to friendly copy', () => {
+    expect(authErrorMessage('auth/invalid-email')).toMatch(/valid email/i)
+    expect(authErrorMessage('auth/email-already-in-use')).toMatch(/already exists/i)
+    expect(authErrorMessage('auth/weak-password')).toMatch(/at least 6/i)
+    expect(authErrorMessage('auth/too-many-requests')).toMatch(/too many/i)
+    expect(authErrorMessage('auth/network-request-failed')).toMatch(/network/i)
+  })
+
+  it('falls back to a generic message for unknown codes', () => {
+    expect(authErrorMessage('auth/some-future-code')).toBe(
+      'Something went wrong. Please try again.'
+    )
+    expect(authErrorMessage('')).toBe('Something went wrong. Please try again.')
+  })
+})

--- a/src/util/authErrors.ts
+++ b/src/util/authErrors.ts
@@ -1,0 +1,33 @@
+// Maps raw Firebase Auth error codes to human-readable, non-leaky messages.
+// Keeps user-facing copy out of the auth flow and avoids surfacing codes like
+// `auth/invalid-credential` directly. Returns '' for benign cases (e.g. the
+// user closing the Google popup) so callers can skip showing an error banner.
+export const authErrorMessage = (code: string): string => {
+  switch (code) {
+    case 'auth/invalid-email':
+      return 'Please enter a valid email address.'
+    case 'auth/user-disabled':
+      return 'This account has been disabled. Contact support for help.'
+    // Firebase collapses wrong-email / wrong-password into invalid-credential
+    // when email-enumeration protection is on; treat them all the same so we
+    // never reveal whether an email is registered.
+    case 'auth/invalid-credential':
+    case 'auth/wrong-password':
+    case 'auth/user-not-found':
+      return 'Incorrect email or password. Please try again.'
+    case 'auth/too-many-requests':
+      return 'Too many attempts. Please wait a moment and try again.'
+    case 'auth/network-request-failed':
+      return 'Network error. Check your connection and try again.'
+    case 'auth/email-already-in-use':
+      return 'An account with this email already exists.'
+    case 'auth/weak-password':
+      return 'Password must be at least 6 characters.'
+    // User dismissed the Google popup — not worth an error banner.
+    case 'auth/popup-closed-by-user':
+    case 'auth/cancelled-popup-request':
+      return ''
+    default:
+      return 'Something went wrong. Please try again.'
+  }
+}


### PR DESCRIPTION
## What

Overhaul of the auth surface — visual redesign + functionality — across **Login / Signup / Forgot-password** and a new post-signup **onboarding** step.

### Design ("soft glass")
- Frosted card on a calm pastel peach→teal backdrop, a teal **"P"** brand mark (Montserrat thin italic), one short title, and deliberate grouped spacing — all driven from the shared `FormStyles.scss` so the pages stay consistent.
- Custom **"Remember me"** checkbox (rounded box, teal fill + white check, hover + focus ring) — matches the inputs and is consistent across browsers.

### Functionality
- **Signup** gains a confirm-password field + Terms/Privacy consent. Username / bio / location moved to a **post-signup onboarding** step (`CreateUsername` → "Finish your profile", live username availability + optional details).
- **FormInput**: built-in password show/hide toggle; `label`/`hint`/`maxLength` props.
- Friendly auth errors via `src/util/authErrors.ts`; loading + submit-disable on every form; **Remember-me** wired to Firebase persistence; **forgot-password no longer reveals whether an account exists**; `aria-live` on banners.

## Tests
Added `authErrors` / `FormInput` / `Login` / `ForgotPassword` / `CreateUsername` suites (**+16**) covering error mapping, password toggle, remember-me wiring, no-enumeration reset, and onboarding gating/optional-save. **Suite 265 → 281**, tsc clean, production build OK.

## Verification
- **Runtime `/verify` PASS** — drove every flow live (Playwright on the running app): password toggle, custom checkbox, wrong-creds → friendly error, signup → onboarding → home (real backend `setUsername` write), forgot-password no-enumeration.
- **Adversarial smoke 10/10** — logged-out onboarding guard, duplicate email, weak/short/whitespace/taken inputs, malformed email, bio cap, double-submit guard all handled gracefully.