### PR TITLE
feat: bug reporting system (Sentry + in-app report form + admin queue)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ VITE_OPEN_AI_API_KEY=<your-openai-api-key>
 VITE_API_URL=http://localhost:4000
 VITE_INGREDIENT_PARSER_URL=https://<your-railway-ingredient-parser-url>
 VITE_CYPRESS=false
+# Sentry client error monitoring. Leave empty to disable entirely — the app
+# no-ops (no init, no reporting) without a DSN, so local dev/CI stay quiet.
+VITE_SENTRY_DSN=

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -135,8 +135,17 @@ a feature flag. Do these together:
   the API origin, with valid certs. **(blocker)**
 - `[ ]` **Support / contact path** — a way for users to report issues (Formspree is already a
   dependency — wire a contact form, or list an email). **(nice-to-have)**
-- `[ ]` **Error tracking decision** — decide whether to add basic error tracking (e.g. Sentry) before
-  or after 1.0. Out of the current scope, but flag the call. **(needs decision)**
+- `[x]` **Error tracking (Sentry) — wired; prod env vars are a launch step** — Sentry error monitoring
+  is implemented frontend + backend (env-gated; no DSN ⇒ no-ops). Also shipped: an in-app "Report a
+  bug" form (footer, open to logged-out users) → `bugReports` collection → `/admin/bug-reports` queue.
+  **Before/at launch, set the production env vars or nothing is captured/emailed:**
+  - **Backend (Railway):** `SENTRY_DSN` = the Node-project DSN.
+  - **Frontend build env (Netlify / Firebase Hosting):** `VITE_SENTRY_DSN` = the React-project DSN.
+    It's compiled into the bundle, so it **must be set before `npm run build`**, not at runtime.
+  - **Backend (Railway):** `ADMIN_NOTIFY_EMAIL` (optional) — where new bug-report alerts are sent;
+    defaults to `jesselindcs@gmail.com`. Only sends when `RESEND_API_KEY` is configured.
+  DSNs are public (safe to ship in the client bundle). No DB migration — `bugReports` indexes
+  auto-build at startup. **(was: needs decision → done; the env vars are the remaining launch task)**
 - `[ ]` **Performance / Lighthouse pass** — run Lighthouse on the prod build; address obvious image-size
   and bundle-size wins. **(nice-to-have)**
 - `[ ]` **README cleanup** — the README still has placeholder `your-username` clone URLs and generic
@@ -222,7 +231,9 @@ the actual flip. Deploy is currently manual (Firebase Hosting frontend + Railway
 2. `[ ]` Bump `version` in `package.json` to `1.0.0`.
 3. `[ ]` Flip the beta tag off (the three edits in the blockers section).
 4. `[ ]` Update release-notes content for 1.0 and tag a GitHub Release.
-5. `[ ]` Deploy frontend (`npm run build` → Firebase Hosting) and backend (Railway).
+5. `[ ]` Deploy frontend (`npm run build` → Firebase Hosting) and backend (Railway). **First set prod
+   env vars:** `VITE_SENTRY_DSN` in the frontend build env (before `npm run build`), and `SENTRY_DSN`
+   + `ADMIN_NOTIFY_EMAIL` on Railway. See Section C → "Error tracking (Sentry)".
 6. `[ ]` Smoke-test production: load home, view a recipe, sign in, create a recipe, leave a review.
 7. `[ ]` Watch logs/analytics for the first hours.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@formspree/react": "^3.0.0",
         "@hello-pangea/dnd": "^18.0.1",
         "@jclind/ingredient-parser": "^1.3.4",
+        "@sentry/react": "^10.57.0",
         "@tanstack/react-query": "^5.100.10",
         "@types/node": "^25.6.2",
         "@types/react": "^19.2.14",
@@ -2616,6 +2617,97 @@
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.57.0.tgz",
+      "integrity": "sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.57.0.tgz",
+      "integrity": "sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.57.0.tgz",
+      "integrity": "sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.57.0.tgz",
+      "integrity": "sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.57.0.tgz",
+      "integrity": "sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.57.0",
+        "@sentry-internal/feedback": "10.57.0",
+        "@sentry-internal/replay": "10.57.0",
+        "@sentry-internal/replay-canvas": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.57.0.tgz",
+      "integrity": "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.57.0.tgz",
+      "integrity": "sha512-6QThwQ4XWQ2rwKZEVQ9P9WKl7JlowC7S5LpAvmMdrwlfJBpLDFOsM7tycnIvbXTXf0ZOOuLFPa4L4YYbdyNGmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@formspree/react": "^3.0.0",
     "@hello-pangea/dnd": "^18.0.1",
     "@jclind/ingredient-parser": "^1.3.4",
+    "@sentry/react": "^10.57.0",
     "@tanstack/react-query": "^5.100.10",
     "@types/node": "^25.6.2",
     "@types/react": "^19.2.14",

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,6 +2,11 @@ MONGO_URI=mongodb+srv://<user>:<password>@cluster0.xxxxx.mongodb.net/prepify?ret
 PORT=4000
 SPOONACULAR_API_KEY=<your-spoonacular-api-key>
 
+# Sentry server error monitoring. Leave empty to disable entirely — without a
+# DSN, Sentry is never initialized and all capture calls no-op, so dev/CI stay
+# quiet. Use a separate DSN/project from the frontend.
+SENTRY_DSN=
+
 # Email notifications (Resend). Leave RESEND_API_KEY empty to disable email
 # entirely — the wrapper no-ops silently, so dev/CI without a key just skip sends.
 RESEND_API_KEY=
@@ -13,4 +18,7 @@ APP_BASE_URL=http://localhost:3000
 # Address shown in moderation emails for appeals/support (the from-address is
 # no-reply). Leave empty to fall back to generic "contact Prepify support" wording.
 SUPPORT_EMAIL=
+# Where new-bug-report alerts are sent. Leave empty to use the built-in default
+# (jesselindcs@gmail.com). Only used when email is enabled (RESEND_API_KEY set).
+ADMIN_NOTIFY_EMAIL=
 # EMAIL_ENABLED=true   # optional kill switch; an empty RESEND_API_KEY already disables sending

--- a/server/__tests__/bugReports.test.js
+++ b/server/__tests__/bugReports.test.js
@@ -177,6 +177,22 @@ describe('PATCH /api/admin/bug-reports/:id', () => {
     const malformed = await request(app).patch('/api/admin/bug-reports/not-an-id').set(AUTH_HEADER).send({ status: 'resolved' })
     expect(malformed.status).toBe(404)
   })
+
+  it('409s for an already-closed report without overwriting the original resolution or re-auditing', async () => {
+    admin.__setClaims({ admin: true })
+    const report = await seedReport({
+      status: 'resolved',
+      resolvedBy: 'first-admin',
+      resolvedAt: new Date('2026-06-01'),
+    })
+    const res = await request(app).patch(`/api/admin/bug-reports/${report._id}`).set(AUTH_HEADER).send({ status: 'dismissed' })
+    expect(res.status).toBe(409)
+    const after = await getDB().collection('bugReports').findOne({ _id: report._id })
+    expect(after.status).toBe('resolved')
+    expect(after.resolvedBy).toBe('first-admin')
+    const entries = await getDB().collection('auditLog').find({}).toArray()
+    expect(entries).toHaveLength(0)
+  })
 })
 
 describe('PATCH /api/admin/bug-reports/bulk', () => {

--- a/server/__tests__/bugReports.test.js
+++ b/server/__tests__/bugReports.test.js
@@ -1,0 +1,245 @@
+/**
+ * Bug report endpoints (server/routes/bugReports.js).
+ *
+ * Auth: server/__mocks__/firebase-admin.js resolves verifyIdToken to
+ * { uid: 'test-uid' }. The POST endpoint uses optionalAuth (no header ⇒
+ * anonymous). Admin-only routes require the `admin` claim, set via
+ * admin.__setClaims({ admin: true }) and cleared in afterEach.
+ */
+
+const request = require('supertest')
+const admin = require('firebase-admin') // auto-mocked
+const { ObjectId } = require('mongodb')
+const app = require('../app')
+const { getDB } = require('../db')
+
+const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
+const TEST_UID = 'test-uid'
+
+afterEach(async () => {
+  admin.__resetClaims()
+  const db = getDB()
+  await Promise.all([
+    db.collection('bugReports').deleteMany({}),
+    db.collection('usernames').deleteMany({}),
+    db.collection('auditLog').deleteMany({}),
+  ])
+})
+
+const validReport = {
+  category: 'bug',
+  description: 'The save button does nothing on the recipe page.',
+  url: '/recipes/abc',
+  appVersion: '2.6.3',
+}
+
+describe('POST /api/bug-reports', () => {
+  it('accepts an anonymous submission (no auth) and stores null reporterUid', async () => {
+    const res = await request(app)
+      .post('/api/bug-reports')
+      .set('User-Agent', 'jest-agent')
+      .send(validReport)
+    expect(res.status).toBe(201)
+    expect(res.body.category).toBe('bug')
+    expect(res.body.reporterUid).toBeNull()
+    expect(res.body.status).toBe('open')
+    expect(res.body.userAgent).toBe('jest-agent')
+  })
+
+  it('attaches reporterUid when a valid token is present', async () => {
+    const res = await request(app).post('/api/bug-reports').set(AUTH_HEADER).send(validReport)
+    expect(res.status).toBe(201)
+    expect(res.body.reporterUid).toBe(TEST_UID)
+  })
+
+  it('rejects an invalid category', async () => {
+    const res = await request(app)
+      .post('/api/bug-reports')
+      .send({ ...validReport, category: 'rant' })
+    expect(res.status).toBe(400)
+  })
+
+  it('requires a non-empty description', async () => {
+    const res = await request(app)
+      .post('/api/bug-reports')
+      .send({ ...validReport, description: '   ' })
+    expect(res.status).toBe(400)
+  })
+
+  it('caps an over-long description rather than rejecting it', async () => {
+    const res = await request(app)
+      .post('/api/bug-reports')
+      .send({ ...validReport, description: 'a'.repeat(5000) })
+    expect(res.status).toBe(201)
+    expect(res.body.description).toHaveLength(2000)
+  })
+
+  it('rejects a malformed optional email', async () => {
+    const res = await request(app)
+      .post('/api/bug-reports')
+      .send({ ...validReport, email: 'not-an-email' })
+    expect(res.status).toBe(400)
+  })
+
+  it('keeps a valid optional email for anonymous follow-up', async () => {
+    const res = await request(app)
+      .post('/api/bug-reports')
+      .send({ ...validReport, email: 'reporter@example.com' })
+    expect(res.status).toBe(201)
+    expect(res.body.reporterEmail).toBe('reporter@example.com')
+  })
+})
+
+describe('GET /api/admin/bug-reports', () => {
+  it('requires admin (403 for a logged-in non-admin)', async () => {
+    const res = await request(app).get('/api/admin/bug-reports').set(AUTH_HEADER)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns the queue with open count and reporter username enrichment', async () => {
+    admin.__setClaims({ admin: true })
+    await getDB().collection('usernames').insertOne({ _id: 'u1', username: 'reporterUser' })
+    await getDB().collection('bugReports').insertMany([
+      { _id: new ObjectId(), reporterUid: 'u1', category: 'bug', description: 'x', status: 'open', createdAt: new Date() },
+      { _id: new ObjectId(), reporterUid: null, category: 'idea', description: 'y', status: 'resolved', createdAt: new Date() },
+    ])
+
+    const res = await request(app).get('/api/admin/bug-reports').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.totalCount).toBe(2)
+    expect(res.body.openCount).toBe(1)
+    const named = res.body.reports.find((r) => r.reporterUid === 'u1')
+    expect(named.reporterUsername).toBe('reporterUser')
+    const anon = res.body.reports.find((r) => r.reporterUid === null)
+    expect(anon.reporterUsername).toBeNull()
+  })
+
+  it('filters by status and category', async () => {
+    admin.__setClaims({ admin: true })
+    await getDB().collection('bugReports').insertMany([
+      { _id: new ObjectId(), reporterUid: null, category: 'bug', description: 'a', status: 'open', createdAt: new Date() },
+      { _id: new ObjectId(), reporterUid: null, category: 'idea', description: 'b', status: 'open', createdAt: new Date() },
+      { _id: new ObjectId(), reporterUid: null, category: 'bug', description: 'c', status: 'resolved', createdAt: new Date() },
+    ])
+    const byStatus = await request(app).get('/api/admin/bug-reports?status=open').set(AUTH_HEADER)
+    expect(byStatus.body.totalCount).toBe(2)
+    const byCategory = await request(app).get('/api/admin/bug-reports?category=bug&status=open').set(AUTH_HEADER)
+    expect(byCategory.body.totalCount).toBe(1)
+  })
+})
+
+describe('PATCH /api/admin/bug-reports/:id', () => {
+  async function seedReport(overrides = {}) {
+    const doc = {
+      _id: new ObjectId(),
+      reporterUid: null,
+      category: 'bug',
+      description: 'x',
+      status: 'open',
+      createdAt: new Date(),
+      ...overrides,
+    }
+    await getDB().collection('bugReports').insertOne(doc)
+    return doc
+  }
+
+  it('requires admin', async () => {
+    const report = await seedReport()
+    const res = await request(app).patch(`/api/admin/bug-reports/${report._id}`).set(AUTH_HEADER).send({ status: 'resolved' })
+    expect(res.status).toBe(403)
+  })
+
+  it('resolves a report, stamps resolvedBy/resolvedAt, and writes an audit entry', async () => {
+    admin.__setClaims({ admin: true })
+    const report = await seedReport()
+    const res = await request(app).patch(`/api/admin/bug-reports/${report._id}`).set(AUTH_HEADER).send({ status: 'resolved' })
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('resolved')
+    expect(res.body.resolvedBy).toBe(TEST_UID)
+    expect(res.body.resolvedAt).toBeDefined()
+    const entries = await getDB().collection('auditLog').find({}).toArray()
+    expect(entries).toHaveLength(1)
+    expect(entries[0].action).toBe('bugReport.resolve')
+    expect(entries[0].targetType).toBe('bugReport')
+  })
+
+  it('rejects an invalid status', async () => {
+    admin.__setClaims({ admin: true })
+    const report = await seedReport()
+    const res = await request(app).patch(`/api/admin/bug-reports/${report._id}`).set(AUTH_HEADER).send({ status: 'open' })
+    expect(res.status).toBe(400)
+  })
+
+  it('404s for a missing or malformed id', async () => {
+    admin.__setClaims({ admin: true })
+    const missing = await request(app).patch(`/api/admin/bug-reports/${new ObjectId()}`).set(AUTH_HEADER).send({ status: 'resolved' })
+    expect(missing.status).toBe(404)
+    const malformed = await request(app).patch('/api/admin/bug-reports/not-an-id').set(AUTH_HEADER).send({ status: 'resolved' })
+    expect(malformed.status).toBe(404)
+  })
+})
+
+describe('PATCH /api/admin/bug-reports/bulk', () => {
+  async function seedReports(n, overrides = {}) {
+    const docs = Array.from({ length: n }, () => ({
+      _id: new ObjectId(),
+      reporterUid: null,
+      category: 'bug',
+      description: 'x',
+      status: 'open',
+      createdAt: new Date(),
+      ...overrides,
+    }))
+    await getDB().collection('bugReports').insertMany(docs)
+    return docs
+  }
+
+  it('requires admin', async () => {
+    const [a] = await seedReports(1)
+    const res = await request(app)
+      .patch('/api/admin/bug-reports/bulk')
+      .set(AUTH_HEADER)
+      .send({ ids: [String(a._id)], status: 'resolved' })
+    expect(res.status).toBe(403)
+  })
+
+  it('resolves many open reports, reports how many changed, and audits each', async () => {
+    admin.__setClaims({ admin: true })
+    const docs = await seedReports(3)
+    const ids = docs.map((d) => String(d._id))
+    const res = await request(app)
+      .patch('/api/admin/bug-reports/bulk')
+      .set(AUTH_HEADER)
+      .send({ ids, status: 'dismissed' })
+    expect(res.status).toBe(200)
+    expect(res.body.updated).toBe(3)
+    const remaining = await getDB().collection('bugReports').countDocuments({ status: 'open' })
+    expect(remaining).toBe(0)
+    const audits = await getDB().collection('auditLog').countDocuments({ action: 'bugReport.dismiss' })
+    expect(audits).toBe(3)
+  })
+
+  it('only touches open reports (skips already-closed ids in the batch)', async () => {
+    admin.__setClaims({ admin: true })
+    const open = await seedReports(2)
+    const closed = await seedReports(1, { status: 'dismissed' })
+    const ids = [...open, ...closed].map((d) => String(d._id))
+    const res = await request(app)
+      .patch('/api/admin/bug-reports/bulk')
+      .set(AUTH_HEADER)
+      .send({ ids, status: 'resolved' })
+    expect(res.status).toBe(200)
+    expect(res.body.updated).toBe(2)
+  })
+
+  it('rejects an empty id list, an invalid status, and an over-cap batch', async () => {
+    admin.__setClaims({ admin: true })
+    const empty = await request(app).patch('/api/admin/bug-reports/bulk').set(AUTH_HEADER).send({ ids: [], status: 'resolved' })
+    expect(empty.status).toBe(400)
+    const badStatus = await request(app).patch('/api/admin/bug-reports/bulk').set(AUTH_HEADER).send({ ids: ['x'], status: 'open' })
+    expect(badStatus.status).toBe(400)
+    const ids = Array.from({ length: 101 }, () => String(new ObjectId()))
+    const tooMany = await request(app).patch('/api/admin/bug-reports/bulk').set(AUTH_HEADER).send({ ids, status: 'resolved' })
+    expect(tooMany.status).toBe(400)
+  })
+})

--- a/server/app.js
+++ b/server/app.js
@@ -11,7 +11,9 @@ const draftRoutes = require('./routes/drafts')
 const gamificationRoutes = require('./routes/gamification')
 const publicProfileRoutes = require('./routes/publicProfile')
 const reportRoutes = require('./routes/reports')
+const bugReportRoutes = require('./routes/bugReports')
 const adminRoutes = require('./routes/admin')
+const Sentry = require('@sentry/node')
 const { GENERIC_500_MESSAGE } = require('./util/respondServerError')
 
 const app = express()
@@ -86,6 +88,7 @@ app.use('/api', publicProfileRoutes)
 app.use('/api/ingredients', ingredientRoutes)
 app.use('/api/drafts', draftRoutes)
 app.use('/api', reportRoutes)
+app.use('/api', bugReportRoutes)
 app.use('/api', adminRoutes)
 
 // Central error backstop. Route handlers catch their own errors (via
@@ -100,6 +103,10 @@ app.use((err, req, res, next) => {
   if (res.headersSent) return next(err)
   const status = err.status || err.statusCode || 500
   console.error(`[${status}] ${req.method} ${req.originalUrl}`, err)
+  // Report genuine server faults to Sentry (no-ops without SENTRY_DSN). Skip
+  // client 4xx the thrower set (bad JSON, CORS) — those are expected outcomes,
+  // not bugs. Capture never blocks or changes the client-facing response.
+  if (status >= 500) Sentry.captureException(err)
   res.status(status).json({
     error: status >= 500 ? GENERIC_500_MESSAGE : 'Bad request',
   })

--- a/server/db.js
+++ b/server/db.js
@@ -88,6 +88,16 @@ async function ensureIndexes() {
     console.error('Failed to create indexes on reports:', err.message)
   }
 
+  // User bug reports. New collection, so these build instantly. Backs the admin
+  // queue (filter by status, newest first) and analytics createdAt bucketing.
+  try {
+    const bugReports = db.collection('bugReports')
+    await bugReports.createIndex({ status: 1, createdAt: -1 })
+    await bugReports.createIndex({ createdAt: -1 })
+  } catch (err) {
+    console.error('Failed to create indexes on bugReports:', err.message)
+  }
+
   // Admin audit log (P3). New collection, so these build instantly. Backs the
   // audit page (newest first), and filtering by actor or by a specific target.
   // The action/targetType compounds end in createdAt:-1 so the page's filter

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,5 @@
-require('dotenv').config()
+// Must load first so Sentry instruments express before it's required below.
+require('./instrument')
 const app = require('./app')
 const { connectDB } = require('./db')
 

--- a/server/instrument.js
+++ b/server/instrument.js
@@ -1,0 +1,19 @@
+// Sentry (server error monitoring). Required as the very first thing in
+// index.js — before express/routes load — so Sentry's auto-instrumentation can
+// hook in. Entirely env-gated on SENTRY_DSN: with no DSN (local dev, CI, tests
+// via supertest) init is skipped and every Sentry.* call downstream is a safe
+// no-op, so behaviour is unchanged.
+require('dotenv').config()
+const Sentry = require('@sentry/node')
+
+if (process.env.SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.NODE_ENV || 'development',
+    // Light tracing — enough to surface slow requests without flooding the
+    // free-tier quota.
+    tracesSampleRate: 0.1,
+  })
+}
+
+module.exports = Sentry

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@jclind/ingredient-parser": "^1.3.4",
+        "@sentry/node": "^10.57.0",
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^4.18.2",
@@ -1417,9 +1418,94 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -1529,6 +1615,108 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/@sentry-internal/server-utils": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/server-utils/-/server-utils-10.57.0.tgz",
+      "integrity": "sha512-Qu8ETmX/ITzteG7Im46b9HOxKKzeaIeqNvftaIlFURu1RUQdHbtGerS7QOmXzwnhuqNGNeiCQYkduB798IfRqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.57.0.tgz",
+      "integrity": "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.57.0.tgz",
+      "integrity": "sha512-7KEStrJ97wPf1fA5nU5ONeTTcIIlh7oT8OMffEVA1PXmlhFoXhcQZVzr4rM+zj9tfMWT01og5Ng/Grgh3dN+FA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@sentry-internal/server-utils": "10.57.0",
+        "@sentry/core": "10.57.0",
+        "@sentry/node-core": "10.57.0",
+        "@sentry/opentelemetry": "10.57.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.57.0.tgz",
+      "integrity": "sha512-2v2IF6MfTiu7pimWEq2rYhZsmlwyNbs3bHUsrYFPeP/Rpa6ObDuUWPdVEzJjfyK+AqqYZYxZdV0l3+B13kTEmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0",
+        "@sentry/opentelemetry": "10.57.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.57.0.tgz",
+      "integrity": "sha512-iwRz8cEK0GOISG34aJRO8GdYOk3nfpuT6dT2GDQrxw8f7JjkJKx9LPU8MaenOFa4MhY+Z02hI6NNcrbsoI3cXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
@@ -2121,6 +2309,27 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/agent-base": {
@@ -2836,7 +3045,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui": {
@@ -4456,6 +4664,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.2.tgz",
+      "integrity": "sha512-LGLYRl0A2gtyUJb2WDliBHmk6TtlHwdDjxonacZ8QrEs/ZW+YDgNv2QAfjRQWpS8HqvNcq6GGnN6jrOa5FysDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -5797,6 +6020,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/mongodb": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
@@ -6864,6 +7093,42 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/resend": {
       "version": "6.12.4",

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@jclind/ingredient-parser": "^1.3.4",
+    "@sentry/node": "^10.57.0",
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^4.18.2",

--- a/server/routes/bugReports.js
+++ b/server/routes/bugReports.js
@@ -1,0 +1,205 @@
+const { Router } = require('express')
+const { rateLimit } = require('express-rate-limit')
+const { asyncHandler } = require('../util/asyncHandler')
+const { ObjectId } = require('mongodb')
+const { getDB } = require('../db')
+const { verifyToken, optionalAuth, requireAdmin } = require('../middleware/auth')
+const { recordAudit, recordAuditMany } = require('../util/auditLog')
+const { notifyInBackground, notifyBugReportFiled } = require('../util/email')
+
+const router = Router()
+
+// A bug report is user-submitted product feedback, distinct from a content
+// `report` (moderation). Anyone — including logged-out visitors — can file one,
+// so the shape carries an optional reporterUid/email plus auto-captured client
+// context (route, browser, app version) for triage.
+const CATEGORIES = ['bug', 'confusing', 'idea', 'other']
+const RESOLUTIONS = ['resolved', 'dismissed']
+const MAX_DESCRIPTION_LEN = 2000
+const MAX_EMAIL_LEN = 254
+const MAX_CONTEXT_LEN = 500 // url / userAgent / appVersion individually
+
+// Trim and hard-cap a free-text field; non-strings collapse to ''. Keeps any one
+// field from bloating a document or the admin queue regardless of client input.
+function boundedString(val, max) {
+  return typeof val === 'string' ? val.trim().slice(0, max) : ''
+}
+
+// Tighter per-IP limit than the global /api backstop: a submit form is the kind
+// of public, unauthenticated endpoint a script would hammer. Skipped under Jest
+// (supertest fires many requests from one IP); the global limiter does the same.
+const submitLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 15,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+})
+
+// POST /bug-reports — anyone (logged-in or not) files a bug report. optionalAuth
+// attaches req.uid when a valid token is present; anonymous submissions are kept
+// and may carry an email for follow-up.
+router.post('/bug-reports', submitLimiter, optionalAuth, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { category, description, url, appVersion, email } = req.body
+
+  if (!CATEGORIES.includes(category)) {
+    return res.status(400).json({ error: 'Invalid category' })
+  }
+  const desc = boundedString(description, MAX_DESCRIPTION_LEN)
+  if (!desc) {
+    return res.status(400).json({ error: 'description is required' })
+  }
+  // Email is optional; when present it must look minimally like an address.
+  const reporterEmail = boundedString(email, MAX_EMAIL_LEN)
+  if (reporterEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(reporterEmail)) {
+    return res.status(400).json({ error: 'email must be a valid address' })
+  }
+
+  const doc = {
+    _id: new ObjectId(),
+    reporterUid: req.uid || null,
+    reporterEmail: reporterEmail || null,
+    category,
+    description: desc,
+    // User-Agent is read server-side (more reliable than a client-sent value);
+    // url + appVersion come from the client since only it knows the SPA route
+    // and the build it's running.
+    url: boundedString(url, MAX_CONTEXT_LEN),
+    userAgent: boundedString(req.headers['user-agent'], MAX_CONTEXT_LEN),
+    appVersion: boundedString(appVersion, MAX_CONTEXT_LEN),
+    status: 'open',
+    createdAt: new Date(),
+  }
+  await db.collection('bugReports').insertOne(doc)
+
+  // Ping the admin so a new report doesn't sit unseen in the queue. Background +
+  // best-effort: a slow/missing email provider never affects the submitter.
+  notifyInBackground(
+    notifyBugReportFiled({
+      category: doc.category,
+      description: doc.description,
+      url: doc.url,
+      reporterLabel: doc.reporterUid ? `uid ${doc.reporterUid}` : doc.reporterEmail || 'anonymous',
+    })
+  )
+
+  res.status(201).json(doc)
+}))
+
+// GET /admin/bug-reports — admin queue. Filter by status/category, paginate, and
+// enrich each report's reporterUid with a username in one batched lookup.
+router.get('/admin/bug-reports', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { status, category, page = 0, perPage = 20 } = req.query
+
+  const filter = {}
+  if (status && ['open', ...RESOLUTIONS].includes(status)) filter.status = status
+  if (category && CATEGORIES.includes(category)) filter.category = category
+
+  const skip = parseInt(page) * parseInt(perPage)
+  const limit = parseInt(perPage)
+
+  const [reports, totalCount, openCount] = await Promise.all([
+    db.collection('bugReports').find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit).toArray(),
+    db.collection('bugReports').countDocuments(filter),
+    db.collection('bugReports').countDocuments({ status: 'open' }),
+  ])
+
+  // Resolve reporter usernames in one query (usernames is _id=uid → username),
+  // so the queue shows "@user" without a per-row lookup. Anonymous reports
+  // (null uid) simply have no username.
+  const reporterUids = [...new Set(reports.map((r) => r.reporterUid).filter(Boolean))]
+  const reporterDocs = reporterUids.length
+    ? await db.collection('usernames').find({ _id: { $in: reporterUids } }).toArray()
+    : []
+  const usernameByUid = Object.fromEntries(reporterDocs.map((d) => [d._id, d.username]))
+  const enriched = reports.map((r) => ({
+    ...r,
+    reporterUsername: r.reporterUid ? usernameByUid[r.reporterUid] || null : null,
+  }))
+
+  res.json({ reports: enriched, totalCount, openCount })
+}))
+
+// Most reports a single admin sweep would ever clear at once. Bounds the bulk
+// updateMany and the audit insert.
+const MAX_BULK = 100
+
+// PATCH /admin/bug-reports/bulk — resolve/dismiss many in one sweep. Declared
+// BEFORE /:id so 'bulk' isn't captured as an :id. Mirrors reports/bulk: only OPEN
+// reports are touched, stamped with one timestamp, then re-read by that stamp so
+// a report closed concurrently by another admin can't enter our audit trail.
+router.patch('/admin/bug-reports/bulk', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { ids, status } = req.body
+  if (!RESOLUTIONS.includes(status)) {
+    return res.status(400).json({ error: "status must be 'resolved' or 'dismissed'" })
+  }
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return res.status(400).json({ error: 'ids must be a non-empty array' })
+  }
+  if (ids.length > MAX_BULK) {
+    return res.status(400).json({ error: `Cannot update more than ${MAX_BULK} reports at once` })
+  }
+  const objectIds = ids.filter((id) => typeof id === 'string' && ObjectId.isValid(id)).map((id) => new ObjectId(id))
+  if (objectIds.length === 0) {
+    return res.status(400).json({ error: 'No valid report ids' })
+  }
+
+  const resolvedAt = new Date()
+  const result = await db.collection('bugReports').updateMany(
+    { _id: { $in: objectIds }, status: 'open' },
+    { $set: { status, resolvedBy: req.uid, resolvedAt } }
+  )
+
+  const closed = result.modifiedCount
+    ? await db
+        .collection('bugReports')
+        .find({ _id: { $in: objectIds }, resolvedBy: req.uid, resolvedAt })
+        .toArray()
+    : []
+
+  await recordAuditMany(
+    db,
+    closed.map((r) => ({
+      action: status === 'resolved' ? 'bugReport.resolve' : 'bugReport.dismiss',
+      actorUid: req.uid,
+      targetType: 'bugReport',
+      targetId: r._id,
+      targetLabel: r.category,
+      metadata: { category: r.category, bulk: true },
+    }))
+  )
+
+  res.json({ updated: result.modifiedCount })
+}))
+
+// PATCH /admin/bug-reports/:id — resolve or dismiss a single report.
+router.patch('/admin/bug-reports/:id', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  if (!ObjectId.isValid(req.params.id)) {
+    return res.status(404).json({ error: 'Bug report not found' })
+  }
+  const { status } = req.body
+  if (!RESOLUTIONS.includes(status)) {
+    return res.status(400).json({ error: "status must be 'resolved' or 'dismissed'" })
+  }
+  const updated = await db.collection('bugReports').findOneAndUpdate(
+    { _id: new ObjectId(req.params.id) },
+    { $set: { status, resolvedBy: req.uid, resolvedAt: new Date() } },
+    { returnDocument: 'after' }
+  )
+  if (!updated) return res.status(404).json({ error: 'Bug report not found' })
+  await recordAudit(db, {
+    action: status === 'resolved' ? 'bugReport.resolve' : 'bugReport.dismiss',
+    actorUid: req.uid,
+    targetType: 'bugReport',
+    targetId: updated._id,
+    targetLabel: updated.category,
+    metadata: { category: updated.category },
+  })
+  res.json(updated)
+}))
+
+module.exports = router

--- a/server/routes/bugReports.js
+++ b/server/routes/bugReports.js
@@ -18,6 +18,8 @@ const RESOLUTIONS = ['resolved', 'dismissed']
 const MAX_DESCRIPTION_LEN = 2000
 const MAX_EMAIL_LEN = 254
 const MAX_CONTEXT_LEN = 500 // url / userAgent / appVersion individually
+const DEFAULT_PER_PAGE = 20
+const MAX_PER_PAGE = 100 // cap the admin page size so one query can't pull the whole collection
 
 // Trim and hard-cap a free-text field; non-strings collapse to ''. Keeps any one
 // field from bloating a document or the admin queue regardless of client input.
@@ -91,14 +93,18 @@ router.post('/bug-reports', submitLimiter, optionalAuth, asyncHandler(async (req
 // enrich each report's reporterUid with a username in one batched lookup.
 router.get('/admin/bug-reports', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
   const db = getDB()
-  const { status, category, page = 0, perPage = 20 } = req.query
+  const { status, category } = req.query
 
   const filter = {}
   if (status && ['open', ...RESOLUTIONS].includes(status)) filter.status = status
   if (category && CATEGORIES.includes(category)) filter.category = category
 
-  const skip = parseInt(page) * parseInt(perPage)
-  const limit = parseInt(perPage)
+  // Clamp paging so a malformed (NaN) or oversized perPage can't crash the
+  // cursor or pull the whole collection in one query.
+  const perPage = Math.min(Math.max(parseInt(req.query.perPage, 10) || DEFAULT_PER_PAGE, 1), MAX_PER_PAGE)
+  const page = Math.max(parseInt(req.query.page, 10) || 0, 0)
+  const skip = page * perPage
+  const limit = perPage
 
   const [reports, totalCount, openCount] = await Promise.all([
     db.collection('bugReports').find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit).toArray(),
@@ -185,12 +191,24 @@ router.patch('/admin/bug-reports/:id', verifyToken, requireAdmin, asyncHandler(a
   if (!RESOLUTIONS.includes(status)) {
     return res.status(400).json({ error: "status must be 'resolved' or 'dismissed'" })
   }
+  // Only OPEN reports can be closed — same invariant the bulk route enforces.
+  // Guarding on status here means a report another admin already closed (or a
+  // stale queue view) can't overwrite the original resolvedBy/resolvedAt or
+  // write a second, misattributed audit entry.
+  const _id = new ObjectId(req.params.id)
   const updated = await db.collection('bugReports').findOneAndUpdate(
-    { _id: new ObjectId(req.params.id) },
+    { _id, status: 'open' },
     { $set: { status, resolvedBy: req.uid, resolvedAt: new Date() } },
     { returnDocument: 'after' }
   )
-  if (!updated) return res.status(404).json({ error: 'Bug report not found' })
+  if (!updated) {
+    // No open report matched: distinguish a missing id (404) from one that was
+    // already closed (409) so the client can refresh rather than treat it as gone.
+    const exists = await db.collection('bugReports').findOne({ _id }, { projection: { _id: 1 } })
+    return res
+      .status(exists ? 409 : 404)
+      .json({ error: exists ? 'Bug report is already closed' : 'Bug report not found' })
+  }
   await recordAudit(db, {
     action: status === 'resolved' ? 'bugReport.resolve' : 'bugReport.dismiss',
     actorUid: req.uid,

--- a/server/util/auditLog.js
+++ b/server/util/auditLog.js
@@ -17,9 +17,11 @@ const AUDIT_ACTIONS = [
   'user.activate',
   'report.resolve',
   'report.dismiss',
+  'bugReport.resolve',
+  'bugReport.dismiss',
 ]
 
-const AUDIT_TARGET_TYPES = ['recipe', 'review', 'user', 'report']
+const AUDIT_TARGET_TYPES = ['recipe', 'review', 'user', 'report', 'bugReport']
 
 /**
  * Append one immutable entry to the `auditLog` collection describing an admin

--- a/server/util/email.js
+++ b/server/util/email.js
@@ -230,6 +230,19 @@ const templates = {
       }),
     }
   },
+
+  // Admin-facing: a new user bug report landed. No appeal line (internal); the
+  // CTA button drops the admin at Prepify, and the body carries the triage bits.
+  bugReportFiled({ category, description, url, reporterLabel }) {
+    const subject = `New bug report: ${category}`
+    const paragraphs = [
+      `A new ${category} report was submitted by ${reporterLabel || 'a user'}.`,
+    ]
+    if (url) paragraphs.push(`Page: ${url}`)
+    paragraphs.push(`Description: ${description}`)
+    paragraphs.push('Open the admin bug-reports queue to triage it.')
+    return { subject, ...layout({ heading: subject, paragraphs }) }
+  },
 }
 
 // --- Per-event helpers ------------------------------------------------------
@@ -299,6 +312,26 @@ function notifyReviewTakenDown(db, ownerUsername, recipeId) {
   )
 }
 
+// Where new-bug-report alerts go. ADMIN_NOTIFY_EMAIL overrides; otherwise this
+// hardcoded default (same inbox already used for contact in the footer). Set the
+// env var to point alerts at a dedicated support inbox later without a code change.
+const DEFAULT_ADMIN_EMAIL = 'jesselindcs@gmail.com'
+function adminNotifyAddress() {
+  return process.env.ADMIN_NOTIFY_EMAIL || DEFAULT_ADMIN_EMAIL
+}
+
+// New bug report → email the admin so the queue isn't only pull-based. Unlike the
+// moderation events this notifies a fixed internal address, not the actor.
+function notifyBugReportFiled({ category, description, url, reporterLabel }) {
+  if (!emailEnabled()) return Promise.resolve()
+  const to = adminNotifyAddress()
+  if (!to) return Promise.resolve()
+  return deliver(
+    () => to,
+    () => templates.bugReportFiled({ category, description, url, reporterLabel })
+  )
+}
+
 // --- Background dispatch -----------------------------------------------------
 // Moderation routes fire notifications WITHOUT awaiting them, so the admin's
 // HTTP response never waits on Firebase + the email provider (the action has
@@ -330,4 +363,5 @@ module.exports = {
   notifyAccountStatus,
   notifyRecipeHidden,
   notifyReviewTakenDown,
+  notifyBugReportFiled,
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import AdminRoute from 'src/Components/AdminRoute'
 import AdminLayout from 'src/pages/Admin/AdminLayout'
 import Analytics from 'src/pages/Admin/Analytics/Analytics'
 import Reports from 'src/pages/Admin/Reports/Reports'
+import BugReports from 'src/pages/Admin/BugReports/BugReports'
 import Users from 'src/pages/Admin/Users/Users'
 import Audit from 'src/pages/Admin/Audit/Audit'
 import CreateUsername from 'src/pages/CreateUsername/CreateUsername'
@@ -38,6 +39,8 @@ import { Toaster } from 'react-hot-toast'
 import Settings from 'src/pages/Settings/Settings'
 import Profile from 'src/pages/Settings/SubSettings/Profile'
 import Password from 'src/pages/Settings/SubSettings/Password'
+import { Sentry } from 'src/util/sentry'
+import AppErrorFallback from 'src/Components/AppErrorFallback/AppErrorFallback'
 // import RecipeAI from './pages/RecipeAI/RecipeAI'
 
 const ScrollToTop: FC = () => {
@@ -49,8 +52,11 @@ const ScrollToTop: FC = () => {
 }
 const App: FC = () => {
   return (
-    <HelmetProvider>
-      <AuthProvider>
+    <Sentry.ErrorBoundary
+      fallback={({ resetError }) => <AppErrorFallback resetError={resetError} />}
+    >
+      <HelmetProvider>
+        <AuthProvider>
         <Toaster position='bottom-center' toastOptions={{ duration: 5000 }} />
         <ScrollToTop />
         <Routes>
@@ -192,6 +198,7 @@ const App: FC = () => {
                 <Route index element={<Navigate to='/admin/analytics' replace />} />
                 <Route path='analytics' element={<Analytics />} />
                 <Route path='reports' element={<Reports />} />
+                <Route path='bug-reports' element={<BugReports />} />
                 <Route path='users' element={<Users />} />
                 <Route path='audit' element={<Audit />} />
               </Route>
@@ -202,8 +209,9 @@ const App: FC = () => {
             <Route path='/create-username' element={<CreateUsername />} />
             <Route path='/forgot-password' element={<ForgotPassword />} />
           </Routes>
-      </AuthProvider>
-    </HelmetProvider>
+        </AuthProvider>
+      </HelmetProvider>
+    </Sentry.ErrorBoundary>
   )
 }
 

--- a/src/Components/AppErrorFallback/AppErrorFallback.scss
+++ b/src/Components/AppErrorFallback/AppErrorFallback.scss
@@ -1,0 +1,52 @@
+.app-error-fallback {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: #fff;
+
+  .app-error-content {
+    max-width: 480px;
+    text-align: center;
+
+    h1 {
+      font-size: 1.75rem;
+      margin-bottom: 0.75rem;
+      color: #1f2430;
+    }
+
+    p {
+      color: #374151;
+      line-height: 1.5;
+      margin-bottom: 1.5rem;
+    }
+
+    .app-error-actions {
+      display: flex;
+      gap: 0.75rem;
+      justify-content: center;
+      flex-wrap: wrap;
+
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.65rem 1.25rem;
+        border-radius: 8px;
+        border: none;
+        cursor: pointer;
+        font-weight: 600;
+        text-decoration: none;
+        background: #1f2430;
+        color: #fff;
+
+        &.secondary {
+          background: #fff;
+          color: #1f2430;
+          border: 1px solid #d1d5db;
+        }
+      }
+    }
+  }
+}

--- a/src/Components/AppErrorFallback/AppErrorFallback.tsx
+++ b/src/Components/AppErrorFallback/AppErrorFallback.tsx
@@ -1,0 +1,35 @@
+import React, { FC } from 'react'
+import './AppErrorFallback.scss'
+
+interface AppErrorFallbackProps {
+  /** Provided by Sentry.ErrorBoundary — clears the boundary's error state. */
+  resetError: () => void
+}
+
+// Shown by the global Sentry.ErrorBoundary in App.tsx when an unhandled render
+// error escapes a route. The error itself is already reported to Sentry by the
+// boundary; this is purely the friendly recovery UI. Kept dependency-free (no
+// router/auth) so it renders even if a provider is what crashed.
+const AppErrorFallback: FC<AppErrorFallbackProps> = ({ resetError }) => {
+  return (
+    <div className='app-error-fallback'>
+      <div className='app-error-content'>
+        <h1>Something went wrong</h1>
+        <p>
+          An unexpected error occurred. Our team has been notified. You can try
+          again, or head back to the homepage.
+        </p>
+        <div className='app-error-actions'>
+          <button className='btn' onClick={resetError}>
+            Try again
+          </button>
+          <a className='btn secondary' href='/'>
+            Return home
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default AppErrorFallback

--- a/src/Components/BugReport/BugReportModal.scss
+++ b/src/Components/BugReport/BugReportModal.scss
@@ -1,0 +1,103 @@
+.bug-report-trigger {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #8a8f99;
+  font-size: 0.8rem;
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: #2563eb;
+    background: rgba(37, 99, 235, 0.08);
+  }
+
+  &.button {
+    border: 1px solid #d8dbe0;
+    padding: 0.4rem 0.75rem;
+    font-size: 0.85rem;
+  }
+}
+
+.bug-report-modal {
+  outline: none;
+
+  .bug-report-modal-title {
+    margin: 0 0 0.35rem;
+    font-size: 1.25rem;
+  }
+
+  .bug-report-modal-sub {
+    margin: 0 0 1.25rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+  }
+
+  .bug-report-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 1rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #374151;
+
+    select,
+    textarea,
+    input {
+      font-weight: 400;
+      font-size: 0.9rem;
+      padding: 0.55rem 0.65rem;
+      border: 1px solid #d8dbe0;
+      border-radius: 6px;
+      font-family: inherit;
+      resize: vertical;
+
+      &:focus {
+        outline: none;
+        border-color: #3b82f6;
+      }
+    }
+  }
+
+  .bug-report-modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.6rem;
+    margin-top: 0.5rem;
+
+    button {
+      cursor: pointer;
+      border-radius: 6px;
+      padding: 0.55rem 1rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      position: relative;
+    }
+
+    .bug-report-cancel-btn {
+      background: #f1f2f4;
+      border: 1px solid #d8dbe0;
+      color: #374151;
+    }
+
+    .bug-report-submit-btn {
+      background: #16a34a;
+      border: 1px solid #16a34a;
+      color: #fff;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+
+      &:disabled {
+        opacity: 0.7;
+        cursor: default;
+      }
+    }
+
+    .bug-report-btn-spinner {
+      display: inline-flex;
+    }
+  }
+}

--- a/src/Components/BugReport/BugReportModal.scss
+++ b/src/Components/BugReport/BugReportModal.scss
@@ -34,6 +34,19 @@
     font-size: 0.9rem;
   }
 
+  .bug-report-identity {
+    margin: -0.75rem 0 1.25rem;
+    padding: 0.5rem 0.7rem;
+    background: #f1f5f9;
+    border-radius: 6px;
+    color: #374151;
+    font-size: 0.85rem;
+
+    strong {
+      font-weight: 600;
+    }
+  }
+
   .bug-report-field {
     display: flex;
     flex-direction: column;

--- a/src/Components/BugReport/BugReportModal.tsx
+++ b/src/Components/BugReport/BugReportModal.tsx
@@ -1,0 +1,184 @@
+import React, { FC, useState } from 'react'
+import Modal from 'react-modal'
+import toast from 'react-hot-toast'
+import { TailSpin } from 'react-loader-spinner'
+import { BugReportCategory } from 'types'
+import { useAuth } from 'src/context/AuthContext'
+import BugReportAPI from 'src/api/bugReports'
+import { version } from 'src/Components/Footer/footerData'
+import './BugReportModal.scss'
+
+Modal.setAppElement('#root')
+
+type BugReportModalProps = {
+  // Visual style of the trigger: a small text link (default) or a plain button.
+  variant?: 'link' | 'button'
+}
+
+const CATEGORY_OPTIONS: { value: BugReportCategory; label: string }[] = [
+  { value: 'bug', label: 'Something is broken' },
+  { value: 'confusing', label: 'Something is confusing' },
+  { value: 'idea', label: 'I have an idea' },
+  { value: 'other', label: 'Something else' },
+]
+
+const customStyles = {
+  content: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    right: 'auto',
+    bottom: 'auto',
+    marginRight: '-50%',
+    transform: 'translate(-50%, -50%)',
+    background: '#fff',
+    padding: '2rem',
+    borderRadius: '8px',
+    maxWidth: '460px',
+    width: '90vw',
+  },
+  overlay: {
+    zIndex: 1000,
+    background: 'rgba(0, 0, 0, 0.5)',
+  },
+} as const
+
+const MAX_DESCRIPTION = 2000
+
+// "Report a bug" trigger + modal form. Open to everyone — logged-out included —
+// so unlike ReportControl there is no auth gate. Auto-captures the current route
+// and app version; logged-out users may add an email for follow-up. The server
+// reads the User-Agent itself, so we don't send it.
+const BugReportModal: FC<BugReportModalProps> = ({ variant = 'link' }) => {
+  const authRes = useAuth()
+  const [isOpen, setIsOpen] = useState(false)
+  const [category, setCategory] = useState<BugReportCategory>('bug')
+  const [description, setDescription] = useState('')
+  const [email, setEmail] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const loggedOut = !authRes?.user
+
+  const close = () => {
+    if (submitting) return
+    setIsOpen(false)
+  }
+
+  const reset = () => {
+    setDescription('')
+    setEmail('')
+    setCategory('bug')
+  }
+
+  const handleSubmit = async () => {
+    if (!description.trim()) {
+      toast.error('Please describe what happened.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await BugReportAPI.createBugReport({
+        category,
+        description: description.trim(),
+        // Captured at submit time so the report reflects the page the user was on.
+        url: window.location.pathname + window.location.search,
+        appVersion: version,
+        email: loggedOut && email.trim() ? email.trim() : undefined,
+      })
+      toast.success('Thanks — your report has been sent.')
+      setIsOpen(false)
+      reset()
+    } catch {
+      toast.error('Could not send your report. Please try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        type='button'
+        className={`bug-report-trigger ${variant}`}
+        onClick={() => setIsOpen(true)}
+      >
+        Report a bug
+      </button>
+
+      <Modal
+        isOpen={isOpen}
+        onRequestClose={close}
+        style={customStyles}
+        className='bug-report-modal'
+      >
+        <h2 className='bug-report-modal-title'>Report a bug or send feedback</h2>
+        <p className='bug-report-modal-sub'>
+          Tell us what happened. We’ll attach the page you’re on automatically.
+        </p>
+
+        <label className='bug-report-field'>
+          <span>What kind of issue?</span>
+          <select
+            value={category}
+            onChange={e => setCategory(e.target.value as BugReportCategory)}
+          >
+            {CATEGORY_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className='bug-report-field'>
+          <span>Description</span>
+          <textarea
+            value={description}
+            maxLength={MAX_DESCRIPTION}
+            rows={5}
+            placeholder='What went wrong, and what did you expect to happen?'
+            onChange={e => setDescription(e.target.value)}
+          />
+        </label>
+
+        {loggedOut && (
+          <label className='bug-report-field'>
+            <span>Email (optional)</span>
+            <input
+              type='email'
+              value={email}
+              placeholder='So we can follow up if needed'
+              onChange={e => setEmail(e.target.value)}
+            />
+          </label>
+        )}
+
+        <div className='bug-report-modal-actions'>
+          <button
+            type='button'
+            className='bug-report-cancel-btn'
+            onClick={close}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type='button'
+            className='bug-report-submit-btn'
+            onClick={handleSubmit}
+            disabled={submitting}
+          >
+            Send report
+            {submitting && (
+              <span className='bug-report-btn-spinner'>
+                <TailSpin height='18' width='18' color='#fff' ariaLabel='loading' />
+              </span>
+            )}
+          </button>
+        </div>
+      </Modal>
+    </>
+  )
+}
+
+export default BugReportModal

--- a/src/Components/BugReport/BugReportModal.tsx
+++ b/src/Components/BugReport/BugReportModal.tsx
@@ -58,6 +58,11 @@ const BugReportModal: FC<BugReportModalProps> = ({ variant = 'link' }) => {
   const [submitting, setSubmitting] = useState(false)
 
   const loggedOut = !authRes?.user
+  // Identity shown to a signed-in reporter so they know the report is tied to
+  // their account (which is why we don't ask logged-in users for an email). The
+  // server attaches reporterUid from the token regardless of this label.
+  const reporterName =
+    authRes?.user?.displayName || authRes?.user?.email || null
 
   const close = () => {
     if (submitting) return
@@ -115,6 +120,12 @@ const BugReportModal: FC<BugReportModalProps> = ({ variant = 'link' }) => {
         <p className='bug-report-modal-sub'>
           Tell us what happened. We’ll attach the page you’re on automatically.
         </p>
+
+        {!loggedOut && reporterName && (
+          <p className='bug-report-identity'>
+            Reporting as <strong>{reporterName}</strong>
+          </p>
+        )}
 
         <label className='bug-report-field'>
           <span>What kind of issue?</span>

--- a/src/Components/Footer/shared/LegalBar.tsx
+++ b/src/Components/Footer/shared/LegalBar.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 import { currentYear, version } from '../footerData'
+import BugReportModal from 'src/Components/BugReport/BugReportModal'
 
 type LegalBarProps = {
   /** Show the version tag (kept from the original footer, de-emphasized). */
@@ -7,10 +8,11 @@ type LegalBarProps = {
   className?: string
 }
 
-/** Bottom copyright + version strip. */
+/** Bottom copyright + version strip, with a global "Report a bug" entry. */
 const LegalBar: FC<LegalBarProps> = ({ showVersion = true, className = '' }) => (
   <div className={`footer-legal ${className}`.trim()}>
     <span className='footer-copy'>© {currentYear} Prepify</span>
+    <BugReportModal />
     {showVersion && <span className='footer-version'>v{version}-beta</span>}
   </div>
 )

--- a/src/api/bugReports.ts
+++ b/src/api/bugReports.ts
@@ -1,0 +1,65 @@
+import {
+  NewBugReportType,
+  BugReportType,
+  AdminBugReportsResponse,
+  BugReportCategory,
+  BugReportStatus,
+} from 'types'
+import { http } from 'src/api/http-common'
+
+// Client for the bug-report endpoints (server/routes/bugReports.js). Submitting
+// is open to anyone — logged-out included — so createBugReport does NOT gate on a
+// uid (the request interceptor attaches a token when one exists). The queue +
+// resolution calls are admin-only and the server enforces that via the `admin`
+// custom claim.
+class BugReportAPIClass {
+  // Anyone can file a bug report. The Firebase token is attached automatically
+  // when the user is signed in; otherwise the report is stored anonymously.
+  async createBugReport(report: NewBugReportType): Promise<BugReportType> {
+    const result = await http.post<BugReportType>('api/bug-reports', report)
+    return result.data
+  }
+
+  // Admin: the bug-report queue, optionally filtered by status / category.
+  async listBugReports(params?: {
+    status?: BugReportStatus
+    category?: BugReportCategory
+    page?: number
+    perPage?: number
+  }): Promise<AdminBugReportsResponse> {
+    const result = await http.get<AdminBugReportsResponse>(
+      'api/admin/bug-reports',
+      { params }
+    )
+    return result.data
+  }
+
+  // Admin: close a single bug report.
+  async resolveBugReport(
+    id: string,
+    status: 'resolved' | 'dismissed'
+  ): Promise<BugReportType> {
+    const result = await http.patch<BugReportType>(
+      `api/admin/bug-reports/${id}`,
+      { status }
+    )
+    return result.data
+  }
+
+  // Admin: close many at once. Returns how many were actually updated
+  // (already-closed ids in the batch are skipped server-side).
+  async bulkResolve(
+    ids: string[],
+    status: 'resolved' | 'dismissed'
+  ): Promise<{ updated: number }> {
+    const result = await http.patch<{ updated: number }>(
+      'api/admin/bug-reports/bulk',
+      { ids, status }
+    )
+    return result.data
+  }
+}
+
+const BugReportAPI = new BugReportAPIClass()
+
+export default BugReportAPI

--- a/src/api/http-common.ts
+++ b/src/api/http-common.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { getAuth } from 'firebase/auth'
 import toast from 'react-hot-toast'
+import { Sentry, sentryEnabled } from 'src/util/sentry'
 
 export const http = axios.create({
   baseURL: import.meta.env.VITE_API_URL || 'http://localhost:4000',
@@ -33,6 +34,21 @@ http.interceptors.response.use(
           ? 'Your account has been banned.'
           : 'Your account is suspended.'
       toast.error(data.reason ? `${base} ${data.reason}` : base)
+    }
+    // Report server faults (5xx) and network failures (no response) to Sentry
+    // so silent backend breakage is visible without relying on a user report.
+    // Client-side 4xx are expected validation/auth outcomes and stay out of the
+    // error stream. The rejection still propagates to callers unchanged.
+    if (sentryEnabled) {
+      const status = error.response?.status
+      if (!status || status >= 500) {
+        const method = error.config?.method?.toUpperCase() ?? 'REQUEST'
+        const url = error.config?.url ?? 'unknown'
+        Sentry.captureException(error, {
+          tags: { kind: 'network', http_status: status ?? 'no-response' },
+          extra: { method, url },
+        })
+      }
     }
     return Promise.reject(error)
   }

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -20,6 +20,7 @@ import AuthAPI from 'src/api/auth'
 import { TailSpin } from 'react-loader-spinner'
 import { getDownloadURL, getStorage, ref, uploadBytes } from 'firebase/storage'
 import { ErrorWithData } from 'src/util/ErrorWithData'
+import { setSentryUser } from 'src/util/sentry'
 
 export function useAuth() {
   return useContext(AuthContext)
@@ -240,6 +241,9 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
   // Check for auth status on page load
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged(async userInstance => {
+      // Attribute Sentry error reports to the signed-in account (cleared on
+      // logout). No-ops when Sentry is disabled.
+      setSentryUser(userInstance ? { uid: userInstance.uid } : null)
       if (userInstance) {
         setUser(userInstance)
         // Read the admin custom claim off the verified ID token. Mirrors the

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import './index.scss'
 import App from 'src/App'
+import { initSentry } from 'src/util/sentry'
+
+// Init error monitoring before the app mounts so the global ErrorBoundary and
+// the axios interceptor have a live client. No-ops without VITE_SENTRY_DSN.
+initSentry()
 
 const queryClient = new QueryClient()
 

--- a/src/pages/Admin/AdminLayout.tsx
+++ b/src/pages/Admin/AdminLayout.tsx
@@ -8,6 +8,7 @@ import './AdminLayout.scss'
 const ADMIN_NAV = [
   { to: '/admin/analytics', label: 'Overview' },
   { to: '/admin/reports', label: 'Reports' },
+  { to: '/admin/bug-reports', label: 'Bug reports' },
   { to: '/admin/users', label: 'Users' },
   { to: '/admin/audit', label: 'Audit log' },
 ]

--- a/src/pages/Admin/BugReports/BugReports.scss
+++ b/src/pages/Admin/BugReports/BugReports.scss
@@ -1,0 +1,297 @@
+.admin-bug-reports {
+  max-width: 820px;
+
+  .admin-bug-reports-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+
+    h1 {
+      margin: 0;
+      font-size: 1.6rem;
+    }
+
+    .open-count {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: #b45309;
+      background: #fef3c7;
+      padding: 0.2rem 0.55rem;
+      border-radius: 999px;
+    }
+  }
+
+  .status-tabs {
+    display: flex;
+    gap: 0.4rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+    align-items: center;
+
+    .tab {
+      border: 1px solid #d8dbe0;
+      background: #fff;
+      color: #4b5563;
+      padding: 0.4rem 0.9rem;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      cursor: pointer;
+      transition: all 0.15s;
+
+      &:hover {
+        border-color: #9ca3af;
+      }
+
+      &.active {
+        background: #1f2430;
+        border-color: #1f2430;
+        color: #fff;
+      }
+    }
+
+    .category-select {
+      margin-left: auto;
+      border: 1px solid #d8dbe0;
+      background: #fff;
+      color: #374151;
+      padding: 0.4rem 0.7rem;
+      border-radius: 8px;
+      font-size: 0.85rem;
+      cursor: pointer;
+    }
+  }
+
+  .bug-reports-state {
+    color: #6b7280;
+    font-size: 0.95rem;
+
+    &.error {
+      color: #b91c1c;
+    }
+  }
+
+  .bulk-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+    padding: 0.6rem 0.9rem;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+
+    .bulk-select-all {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+      color: #374151;
+      cursor: pointer;
+    }
+
+    .bulk-actions {
+      display: flex;
+      gap: 0.5rem;
+
+      .action {
+        cursor: pointer;
+        border-radius: 6px;
+        padding: 0.4rem 0.8rem;
+        font-size: 0.82rem;
+        font-weight: 600;
+        border: 1px solid transparent;
+        white-space: nowrap;
+
+        &:disabled {
+          opacity: 0.6;
+          cursor: default;
+        }
+
+        &.resolve {
+          background: #16a34a;
+          border-color: #16a34a;
+          color: #fff;
+        }
+
+        &.dismiss {
+          background: #fff;
+          border-color: #d1d5db;
+          color: #6b7280;
+        }
+      }
+    }
+  }
+
+  .bug-report-select {
+    margin-top: 0.3rem;
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+  }
+
+  .bug-reports-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .bug-report-card {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+    padding: 1.1rem 1.25rem;
+    display: flex;
+    justify-content: space-between;
+    gap: 1.25rem;
+
+    .bug-report-main {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .bug-report-tags {
+      display: flex;
+      gap: 0.4rem;
+      margin-bottom: 0.65rem;
+      flex-wrap: wrap;
+
+      span {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        padding: 0.15rem 0.45rem;
+        border-radius: 4px;
+      }
+
+      .category-pill {
+        background: #e0e7ff;
+        color: #3730a3;
+
+        &.idea {
+          background: #dcfce7;
+          color: #166534;
+        }
+
+        &.confusing {
+          background: #fef3c7;
+          color: #92400e;
+        }
+
+        &.other {
+          background: #f3f4f6;
+          color: #374151;
+        }
+      }
+
+      .status-pill {
+        background: #fef3c7;
+        color: #92400e;
+
+        &.resolved {
+          background: #dcfce7;
+          color: #166534;
+        }
+
+        &.dismissed {
+          background: #f3f4f6;
+          color: #6b7280;
+        }
+      }
+    }
+
+    .bug-report-description {
+      margin: 0;
+      font-size: 0.95rem;
+      color: #111827;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .bug-report-context {
+      margin: 0.6rem 0 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+
+      .ctx {
+        font-size: 0.78rem;
+        color: #4b5563;
+        background: #f3f4f6;
+        padding: 0.1rem 0.4rem;
+        border-radius: 4px;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+
+    .bug-report-ua {
+      margin: 0.4rem 0 0;
+      font-size: 0.72rem;
+      color: #9ca3af;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .bug-report-foot {
+      margin: 0.6rem 0 0;
+      font-size: 0.78rem;
+      color: #9ca3af;
+    }
+
+    .bug-report-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      flex-shrink: 0;
+
+      .action {
+        cursor: pointer;
+        border-radius: 6px;
+        padding: 0.4rem 0.8rem;
+        font-size: 0.82rem;
+        font-weight: 600;
+        border: 1px solid transparent;
+        white-space: nowrap;
+
+        &:disabled {
+          opacity: 0.6;
+          cursor: default;
+        }
+
+        &.resolve {
+          background: #fff;
+          border-color: #16a34a;
+          color: #16a34a;
+        }
+
+        &.dismiss {
+          background: #fff;
+          border-color: #d1d5db;
+          color: #6b7280;
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: 640px) {
+  .admin-bug-reports .bug-report-card {
+    flex-direction: column;
+
+    .bug-report-actions {
+      flex-direction: row;
+    }
+  }
+}

--- a/src/pages/Admin/BugReports/BugReports.scss
+++ b/src/pages/Admin/BugReports/BugReports.scss
@@ -284,6 +284,51 @@
       }
     }
   }
+
+  .bug-reports-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 1.5rem;
+
+    .page-info {
+      font-size: 0.82rem;
+      color: #6b7280;
+    }
+
+    .page-controls {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+
+      .page-indicator {
+        font-size: 0.82rem;
+        color: #374151;
+      }
+
+      .page-btn {
+        cursor: pointer;
+        border: 1px solid #d8dbe0;
+        background: #fff;
+        color: #374151;
+        border-radius: 6px;
+        padding: 0.4rem 0.8rem;
+        font-size: 0.82rem;
+        font-weight: 600;
+
+        &:hover:not(:disabled) {
+          border-color: #9ca3af;
+        }
+
+        &:disabled {
+          opacity: 0.5;
+          cursor: default;
+        }
+      }
+    }
+  }
 }
 
 @media (max-width: 640px) {

--- a/src/pages/Admin/BugReports/BugReports.tsx
+++ b/src/pages/Admin/BugReports/BugReports.tsx
@@ -1,5 +1,10 @@
-import React, { FC, useState } from 'react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import React, { FC, useEffect, useState } from 'react'
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import { AdminBugReportType, BugReportStatus, BugReportCategory } from 'types'
 import BugReportAPI from 'src/api/bugReports'
@@ -24,34 +29,54 @@ const CATEGORY_OPTIONS: { value: CategoryFilter; label: string }[] = [
   { value: 'other', label: 'Other' },
 ]
 
+// Server caps perPage at 100; 50 keeps each page light while still showing a
+// useful chunk. Pagination below lets admins reach reports beyond the first page.
+const PER_PAGE = 50
+
 const BugReports: FC = () => {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('open')
   const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>('all')
+  const [page, setPage] = useState(0)
   // Ids ticked for a bulk resolve/dismiss sweep. Only open reports are
   // selectable; changing any filter clears the selection.
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const queryClient = useQueryClient()
 
   const { data, isPending, isError } = useQuery({
-    queryKey: ['admin-bug-reports', statusFilter, categoryFilter],
+    queryKey: ['admin-bug-reports', statusFilter, categoryFilter, page],
     queryFn: () =>
       BugReportAPI.listBugReports({
         status: statusFilter === 'all' ? undefined : statusFilter,
         category: categoryFilter === 'all' ? undefined : categoryFilter,
-        perPage: 50,
+        page,
+        perPage: PER_PAGE,
       }),
+    // Keep the current page visible while the next one loads, so paging doesn't
+    // flash the empty/loading state.
+    placeholderData: keepPreviousData,
   })
+
+  const totalCount = data?.totalCount ?? 0
+  const totalPages = Math.max(1, Math.ceil(totalCount / PER_PAGE))
+
+  // If reports drain off the last page (e.g. the admin resolved the only item on
+  // it), step back so they aren't stranded on an empty page.
+  useEffect(() => {
+    if (page > 0 && page >= totalPages) setPage(totalPages - 1)
+  }, [page, totalPages])
 
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: ['admin-bug-reports'] })
 
   const changeTab = (value: StatusFilter) => {
     setStatusFilter(value)
+    setPage(0)
     setSelected(new Set())
   }
 
   const changeCategory = (value: CategoryFilter) => {
     setCategoryFilter(value)
+    setPage(0)
     setSelected(new Set())
   }
 
@@ -138,6 +163,7 @@ const BugReports: FC = () => {
         onApply={f => {
           setStatusFilter(f.status)
           setCategoryFilter(f.category)
+          setPage(0)
           setSelected(new Set())
         }}
       />
@@ -152,7 +178,9 @@ const BugReports: FC = () => {
             />
             {selected.size > 0
               ? `${selected.size} selected`
-              : `Select all ${openReports.length} open`}
+              : `Select all ${openReports.length} open${
+                  totalPages > 1 ? ' on this page' : ''
+                }`}
           </label>
           {selected.size > 0 && (
             <div className='bulk-actions'>
@@ -250,6 +278,34 @@ const BugReports: FC = () => {
             </li>
           ))}
         </ul>
+      )}
+
+      {data && !isError && totalCount > 0 && totalPages > 1 && (
+        <div className='bug-reports-pagination'>
+          <span className='page-info'>
+            Showing {page * PER_PAGE + 1}–
+            {Math.min((page + 1) * PER_PAGE, totalCount)} of {totalCount}
+          </span>
+          <div className='page-controls'>
+            <button
+              className='page-btn'
+              disabled={page === 0}
+              onClick={() => setPage(p => Math.max(0, p - 1))}
+            >
+              Previous
+            </button>
+            <span className='page-indicator'>
+              Page {page + 1} of {totalPages}
+            </span>
+            <button
+              className='page-btn'
+              disabled={page >= totalPages - 1}
+              onClick={() => setPage(p => p + 1)}
+            >
+              Next
+            </button>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/src/pages/Admin/BugReports/BugReports.tsx
+++ b/src/pages/Admin/BugReports/BugReports.tsx
@@ -1,0 +1,258 @@
+import React, { FC, useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import { AdminBugReportType, BugReportStatus, BugReportCategory } from 'types'
+import BugReportAPI from 'src/api/bugReports'
+import SavedFilterBar from 'src/Components/SavedFilters/SavedFilterBar'
+import './BugReports.scss'
+
+type StatusFilter = BugReportStatus | 'all'
+type CategoryFilter = BugReportCategory | 'all'
+
+const STATUS_TABS: { value: StatusFilter; label: string }[] = [
+  { value: 'open', label: 'Open' },
+  { value: 'resolved', label: 'Resolved' },
+  { value: 'dismissed', label: 'Dismissed' },
+  { value: 'all', label: 'All' },
+]
+
+const CATEGORY_OPTIONS: { value: CategoryFilter; label: string }[] = [
+  { value: 'all', label: 'All categories' },
+  { value: 'bug', label: 'Bug' },
+  { value: 'confusing', label: 'Confusing' },
+  { value: 'idea', label: 'Idea' },
+  { value: 'other', label: 'Other' },
+]
+
+const BugReports: FC = () => {
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('open')
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>('all')
+  // Ids ticked for a bulk resolve/dismiss sweep. Only open reports are
+  // selectable; changing any filter clears the selection.
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const queryClient = useQueryClient()
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['admin-bug-reports', statusFilter, categoryFilter],
+    queryFn: () =>
+      BugReportAPI.listBugReports({
+        status: statusFilter === 'all' ? undefined : statusFilter,
+        category: categoryFilter === 'all' ? undefined : categoryFilter,
+        perPage: 50,
+      }),
+  })
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ['admin-bug-reports'] })
+
+  const changeTab = (value: StatusFilter) => {
+    setStatusFilter(value)
+    setSelected(new Set())
+  }
+
+  const changeCategory = (value: CategoryFilter) => {
+    setCategoryFilter(value)
+    setSelected(new Set())
+  }
+
+  const toggleSelect = (id: string) =>
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+
+  const openReports = (data?.reports || []).filter(r => r.status === 'open')
+  const allOpenSelected =
+    openReports.length > 0 && openReports.every(r => selected.has(r._id))
+
+  const toggleSelectAll = () =>
+    setSelected(
+      allOpenSelected ? new Set() : new Set(openReports.map(r => r._id))
+    )
+
+  const bulkMutation = useMutation({
+    mutationFn: ({ status }: { status: 'resolved' | 'dismissed' }) =>
+      BugReportAPI.bulkResolve(Array.from(selected), status),
+    onSuccess: (res, vars) => {
+      toast.success(`${res.updated} report${res.updated === 1 ? '' : 's'} ${vars.status}.`)
+      setSelected(new Set())
+      invalidate()
+    },
+    onError: () => toast.error('Could not update the selected reports.'),
+  })
+
+  const resolveMutation = useMutation({
+    mutationFn: ({ id, status }: { id: string; status: 'resolved' | 'dismissed' }) =>
+      BugReportAPI.resolveBugReport(id, status),
+    onSuccess: (_d, vars) => {
+      toast.success(`Report ${vars.status}.`)
+      invalidate()
+    },
+    onError: () => toast.error('Could not update the report.'),
+  })
+
+  const busy = resolveMutation.isPending || bulkMutation.isPending
+
+  const reporterLabel = (report: AdminBugReportType) => {
+    if (report.reporterUsername) return `@${report.reporterUsername}`
+    if (report.reporterEmail) return report.reporterEmail
+    return 'Anonymous'
+  }
+
+  return (
+    <div className='admin-bug-reports'>
+      <header className='admin-bug-reports-head'>
+        <h1>Bug reports</h1>
+        {data && <span className='open-count'>{data.openCount} open</span>}
+      </header>
+
+      <div className='status-tabs'>
+        {STATUS_TABS.map(tab => (
+          <button
+            key={tab.value}
+            className={statusFilter === tab.value ? 'tab active' : 'tab'}
+            onClick={() => changeTab(tab.value)}
+          >
+            {tab.label}
+          </button>
+        ))}
+        <select
+          className='category-select'
+          value={categoryFilter}
+          onChange={e => changeCategory(e.target.value as CategoryFilter)}
+          aria-label='Filter by category'
+        >
+          {CATEGORY_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <SavedFilterBar<{ status: StatusFilter; category: CategoryFilter }>
+        page='bug-reports'
+        current={{ status: statusFilter, category: categoryFilter }}
+        onApply={f => {
+          setStatusFilter(f.status)
+          setCategoryFilter(f.category)
+          setSelected(new Set())
+        }}
+      />
+
+      {openReports.length > 0 && (
+        <div className='bulk-bar'>
+          <label className='bulk-select-all'>
+            <input
+              type='checkbox'
+              checked={allOpenSelected}
+              onChange={toggleSelectAll}
+            />
+            {selected.size > 0
+              ? `${selected.size} selected`
+              : `Select all ${openReports.length} open`}
+          </label>
+          {selected.size > 0 && (
+            <div className='bulk-actions'>
+              <button
+                className='action resolve'
+                disabled={busy}
+                onClick={() => bulkMutation.mutate({ status: 'resolved' })}
+              >
+                Resolve selected
+              </button>
+              <button
+                className='action dismiss'
+                disabled={busy}
+                onClick={() => bulkMutation.mutate({ status: 'dismissed' })}
+              >
+                Dismiss selected
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {isPending ? (
+        <p className='bug-reports-state'>Loading bug reports…</p>
+      ) : isError ? (
+        <p className='bug-reports-state error'>Failed to load bug reports.</p>
+      ) : data.reports.length === 0 ? (
+        <p className='bug-reports-state'>
+          No {statusFilter === 'all' ? '' : statusFilter} bug reports.
+        </p>
+      ) : (
+        <ul className='bug-reports-list'>
+          {data.reports.map(report => (
+            <li key={report._id} className='bug-report-card'>
+              {report.status === 'open' && (
+                <input
+                  type='checkbox'
+                  className='bug-report-select'
+                  checked={selected.has(report._id)}
+                  onChange={() => toggleSelect(report._id)}
+                  aria-label='Select report for bulk action'
+                />
+              )}
+              <div className='bug-report-main'>
+                <div className='bug-report-tags'>
+                  <span className={`category-pill ${report.category}`}>
+                    {report.category}
+                  </span>
+                  <span className={`status-pill ${report.status}`}>
+                    {report.status}
+                  </span>
+                </div>
+
+                <p className='bug-report-description'>{report.description}</p>
+
+                <p className='bug-report-context'>
+                  {report.url && <span className='ctx'>{report.url}</span>}
+                  {report.appVersion && (
+                    <span className='ctx'>v{report.appVersion}</span>
+                  )}
+                  <span className='ctx'>{reporterLabel(report)}</span>
+                </p>
+                {report.userAgent && (
+                  <p className='bug-report-ua' title={report.userAgent}>
+                    {report.userAgent}
+                  </p>
+                )}
+                <p className='bug-report-foot'>
+                  Submitted {new Date(report.createdAt).toLocaleString()}
+                </p>
+              </div>
+
+              {report.status === 'open' && (
+                <div className='bug-report-actions'>
+                  <button
+                    className='action resolve'
+                    disabled={busy}
+                    onClick={() =>
+                      resolveMutation.mutate({ id: report._id, status: 'resolved' })
+                    }
+                  >
+                    Resolve
+                  </button>
+                  <button
+                    className='action dismiss'
+                    disabled={busy}
+                    onClick={() =>
+                      resolveMutation.mutate({ id: report._id, status: 'dismissed' })
+                    }
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default BugReports

--- a/src/pages/Admin/auditMeta.ts
+++ b/src/pages/Admin/auditMeta.ts
@@ -18,4 +18,6 @@ export const ACTION_META: Record<AuditAction, { label: string; tone: string }> =
   'user.activate': { label: 'reactivated', tone: 'good' },
   'report.resolve': { label: 'resolved report', tone: 'good' },
   'report.dismiss': { label: 'dismissed report', tone: 'neutral' },
+  'bugReport.resolve': { label: 'resolved bug report', tone: 'good' },
+  'bugReport.dismiss': { label: 'dismissed bug report', tone: 'neutral' },
 }

--- a/src/test/AdminBugReports.test.tsx
+++ b/src/test/AdminBugReports.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Admin Bug Reports queue — rendering, reporter enrichment, and bulk
+ * resolve/dismiss. The BugReportAPI and toast are mocked; react-query/router
+ * are real.
+ */
+
+import React from 'react'
+import { vi, Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import BugReports from 'src/pages/Admin/BugReports/BugReports'
+import BugReportAPI from 'src/api/bugReports'
+
+vi.mock('src/api/bugReports', () => ({
+  __esModule: true,
+  default: {
+    listBugReports: vi.fn(),
+    resolveBugReport: vi.fn(),
+    bulkResolve: vi.fn().mockResolvedValue({ updated: 2 }),
+  },
+}))
+vi.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: { success: vi.fn(), error: vi.fn() },
+}))
+
+const mockedList = BugReportAPI.listBugReports as unknown as Mock
+const mockedBulk = BugReportAPI.bulkResolve as unknown as Mock
+
+const openReport = (id: string, overrides = {}) => ({
+  _id: id,
+  reporterUid: 'u1',
+  reporterEmail: null,
+  reporterUsername: 'reporterUser',
+  category: 'bug' as const,
+  description: `Issue ${id}`,
+  url: '/recipes/abc',
+  userAgent: 'jest-agent',
+  appVersion: '2.6.3',
+  status: 'open' as const,
+  createdAt: new Date('2026-06-01').toISOString(),
+  ...overrides,
+})
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+    >
+      <MemoryRouter>
+        <BugReports />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+
+afterEach(() => vi.clearAllMocks())
+
+describe('Admin Bug Reports', () => {
+  it('renders reports with reporter and context', async () => {
+    mockedList.mockResolvedValue({
+      reports: [openReport('b1')],
+      totalCount: 1,
+      openCount: 1,
+    })
+    renderPage()
+    await screen.findByText('Issue b1')
+    expect(screen.getByText('@reporterUser')).toBeInTheDocument()
+    expect(screen.getByText('/recipes/abc')).toBeInTheDocument()
+  })
+
+  it('selects all open reports and bulk-dismisses them', async () => {
+    mockedList.mockResolvedValue({
+      reports: [openReport('b1'), openReport('b2')],
+      totalCount: 2,
+      openCount: 2,
+    })
+    renderPage()
+    await screen.findByText('Issue b1')
+
+    fireEvent.click(screen.getByText(/select all 2 open/i))
+    expect(await screen.findByText(/2 selected/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss selected/i }))
+
+    await waitFor(() => expect(mockedBulk).toHaveBeenCalledTimes(1))
+    const [ids, status] = mockedBulk.mock.calls[0]
+    expect(ids.sort()).toEqual(['b1', 'b2'])
+    expect(status).toBe('dismissed')
+  })
+
+  it('falls back to Anonymous when there is no reporter', async () => {
+    mockedList.mockResolvedValue({
+      reports: [
+        openReport('b1', { reporterUid: null, reporterUsername: null, reporterEmail: null }),
+      ],
+      totalCount: 1,
+      openCount: 1,
+    })
+    renderPage()
+    await screen.findByText('Issue b1')
+    expect(screen.getByText('Anonymous')).toBeInTheDocument()
+  })
+})

--- a/src/test/BugReportModal.test.tsx
+++ b/src/test/BugReportModal.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * BugReportModal: the global "Report a bug" affordance. useAuth and the bug
+ * report API are mocked so we can verify (a) it renders the trigger for everyone
+ * (logged-out included), (b) a submission posts through the API with the
+ * auto-captured context, and (c) the optional email field shows only when logged
+ * out.
+ */
+
+import React from 'react'
+import { vi, Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import BugReportModal from 'src/Components/BugReport/BugReportModal'
+import { useAuth } from 'src/context/AuthContext'
+import BugReportAPI from 'src/api/bugReports'
+
+vi.mock('src/context/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('src/api/bugReports', () => ({
+  __esModule: true,
+  default: { createBugReport: vi.fn().mockResolvedValue({ _id: 'bug1' }) },
+}))
+vi.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: { success: vi.fn(), error: vi.fn() },
+}))
+
+const mockedUseAuth = useAuth as unknown as Mock
+const mockedCreate = BugReportAPI.createBugReport as unknown as Mock
+
+afterEach(() => vi.clearAllMocks())
+
+describe('BugReportModal', () => {
+  it('renders the trigger even for logged-out users', () => {
+    mockedUseAuth.mockReturnValue({ user: null })
+    render(<BugReportModal />)
+    expect(screen.getByRole('button', { name: /report a bug/i })).toBeInTheDocument()
+  })
+
+  it('submits a report with auto-captured url and app version', async () => {
+    mockedUseAuth.mockReturnValue({ user: { uid: 'u1' } })
+    render(<BugReportModal />)
+
+    fireEvent.click(screen.getByRole('button', { name: /report a bug/i }))
+    fireEvent.change(screen.getByPlaceholderText(/what went wrong/i), {
+      target: { value: 'Save button does nothing' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send report/i }))
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1))
+    expect(mockedCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'bug',
+        description: 'Save button does nothing',
+        url: expect.any(String),
+        appVersion: expect.any(String),
+      })
+    )
+  })
+
+  it('blocks an empty submission', async () => {
+    mockedUseAuth.mockReturnValue({ user: { uid: 'u1' } })
+    render(<BugReportModal />)
+    fireEvent.click(screen.getByRole('button', { name: /report a bug/i }))
+    fireEvent.click(screen.getByRole('button', { name: /send report/i }))
+    expect(mockedCreate).not.toHaveBeenCalled()
+  })
+
+  it('shows the optional email field only when logged out', () => {
+    mockedUseAuth.mockReturnValue({ user: null })
+    const { rerender } = render(<BugReportModal />)
+    fireEvent.click(screen.getByRole('button', { name: /report a bug/i }))
+    expect(screen.getByPlaceholderText(/follow up/i)).toBeInTheDocument()
+
+    vi.clearAllMocks()
+    mockedUseAuth.mockReturnValue({ user: { uid: 'u1' } })
+    rerender(<BugReportModal />)
+    expect(screen.queryByPlaceholderText(/follow up/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/test/BugReportModal.test.tsx
+++ b/src/test/BugReportModal.test.tsx
@@ -75,4 +75,17 @@ describe('BugReportModal', () => {
     rerender(<BugReportModal />)
     expect(screen.queryByPlaceholderText(/follow up/i)).not.toBeInTheDocument()
   })
+
+  it('shows "Reporting as <name>" for a signed-in user and not when logged out', () => {
+    mockedUseAuth.mockReturnValue({ user: { uid: 'u1', displayName: 'chefSam' } })
+    const { rerender } = render(<BugReportModal />)
+    fireEvent.click(screen.getByRole('button', { name: /report a bug/i }))
+    expect(screen.getByText(/reporting as/i)).toBeInTheDocument()
+    expect(screen.getByText('chefSam')).toBeInTheDocument()
+
+    vi.clearAllMocks()
+    mockedUseAuth.mockReturnValue({ user: null })
+    rerender(<BugReportModal />)
+    expect(screen.queryByText(/reporting as/i)).not.toBeInTheDocument()
+  })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,6 +236,49 @@ export interface AdminReportsResponse {
   openCount: number
 }
 
+// ─── Bug reports (user-submitted product feedback) ─────────────────────────
+export type BugReportCategory = 'bug' | 'confusing' | 'idea' | 'other'
+
+// Status reuses the moderation lifecycle values.
+export type BugReportStatus = ReportStatus
+
+// What the client sends. Context (url, appVersion) is auto-captured by the form;
+// email is only collected from logged-out users for follow-up.
+export interface NewBugReportType {
+  category: BugReportCategory
+  description: string
+  url?: string
+  appVersion?: string
+  email?: string
+}
+
+export interface BugReportType {
+  _id: string
+  reporterUid: string | null
+  reporterEmail: string | null
+  category: BugReportCategory
+  description: string
+  url: string
+  userAgent: string
+  appVersion: string
+  status: BugReportStatus
+  createdAt: string
+  resolvedBy?: string
+  resolvedAt?: string
+}
+
+// Bug report enriched with the reporter's username, as returned by the admin
+// GET /admin/bug-reports queue. Null username = anonymous or no username on file.
+export interface AdminBugReportType extends BugReportType {
+  reporterUsername: string | null
+}
+
+export interface AdminBugReportsResponse {
+  reports: AdminBugReportType[]
+  totalCount: number
+  openCount: number
+}
+
 // ─── User moderation (P2) ──────────────────────────────────────────────────
 export type UserStatus = 'active' | 'suspended' | 'banned'
 
@@ -280,8 +323,15 @@ export type AuditAction =
   | 'user.activate'
   | 'report.resolve'
   | 'report.dismiss'
+  | 'bugReport.resolve'
+  | 'bugReport.dismiss'
 
-export type AuditTargetType = 'recipe' | 'review' | 'user' | 'report'
+export type AuditTargetType =
+  | 'recipe'
+  | 'review'
+  | 'user'
+  | 'report'
+  | 'bugReport'
 
 export interface AuditEntryType {
   _id: string

--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -1,0 +1,39 @@
+import * as Sentry from '@sentry/react'
+import { version } from 'src/Components/Footer/footerData'
+
+// ---------------------------------------------------------------------------
+// Sentry (client error monitoring). Entirely env-gated on VITE_SENTRY_DSN: with
+// no DSN set — local dev, CI, anyone who hasn't configured it — every export
+// here no-ops, so the app behaves exactly as before. Init runs once at startup
+// (src/index.tsx) before the app mounts so the global ErrorBoundary and network
+// interceptor have a live client to report to.
+// ---------------------------------------------------------------------------
+
+const dsn = import.meta.env.VITE_SENTRY_DSN
+
+/** True only once a DSN is configured and init has run. */
+export const sentryEnabled = Boolean(dsn)
+
+export function initSentry(): void {
+  if (!sentryEnabled) return
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.MODE,
+    release: version,
+    // Light tracing — enough to spot slow transactions without flooding the
+    // free-tier quota. Bump if/when we actually use performance data.
+    tracesSampleRate: 0.1,
+  })
+}
+
+/**
+ * Attach the signed-in user to error reports so a crash is traceable to an
+ * account. Called from AuthContext on auth state changes; clears on logout.
+ * No-ops when Sentry is disabled.
+ */
+export function setSentryUser(user: { uid: string } | null): void {
+  if (!sentryEnabled) return
+  Sentry.setUser(user ? { id: user.uid } : null)
+}
+
+export { Sentry }


### PR DESCRIPTION
## Bug reporting system

Adds error monitoring + an in-app feedback channel, plus an admin queue to triage it.

### Frontend
- **Sentry** (env-gated on `VITE_SENTRY_DSN` — no DSN ⇒ fully no-ops): global `ErrorBoundary` with a friendly fallback, axios interceptor reports 5xx/network failures, signed-in user attached to reports.
- **"Report a bug" modal** in the footer, open to everyone (logged-out included). Auto-captures route + app version; logged-out users may leave an email. Signed-in users see **"Reporting as &lt;name&gt;"** so they know the report is tied to their account.

### Backend
- `POST /api/bug-reports` (open, rate-limited, optional auth) → `bugReports` collection.
- Admin queue: `GET /api/admin/bug-reports` (filter by status/category, **paginated**), `PATCH /:id`, `PATCH /bulk` — reusing the existing audit-log + email-notify infrastructure.
- **Sentry** (env-gated on `SENTRY_DSN`): server fault capture in the central error backstop. New-report email alert to `ADMIN_NOTIFY_EMAIL`.

### Admin UI
- New **Bug reports** page: status tabs, category filter, saved filters, single + bulk resolve/dismiss, pagination.

### Local code-review fixes (applied + runtime-verified)
- Admin queue **paginates** instead of silently capping at 50.
- Single `PATCH /:id` only closes **open** reports → **409** if already closed, so a stale/concurrent admin action can't overwrite the original resolution or write a duplicate/misattributed audit entry.
- `perPage`/`page` **clamped** (1–100 / ≥0) so a malformed or oversized value can't crash the cursor or pull the whole collection.

Verified at runtime against the real Express app + Firebase auth (in-memory Mongo): clamp/pagination slices, 409 guard preserving original `resolvedBy`, and exactly one audit entry per real close.

### ⚠️ Launch step (not a code blocker)
Set prod env vars or nothing is captured/emailed: `VITE_SENTRY_DSN` (frontend build env, before `npm run build`), `SENTRY_DSN` + `ADMIN_NOTIFY_EMAIL` (Railway). `bugReports` indexes auto-build at startup; no migration.

### Tests
Server bug-report suite 19/19, frontend modal/admin suites 12/12, `tsc` clean, build OK.
