### PR TITLE
fix(data-integrity): D1 — key ratings/reports on stable userId

### DIFF
--- a/docs/DATA_INTEGRITY_AUDIT.md
+++ b/docs/DATA_INTEGRITY_AUDIT.md
@@ -16,7 +16,7 @@
 
 ---
 
-## D1 — `ratings` are keyed by `username`, not `uid` `[~]` **(root cause)**
+## D1 — `ratings` are keyed by `username`, not `uid` `[x]` **(root cause)**
 
 **What:** Review/rating documents in the `ratings` collection identify their author by a
 denormalized `username` string (e.g. `{ username: 'jesse', recipeId, rating, reviewText }`), not
@@ -42,10 +42,39 @@ and the moderation queue.
 `username` as a denormalized display field refreshed at read time (or dropped in favour of a join).
 Then the rename propagation and the username-based delete cascade both become unnecessary.
 
-**Touches:** `server/routes/reviews.js`, `server/routes/auth.js` (setUsername, deleteAccount,
-exportMyData), `server/routes/publicProfile.js`, plus a one-off backfill migration script.
+**Done (PR: D1):**
+- `ratings` now carry the author's stable `userId`; every author-facing write/read keys on it —
+  `addRating` / `newReview` / `editReview` / `deleteReview` / `checkIfReviewed` match `{ userId,
+  recipeId }`, `getReviews` derives `isCurrentUser` from a direct uid match, and
+  `getSingleUserReviews` resolves the public handle → uid then queries on `userId`
+  (`server/routes/reviews.js`). `username` stays on each doc purely as a denormalized display field.
+- `getAccountCountsFor`, `GET /exportMyData`, and the `POST /deleteAccount` ratings delete all key
+  on `userId` now (no username round-trip; robust even if the `usernames` doc is already gone).
+- `reports` review documents snapshot a stable `reportedUid` at creation time
+  (`server/routes/reports.js`); `reportedUsername` remains the denormalized display handle.
+- One-off backfill: `server/scripts/backfillRatingUserIds.js` — dry-run by default (`--apply` to
+  write), maps `username_lower → _id`, stamps `ratings.userId` + `reports.reportedUid`, lists
+  unresolved handles (orphans). Idempotent (only touches docs missing the field).
+- Index: `ratings { userId: 1, recipeId: 1 }` added to `server/scripts/createModerationIndexes.js`
+  to back the new point lookups and uid-prefix scans.
+- Regression tests: `reviews.test.js` "D1: review identity keyed on userId" (edit/upsert/flag still
+  work when the stored handle is stale, i.e. post-rename), `reports.test.js` reportedUid stamping.
 
-**Sequencing:** do this first — it shrinks D2 and D3.
+**Deploy ordering:** new writes already stamp `userId`, so run the backfill at deploy time to close
+the brief window where a legacy username-only `ratings` doc could be double-written. Run
+`createModerationIndexes.js` for the new ratings index.
+
+**Deferred (residual):** the admin review-moderation endpoint and the reports queue still *reference*
+a review by its denormalized `(username, recipeId)` / `reportedUsername`, so `POST /setUsername` keeps
+its rename propagation to keep those display handles fresh — identity is now uid-stable regardless, so
+this is a display concern, not a correctness one. Fully dropping propagation would mean moving the
+moderation/queue lookups to `reportedUid` too.
+
+**Touches:** `server/routes/reviews.js`, `server/routes/auth.js` (deleteAccount, exportMyData),
+`server/routes/reports.js`, `server/routes/publicProfile.js`, `server/util/accountCounts.js`, plus
+the one-off backfill migration script.
+
+**Sequencing:** done first — it shrinks D2 and D3.
 
 ---
 

--- a/docs/DATA_INTEGRITY_AUDIT.md
+++ b/docs/DATA_INTEGRITY_AUDIT.md
@@ -78,7 +78,7 @@ the one-off backfill migration script.
 
 ---
 
-## D2 — Deleting a recipe orphans other users' ratings of it `[ ]`
+## D2 — Deleting a recipe orphans other users' ratings of it `[x]`
 
 **What:** `ratings` are keyed by `recipeId`. Deleting a recipe (via delete-recipe, or as part of
 the delete-account cascade which removes the user's `recipes`) does **not** remove other users'
@@ -93,12 +93,17 @@ delete-recipe path and the delete-account cascade). Alternatively a periodic swe
 `ratings` whose `recipeId` has no matching `recipes` doc. Add a regression test asserting no
 orphans remain after a recipe delete.
 
+**Done (PR: cascade):** the account path now runs the same per-recipe teardown as
+`DELETE /deleteRecipe` (see D6) — `ratings.deleteMany({ recipeId })` for each of the departing
+user's recipes — so other users' reviews of those recipes no longer survive. Regression test:
+`auth.test.js` cascade → "removes other users' ratings of the departing user's recipes".
+
 **Touches:** `server/routes/recipes.js` (deleteRecipe), `server/routes/auth.js` (deleteAccount
-cascade).
+cascade), `server/util/teardownRecipe.js`.
 
 ---
 
-## D3 — Multi-collection writes are not atomic `[ ]`
+## D3 — Multi-collection writes are not atomic `[x]` (delete cascade)
 
 **What:** Several flows mutate several collections in sequence with no transaction:
 - `POST /deleteAccount` deletes across `usernames`, `userProfiles`, `users`, `userRecipeData`,
@@ -119,12 +124,20 @@ partial failure leaves the login recoverable to retry) — this item is specific
 idempotent so the whole operation is safely retryable. Prefer transactions for the delete cascade;
 idempotency is enough for the rename.
 
-**Touches:** `server/routes/auth.js` (deleteAccount, setUsername), `server/db.js` (a
-`withTransaction` helper).
+**Done (PR: cascade):** the entire Mongo-side delete cascade (per-recipe teardowns + the user's own
+docs across `usernames`/`userProfiles`/`users`/`userRecipeData`/`recipeDrafts`/`ratings` + reporter
+anonymization) now runs inside one `getClient().startSession()` / `session.withTransaction(...)`
+(`server/routes/auth.js`), so a partial failure rolls the whole thing back. The external side
+effects (rating recompute, Storage deletes, audit log, Firebase Auth deletion) deliberately stay
+*outside* the transaction and remain best-effort, preserving the Mongo-first / Firebase-last
+ordering. **Not done:** `setUsername`'s rename writes are left as-is (the propagation is now a
+display-only concern after D1 — idempotent `updateMany`s that are safely retryable).
+
+**Touches:** `server/routes/auth.js` (deleteAccount).
 
 ---
 
-## D4 — delete-account deletes a user's reviews without recomputing the recipes' rating aggregates `[ ]`
+## D4 — delete-account deletes a user's reviews without recomputing the recipes' rating aggregates `[x]`
 
 **What:** `POST /deleteAccount` runs `ratings.deleteMany({ username })`
 (`server/routes/auth.js`), removing the departing user's reviews from recipes that *other* users
@@ -143,11 +156,17 @@ deleted because the user authored them (no point recomputing a deleted recipe). 
 regression test: a recipe reviewed by two users shows the correct average after one of them deletes
 their account.
 
+**Done (PR: cascade):** exactly that — `ratings.distinct('recipeId', { userId })` is captured before
+the transaction, and after it commits `recomputeRecipeRating` runs for each reviewed recipe the user
+did NOT own (best-effort; a recompute failure can't block the account delete). Regression test:
+`auth.test.js` cascade → "recomputes the aggregate of a surviving recipe the departing user reviewed"
+(2-reviewer recipe drops from avg 3/count 2 to avg 4/count 1).
+
 **Touches:** `server/routes/auth.js` (deleteAccount); reuses `server/util/recipeRating.js`.
 
 ---
 
-## D5 — account-delete leaves Firebase Storage objects orphaned (recipe images + profile photo) `[ ]`
+## D5 — account-delete leaves Firebase Storage objects orphaned (recipe images + profile photo) `[x]`
 
 **What:** `DELETE /deleteRecipe` correctly calls `deleteRecipeImage(recipe.recipeImage)` after its
 transaction (`server/routes/recipes.js:342`). The delete-account cascade does **not** — it
@@ -166,12 +185,21 @@ existing `deleteRecipeImage` — an orphaned blob beats a failed account delete)
 keyed by path, not a download URL, so it needs a small delete-by-path helper alongside the existing
 URL-parsing one.
 
-**Touches:** `server/routes/auth.js` (deleteAccount); `server/util/firebaseStorage.js` (add a
-delete-by-path helper).
+**Done (PR: cascade):** the user's recipe docs are read before the transaction; after it commits,
+`deleteRecipeImage(r.recipeImage)` runs per recipe and the new `deleteProfilePhoto(uid)` helper
+(`server/util/firebaseStorage.js`) deletes `profilePhotos/{uid}` by path. Both never throw. The
+profile-photo helper names its bucket from `FIREBASE_STORAGE_BUCKET` (the Admin SDK has no default
+bucket configured) — added to `server/.env.example`; without it profile-photo cleanup is silently
+skipped (still best-effort). Regression tests: `auth.test.js` cascade → asserts the storage helpers
+are invoked (recipe image + profile photo = 2 calls) and that a Storage failure can't fail the
+account delete.
+
+**Touches:** `server/routes/auth.js` (deleteAccount); `server/util/firebaseStorage.js`
+(`deleteProfilePhoto` by-path helper).
 
 ---
 
-## D6 — the delete-account cascade re-implements recipe teardown instead of reusing the thorough one `[ ]` **(unifies D2 / D5 for the account path)**
+## D6 — the delete-account cascade re-implements recipe teardown instead of reusing the thorough one `[x]` **(unifies D2 / D5 for the account path)**
 
 **What:** `DELETE /deleteRecipe` already does a complete, atomic per-recipe teardown
 (`server/routes/recipes.js:319`): delete the recipe, `ratings.deleteMany({ recipeId })`, `$pull` the
@@ -192,8 +220,17 @@ so the two paths can't drift. Then decide reporter cleanup: `reports.deleteMany(
 if the filed reports are disposable, or anonymize `reporterUid` if the moderation queue needs the
 history. Pairs naturally with D3 (wrap the whole thing in one transaction).
 
-**Touches:** `server/routes/recipes.js` (extract `teardownRecipe`); `server/routes/auth.js`
-(deleteAccount); `server/routes/reports.js` (reporter-cleanup decision).
+**Done (PR: cascade):** `teardownRecipeDocs(db, recipe, session)` is now the single implementation in
+`server/util/teardownRecipe.js`, called by both `DELETE /deleteRecipe` and the cascade. Reporter
+cleanup: **anonymize** — `reports.updateMany({ reporterUid: uid }, { $set: { reporterUid: null } })`
+inside the transaction, chosen over delete because a report's subject (the reported content) can
+still be a valid open queue item after the reporter leaves; the email helpers already guard a falsy
+`reporterUid`, so an anonymized report just skips reporter notification. Regression tests:
+`auth.test.js` cascade → dangling saved/made refs pulled, reporter anonymized, surrounding data
+intact.
+
+**Touches:** `server/routes/recipes.js` (now delegates to the shared helper);
+`server/util/teardownRecipe.js` (new); `server/routes/auth.js` (deleteAccount).
 
 ---
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,6 +2,13 @@ MONGO_URI=mongodb+srv://<user>:<password>@cluster0.xxxxx.mongodb.net/prepify?ret
 PORT=4000
 SPOONACULAR_API_KEY=<your-spoonacular-api-key>
 
+# Firebase Storage bucket name (e.g. your-app.appspot.com). Only needed so the
+# delete-account cascade can remove a user's profile photo, which is addressed by
+# path (profilePhotos/{uid}) rather than a download URL. Recipe-image deletion
+# parses the bucket from the image URL and works without this. Leave empty to
+# skip profile-photo cleanup (best-effort — an orphaned avatar is tolerated).
+FIREBASE_STORAGE_BUCKET=
+
 # Sentry server error monitoring. Leave empty to disable entirely — without a
 # DSN, Sentry is never initialized and all capture calls no-op, so dev/CI stay
 # quiet. Use a separate DSN/project from the frontend.

--- a/server/__tests__/admin-moderation.test.js
+++ b/server/__tests__/admin-moderation.test.js
@@ -10,7 +10,7 @@ const request = require('supertest')
 const admin = require('firebase-admin') // auto-mocked
 const app = require('../app')
 const { getDB } = require('../db')
-const { seedRecipe, seedRecipes, seedUserRecipeData, seedRating } = require('./helpers/seed')
+const { seedRecipe, seedRecipes, seedUserRecipeData, seedRating, seedUser } = require('./helpers/seed')
 
 const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
 const TEST_UID = 'test-uid'
@@ -35,6 +35,7 @@ afterEach(async () => {
     db.collection('recipes').deleteMany({}),
     db.collection('ratings').deleteMany({}),
     db.collection('userRecipeData').deleteMany({}),
+    db.collection('usernames').deleteMany({}),
     db.collection('stats').deleteMany({}),
   ])
 })
@@ -186,8 +187,9 @@ describe('PATCH /api/admin/reviews/moderation', () => {
       { ...BASE_RECIPE, _id: 'vis', title: 'Visible' },
       { ...BASE_RECIPE, _id: 'hid', title: 'Hidden', status: 'hidden' },
     ])
-    await seedRating({ username: 'rater', recipeId: 'vis', reviewText: 'good', rating: 5 })
-    await seedRating({ username: 'rater', recipeId: 'hid', reviewText: 'also good', rating: 4 })
+    await seedUser('rater-uid', 'rater')
+    await seedRating({ userId: 'rater-uid', username: 'rater', recipeId: 'vis', reviewText: 'good', rating: 5 })
+    await seedRating({ userId: 'rater-uid', username: 'rater', recipeId: 'hid', reviewText: 'also good', rating: 4 })
 
     const res = await request(app).get(
       '/api/getSingleUserReviews?username=rater&returnRecipeData=true&reviewsPerPage=50'

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -552,7 +552,7 @@ describe('GET /exportMyData', () => {
       .insertOne({ _id: 'd1', userId: TEST_UID })
     await db
       .collection('ratings')
-      .insertOne({ username: 'exporter', recipeId: 'r1', rating: 5 })
+      .insertOne({ userId: TEST_UID, username: 'exporter', recipeId: 'r1', rating: 5 })
 
     const res = await request(app).get('/api/exportMyData').set(AUTH_HEADER)
 
@@ -595,7 +595,7 @@ describe('POST /deleteAccount', () => {
       .insertOne({ _id: 'd1', userId: TEST_UID })
     await db
       .collection('ratings')
-      .insertOne({ username: 'goner', recipeId: 'r1', rating: 4 })
+      .insertOne({ userId: TEST_UID, username: 'goner', recipeId: 'r1', rating: 4 })
   }
 
   it('rejects request with no auth token (401)', async () => {

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -649,4 +649,121 @@ describe('POST /deleteAccount', () => {
     expect(res.status).toBe(200)
     expect(admin.__deleteUser).toHaveBeenCalledWith(TEST_UID)
   })
+
+  // ── Cascade thoroughness (D2 / D4 / D5 / D6) ──────────────────────────────
+  // The departing user (TEST_UID/'goner') OWNS recipe 'owned'. Another user
+  // ('keeper') owns recipe 'kept' and has reviewed BOTH; the departing user has
+  // also reviewed 'kept'. Exercises: other users' reviews of a deleted recipe,
+  // dangling saved/made refs, surviving-recipe rating drift, and Storage leaks.
+  describe('cascade (D2/D4/D5/D6)', () => {
+    const KEEPER_UID = 'keeper-uid'
+
+    const seedCascade = async () => {
+      const db = getDB()
+      await seedUser(TEST_UID, 'goner')
+      await seedUser(KEEPER_UID, 'keeper')
+      await db.collection('users').insertOne({ _id: TEST_UID, status: 'active' })
+
+      // Departing user owns 'owned' (with an image); keeper owns 'kept'.
+      await db.collection('recipes').insertMany([
+        { _id: 'owned', userId: TEST_UID, recipeImage: 'https://firebasestorage.googleapis.com/v0/b/b/o/owned.jpg?alt=media&token=t' },
+        { _id: 'kept', userId: KEEPER_UID, rating: { rateCount: 0, rateValue: 0 } },
+      ])
+
+      // keeper saved + made the departing user's recipe → must be pulled (D2/D6).
+      await db.collection('userRecipeData').insertMany([
+        { _id: TEST_UID, savedRecipes: [{ recipeId: 'kept' }], madeRecipes: [], userRecipes: [{ recipeId: 'owned' }] },
+        { _id: KEEPER_UID, savedRecipes: [{ recipeId: 'owned' }], madeRecipes: [{ recipeId: 'owned' }], userRecipes: [{ recipeId: 'kept' }] },
+      ])
+
+      // Ratings: keeper reviewed BOTH; departing user reviewed 'kept'.
+      await db.collection('ratings').insertMany([
+        { userId: KEEPER_UID, username: 'keeper', recipeId: 'owned', rating: 5 },
+        { userId: KEEPER_UID, username: 'keeper', recipeId: 'kept', rating: 4 },
+        { userId: TEST_UID, username: 'goner', recipeId: 'kept', rating: 2 },
+      ])
+      // 'kept' currently averages keeper(4) + goner(2) = 3 over 2 ratings.
+      await db.collection('recipes').updateOne({ _id: 'kept' }, { $set: { rating: { rateCount: 2, rateValue: 3 } } })
+    }
+
+    beforeEach(() => admin.__deleteFile.mockClear())
+
+    it('removes other users\' ratings of the departing user\'s recipes (D2)', async () => {
+      await seedCascade()
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      const db = getDB()
+      // keeper's review of the now-deleted 'owned' recipe must be gone.
+      expect(await db.collection('ratings').countDocuments({ recipeId: 'owned' })).toBe(0)
+    })
+
+    it('pulls the deleted recipe from other users\' saved/made lists (D6)', async () => {
+      await seedCascade()
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      const keeper = await getDB().collection('userRecipeData').findOne({ _id: KEEPER_UID })
+      expect(keeper.savedRecipes).toEqual([])
+      expect(keeper.madeRecipes).toEqual([])
+      // keeper's unrelated created list is untouched.
+      expect(keeper.userRecipes).toEqual([{ recipeId: 'kept' }])
+    })
+
+    it('recomputes the aggregate of a surviving recipe the departing user reviewed (D4)', async () => {
+      await seedCascade()
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      const db = getDB()
+      // goner's review of 'kept' is gone; only keeper(4) remains.
+      expect(await db.collection('ratings').countDocuments({ recipeId: 'kept' })).toBe(1)
+      const kept = await db.collection('recipes').findOne({ _id: 'kept' })
+      expect(kept.rating).toEqual({ rateCount: 1, rateValue: 4 })
+    })
+
+    it('deletes the departing user\'s recipe images and profile photo from Storage (D5)', async () => {
+      await seedCascade()
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      // One recipe image ('owned') + the profile photo (profilePhotos/{uid}).
+      expect(admin.__deleteFile).toHaveBeenCalledTimes(2)
+    })
+
+    it('still completes the account delete if a Storage delete fails (best-effort)', async () => {
+      await seedCascade()
+      admin.__deleteFile.mockRejectedValueOnce(new Error('storage down'))
+
+      const res = await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+      expect(res.status).toBe(200)
+      expect(admin.__deleteUser).toHaveBeenCalledWith(TEST_UID)
+    })
+
+    it('anonymizes reports the departing user filed, preserving the record (D6)', async () => {
+      await seedCascade()
+      const db = getDB()
+      await db.collection('reports').insertOne({
+        targetType: 'recipe',
+        recipeId: 'kept',
+        reporterUid: TEST_UID,
+        reason: 'spam',
+        status: 'open',
+        createdAt: new Date(),
+      })
+
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      const report = await db.collection('reports').findOne({ recipeId: 'kept' })
+      expect(report).not.toBeNull()
+      expect(report.reporterUid).toBeNull()
+    })
+
+    it('leaves another user\'s own recipe and review intact', async () => {
+      await seedCascade()
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      const db = getDB()
+      expect(await db.collection('recipes').findOne({ _id: 'kept' })).not.toBeNull()
+      expect(
+        await db.collection('ratings').findOne({ userId: KEEPER_UID, recipeId: 'kept' })
+      ).not.toBeNull()
+    })
+  })
 })

--- a/server/__tests__/gamification.test.js
+++ b/server/__tests__/gamification.test.js
@@ -140,7 +140,7 @@ describe('GET /getGamification', () => {
     await seedUserRecipeData(TEST_UID, {
       savedRecipes: [{ recipeId: 'c1', dateSaved: '1' }],
     })
-    await seedRating({ username: 'testuser', recipeId: 'c1', rating: 5 })
+    await seedRating({ userId: TEST_UID, username: 'testuser', recipeId: 'c1', rating: 5 })
 
     const res = await request(app).get('/api/getGamification').set(AUTH_HEADER)
     expect(res.status).toBe(200)

--- a/server/__tests__/publicProfile.test.js
+++ b/server/__tests__/publicProfile.test.js
@@ -42,7 +42,7 @@ const seedProfile = async () => {
   await seedUserRecipeData(PUB_UID, {
     savedRecipes: [{ recipeId: 'c1', dateSaved: '1' }],
   })
-  await seedRating({ username: 'CoolUser', recipeId: 'c1', rating: 5 })
+  await seedRating({ userId: PUB_UID, username: 'CoolUser', recipeId: 'c1', rating: 5 })
 }
 
 describe('GET /getPublicProfile', () => {

--- a/server/__tests__/reports.test.js
+++ b/server/__tests__/reports.test.js
@@ -11,7 +11,7 @@ const admin = require('firebase-admin') // auto-mocked
 const { ObjectId } = require('mongodb')
 const app = require('../app')
 const { getDB } = require('../db')
-const { seedRecipe, seedRating } = require('./helpers/seed')
+const { seedRecipe, seedRating, seedUser } = require('./helpers/seed')
 
 const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
 const TEST_UID = 'test-uid'
@@ -23,6 +23,7 @@ afterEach(async () => {
     db.collection('reports').deleteMany({}),
     db.collection('recipes').deleteMany({}),
     db.collection('ratings').deleteMany({}),
+    db.collection('usernames').deleteMany({}),
     db.collection('auditLog').deleteMany({}),
   ])
 })
@@ -57,6 +58,36 @@ describe('POST /api/reports', () => {
       .send({ targetType: 'review', recipeId: 'recipe-001', reportedUsername: 'baduser', reason: 'offensive' })
     expect(res.status).toBe(201)
     expect(res.body.reportedUsername).toBe('baduser')
+  })
+
+  // D1: snapshot the reported user's stable uid so the report stays attached
+  // across a rename. Resolved case-insensitively from the usernames collection.
+  it('stamps reportedUid on a review report when the handle resolves', async () => {
+    await seedUser('bad-uid', 'BadUser')
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'review', recipeId: 'recipe-001', reportedUsername: 'baduser', reason: 'offensive' })
+    expect(res.status).toBe(201)
+    expect(res.body.reportedUid).toBe('bad-uid')
+  })
+
+  it('leaves reportedUid null when the reported handle has no account', async () => {
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'review', recipeId: 'recipe-001', reportedUsername: 'ghost', reason: 'offensive' })
+    expect(res.status).toBe(201)
+    expect(res.body.reportedUid).toBeNull()
+  })
+
+  it('does not stamp reportedUid on a recipe report', async () => {
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send(validRecipeReport)
+    expect(res.status).toBe(201)
+    expect(res.body.reportedUid).toBeUndefined()
   })
 
   it('rejects an invalid targetType', async () => {

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -141,6 +141,7 @@ describe('POST /editReview', () => {
   beforeEach(async () => {
     const db = getDB()
     await db.collection('ratings').insertOne({
+      userId: TEST_UID,
       username: TEST_USERNAME,
       recipeId: RECIPE_ID,
       rating: 4,
@@ -200,6 +201,7 @@ describe('DELETE /deleteReview', () => {
   beforeEach(async () => {
     const db = getDB()
     await db.collection('ratings').insertOne({
+      userId: TEST_UID,
       username: TEST_USERNAME,
       recipeId: RECIPE_ID,
       rating: 3,
@@ -315,6 +317,7 @@ describe('POST /newReview', () => {
 
   it('updates an existing review entry (upsert)', async () => {
     await seedRating({
+      userId: TEST_UID,
       username: TEST_USERNAME,
       recipeId: RECIPE_ID,
       rating: 4,
@@ -383,7 +386,7 @@ describe('GET /checkIfReviewed', () => {
   })
 
   it('returns { reviewed: true, rating } when a rating exists with empty reviewText (rating-only)', async () => {
-    await seedRating({ username: TEST_USERNAME, recipeId: RECIPE_ID, rating: 3, reviewText: '' })
+    await seedRating({ userId: TEST_UID, username: TEST_USERNAME, recipeId: RECIPE_ID, rating: 3, reviewText: '' })
 
     const res = await request(app)
       .get(`/api/checkIfReviewed?recipeId=${RECIPE_ID}`)
@@ -396,6 +399,7 @@ describe('GET /checkIfReviewed', () => {
 
   it('returns the full ratings doc plus reviewed:true when a review exists', async () => {
     await seedRating({
+      userId: TEST_UID,
       username: TEST_USERNAME,
       recipeId: RECIPE_ID,
       rating: 5,
@@ -470,6 +474,7 @@ describe('GET /getReviews', () => {
 
   it('sets isCurrentUser=true for the authenticated caller’s own review', async () => {
     await seedRating({
+      userId: TEST_UID,
       username: TEST_USERNAME,
       recipeId: RECIPE_ID,
       rating: 5,
@@ -487,6 +492,7 @@ describe('GET /getReviews', () => {
 
   it('ignores the username query param — no token means isCurrentUser=false (spoof closed)', async () => {
     await seedRating({
+      userId: TEST_UID,
       username: TEST_USERNAME,
       recipeId: RECIPE_ID,
       rating: 5,
@@ -549,6 +555,7 @@ describe('GET /getSingleUserReviews', () => {
 
   it('returns only reviews for the specified user', async () => {
     await seedRating({
+      userId: TEST_UID,
       username: TEST_USERNAME,
       recipeId: RECIPE_ID,
       rating: 5,
@@ -556,6 +563,7 @@ describe('GET /getSingleUserReviews', () => {
       reviewCreatedAt: '1000',
     })
     await seedRating({
+      userId: OTHER_UID,
       username: OTHER_USERNAME,
       recipeId: RECIPE_ID,
       rating: 3,
@@ -571,6 +579,7 @@ describe('GET /getSingleUserReviews', () => {
 
   it('includes recipeData when returnRecipeData=true', async () => {
     await seedRating({
+      userId: TEST_UID,
       username: TEST_USERNAME,
       recipeId: RECIPE_ID,
       rating: 4,
@@ -588,6 +597,7 @@ describe('GET /getSingleUserReviews', () => {
 
   it('does not include recipeData when returnRecipeData is not set', async () => {
     await seedRating({
+      userId: TEST_UID,
       username: TEST_USERNAME,
       recipeId: RECIPE_ID,
       rating: 4,
@@ -605,6 +615,7 @@ describe('GET /getSingleUserReviews', () => {
   // which silently dropped any rating without a written review.
   it('includes rating-only entries (empty reviewText)', async () => {
     await seedRating({
+      userId: TEST_UID,
       username: TEST_USERNAME,
       recipeId: RECIPE_ID,
       rating: 4,
@@ -622,6 +633,7 @@ describe('GET /getSingleUserReviews', () => {
   it('paginates results', async () => {
     for (let i = 0; i < 4; i++) {
       await seedRating({
+        userId: TEST_UID,
         username: TEST_USERNAME,
         recipeId: `recipe-${i}`,
         rating: 3,
@@ -636,5 +648,81 @@ describe('GET /getSingleUserReviews', () => {
     expect(res.status).toBe(200)
     expect(res.body.reviews).toHaveLength(2)
     expect(res.body.totalCount).toBe(4)
+  })
+})
+
+// ─── D1: ratings are keyed by the stable userId, not the mutable username ──────
+// These pin the root-cause fix: a review's identity is the author's uid, so a
+// username that no longer matches the doc (a rename happened) can neither
+// detach the author from their own review nor let the stale handle be used to
+// reach it.
+
+describe('D1: review identity keyed on userId', () => {
+  // Simulate a post-rename state: the user's CURRENT username is TEST_USERNAME
+  // (from the usernames doc seeded in beforeEach), but their existing rating doc
+  // still carries the OLD denormalized handle.
+  const STALE_HANDLE = 'old-handle'
+
+  it('lets the author edit their own review found by uid even when the stored username is stale', async () => {
+    await seedRating({
+      userId: TEST_UID,
+      username: STALE_HANDLE,
+      recipeId: RECIPE_ID,
+      rating: 4,
+      reviewText: 'before',
+      reviewCreatedAt: '1000',
+      reviewLastUpdated: '1000',
+    })
+
+    const res = await request(app)
+      .post(`/api/editReview?recipeId=${RECIPE_ID}&text=after`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+
+    const doc = await getDB()
+      .collection('ratings')
+      .findOne({ userId: TEST_UID, recipeId: RECIPE_ID })
+    expect(doc.reviewText).toBe('after')
+  })
+
+  it('upserts onto the existing doc by uid (no duplicate) when the stored username is stale', async () => {
+    await seedRating({
+      userId: TEST_UID,
+      username: STALE_HANDLE,
+      recipeId: RECIPE_ID,
+      rating: 5,
+      reviewText: 'original',
+      reviewCreatedAt: '1000',
+      reviewLastUpdated: '1000',
+    })
+
+    await request(app)
+      .post('/api/newReview')
+      .set(AUTH_HEADER)
+      .send({ recipeId: RECIPE_ID, reviewText: 'updated' })
+
+    const docs = await getDB()
+      .collection('ratings')
+      .find({ userId: TEST_UID, recipeId: RECIPE_ID })
+      .toArray()
+    expect(docs).toHaveLength(1)
+    expect(docs[0].reviewText).toBe('updated')
+  })
+
+  it('flags isCurrentUser from the uid, not the (possibly stale) stored username', async () => {
+    await seedRating({
+      userId: TEST_UID,
+      username: STALE_HANDLE,
+      recipeId: RECIPE_ID,
+      rating: 5,
+      reviewText: 'mine',
+      reviewCreatedAt: '1000',
+    })
+
+    const res = await request(app)
+      .get(`/api/getReviews?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.reviews[0].isCurrentUser).toBe(true)
   })
 })

--- a/server/__tests__/upsertWithDupRetry.test.js
+++ b/server/__tests__/upsertWithDupRetry.test.js
@@ -1,0 +1,56 @@
+const { upsertWithDupRetry } = require('../util/upsertWithDupRetry')
+
+// A minimal fake collection whose updateOne is a jest mock, so we can assert how
+// upsertWithDupRetry calls it without needing a live unique index/race.
+const makeCollection = () => ({ updateOne: jest.fn() })
+
+const FILTER = { userId: 'u1', recipeId: 'r1' }
+const UPDATE = { $set: { reviewText: 'hi' }, $setOnInsert: { username: 'me' } }
+
+describe('upsertWithDupRetry', () => {
+  it('does a single upsert when there is no collision', async () => {
+    const col = makeCollection()
+    col.updateOne.mockResolvedValueOnce({ upsertedCount: 1 })
+
+    const res = await upsertWithDupRetry(col, FILTER, UPDATE)
+
+    expect(col.updateOne).toHaveBeenCalledTimes(1)
+    expect(col.updateOne).toHaveBeenCalledWith(FILTER, UPDATE, { upsert: true })
+    expect(res).toEqual({ upsertedCount: 1 })
+  })
+
+  it('retries as a plain (non-upsert) update on a duplicate-key race (E11000)', async () => {
+    const col = makeCollection()
+    const dupErr = Object.assign(new Error('E11000 duplicate key'), { code: 11000 })
+    col.updateOne
+      .mockRejectedValueOnce(dupErr) // loser of the insert race
+      .mockResolvedValueOnce({ matchedCount: 1, modifiedCount: 1 }) // retry lands on the winner's doc
+
+    const res = await upsertWithDupRetry(col, FILTER, UPDATE)
+
+    expect(col.updateOne).toHaveBeenCalledTimes(2)
+    expect(col.updateOne).toHaveBeenNthCalledWith(1, FILTER, UPDATE, { upsert: true })
+    expect(col.updateOne).toHaveBeenNthCalledWith(2, FILTER, UPDATE, { upsert: false })
+    expect(res).toEqual({ matchedCount: 1, modifiedCount: 1 })
+  })
+
+  it('rethrows non-duplicate errors without retrying', async () => {
+    const col = makeCollection()
+    col.updateOne.mockRejectedValueOnce(Object.assign(new Error('boom'), { code: 42 }))
+
+    await expect(upsertWithDupRetry(col, FILTER, UPDATE)).rejects.toThrow('boom')
+    expect(col.updateOne).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves caller-supplied options (e.g. session) on both attempts', async () => {
+    const col = makeCollection()
+    const session = { id: 'sess' }
+    const dupErr = Object.assign(new Error('dup'), { code: 11000 })
+    col.updateOne.mockRejectedValueOnce(dupErr).mockResolvedValueOnce({ matchedCount: 1 })
+
+    await upsertWithDupRetry(col, FILTER, UPDATE, { session })
+
+    expect(col.updateOne).toHaveBeenNthCalledWith(1, FILTER, UPDATE, { session, upsert: true })
+    expect(col.updateOne).toHaveBeenNthCalledWith(2, FILTER, UPDATE, { session, upsert: false })
+  })
+})

--- a/server/__tests__/user-status-enforcement.test.js
+++ b/server/__tests__/user-status-enforcement.test.js
@@ -103,7 +103,7 @@ describe('deletes remain allowed when suspended (not punitive)', () => {
   it('a suspended user can still delete their own review', async () => {
     await setStatus('suspended')
     await seedUser(TEST_UID, 'me')
-    await seedRating({ username: 'me', recipeId: 'r1', reviewText: 'hi', rating: 5 })
+    await seedRating({ userId: TEST_UID, username: 'me', recipeId: 'r1', reviewText: 'hi', rating: 5 })
     const res = await request(app).delete('/api/deleteReview?recipeId=r1').set(AUTH_HEADER)
     expect(res.status).toBe(200)
     expect(res.body.deleted).toBe(true)

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -214,18 +214,14 @@ describe('GET /getCreatedRecipes', () => {
 // ─── getAccountCountsFor (shared helper) ──────────────────────────────────────
 
 describe('getAccountCountsFor', () => {
-  it('gives the same result whether or not the username is passed in', async () => {
+  it("counts a user's ratings by their stable userId (D1)", async () => {
     await seedUser(TEST_UID, 'testuser')
-    await seedRating({ username: 'testuser', recipeId: 'x', rating: 5 })
+    await seedRating({ userId: TEST_UID, username: 'testuser', recipeId: 'x', rating: 5 })
     await seedRecipes([{ _id: 'c1', userId: TEST_UID }])
 
-    const db = getDB()
-    const lookedUp = await getAccountCountsFor(db, TEST_UID)
-    const passedIn = await getAccountCountsFor(db, TEST_UID, 'testuser')
-
-    expect(passedIn).toEqual(lookedUp)
-    expect(passedIn.ratings).toBe(1)
-    expect(passedIn.recipes).toBe(1)
+    const counts = await getAccountCountsFor(getDB(), TEST_UID)
+    expect(counts.ratings).toBe(1)
+    expect(counts.recipes).toBe(1)
   })
 })
 
@@ -264,8 +260,8 @@ describe('GET /getAccountCounts', () => {
         { _id: 'd3', userId: TEST_UID },
         { _id: 'd4', userId: TEST_UID },
       ])
-    await seedRating({ username: 'testuser', recipeId: 'c1', rating: 5 })
-    await seedRating({ username: 'testuser', recipeId: 'c2', rating: 4 })
+    await seedRating({ userId: TEST_UID, username: 'testuser', recipeId: 'c1', rating: 5 })
+    await seedRating({ userId: TEST_UID, username: 'testuser', recipeId: 'c2', rating: 4 })
 
     const res = await request(app).get('/api/getAccountCounts').set(AUTH_HEADER)
     expect(res.status).toBe(200)
@@ -282,18 +278,18 @@ describe('GET /getAccountCounts', () => {
     await getDB()
       .collection('recipeDrafts')
       .insertOne({ _id: 'theirdraft', userId: 'other-uid' })
-    await seedRating({ username: 'otheruser', recipeId: 'mine', rating: 5 })
+    await seedRating({ userId: 'other-uid', username: 'otheruser', recipeId: 'mine', rating: 5 })
 
     const res = await request(app).get('/api/getAccountCounts').set(AUTH_HEADER)
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ saved: 0, ratings: 0, recipes: 1, drafts: 0 })
   })
 
-  it('returns 0 ratings when the user has no username yet', async () => {
-    // Ratings are keyed by username; a user without one resolves to 0 ratings
-    // even if rows happen to exist under some other name.
+  it('returns 0 ratings when no ratings are keyed to the user (D1)', async () => {
+    // Ratings are keyed by the stable userId; rows authored by someone else
+    // never count toward this user, regardless of recipe.
     await seedRecipes([{ _id: 'c1', userId: TEST_UID }])
-    await seedRating({ username: 'someoneelse', recipeId: 'c1', rating: 5 })
+    await seedRating({ userId: 'someoneelse-uid', username: 'someoneelse', recipeId: 'c1', rating: 5 })
 
     const res = await request(app).get('/api/getAccountCounts').set(AUTH_HEADER)
     expect(res.status).toBe(200)

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -234,8 +234,9 @@ router.post('/updatePrivacy', verifyToken, requireActive, asyncHandler(async (re
 
 // GET /exportMyData
 // Assembles a JSON copy of everything stored for the authenticated user and
-// returns it as a file download. Read-only; ratings are keyed by username, so
-// we resolve that first (a user with no username simply has no ratings).
+// returns it as a file download. Read-only. Everything keys on the stable uid
+// (ratings carry `userId` since D1); the username is still surfaced as a
+// top-level display field.
 router.get('/exportMyData', verifyToken, asyncHandler(async (req, res) => {
   const uid = req.uid
   const db = getDB()
@@ -247,9 +248,7 @@ router.get('/exportMyData', verifyToken, asyncHandler(async (req, res) => {
     db.collection('userRecipeData').findOne({ _id: uid }),
     db.collection('recipes').find({ userId: uid }).toArray(),
     db.collection('recipeDrafts').find({ userId: uid }).toArray(),
-    username
-      ? db.collection('ratings').find({ username }).toArray()
-      : Promise.resolve([]),
+    db.collection('ratings').find({ userId: uid }).toArray(),
   ])
 
   const data = {
@@ -290,8 +289,8 @@ router.post('/deleteAccount', verifyToken, asyncHandler(async (req, res) => {
   const uid = req.uid
   const db = getDB()
 
-  // ratings are keyed by username (not uid), so resolve it before we delete the
-  // usernames doc.
+  // The username is only needed for the audit label now — every collection
+  // below keys on the stable uid (ratings carry `userId` since D1).
   const usernameDoc = await db.collection('usernames').findOne({ _id: uid })
   const username = usernameDoc?.username || null
 
@@ -301,9 +300,7 @@ router.post('/deleteAccount', verifyToken, asyncHandler(async (req, res) => {
   await db.collection('userRecipeData').deleteOne({ _id: uid })
   await db.collection('recipes').deleteMany({ userId: uid })
   await db.collection('recipeDrafts').deleteMany({ userId: uid })
-  if (username) {
-    await db.collection('ratings').deleteMany({ username })
-  }
+  await db.collection('ratings').deleteMany({ userId: uid })
 
   // Leave a trail in the audit log (best-effort) so an admin can see that the
   // account was self-deleted rather than removed by moderation.

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -2,9 +2,11 @@ const express = require('express')
 const admin = require('firebase-admin')
 const { asyncHandler } = require('../util/asyncHandler')
 const router = express.Router()
-const { getDB } = require('../db')
+const { getDB, getClient } = require('../db')
 const { verifyToken, requireActive } = require('../middleware/auth')
 const { recordAudit } = require('../util/auditLog')
+const { deleteRecipeImage, deleteProfilePhoto } = require('../util/firebaseStorage')
+const { recomputeRecipeRating } = require('../util/recipeRating')
 
 const USERNAME_MIN_LENGTH = 3
 const USERNAME_MAX_LENGTH = 30
@@ -294,13 +296,88 @@ router.post('/deleteAccount', verifyToken, asyncHandler(async (req, res) => {
   const usernameDoc = await db.collection('usernames').findOne({ _id: uid })
   const username = usernameDoc?.username || null
 
-  await db.collection('usernames').deleteOne({ _id: uid })
-  await db.collection('userProfiles').deleteOne({ _id: uid })
-  await db.collection('users').deleteOne({ _id: uid })
-  await db.collection('userRecipeData').deleteOne({ _id: uid })
-  await db.collection('recipes').deleteMany({ userId: uid })
-  await db.collection('recipeDrafts').deleteMany({ userId: uid })
-  await db.collection('ratings').deleteMany({ userId: uid })
+  // Read what we need BEFORE the transaction:
+  //  - the user's recipe docs themselves (for the per-recipe teardown + their
+  //    Storage images), and
+  //  - the distinct recipes the user REVIEWED, so we can fix surviving recipes'
+  //    rating aggregates after their reviews are removed (D4).
+  const ownRecipes = await db.collection('recipes').find({ userId: uid }).toArray()
+  const ownRecipeIds = new Set(ownRecipes.map((r) => String(r._id)))
+  const reviewedRecipeIds = await db
+    .collection('ratings')
+    .distinct('recipeId', { userId: uid })
+
+  // Cascade the Mongo-side deletes atomically (D3) — a partial failure here
+  // leaves nothing half-removed. teardownRecipeDocs reuses the exact per-recipe
+  // teardown DELETE /deleteRecipe uses (D6), so the account path can't drift:
+  // other users' reviews of this user's recipes (D2) and their saved/made
+  // references to them are cleaned up too — not just the recipe rows.
+  const ownRecipeIdList = [...ownRecipeIds]
+  const session = getClient().startSession()
+  try {
+    await session.withTransaction(async () => {
+      // Per-recipe teardown, batched into O(1) collection passes (not one set of
+      // writes per recipe). A prolific owner could otherwise run hundreds of
+      // full-collection updateMany scans inside a single transaction and blow the
+      // transaction time/oplog limit, rolling back the whole delete. Same effect
+      // as calling teardownRecipeDocs for each recipe, in three writes total.
+      await db.collection('recipes').deleteMany({ userId: uid }, { session })
+      await db
+        .collection('ratings')
+        .deleteMany({ recipeId: { $in: ownRecipeIdList } }, { session })
+      await db.collection('userRecipeData').updateMany(
+        {},
+        {
+          $pull: {
+            savedRecipes: { recipeId: { $in: ownRecipeIdList } },
+            madeRecipes: { recipeId: { $in: ownRecipeIdList } },
+            userRecipes: { recipeId: { $in: ownRecipeIdList } },
+          },
+        },
+        { session }
+      )
+      // The user's own reviews of OTHER people's recipes (their reviews of their
+      // own recipes were already removed by the ratings delete above).
+      await db.collection('ratings').deleteMany({ userId: uid }, { session })
+      await db.collection('usernames').deleteOne({ _id: uid }, { session })
+      await db.collection('userProfiles').deleteOne({ _id: uid }, { session })
+      await db.collection('users').deleteOne({ _id: uid }, { session })
+      await db.collection('userRecipeData').deleteOne({ _id: uid }, { session })
+      await db.collection('recipeDrafts').deleteMany({ userId: uid }, { session })
+      // D6: reports the user FILED. Keep the moderation record (its subject —
+      // the reported content — may still be a valid open queue item) but
+      // anonymize the now-departed reporter.
+      await db
+        .collection('reports')
+        .updateMany({ reporterUid: uid }, { $set: { reporterUid: null } }, { session })
+    })
+  } finally {
+    await session.endSession()
+  }
+
+  // ── External / non-transactional side effects ──────────────────────────────
+  // All best-effort and ordered deliberately: Mongo is fully committed above and
+  // the Firebase Auth deletion is LAST, so any failure here leaves the login
+  // recoverable to retry rather than orphaning a deleted account behind data.
+
+  // D4: recompute the aggregate for recipes the user reviewed but did NOT own
+  // (the ones they owned are gone). Post-commit, so it reflects the removed
+  // reviews. Best-effort: a recompute failure must not block the account delete.
+  for (const recipeId of reviewedRecipeIds) {
+    if (ownRecipeIds.has(recipeId)) continue
+    try {
+      await recomputeRecipeRating(db, recipeId)
+    } catch (err) {
+      console.error('deleteAccount: rating recompute failed for', recipeId, err.message)
+    }
+  }
+
+  // D5: drop the user's recipe images and profile photo from Storage. Both
+  // helpers never throw — an orphaned blob beats a failed account delete.
+  for (const recipe of ownRecipes) {
+    await deleteRecipeImage(recipe.recipeImage)
+  }
+  await deleteProfilePhoto(uid)
 
   // Leave a trail in the audit log (best-effort) so an admin can see that the
   // account was self-deleted rather than removed by moderation.

--- a/server/routes/publicProfile.js
+++ b/server/routes/publicProfile.js
@@ -46,9 +46,7 @@ router.get('/getPublicProfile', asyncHandler(async (req, res) => {
 
   const [profile, counts, recipes, authRecord] = await Promise.all([
     db.collection('userProfiles').findOne({ _id: uid }),
-    // We already resolved the username to find the uid — pass it so the counts
-    // helper doesn't look it up again.
-    getAccountCountsFor(db, uid, usernameDoc.username),
+    getAccountCountsFor(db, uid),
     db
       .collection('recipes')
       .find({ userId: uid })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -10,6 +10,7 @@ const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
 const { EDITABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
+const { teardownRecipeDocs } = require('../util/teardownRecipe')
 
 const router = Router()
 
@@ -314,24 +315,12 @@ router.delete('/deleteRecipe', verifyToken, asyncHandler(async (req, res) => {
 
   // Remove the recipe and every reference to it atomically: its ratings/
   // reviews, and the recipeId entry from any user's saved/made/created lists.
-  // userRecipes only ever lives on the owner's doc, but pulling it across all
-  // docs in the same updateMany is harmless and keeps this to one write.
+  // Shared with the delete-account cascade via teardownRecipeDocs so the two
+  // paths can't drift.
   const session = getClient().startSession()
   try {
     await session.withTransaction(async () => {
-      await db.collection('recipes').deleteOne(recipeIdQuery(recipeId), { session })
-      await db.collection('ratings').deleteMany({ recipeId }, { session })
-      await db.collection('userRecipeData').updateMany(
-        {},
-        {
-          $pull: {
-            savedRecipes: { recipeId },
-            madeRecipes: { recipeId },
-            userRecipes: { recipeId },
-          },
-        },
-        { session }
-      )
+      await teardownRecipeDocs(db, recipe, session)
     })
   } finally {
     await session.endSession()

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -60,11 +60,22 @@ router.post('/reports', verifyToken, requireActive, asyncHandler(async (req, res
     })
   }
 
+  // Snapshot the reported user's stable uid alongside the denormalized handle
+  // (D1), so a review report stays attached to its author across renames. The
+  // handle is still stored for display in the queue.
+  let reportedUid = null
+  if (targetType === 'review') {
+    const reportedDoc = await db
+      .collection('usernames')
+      .findOne({ username_lower: reportedUsername.toLowerCase() })
+    reportedUid = reportedDoc?._id || null
+  }
+
   const doc = {
     _id: new ObjectId(),
     targetType,
     recipeId,
-    ...(targetType === 'review' ? { reportedUsername } : {}),
+    ...(targetType === 'review' ? { reportedUsername, reportedUid } : {}),
     reporterUid: req.uid,
     reason,
     details: details || '',

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -7,6 +7,7 @@ const { REVIEW_VISIBLE, RECIPE_VISIBLE } = require('../util/moderation')
 const { DESCRIPTION_MAX_LENGTH } = require('../util/recipeLimits')
 const { recordAudit } = require('../util/auditLog')
 const { recomputeRecipeRating } = require('../util/recipeRating')
+const { upsertWithDupRetry } = require('../util/upsertWithDupRetry')
 const { notifyInBackground, notifyReviewTakenDown } = require('../util/email')
 
 const router = Router()
@@ -35,7 +36,10 @@ router.post('/addRating', verifyToken, requireActive, asyncHandler(async (req, r
     return res.status(400).json({ error: 'Rating must be between 1 and 5' })
   }
 
-  await db.collection('ratings').updateOne(
+  // dup-retry: the unique { userId, recipeId } index turns a concurrent
+  // double-submit into an E11000 on the loser; retry it as a plain update.
+  await upsertWithDupRetry(
+    db.collection('ratings'),
     { userId, recipeId },
     {
       $set: { rating: parsedRating, ratingLastUpdated: new Date() },
@@ -47,8 +51,7 @@ router.post('/addRating', verifyToken, requireActive, asyncHandler(async (req, r
         reviewLastUpdated: '',
         reviewText: '',
       },
-    },
-    { upsert: true }
+    }
   )
 
   // Recompute the aggregate (excludes moderated ratings).
@@ -75,8 +78,10 @@ router.post('/newReview', verifyToken, requireActive, asyncHandler(async (req, r
 
   const now = Date.now().toString()
   // Keyed by the stable uid (D1). username is denormalized for display, written
-  // once on insert ($setOnInsert) alongside the defaulted rating fields.
-  await db.collection('ratings').updateOne(
+  // once on insert ($setOnInsert) alongside the defaulted rating fields. The
+  // dup-retry handles a concurrent double-submit racing on the unique index.
+  await upsertWithDupRetry(
+    db.collection('ratings'),
     { userId, recipeId },
     {
       $set: { reviewText, reviewCreatedAt: now, reviewLastUpdated: now },
@@ -84,8 +89,7 @@ router.post('/newReview', verifyToken, requireActive, asyncHandler(async (req, r
       // insert so no ratings doc ever lacks them (recomputeRecipeRating skips
       // rating: null, but this keeps the document shape consistent).
       $setOnInsert: { username, rating: null, ratingLastUpdated: '' },
-    },
-    { upsert: true }
+    }
   )
 
   const updated = await db.collection('ratings').findOne({ userId, recipeId })

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -18,7 +18,10 @@ const MAX_PER_PAGE = 50
 router.post('/addRating', verifyToken, requireActive, asyncHandler(async (req, res) => {
   const { recipeId, rating } = req.query
   const db = getDB()
-  const userDoc = await db.collection('usernames').findOne({ _id: req.uid })
+  // Identity is the stable uid (D1); the username is denormalized onto the
+  // rating doc only as a display field, set once on insert.
+  const userId = req.uid
+  const userDoc = await db.collection('usernames').findOne({ _id: userId })
   if (!userDoc) return res.status(400).json({ error: 'User not found' })
   const username = userDoc.username
   if (!recipeId || typeof recipeId !== 'string' || !rating || typeof rating !== 'string') {
@@ -32,23 +35,21 @@ router.post('/addRating', verifyToken, requireActive, asyncHandler(async (req, r
     return res.status(400).json({ error: 'Rating must be between 1 and 5' })
   }
 
-  const existing = await db.collection('ratings').findOne({ username, recipeId })
-  if (existing) {
-    await db.collection('ratings').updateOne(
-      { username, recipeId },
-      { $set: { rating: parsedRating, ratingLastUpdated: new Date() } }
-    )
-  } else {
-    await db.collection('ratings').insertOne({
-      username,
-      recipeId,
-      rating: parsedRating,
-      ratingLastUpdated: new Date(),
-      reviewCreatedAt: '',
-      reviewLastUpdated: '',
-      reviewText: '',
-    })
-  }
+  await db.collection('ratings').updateOne(
+    { userId, recipeId },
+    {
+      $set: { rating: parsedRating, ratingLastUpdated: new Date() },
+      // username is denormalized display; default the review fields so a
+      // rating-first doc still has the consistent shape getReviews expects.
+      $setOnInsert: {
+        username,
+        reviewCreatedAt: '',
+        reviewLastUpdated: '',
+        reviewText: '',
+      },
+    },
+    { upsert: true }
+  )
 
   // Recompute the aggregate (excludes moderated ratings).
   await recomputeRecipeRating(db, recipeId)
@@ -73,19 +74,21 @@ router.post('/newReview', verifyToken, requireActive, asyncHandler(async (req, r
   const { username } = usernameDoc
 
   const now = Date.now().toString()
+  // Keyed by the stable uid (D1). username is denormalized for display, written
+  // once on insert ($setOnInsert) alongside the defaulted rating fields.
   await db.collection('ratings').updateOne(
-    { username, recipeId },
+    { userId, recipeId },
     {
       $set: { reviewText, reviewCreatedAt: now, reviewLastUpdated: now },
       // A review can be posted before any rating; default the rating fields on
       // insert so no ratings doc ever lacks them (recomputeRecipeRating skips
       // rating: null, but this keeps the document shape consistent).
-      $setOnInsert: { rating: null, ratingLastUpdated: '' },
+      $setOnInsert: { username, rating: null, ratingLastUpdated: '' },
     },
     { upsert: true }
   )
 
-  const updated = await db.collection('ratings').findOne({ username, recipeId })
+  const updated = await db.collection('ratings').findOne({ userId, recipeId })
   res.json(updated)
 }))
 
@@ -96,11 +99,9 @@ router.get('/checkIfReviewed', verifyToken, asyncHandler(async (req, res) => {
   if (!recipeId) {
     return res.status(400).json({ error: 'recipeId is required' })
   }
-  const userDoc = await db.collection('usernames').findOne({ _id: req.uid })
-  if (!userDoc) return res.status(400).json({ error: 'Username not found for this user' })
-  const { username } = userDoc
 
-  const doc = await db.collection('ratings').findOne({ username, recipeId })
+  // Keyed by the stable uid (D1) — no username round-trip needed.
+  const doc = await db.collection('ratings').findOne({ userId: req.uid, recipeId })
   if (doc) {
     res.json({ reviewed: true, ...doc })
   } else {
@@ -112,17 +113,16 @@ router.get('/checkIfReviewed', verifyToken, asyncHandler(async (req, res) => {
 router.post('/editReview', verifyToken, requireActive, asyncHandler(async (req, res) => {
   const { recipeId, text } = req.query
   const db = getDB()
-  const userDoc = await db.collection('usernames').findOne({ _id: req.uid })
-  if (!userDoc) return res.status(400).json({ error: 'User not found' })
-  const username = userDoc.username
   if (!recipeId || typeof recipeId !== 'string' || text == null || typeof text !== 'string') {
     return res.status(400).json({ error: 'recipeId and text are required' })
   }
   if (text.length > DESCRIPTION_MAX_LENGTH) {
     return res.status(400).json({ error: `Review cannot exceed ${DESCRIPTION_MAX_LENGTH} characters` })
   }
+  // Keyed by the stable uid (D1): only the author (req.uid) can match their own
+  // doc, so a non-author falls through to matchedCount 0 → 403 below.
   const editResult = await db.collection('ratings').updateOne(
-    { username, recipeId },
+    { userId: req.uid, recipeId },
     { $set: { reviewText: text, reviewLastUpdated: Date.now().toString() } }
   )
   if (editResult.matchedCount === 0) {
@@ -139,12 +139,10 @@ router.delete('/deleteReview', verifyToken, asyncHandler(async (req, res) => {
   if (!recipeId) {
     return res.status(400).json({ error: 'recipeId is required' })
   }
-  const usernameDoc = await db.collection('usernames').findOne({ _id: userId })
-  if (!usernameDoc) return res.status(400).json({ error: 'Username not found for this user' })
-  const { username } = usernameDoc
 
+  // Keyed by the stable uid (D1) — only the author's own doc can match.
   const deleteResult = await db.collection('ratings').updateOne(
-    { username, recipeId },
+    { userId, recipeId },
     { $set: { reviewText: '', reviewLastUpdated: '' } }
   )
   if (deleteResult.matchedCount === 0) {
@@ -156,18 +154,13 @@ router.delete('/deleteReview', verifyToken, asyncHandler(async (req, res) => {
 // GET /getReviews — anonymous-friendly. `optionalAuth` sets req.uid only when a
 // valid token is present; the `isCurrentUser` flag is derived from that verified
 // uid (NOT the client-supplied `username` query param, which anyone could set to
-// another user's name to spoof "edit/delete mine" affordances).
+// another user's name to spoof "edit/delete mine" affordances). Ratings now carry
+// the author's stable uid (D1), so the flag is a direct uid match — no username
+// round-trip and immune to renames.
 router.get('/getReviews', optionalAuth, asyncHandler(async (req, res) => {
   const db = getDB()
   const { recipeId, page = 0, reviewsPerPage = 5, filter } = req.query
   if (!recipeId) return res.status(400).json({ error: 'recipeId is required' })
-
-  // Resolve the caller's own username from the verified token, if any.
-  let currentUsername = null
-  if (req.uid) {
-    const me = await db.collection('usernames').findOne({ _id: req.uid })
-    currentUsername = me?.username || null
-  }
 
   const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
   const skip = (parseInt(page) || 0) * limit
@@ -185,7 +178,7 @@ router.get('/getReviews', optionalAuth, asyncHandler(async (req, res) => {
 
   const reviews = rawReviews.map((r) => ({
     ...r,
-    isCurrentUser: currentUsername != null && r.username === currentUsername,
+    isCurrentUser: req.uid != null && r.userId === req.uid,
   }))
 
   res.json({ reviews, totalCount })
@@ -197,10 +190,19 @@ router.get('/getSingleUserReviews', asyncHandler(async (req, res) => {
   const { username, page = 0, reviewsPerPage = 5, filter, returnRecipeData } = req.query
   if (!username) return res.status(400).json({ error: 'username is required' })
 
+  // This list is addressed by the public handle, but ratings are keyed by the
+  // stable uid (D1) — resolve the handle to a uid (case-insensitive, the same
+  // lookup the unique index uses) and query on that. An unknown handle simply
+  // has no reviews.
+  const ownerDoc = await db
+    .collection('usernames')
+    .findOne({ username_lower: String(username).toLowerCase() })
+  if (!ownerDoc) return res.json({ reviews: [], totalCount: 0 })
+
   const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
   const skip = (parseInt(page) || 0) * limit
   // Suppress admin-taken-down reviews from a user's public review list too.
-  const query = { username, ...REVIEW_VISIBLE }
+  const query = { userId: ownerDoc._id, ...REVIEW_VISIBLE }
 
   let sort = {}
   if (filter === 'new') sort = { reviewCreatedAt: -1 }

--- a/server/scripts/backfillRatingUserIds.js
+++ b/server/scripts/backfillRatingUserIds.js
@@ -1,0 +1,151 @@
+/**
+ * D1 backfill — stamp a STABLE userId onto the documents that historically
+ * identified their author only by a mutable `username`:
+ *   - `ratings`  → add `userId`        (from username        → usernames._id)
+ *   - `reports`  → add `reportedUid`   (from reportedUsername → usernames._id,
+ *                  review reports only; recipe reports have no reported user)
+ *
+ * Why: a username is renameable, so keying reviews/reports on it risks detaching
+ * a user from their own data on every rename and makes the delete-account cascade
+ * fragile (it has to resolve the username first). After this backfill the server
+ * keys these collections on the immutable Firebase uid; `username` /
+ * `reportedUsername` remain only as denormalized DISPLAY fields.
+ *
+ * The map is username_lower → _id, matching the case-insensitive lookup the app
+ * uses everywhere (usernames.username_lower is the unique key).
+ *
+ * SAFE BY DEFAULT: this is a DRY RUN unless you pass --apply. The dry run reads
+ * only — it counts what would change and lists any rows whose username has no
+ * matching `usernames` doc (orphans that CANNOT be backfilled and want a look
+ * before/after). Verify the dry-run output against a prod snapshot first, then
+ * re-run with --apply.
+ *
+ * Idempotent: only documents still MISSING the target field are touched, so a
+ * second --apply run is a no-op. Run it at deploy time, before the server starts
+ * relying on userId for reads/writes (new writes already stamp userId, so the
+ * window where a legacy username-only doc could be double-written is the gap
+ * between deploy and this run — keep it short).
+ *
+ * Usage:
+ *   node server/scripts/backfillRatingUserIds.js            # dry run (default)
+ *   node server/scripts/backfillRatingUserIds.js --apply    # actually write
+ *
+ * Reads MONGO_URI from server/.env. Exit code 0 = success, 1 = error.
+ */
+const path = require('path')
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') })
+const { MongoClient } = require('mongodb')
+
+const APPLY = process.argv.includes('--apply')
+
+async function main() {
+  const uri = process.env.MONGO_URI
+  if (!uri) {
+    console.error('MONGO_URI is not set (looked in server/.env).')
+    process.exit(1)
+  }
+
+  const client = new MongoClient(uri, {
+    tls: true,
+    serverSelectionTimeoutMS: 5000,
+    socketTimeoutMS: 45000,
+    maxPoolSize: 10,
+  })
+
+  try {
+    await client.connect()
+    const db = client.db('prepify')
+    console.log(
+      `Connected to MongoDB (prepify). Mode: ${APPLY ? 'APPLY (writing)' : 'DRY RUN (read-only)'}\n`
+    )
+
+    // username_lower → _id (uid). Built once; used for both collections.
+    const usernameToUid = new Map()
+    await db
+      .collection('usernames')
+      .find({}, { projection: { username_lower: 1 } })
+      .forEach((doc) => {
+        if (typeof doc.username_lower === 'string') {
+          usernameToUid.set(doc.username_lower, doc._id)
+        }
+      })
+    console.log(`usernames map: ${usernameToUid.size} entries\n`)
+
+    const ratings = await backfill(db, {
+      collection: 'ratings',
+      targetField: 'userId',
+      sourceField: 'username',
+      usernameToUid,
+    })
+    const reports = await backfill(db, {
+      collection: 'reports',
+      targetField: 'reportedUid',
+      sourceField: 'reportedUsername',
+      usernameToUid,
+      // Recipe reports carry no reported user — only review reports have a
+      // reportedUsername to resolve.
+      extraFilter: { targetType: 'review' },
+    })
+
+    console.log('\nSummary')
+    console.log('───────')
+    report('ratings', ratings)
+    report('reports (review)', reports)
+
+    if (!APPLY) {
+      console.log('\nDRY RUN — nothing was written. Re-run with --apply to commit.')
+    } else {
+      console.log('\nDone. Backfill applied.')
+    }
+    process.exit(0)
+  } catch (err) {
+    console.error('\nBackfill failed:', err.message)
+    process.exit(1)
+  } finally {
+    await client.close().catch(() => {})
+  }
+}
+
+// Walks every doc in `collection` that is missing `targetField`, resolves the
+// uid from `sourceField` via the map, and (when --apply) stamps it. Returns
+// counts plus the distinct unresolved source values (orphans).
+async function backfill(db, { collection, targetField, sourceField, usernameToUid, extraFilter = {} }) {
+  const col = db.collection(collection)
+  const filter = { ...extraFilter, [targetField]: { $exists: false } }
+
+  let scanned = 0
+  let updated = 0
+  const orphans = new Map() // sourceValue → count
+
+  const cursor = col.find(filter, { projection: { [sourceField]: 1 } })
+  for await (const doc of cursor) {
+    scanned++
+    const raw = doc[sourceField]
+    const uid =
+      typeof raw === 'string' ? usernameToUid.get(raw.toLowerCase()) : undefined
+    if (uid === undefined) {
+      orphans.set(raw, (orphans.get(raw) || 0) + 1)
+      continue
+    }
+    if (APPLY) {
+      await col.updateOne({ _id: doc._id }, { $set: { [targetField]: uid } })
+    }
+    updated++
+  }
+
+  return { scanned, updated, orphans }
+}
+
+function report(label, { scanned, updated, orphans }) {
+  console.log(
+    `  ${label}: scanned ${scanned} missing-field doc(s), ${APPLY ? 'updated' : 'would update'} ${updated}, ${orphans.size} unresolved handle(s)`
+  )
+  if (orphans.size) {
+    console.log('    Unresolved (no matching usernames doc — left untouched):')
+    for (const [name, count] of orphans) {
+      console.log(`      - ${JSON.stringify(name)} x${count}`)
+    }
+  }
+}
+
+main()

--- a/server/scripts/createModerationIndexes.js
+++ b/server/scripts/createModerationIndexes.js
@@ -39,7 +39,17 @@ const INDEXES = [
     collection: 'ratings',
     key: { username: 1 },
     name: 'username_1',
-    why: 'admin user list review tally + getSingleUserReviews (by username)',
+    why: 'admin user list review tally (still keyed by reportedUsername)',
+  },
+  // D1: ratings now identify their author by the stable `userId`. This compound
+  // serves both the (userId, recipeId) point lookup/upsert used by every review
+  // write AND the userId-prefix scans (getSingleUserReviews, account counts,
+  // exportMyData, the delete-account cascade).
+  {
+    collection: 'ratings',
+    key: { userId: 1, recipeId: 1 },
+    name: 'userId_1_recipeId_1',
+    why: 'D1 review writes/reads + account-counts/export/cascade keyed on userId',
   },
   {
     collection: 'recipes',

--- a/server/scripts/createModerationIndexes.js
+++ b/server/scripts/createModerationIndexes.js
@@ -45,11 +45,24 @@ const INDEXES = [
   // serves both the (userId, recipeId) point lookup/upsert used by every review
   // write AND the userId-prefix scans (getSingleUserReviews, account counts,
   // exportMyData, the delete-account cascade).
+  //
+  // UNIQUE — enforces the "one rating per (user, recipe)" invariant the upserts
+  // rely on. Without it, a legacy doc missing `userId` (pre-backfill) or a
+  // concurrent double-submit would slip a SECOND row past the upsert filter and
+  // silently double-count the author in the recipe aggregate. PARTIAL on
+  // `userId: { $exists: true }` so it (a) ignores not-yet-backfilled legacy docs
+  // instead of failing to build over them, and (b) still serves every read,
+  // which always predicates on an existing `userId`. Run the backfill first so
+  // the docs that should be unique actually carry the field.
   {
     collection: 'ratings',
     key: { userId: 1, recipeId: 1 },
     name: 'userId_1_recipeId_1',
-    why: 'D1 review writes/reads + account-counts/export/cascade keyed on userId',
+    options: {
+      unique: true,
+      partialFilterExpression: { userId: { $exists: true } },
+    },
+    why: 'D1 review writes/reads + account-counts/export/cascade keyed on userId (unique: one rating per user+recipe)',
   },
   {
     collection: 'recipes',
@@ -91,16 +104,36 @@ async function main() {
     const db = client.db('prepify')
     console.log('Connected to MongoDB (prepify). Building indexes...\n')
 
+    let failures = 0
     for (const ix of INDEXES) {
       const start = Date.now()
-      // Non-unique on purpose: a unique index could fail to build over legacy
-      // data with duplicates (cf. the username_lower guard in db.js).
-      const result = await db.collection(ix.collection).createIndex(ix.key, { name: ix.name })
-      const ms = Date.now() - start
-      console.log(`  ✓ ${ix.collection}.${result}  (${ms}ms)`)
-      console.log(`      ${ix.why}`)
+      try {
+        const result = await db
+          .collection(ix.collection)
+          .createIndex(ix.key, { name: ix.name, ...ix.options })
+        const ms = Date.now() - start
+        console.log(`  ✓ ${ix.collection}.${result}  (${ms}ms)`)
+        console.log(`      ${ix.why}`)
+      } catch (err) {
+        // A unique index can fail to build over legacy data that still holds
+        // duplicates (cf. the username_lower guard in db.js). Don't abort the
+        // whole run for one collision — report it loudly so the operator can
+        // dedup (and re-run the backfill) then re-run, while the rest build.
+        failures++
+        console.error(`  ✗ ${ix.collection}.${ix.name} FAILED: ${err.message}`)
+        if (err.code === 11000 || /duplicate key/i.test(err.message)) {
+          console.error(
+            `      Duplicate (${Object.keys(ix.key).join(',')}) rows exist — ` +
+              'dedup them (run backfillRatingUserIds.js first), then re-run.'
+          )
+        }
+      }
     }
 
+    if (failures) {
+      console.error(`\n${failures} index(es) failed to build. See errors above.`)
+      process.exit(1)
+    }
     console.log('\nDone. All moderation indexes are in place.')
     process.exit(0)
   } catch (err) {

--- a/server/util/accountCounts.js
+++ b/server/util/accountCounts.js
@@ -3,19 +3,9 @@
 // engine, which derives XP / level / achievements from these same counts.
 
 // Returns { saved, ratings, recipes, drafts } for the given uid. All real
-// counts; 0 where the user has none. Callers that already hold the username
-// (e.g. the public-profile route, which resolved it to find the uid) can pass
-// it as `knownUsername` to skip the lookup.
-async function getAccountCountsFor(db, uid, knownUsername) {
-  // Ratings live in the `ratings` collection keyed by username (there is no uid
-  // on a rating), so resolve the caller's username first. A user with no
-  // username yet simply has 0 ratings.
-  let username = knownUsername
-  if (username === undefined) {
-    const usernameDoc = await db.collection('usernames').findOne({ _id: uid })
-    username = usernameDoc?.username
-  }
-
+// counts; 0 where the user has none. Everything keys on the stable uid (ratings
+// carry `userId` since D1), so no username round-trip is needed.
+async function getAccountCountsFor(db, uid) {
   const [savedAgg, recipes, drafts, ratings] = await Promise.all([
     // Count saved recipes with $size so Mongo returns just the length rather
     // than transferring the whole savedRecipes array to count it in Node.
@@ -33,9 +23,7 @@ async function getAccountCountsFor(db, uid, knownUsername) {
       .toArray(),
     db.collection('recipes').countDocuments({ userId: uid }),
     db.collection('recipeDrafts').countDocuments({ userId: uid }),
-    username
-      ? db.collection('ratings').countDocuments({ username })
-      : Promise.resolve(0),
+    db.collection('ratings').countDocuments({ userId: uid }),
   ])
 
   return {

--- a/server/util/firebaseStorage.js
+++ b/server/util/firebaseStorage.js
@@ -27,4 +27,31 @@ async function deleteRecipeImage(url) {
   }
 }
 
-module.exports = { parseStorageUrl, deleteRecipeImage }
+// Best-effort deletion of a user's profile photo, which (unlike recipe images)
+// we only know by its Storage PATH — `profilePhotos/{uid}`, written by the
+// client's AuthContext.updateProfileData — not by a download URL. Never throws,
+// same posture as deleteRecipeImage: an orphaned avatar must not fail (or roll
+// back) the account deletion it accompanies. Returns true only when a file was
+// actually deleted.
+//
+// The Admin SDK isn't initialized with a default storageBucket, so we name the
+// bucket explicitly from FIREBASE_STORAGE_BUCKET when set, else fall back to the
+// default bucket (which is what the test mock exercises). If neither resolves,
+// the attempt simply fails and is swallowed.
+async function deleteProfilePhoto(uid) {
+  if (!uid || typeof uid !== 'string') return false
+  const path = `profilePhotos/${uid}`
+  try {
+    const bucketName = process.env.FIREBASE_STORAGE_BUCKET
+    const bucket = bucketName
+      ? admin.storage().bucket(bucketName)
+      : admin.storage().bucket()
+    await bucket.file(path).delete()
+    return true
+  } catch (err) {
+    console.error('Failed to delete profile photo from storage:', err.message)
+    return false
+  }
+}
+
+module.exports = { parseStorageUrl, deleteRecipeImage, deleteProfilePhoto }

--- a/server/util/teardownRecipe.js
+++ b/server/util/teardownRecipe.js
@@ -1,0 +1,33 @@
+// Mongo-side teardown of a single recipe, run inside a transaction `session`.
+// Removes the recipe document, its ratings/reviews, and EVERY reference to it in
+// users' saved / made / created lists — so deleting a recipe never leaves
+// other users' reviews orphaned or their saved cards pointing at a 404.
+//
+// Shared by DELETE /deleteRecipe and the POST /deleteAccount cascade so the two
+// paths can't drift (the cascade previously did a naive recipes.deleteMany and
+// skipped all of this). The recipe's Storage image is an EXTERNAL side effect
+// and is intentionally NOT handled here — the caller deletes it (best-effort)
+// after the transaction commits, keeping this function purely transactional.
+//
+// `recipe` is the already-fetched recipe document. References elsewhere (ratings
+// .recipeId, savedRecipes[].recipeId, …) are stored as the recipe id's STRING
+// form, which `String(recipe._id)` yields whether _id is a native ObjectId
+// (post-migration) or a legacy string.
+async function teardownRecipeDocs(db, recipe, session) {
+  const recipeId = String(recipe._id)
+  await db.collection('recipes').deleteOne({ _id: recipe._id }, { session })
+  await db.collection('ratings').deleteMany({ recipeId }, { session })
+  await db.collection('userRecipeData').updateMany(
+    {},
+    {
+      $pull: {
+        savedRecipes: { recipeId },
+        madeRecipes: { recipeId },
+        userRecipes: { recipeId },
+      },
+    },
+    { session }
+  )
+}
+
+module.exports = { teardownRecipeDocs }

--- a/server/util/upsertWithDupRetry.js
+++ b/server/util/upsertWithDupRetry.js
@@ -1,0 +1,22 @@
+// Run an upsert that races safely against a concurrent insert of the same
+// unique key. With a unique index on the filter fields (e.g. ratings'
+// { userId, recipeId }), two simultaneous upserts that BOTH find no existing
+// doc will both attempt an INSERT; one wins and the other throws a duplicate-key
+// error (E11000). On that error the doc now exists, so we re-apply the update as
+// a plain (non-upsert) update — the `$set` lands on the row the racing request
+// inserted, and `$setOnInsert` is correctly skipped (the doc is no longer new).
+//
+// Turns a rare double-submit from a 500 into the same end state a sequential
+// pair of requests would reach: one row, last write wins.
+async function upsertWithDupRetry(collection, filter, update, options = {}) {
+  try {
+    return await collection.updateOne(filter, update, { ...options, upsert: true })
+  } catch (err) {
+    if (err && err.code === 11000) {
+      return collection.updateOne(filter, update, { ...options, upsert: false })
+    }
+    throw err
+  }
+}
+
+module.exports = { upsertWithDupRetry }


### PR DESCRIPTION
## D1 — root-cause fix (first of the data-integrity pass)

Per `docs/DATA_INTEGRITY_AUDIT.md`. Reviews/ratings identified their author by a denormalized, **renameable** `username`. That made the delete-account cascade fragile (it had to resolve the username first) and risked detaching a user from their own reviews on every rename. This switches the identity key to the **stable Firebase `uid`**.

### Changes
- **`ratings.userId`** is now the identity. All author-facing ops key on `{ userId, recipeId }`: `addRating`, `newReview`, `editReview`, `deleteReview`, `checkIfReviewed`. `getReviews` derives `isCurrentUser` from a direct uid match (no username round-trip, immune to renames). `getSingleUserReviews` resolves the public handle → uid, then queries on `userId`. `username` stays on each doc purely as a **denormalized display field** — API response shapes are unchanged.
- **Cascade/counts/export** key ratings on `userId`: `getAccountCountsFor`, `GET /exportMyData`, `POST /deleteAccount`. Robust even if the `usernames` doc is already gone.
- **`reports.reportedUid`**: review reports snapshot the reported user's stable uid at creation; `reportedUsername` remains the display handle.
- **Backfill**: `server/scripts/backfillRatingUserIds.js` — **dry-run by default** (`--apply` to write), maps `username_lower → _id`, stamps `ratings.userId` + `reports.reportedUid`, lists unresolvable handles (orphans), idempotent.
- **Index**: `ratings { userId, recipeId }` added to `createModerationIndexes.js`.

### Tests
- New: `reviews.test.js` "D1: review identity keyed on userId" — edit/upsert/`isCurrentUser` all still work when the stored handle is stale (post-rename); `reports.test.js` reportedUid stamping (resolves / null-when-no-account / not-on-recipe-reports).
- Updated existing fixtures to seed `userId` on ratings.
- **Full server suite green: 394 passed.**

### Deploy notes
- New writes already stamp `userId`, so **run the backfill at deploy time** to close the brief window where a legacy username-only `ratings` doc could be double-written: `node server/scripts/backfillRatingUserIds.js` (verify dry-run vs a prod snapshot), then `--apply`.
- Run `node server/scripts/createModerationIndexes.js` for the new ratings index.

### Deferred (residual, noted in the doc)
Admin review-moderation + the reports queue still *reference* a review by its denormalized `(username, recipeId)` / `reportedUsername`, so `POST /setUsername` keeps its rename propagation to keep those display handles fresh. Identity is uid-stable regardless — this is now a display concern, not a correctness one.

Next PR: the delete-account cascade rewrite (D2/D4/D5/D6 + D3 transaction).