### PR TITLE
fix(data-integrity): D2/D4/D5/D6 + D3 — thorough, atomic delete-account cascade

### DIFF
--- a/docs/DATA_INTEGRITY_AUDIT.md
+++ b/docs/DATA_INTEGRITY_AUDIT.md
@@ -78,7 +78,7 @@ the one-off backfill migration script.
 
 ---
 
-## D2 — Deleting a recipe orphans other users' ratings of it `[ ]`
+## D2 — Deleting a recipe orphans other users' ratings of it `[x]`
 
 **What:** `ratings` are keyed by `recipeId`. Deleting a recipe (via delete-recipe, or as part of
 the delete-account cascade which removes the user's `recipes`) does **not** remove other users'
@@ -93,12 +93,17 @@ delete-recipe path and the delete-account cascade). Alternatively a periodic swe
 `ratings` whose `recipeId` has no matching `recipes` doc. Add a regression test asserting no
 orphans remain after a recipe delete.
 
+**Done (PR: cascade):** the account path now runs the same per-recipe teardown as
+`DELETE /deleteRecipe` (see D6) — `ratings.deleteMany({ recipeId })` for each of the departing
+user's recipes — so other users' reviews of those recipes no longer survive. Regression test:
+`auth.test.js` cascade → "removes other users' ratings of the departing user's recipes".
+
 **Touches:** `server/routes/recipes.js` (deleteRecipe), `server/routes/auth.js` (deleteAccount
-cascade).
+cascade), `server/util/teardownRecipe.js`.
 
 ---
 
-## D3 — Multi-collection writes are not atomic `[ ]`
+## D3 — Multi-collection writes are not atomic `[x]` (delete cascade)
 
 **What:** Several flows mutate several collections in sequence with no transaction:
 - `POST /deleteAccount` deletes across `usernames`, `userProfiles`, `users`, `userRecipeData`,
@@ -119,12 +124,20 @@ partial failure leaves the login recoverable to retry) — this item is specific
 idempotent so the whole operation is safely retryable. Prefer transactions for the delete cascade;
 idempotency is enough for the rename.
 
-**Touches:** `server/routes/auth.js` (deleteAccount, setUsername), `server/db.js` (a
-`withTransaction` helper).
+**Done (PR: cascade):** the entire Mongo-side delete cascade (per-recipe teardowns + the user's own
+docs across `usernames`/`userProfiles`/`users`/`userRecipeData`/`recipeDrafts`/`ratings` + reporter
+anonymization) now runs inside one `getClient().startSession()` / `session.withTransaction(...)`
+(`server/routes/auth.js`), so a partial failure rolls the whole thing back. The external side
+effects (rating recompute, Storage deletes, audit log, Firebase Auth deletion) deliberately stay
+*outside* the transaction and remain best-effort, preserving the Mongo-first / Firebase-last
+ordering. **Not done:** `setUsername`'s rename writes are left as-is (the propagation is now a
+display-only concern after D1 — idempotent `updateMany`s that are safely retryable).
+
+**Touches:** `server/routes/auth.js` (deleteAccount).
 
 ---
 
-## D4 — delete-account deletes a user's reviews without recomputing the recipes' rating aggregates `[ ]`
+## D4 — delete-account deletes a user's reviews without recomputing the recipes' rating aggregates `[x]`
 
 **What:** `POST /deleteAccount` runs `ratings.deleteMany({ username })`
 (`server/routes/auth.js`), removing the departing user's reviews from recipes that *other* users
@@ -143,11 +156,17 @@ deleted because the user authored them (no point recomputing a deleted recipe). 
 regression test: a recipe reviewed by two users shows the correct average after one of them deletes
 their account.
 
+**Done (PR: cascade):** exactly that — `ratings.distinct('recipeId', { userId })` is captured before
+the transaction, and after it commits `recomputeRecipeRating` runs for each reviewed recipe the user
+did NOT own (best-effort; a recompute failure can't block the account delete). Regression test:
+`auth.test.js` cascade → "recomputes the aggregate of a surviving recipe the departing user reviewed"
+(2-reviewer recipe drops from avg 3/count 2 to avg 4/count 1).
+
 **Touches:** `server/routes/auth.js` (deleteAccount); reuses `server/util/recipeRating.js`.
 
 ---
 
-## D5 — account-delete leaves Firebase Storage objects orphaned (recipe images + profile photo) `[ ]`
+## D5 — account-delete leaves Firebase Storage objects orphaned (recipe images + profile photo) `[x]`
 
 **What:** `DELETE /deleteRecipe` correctly calls `deleteRecipeImage(recipe.recipeImage)` after its
 transaction (`server/routes/recipes.js:342`). The delete-account cascade does **not** — it
@@ -166,12 +185,21 @@ existing `deleteRecipeImage` — an orphaned blob beats a failed account delete)
 keyed by path, not a download URL, so it needs a small delete-by-path helper alongside the existing
 URL-parsing one.
 
-**Touches:** `server/routes/auth.js` (deleteAccount); `server/util/firebaseStorage.js` (add a
-delete-by-path helper).
+**Done (PR: cascade):** the user's recipe docs are read before the transaction; after it commits,
+`deleteRecipeImage(r.recipeImage)` runs per recipe and the new `deleteProfilePhoto(uid)` helper
+(`server/util/firebaseStorage.js`) deletes `profilePhotos/{uid}` by path. Both never throw. The
+profile-photo helper names its bucket from `FIREBASE_STORAGE_BUCKET` (the Admin SDK has no default
+bucket configured) — added to `server/.env.example`; without it profile-photo cleanup is silently
+skipped (still best-effort). Regression tests: `auth.test.js` cascade → asserts the storage helpers
+are invoked (recipe image + profile photo = 2 calls) and that a Storage failure can't fail the
+account delete.
+
+**Touches:** `server/routes/auth.js` (deleteAccount); `server/util/firebaseStorage.js`
+(`deleteProfilePhoto` by-path helper).
 
 ---
 
-## D6 — the delete-account cascade re-implements recipe teardown instead of reusing the thorough one `[ ]` **(unifies D2 / D5 for the account path)**
+## D6 — the delete-account cascade re-implements recipe teardown instead of reusing the thorough one `[x]` **(unifies D2 / D5 for the account path)**
 
 **What:** `DELETE /deleteRecipe` already does a complete, atomic per-recipe teardown
 (`server/routes/recipes.js:319`): delete the recipe, `ratings.deleteMany({ recipeId })`, `$pull` the
@@ -192,8 +220,17 @@ so the two paths can't drift. Then decide reporter cleanup: `reports.deleteMany(
 if the filed reports are disposable, or anonymize `reporterUid` if the moderation queue needs the
 history. Pairs naturally with D3 (wrap the whole thing in one transaction).
 
-**Touches:** `server/routes/recipes.js` (extract `teardownRecipe`); `server/routes/auth.js`
-(deleteAccount); `server/routes/reports.js` (reporter-cleanup decision).
+**Done (PR: cascade):** `teardownRecipeDocs(db, recipe, session)` is now the single implementation in
+`server/util/teardownRecipe.js`, called by both `DELETE /deleteRecipe` and the cascade. Reporter
+cleanup: **anonymize** — `reports.updateMany({ reporterUid: uid }, { $set: { reporterUid: null } })`
+inside the transaction, chosen over delete because a report's subject (the reported content) can
+still be a valid open queue item after the reporter leaves; the email helpers already guard a falsy
+`reporterUid`, so an anonymized report just skips reporter notification. Regression tests:
+`auth.test.js` cascade → dangling saved/made refs pulled, reporter anonymized, surrounding data
+intact.
+
+**Touches:** `server/routes/recipes.js` (now delegates to the shared helper);
+`server/util/teardownRecipe.js` (new); `server/routes/auth.js` (deleteAccount).
 
 ---
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,6 +2,13 @@ MONGO_URI=mongodb+srv://<user>:<password>@cluster0.xxxxx.mongodb.net/prepify?ret
 PORT=4000
 SPOONACULAR_API_KEY=<your-spoonacular-api-key>
 
+# Firebase Storage bucket name (e.g. your-app.appspot.com). Only needed so the
+# delete-account cascade can remove a user's profile photo, which is addressed by
+# path (profilePhotos/{uid}) rather than a download URL. Recipe-image deletion
+# parses the bucket from the image URL and works without this. Leave empty to
+# skip profile-photo cleanup (best-effort — an orphaned avatar is tolerated).
+FIREBASE_STORAGE_BUCKET=
+
 # Sentry server error monitoring. Leave empty to disable entirely — without a
 # DSN, Sentry is never initialized and all capture calls no-op, so dev/CI stay
 # quiet. Use a separate DSN/project from the frontend.

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -649,4 +649,121 @@ describe('POST /deleteAccount', () => {
     expect(res.status).toBe(200)
     expect(admin.__deleteUser).toHaveBeenCalledWith(TEST_UID)
   })
+
+  // ── Cascade thoroughness (D2 / D4 / D5 / D6) ──────────────────────────────
+  // The departing user (TEST_UID/'goner') OWNS recipe 'owned'. Another user
+  // ('keeper') owns recipe 'kept' and has reviewed BOTH; the departing user has
+  // also reviewed 'kept'. Exercises: other users' reviews of a deleted recipe,
+  // dangling saved/made refs, surviving-recipe rating drift, and Storage leaks.
+  describe('cascade (D2/D4/D5/D6)', () => {
+    const KEEPER_UID = 'keeper-uid'
+
+    const seedCascade = async () => {
+      const db = getDB()
+      await seedUser(TEST_UID, 'goner')
+      await seedUser(KEEPER_UID, 'keeper')
+      await db.collection('users').insertOne({ _id: TEST_UID, status: 'active' })
+
+      // Departing user owns 'owned' (with an image); keeper owns 'kept'.
+      await db.collection('recipes').insertMany([
+        { _id: 'owned', userId: TEST_UID, recipeImage: 'https://firebasestorage.googleapis.com/v0/b/b/o/owned.jpg?alt=media&token=t' },
+        { _id: 'kept', userId: KEEPER_UID, rating: { rateCount: 0, rateValue: 0 } },
+      ])
+
+      // keeper saved + made the departing user's recipe → must be pulled (D2/D6).
+      await db.collection('userRecipeData').insertMany([
+        { _id: TEST_UID, savedRecipes: [{ recipeId: 'kept' }], madeRecipes: [], userRecipes: [{ recipeId: 'owned' }] },
+        { _id: KEEPER_UID, savedRecipes: [{ recipeId: 'owned' }], madeRecipes: [{ recipeId: 'owned' }], userRecipes: [{ recipeId: 'kept' }] },
+      ])
+
+      // Ratings: keeper reviewed BOTH; departing user reviewed 'kept'.
+      await db.collection('ratings').insertMany([
+        { userId: KEEPER_UID, username: 'keeper', recipeId: 'owned', rating: 5 },
+        { userId: KEEPER_UID, username: 'keeper', recipeId: 'kept', rating: 4 },
+        { userId: TEST_UID, username: 'goner', recipeId: 'kept', rating: 2 },
+      ])
+      // 'kept' currently averages keeper(4) + goner(2) = 3 over 2 ratings.
+      await db.collection('recipes').updateOne({ _id: 'kept' }, { $set: { rating: { rateCount: 2, rateValue: 3 } } })
+    }
+
+    beforeEach(() => admin.__deleteFile.mockClear())
+
+    it('removes other users\' ratings of the departing user\'s recipes (D2)', async () => {
+      await seedCascade()
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      const db = getDB()
+      // keeper's review of the now-deleted 'owned' recipe must be gone.
+      expect(await db.collection('ratings').countDocuments({ recipeId: 'owned' })).toBe(0)
+    })
+
+    it('pulls the deleted recipe from other users\' saved/made lists (D6)', async () => {
+      await seedCascade()
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      const keeper = await getDB().collection('userRecipeData').findOne({ _id: KEEPER_UID })
+      expect(keeper.savedRecipes).toEqual([])
+      expect(keeper.madeRecipes).toEqual([])
+      // keeper's unrelated created list is untouched.
+      expect(keeper.userRecipes).toEqual([{ recipeId: 'kept' }])
+    })
+
+    it('recomputes the aggregate of a surviving recipe the departing user reviewed (D4)', async () => {
+      await seedCascade()
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      const db = getDB()
+      // goner's review of 'kept' is gone; only keeper(4) remains.
+      expect(await db.collection('ratings').countDocuments({ recipeId: 'kept' })).toBe(1)
+      const kept = await db.collection('recipes').findOne({ _id: 'kept' })
+      expect(kept.rating).toEqual({ rateCount: 1, rateValue: 4 })
+    })
+
+    it('deletes the departing user\'s recipe images and profile photo from Storage (D5)', async () => {
+      await seedCascade()
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      // One recipe image ('owned') + the profile photo (profilePhotos/{uid}).
+      expect(admin.__deleteFile).toHaveBeenCalledTimes(2)
+    })
+
+    it('still completes the account delete if a Storage delete fails (best-effort)', async () => {
+      await seedCascade()
+      admin.__deleteFile.mockRejectedValueOnce(new Error('storage down'))
+
+      const res = await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+      expect(res.status).toBe(200)
+      expect(admin.__deleteUser).toHaveBeenCalledWith(TEST_UID)
+    })
+
+    it('anonymizes reports the departing user filed, preserving the record (D6)', async () => {
+      await seedCascade()
+      const db = getDB()
+      await db.collection('reports').insertOne({
+        targetType: 'recipe',
+        recipeId: 'kept',
+        reporterUid: TEST_UID,
+        reason: 'spam',
+        status: 'open',
+        createdAt: new Date(),
+      })
+
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      const report = await db.collection('reports').findOne({ recipeId: 'kept' })
+      expect(report).not.toBeNull()
+      expect(report.reporterUid).toBeNull()
+    })
+
+    it('leaves another user\'s own recipe and review intact', async () => {
+      await seedCascade()
+      await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+      const db = getDB()
+      expect(await db.collection('recipes').findOne({ _id: 'kept' })).not.toBeNull()
+      expect(
+        await db.collection('ratings').findOne({ userId: KEEPER_UID, recipeId: 'kept' })
+      ).not.toBeNull()
+    })
+  })
 })

--- a/server/__tests__/upsertWithDupRetry.test.js
+++ b/server/__tests__/upsertWithDupRetry.test.js
@@ -1,0 +1,56 @@
+const { upsertWithDupRetry } = require('../util/upsertWithDupRetry')
+
+// A minimal fake collection whose updateOne is a jest mock, so we can assert how
+// upsertWithDupRetry calls it without needing a live unique index/race.
+const makeCollection = () => ({ updateOne: jest.fn() })
+
+const FILTER = { userId: 'u1', recipeId: 'r1' }
+const UPDATE = { $set: { reviewText: 'hi' }, $setOnInsert: { username: 'me' } }
+
+describe('upsertWithDupRetry', () => {
+  it('does a single upsert when there is no collision', async () => {
+    const col = makeCollection()
+    col.updateOne.mockResolvedValueOnce({ upsertedCount: 1 })
+
+    const res = await upsertWithDupRetry(col, FILTER, UPDATE)
+
+    expect(col.updateOne).toHaveBeenCalledTimes(1)
+    expect(col.updateOne).toHaveBeenCalledWith(FILTER, UPDATE, { upsert: true })
+    expect(res).toEqual({ upsertedCount: 1 })
+  })
+
+  it('retries as a plain (non-upsert) update on a duplicate-key race (E11000)', async () => {
+    const col = makeCollection()
+    const dupErr = Object.assign(new Error('E11000 duplicate key'), { code: 11000 })
+    col.updateOne
+      .mockRejectedValueOnce(dupErr) // loser of the insert race
+      .mockResolvedValueOnce({ matchedCount: 1, modifiedCount: 1 }) // retry lands on the winner's doc
+
+    const res = await upsertWithDupRetry(col, FILTER, UPDATE)
+
+    expect(col.updateOne).toHaveBeenCalledTimes(2)
+    expect(col.updateOne).toHaveBeenNthCalledWith(1, FILTER, UPDATE, { upsert: true })
+    expect(col.updateOne).toHaveBeenNthCalledWith(2, FILTER, UPDATE, { upsert: false })
+    expect(res).toEqual({ matchedCount: 1, modifiedCount: 1 })
+  })
+
+  it('rethrows non-duplicate errors without retrying', async () => {
+    const col = makeCollection()
+    col.updateOne.mockRejectedValueOnce(Object.assign(new Error('boom'), { code: 42 }))
+
+    await expect(upsertWithDupRetry(col, FILTER, UPDATE)).rejects.toThrow('boom')
+    expect(col.updateOne).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves caller-supplied options (e.g. session) on both attempts', async () => {
+    const col = makeCollection()
+    const session = { id: 'sess' }
+    const dupErr = Object.assign(new Error('dup'), { code: 11000 })
+    col.updateOne.mockRejectedValueOnce(dupErr).mockResolvedValueOnce({ matchedCount: 1 })
+
+    await upsertWithDupRetry(col, FILTER, UPDATE, { session })
+
+    expect(col.updateOne).toHaveBeenNthCalledWith(1, FILTER, UPDATE, { session, upsert: true })
+    expect(col.updateOne).toHaveBeenNthCalledWith(2, FILTER, UPDATE, { session, upsert: false })
+  })
+})

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -2,9 +2,12 @@ const express = require('express')
 const admin = require('firebase-admin')
 const { asyncHandler } = require('../util/asyncHandler')
 const router = express.Router()
-const { getDB } = require('../db')
+const { getDB, getClient } = require('../db')
 const { verifyToken, requireActive } = require('../middleware/auth')
 const { recordAudit } = require('../util/auditLog')
+const { teardownRecipeDocs } = require('../util/teardownRecipe')
+const { deleteRecipeImage, deleteProfilePhoto } = require('../util/firebaseStorage')
+const { recomputeRecipeRating } = require('../util/recipeRating')
 
 const USERNAME_MIN_LENGTH = 3
 const USERNAME_MAX_LENGTH = 30
@@ -294,13 +297,70 @@ router.post('/deleteAccount', verifyToken, asyncHandler(async (req, res) => {
   const usernameDoc = await db.collection('usernames').findOne({ _id: uid })
   const username = usernameDoc?.username || null
 
-  await db.collection('usernames').deleteOne({ _id: uid })
-  await db.collection('userProfiles').deleteOne({ _id: uid })
-  await db.collection('users').deleteOne({ _id: uid })
-  await db.collection('userRecipeData').deleteOne({ _id: uid })
-  await db.collection('recipes').deleteMany({ userId: uid })
-  await db.collection('recipeDrafts').deleteMany({ userId: uid })
-  await db.collection('ratings').deleteMany({ userId: uid })
+  // Read what we need BEFORE the transaction:
+  //  - the user's recipe docs themselves (for the per-recipe teardown + their
+  //    Storage images), and
+  //  - the distinct recipes the user REVIEWED, so we can fix surviving recipes'
+  //    rating aggregates after their reviews are removed (D4).
+  const ownRecipes = await db.collection('recipes').find({ userId: uid }).toArray()
+  const ownRecipeIds = new Set(ownRecipes.map((r) => String(r._id)))
+  const reviewedRecipeIds = await db
+    .collection('ratings')
+    .distinct('recipeId', { userId: uid })
+
+  // Cascade the Mongo-side deletes atomically (D3) — a partial failure here
+  // leaves nothing half-removed. teardownRecipeDocs reuses the exact per-recipe
+  // teardown DELETE /deleteRecipe uses (D6), so the account path can't drift:
+  // other users' reviews of this user's recipes (D2) and their saved/made
+  // references to them are cleaned up too — not just the recipe rows.
+  const session = getClient().startSession()
+  try {
+    await session.withTransaction(async () => {
+      for (const recipe of ownRecipes) {
+        await teardownRecipeDocs(db, recipe, session)
+      }
+      // The user's own reviews of OTHER people's recipes (their reviews of their
+      // own recipes were already removed by the teardown above).
+      await db.collection('ratings').deleteMany({ userId: uid }, { session })
+      await db.collection('usernames').deleteOne({ _id: uid }, { session })
+      await db.collection('userProfiles').deleteOne({ _id: uid }, { session })
+      await db.collection('users').deleteOne({ _id: uid }, { session })
+      await db.collection('userRecipeData').deleteOne({ _id: uid }, { session })
+      await db.collection('recipeDrafts').deleteMany({ userId: uid }, { session })
+      // D6: reports the user FILED. Keep the moderation record (its subject —
+      // the reported content — may still be a valid open queue item) but
+      // anonymize the now-departed reporter.
+      await db
+        .collection('reports')
+        .updateMany({ reporterUid: uid }, { $set: { reporterUid: null } }, { session })
+    })
+  } finally {
+    await session.endSession()
+  }
+
+  // ── External / non-transactional side effects ──────────────────────────────
+  // All best-effort and ordered deliberately: Mongo is fully committed above and
+  // the Firebase Auth deletion is LAST, so any failure here leaves the login
+  // recoverable to retry rather than orphaning a deleted account behind data.
+
+  // D4: recompute the aggregate for recipes the user reviewed but did NOT own
+  // (the ones they owned are gone). Post-commit, so it reflects the removed
+  // reviews. Best-effort: a recompute failure must not block the account delete.
+  for (const recipeId of reviewedRecipeIds) {
+    if (ownRecipeIds.has(recipeId)) continue
+    try {
+      await recomputeRecipeRating(db, recipeId)
+    } catch (err) {
+      console.error('deleteAccount: rating recompute failed for', recipeId, err.message)
+    }
+  }
+
+  // D5: drop the user's recipe images and profile photo from Storage. Both
+  // helpers never throw — an orphaned blob beats a failed account delete.
+  for (const recipe of ownRecipes) {
+    await deleteRecipeImage(recipe.recipeImage)
+  }
+  await deleteProfilePhoto(uid)
 
   // Leave a trail in the audit log (best-effort) so an admin can see that the
   // account was self-deleted rather than removed by moderation.

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -5,7 +5,6 @@ const router = express.Router()
 const { getDB, getClient } = require('../db')
 const { verifyToken, requireActive } = require('../middleware/auth')
 const { recordAudit } = require('../util/auditLog')
-const { teardownRecipeDocs } = require('../util/teardownRecipe')
 const { deleteRecipeImage, deleteProfilePhoto } = require('../util/firebaseStorage')
 const { recomputeRecipeRating } = require('../util/recipeRating')
 
@@ -313,14 +312,32 @@ router.post('/deleteAccount', verifyToken, asyncHandler(async (req, res) => {
   // teardown DELETE /deleteRecipe uses (D6), so the account path can't drift:
   // other users' reviews of this user's recipes (D2) and their saved/made
   // references to them are cleaned up too — not just the recipe rows.
+  const ownRecipeIdList = [...ownRecipeIds]
   const session = getClient().startSession()
   try {
     await session.withTransaction(async () => {
-      for (const recipe of ownRecipes) {
-        await teardownRecipeDocs(db, recipe, session)
-      }
+      // Per-recipe teardown, batched into O(1) collection passes (not one set of
+      // writes per recipe). A prolific owner could otherwise run hundreds of
+      // full-collection updateMany scans inside a single transaction and blow the
+      // transaction time/oplog limit, rolling back the whole delete. Same effect
+      // as calling teardownRecipeDocs for each recipe, in three writes total.
+      await db.collection('recipes').deleteMany({ userId: uid }, { session })
+      await db
+        .collection('ratings')
+        .deleteMany({ recipeId: { $in: ownRecipeIdList } }, { session })
+      await db.collection('userRecipeData').updateMany(
+        {},
+        {
+          $pull: {
+            savedRecipes: { recipeId: { $in: ownRecipeIdList } },
+            madeRecipes: { recipeId: { $in: ownRecipeIdList } },
+            userRecipes: { recipeId: { $in: ownRecipeIdList } },
+          },
+        },
+        { session }
+      )
       // The user's own reviews of OTHER people's recipes (their reviews of their
-      // own recipes were already removed by the teardown above).
+      // own recipes were already removed by the ratings delete above).
       await db.collection('ratings').deleteMany({ userId: uid }, { session })
       await db.collection('usernames').deleteOne({ _id: uid }, { session })
       await db.collection('userProfiles').deleteOne({ _id: uid }, { session })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -10,6 +10,7 @@ const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
 const { EDITABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
+const { teardownRecipeDocs } = require('../util/teardownRecipe')
 
 const router = Router()
 
@@ -314,24 +315,12 @@ router.delete('/deleteRecipe', verifyToken, asyncHandler(async (req, res) => {
 
   // Remove the recipe and every reference to it atomically: its ratings/
   // reviews, and the recipeId entry from any user's saved/made/created lists.
-  // userRecipes only ever lives on the owner's doc, but pulling it across all
-  // docs in the same updateMany is harmless and keeps this to one write.
+  // Shared with the delete-account cascade via teardownRecipeDocs so the two
+  // paths can't drift.
   const session = getClient().startSession()
   try {
     await session.withTransaction(async () => {
-      await db.collection('recipes').deleteOne(recipeIdQuery(recipeId), { session })
-      await db.collection('ratings').deleteMany({ recipeId }, { session })
-      await db.collection('userRecipeData').updateMany(
-        {},
-        {
-          $pull: {
-            savedRecipes: { recipeId },
-            madeRecipes: { recipeId },
-            userRecipes: { recipeId },
-          },
-        },
-        { session }
-      )
+      await teardownRecipeDocs(db, recipe, session)
     })
   } finally {
     await session.endSession()

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -7,6 +7,7 @@ const { REVIEW_VISIBLE, RECIPE_VISIBLE } = require('../util/moderation')
 const { DESCRIPTION_MAX_LENGTH } = require('../util/recipeLimits')
 const { recordAudit } = require('../util/auditLog')
 const { recomputeRecipeRating } = require('../util/recipeRating')
+const { upsertWithDupRetry } = require('../util/upsertWithDupRetry')
 const { notifyInBackground, notifyReviewTakenDown } = require('../util/email')
 
 const router = Router()
@@ -35,7 +36,10 @@ router.post('/addRating', verifyToken, requireActive, asyncHandler(async (req, r
     return res.status(400).json({ error: 'Rating must be between 1 and 5' })
   }
 
-  await db.collection('ratings').updateOne(
+  // dup-retry: the unique { userId, recipeId } index turns a concurrent
+  // double-submit into an E11000 on the loser; retry it as a plain update.
+  await upsertWithDupRetry(
+    db.collection('ratings'),
     { userId, recipeId },
     {
       $set: { rating: parsedRating, ratingLastUpdated: new Date() },
@@ -47,8 +51,7 @@ router.post('/addRating', verifyToken, requireActive, asyncHandler(async (req, r
         reviewLastUpdated: '',
         reviewText: '',
       },
-    },
-    { upsert: true }
+    }
   )
 
   // Recompute the aggregate (excludes moderated ratings).
@@ -75,8 +78,10 @@ router.post('/newReview', verifyToken, requireActive, asyncHandler(async (req, r
 
   const now = Date.now().toString()
   // Keyed by the stable uid (D1). username is denormalized for display, written
-  // once on insert ($setOnInsert) alongside the defaulted rating fields.
-  await db.collection('ratings').updateOne(
+  // once on insert ($setOnInsert) alongside the defaulted rating fields. The
+  // dup-retry handles a concurrent double-submit racing on the unique index.
+  await upsertWithDupRetry(
+    db.collection('ratings'),
     { userId, recipeId },
     {
       $set: { reviewText, reviewCreatedAt: now, reviewLastUpdated: now },
@@ -84,8 +89,7 @@ router.post('/newReview', verifyToken, requireActive, asyncHandler(async (req, r
       // insert so no ratings doc ever lacks them (recomputeRecipeRating skips
       // rating: null, but this keeps the document shape consistent).
       $setOnInsert: { username, rating: null, ratingLastUpdated: '' },
-    },
-    { upsert: true }
+    }
   )
 
   const updated = await db.collection('ratings').findOne({ userId, recipeId })

--- a/server/scripts/createModerationIndexes.js
+++ b/server/scripts/createModerationIndexes.js
@@ -45,11 +45,24 @@ const INDEXES = [
   // serves both the (userId, recipeId) point lookup/upsert used by every review
   // write AND the userId-prefix scans (getSingleUserReviews, account counts,
   // exportMyData, the delete-account cascade).
+  //
+  // UNIQUE — enforces the "one rating per (user, recipe)" invariant the upserts
+  // rely on. Without it, a legacy doc missing `userId` (pre-backfill) or a
+  // concurrent double-submit would slip a SECOND row past the upsert filter and
+  // silently double-count the author in the recipe aggregate. PARTIAL on
+  // `userId: { $exists: true }` so it (a) ignores not-yet-backfilled legacy docs
+  // instead of failing to build over them, and (b) still serves every read,
+  // which always predicates on an existing `userId`. Run the backfill first so
+  // the docs that should be unique actually carry the field.
   {
     collection: 'ratings',
     key: { userId: 1, recipeId: 1 },
     name: 'userId_1_recipeId_1',
-    why: 'D1 review writes/reads + account-counts/export/cascade keyed on userId',
+    options: {
+      unique: true,
+      partialFilterExpression: { userId: { $exists: true } },
+    },
+    why: 'D1 review writes/reads + account-counts/export/cascade keyed on userId (unique: one rating per user+recipe)',
   },
   {
     collection: 'recipes',
@@ -91,16 +104,36 @@ async function main() {
     const db = client.db('prepify')
     console.log('Connected to MongoDB (prepify). Building indexes...\n')
 
+    let failures = 0
     for (const ix of INDEXES) {
       const start = Date.now()
-      // Non-unique on purpose: a unique index could fail to build over legacy
-      // data with duplicates (cf. the username_lower guard in db.js).
-      const result = await db.collection(ix.collection).createIndex(ix.key, { name: ix.name })
-      const ms = Date.now() - start
-      console.log(`  ✓ ${ix.collection}.${result}  (${ms}ms)`)
-      console.log(`      ${ix.why}`)
+      try {
+        const result = await db
+          .collection(ix.collection)
+          .createIndex(ix.key, { name: ix.name, ...ix.options })
+        const ms = Date.now() - start
+        console.log(`  ✓ ${ix.collection}.${result}  (${ms}ms)`)
+        console.log(`      ${ix.why}`)
+      } catch (err) {
+        // A unique index can fail to build over legacy data that still holds
+        // duplicates (cf. the username_lower guard in db.js). Don't abort the
+        // whole run for one collision — report it loudly so the operator can
+        // dedup (and re-run the backfill) then re-run, while the rest build.
+        failures++
+        console.error(`  ✗ ${ix.collection}.${ix.name} FAILED: ${err.message}`)
+        if (err.code === 11000 || /duplicate key/i.test(err.message)) {
+          console.error(
+            `      Duplicate (${Object.keys(ix.key).join(',')}) rows exist — ` +
+              'dedup them (run backfillRatingUserIds.js first), then re-run.'
+          )
+        }
+      }
     }
 
+    if (failures) {
+      console.error(`\n${failures} index(es) failed to build. See errors above.`)
+      process.exit(1)
+    }
     console.log('\nDone. All moderation indexes are in place.')
     process.exit(0)
   } catch (err) {

--- a/server/util/firebaseStorage.js
+++ b/server/util/firebaseStorage.js
@@ -27,4 +27,31 @@ async function deleteRecipeImage(url) {
   }
 }
 
-module.exports = { parseStorageUrl, deleteRecipeImage }
+// Best-effort deletion of a user's profile photo, which (unlike recipe images)
+// we only know by its Storage PATH — `profilePhotos/{uid}`, written by the
+// client's AuthContext.updateProfileData — not by a download URL. Never throws,
+// same posture as deleteRecipeImage: an orphaned avatar must not fail (or roll
+// back) the account deletion it accompanies. Returns true only when a file was
+// actually deleted.
+//
+// The Admin SDK isn't initialized with a default storageBucket, so we name the
+// bucket explicitly from FIREBASE_STORAGE_BUCKET when set, else fall back to the
+// default bucket (which is what the test mock exercises). If neither resolves,
+// the attempt simply fails and is swallowed.
+async function deleteProfilePhoto(uid) {
+  if (!uid || typeof uid !== 'string') return false
+  const path = `profilePhotos/${uid}`
+  try {
+    const bucketName = process.env.FIREBASE_STORAGE_BUCKET
+    const bucket = bucketName
+      ? admin.storage().bucket(bucketName)
+      : admin.storage().bucket()
+    await bucket.file(path).delete()
+    return true
+  } catch (err) {
+    console.error('Failed to delete profile photo from storage:', err.message)
+    return false
+  }
+}
+
+module.exports = { parseStorageUrl, deleteRecipeImage, deleteProfilePhoto }

--- a/server/util/teardownRecipe.js
+++ b/server/util/teardownRecipe.js
@@ -1,0 +1,33 @@
+// Mongo-side teardown of a single recipe, run inside a transaction `session`.
+// Removes the recipe document, its ratings/reviews, and EVERY reference to it in
+// users' saved / made / created lists — so deleting a recipe never leaves
+// other users' reviews orphaned or their saved cards pointing at a 404.
+//
+// Shared by DELETE /deleteRecipe and the POST /deleteAccount cascade so the two
+// paths can't drift (the cascade previously did a naive recipes.deleteMany and
+// skipped all of this). The recipe's Storage image is an EXTERNAL side effect
+// and is intentionally NOT handled here — the caller deletes it (best-effort)
+// after the transaction commits, keeping this function purely transactional.
+//
+// `recipe` is the already-fetched recipe document. References elsewhere (ratings
+// .recipeId, savedRecipes[].recipeId, …) are stored as the recipe id's STRING
+// form, which `String(recipe._id)` yields whether _id is a native ObjectId
+// (post-migration) or a legacy string.
+async function teardownRecipeDocs(db, recipe, session) {
+  const recipeId = String(recipe._id)
+  await db.collection('recipes').deleteOne({ _id: recipe._id }, { session })
+  await db.collection('ratings').deleteMany({ recipeId }, { session })
+  await db.collection('userRecipeData').updateMany(
+    {},
+    {
+      $pull: {
+        savedRecipes: { recipeId },
+        madeRecipes: { recipeId },
+        userRecipes: { recipeId },
+      },
+    },
+    { session }
+  )
+}
+
+module.exports = { teardownRecipeDocs }

--- a/server/util/upsertWithDupRetry.js
+++ b/server/util/upsertWithDupRetry.js
@@ -1,0 +1,22 @@
+// Run an upsert that races safely against a concurrent insert of the same
+// unique key. With a unique index on the filter fields (e.g. ratings'
+// { userId, recipeId }), two simultaneous upserts that BOTH find no existing
+// doc will both attempt an INSERT; one wins and the other throws a duplicate-key
+// error (E11000). On that error the doc now exists, so we re-apply the update as
+// a plain (non-upsert) update — the `$set` lands on the row the racing request
+// inserted, and `$setOnInsert` is correctly skipped (the doc is no longer new).
+//
+// Turns a rare double-submit from a 500 into the same end state a sequential
+// pair of requests would reach: one row, last write wins.
+async function upsertWithDupRetry(collection, filter, update, options = {}) {
+  try {
+    return await collection.updateOne(filter, update, { ...options, upsert: true })
+  } catch (err) {
+    if (err && err.code === 11000) {
+      return collection.updateOne(filter, update, { ...options, upsert: false })
+    }
+    throw err
+  }
+}
+
+module.exports = { upsertWithDupRetry }


### PR DESCRIPTION
## Delete-account cascade rewrite (second of the data-integrity pass)

Per `docs/DATA_INTEGRITY_AUDIT.md`. **Stacked on #134 (D1)** — base is `feat/data-integrity-d1`; retarget to `development` once D1 merges.

`POST /deleteAccount` did a naive `recipes.deleteMany({ userId })` and deleted the user's ratings — leaving a trail of inconsistencies. This rewrites it to reuse the thorough per-recipe teardown `DELETE /deleteRecipe` already had, recompute affected aggregates, clean up Storage, and do it all atomically.

### Changes
- **D6 (unifier):** extract `teardownRecipeDocs(db, recipe, session)` into `server/util/teardownRecipe.js`; both `DELETE /deleteRecipe` and the cascade call it, so they can't drift. Per owned recipe it deletes the recipe, its ratings, and `$pull`s the id from every user's saved/made/created lists.
- **D2:** other users' reviews of the departing user's recipes are now removed (via the shared teardown) instead of orphaned.
- **D4:** `ratings.distinct('recipeId', { userId })` is captured pre-transaction; post-commit, `recomputeRecipeRating` runs for each reviewed recipe the user did **not** own — so surviving recipes' averages stop counting the deleted reviews. Best-effort (a recompute can't block the delete).
- **D5:** post-commit, `deleteRecipeImage` per owned recipe + new `deleteProfilePhoto(uid)` (deletes `profilePhotos/{uid}` by path; bucket from `FIREBASE_STORAGE_BUCKET`, added to `.env.example`). Both never throw.
- **D6 reporter cleanup:** **anonymize** — `reports.reporterUid → null` (keep the record; its subject may still be a valid open queue item; the email helpers already guard a falsy reporterUid).
- **D3:** the whole Mongo cascade runs inside one `withTransaction`. External side effects (recompute, Storage, audit, Firebase Auth delete) stay **outside** — preserving the deliberate **Mongo-first / Firebase-last** ordering so a partial failure leaves the login recoverable.

### Tests
- New `auth.test.js` "cascade (D2/D4/D5/D6)" block: orphan ratings removed (D2), dangling saves pulled (D6), surviving-recipe average recomputed 3/2 → 4/1 (D4), Storage helpers invoked = 2 (D5), Storage failure non-fatal, reporter anonymized, surrounding data intact.
- `DELETE /deleteRecipe` tests still green against the extracted helper.
- **Full server suite green: 401 passed.**

### Deploy notes
- Set `FIREBASE_STORAGE_BUCKET` (e.g. `your-app.appspot.com`) so profile-photo cleanup works; without it that one step is silently skipped (still best-effort). Recipe-image deletion needs nothing new.