### PR TITLE
feat(account): vertical-rail account nav

### DIFF
--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -354,6 +354,10 @@
   // ── Body / sub-page mount ──────────────────────────────────────────────────
   .account-body {
     margin-top: 0;
+    // Sit in the .acct-main 1fr track without letting non-shrinkable content
+    // (a long recipe title, a wide review) force the track wider than its share
+    // and overflow the page horizontally. Grid tracks default to min-width:auto.
+    min-width: 0;
   }
 
   // Shared empty-state used by every sub-page (Saved/Ratings/Recipes/Drafts).

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -242,58 +242,112 @@
     }
   }
 
-  // ── Segmented nav (centered) ───────────────────────────────────────────────
-  .acct-segment {
-    position: relative;
+  // ── Main: nav rail + sub-page (two-column dashboard on desktop) ────────────
+  // The rail sits beside the active sub-page on desktop; under 900px both
+  // collapse to a single column with the rail becoming a four-up tab bar above
+  // the content.
+  .acct-main {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    background: s.$gray-400;
-    border-radius: 14px;
-    padding: 5px;
-    max-width: 560px;
-    margin: 0 auto 1.75rem;
+    grid-template-columns: 230px 1fr;
+    gap: 1.5rem;
+    align-items: start;
+
+    @media (max-width: 900px) {
+      grid-template-columns: 1fr;
+      gap: 1.25rem;
+    }
   }
-  .acct-seg-indicator {
-    position: absolute;
-    top: 5px;
-    bottom: 5px;
-    left: 5px;
-    width: calc((100% - 10px) / var(--seg-n));
-    transform: translateX(calc(var(--seg-i) * 100%));
+
+  // ── Account nav rail ───────────────────────────────────────────────────────
+  .acct-segment {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
     background: #fff;
-    border-radius: 10px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-    transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+    border: 1px solid #ece2d6;
+    border-radius: 16px;
+    padding: 0.6rem;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
+    // Keep the rail in view while scrolling a long sub-page.
+    position: sticky;
+    top: calc(#{s.$nav-height} + 1rem);
+
+    // Collapse to a fixed four-up tab bar — all four destinations fit, no
+    // horizontal scroll.
+    @media (max-width: 900px) {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 0.25rem;
+      position: static;
+      margin-bottom: 0.25rem;
+    }
   }
   .acct-seg {
     position: relative;
-    z-index: 1;
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    justify-content: center;
-    gap: 0.35rem;
+    gap: 0.7rem;
     font-family: inherit;
     font-weight: 700;
-    font-size: 0.85rem;
+    font-size: 0.9rem;
     color: s.$secondary-text;
     text-decoration: none;
-    padding: 0.65rem 0.4rem;
-    border-radius: 10px;
-    transition: color 0.2s ease;
-    &.active {
+    border-radius: 11px;
+    padding: 0.7rem 0.85rem;
+    white-space: nowrap;
+    transition: background 0.12s ease, color 0.12s ease;
+
+    &:hover {
+      background: s.$gray-50;
       color: s.$primary-text;
     }
-    // Per-tab icon + the short-label variant are phone-only (see the ≤600px
-    // block); the desktop control stays text-only.
-    .acct-seg-icon,
+    &.active {
+      color: s.$primary;
+      background: rgba(s.$primary, 0.1);
+    }
+
+    .acct-seg-icon {
+      display: flex;
+      font-size: 1.15rem;
+    }
+    // The short label is phone-only (≤600px); the full label shows otherwise.
     .acct-seg-label-short {
       display: none;
     }
-    // Count badge — a small dimmed number trailing the label.
     .acct-seg-count {
-      font-size: 0.68rem;
+      margin-left: auto;
+      font-size: 0.72rem;
       font-weight: 800;
-      opacity: 0.7;
+      color: s.$secondary-text;
+      background: s.$gray-200;
+      border-radius: 999px;
+      padding: 0.1rem 0.5rem;
+    }
+    &.active .acct-seg-count {
+      color: s.$primary;
+      background: rgba(s.$primary, 0.15);
+    }
+
+    // Tab-bar cell (≤900px): icon over label, centered; count rides as a corner
+    // badge so each cell stays two tidy lines.
+    @media (max-width: 900px) {
+      flex-direction: column;
+      gap: 0.3rem;
+      justify-content: center;
+      text-align: center;
+      padding: 0.65rem 0.25rem;
+      font-size: 0.8rem;
+      .acct-seg-icon {
+        font-size: 1.3rem;
+      }
+      .acct-seg-count {
+        position: absolute;
+        top: 0.25rem;
+        right: 0.4rem;
+        margin-left: 0;
+        font-size: 0.58rem;
+        padding: 0.05rem 0.3rem;
+      }
     }
   }
 
@@ -387,56 +441,20 @@
       height: 42px;
     }
 
-    // ── Icon-led tab bar ──
-    .acct-segment {
-      max-width: none;
-      margin: 0 0 1.5rem;
-      padding: 6px;
-      border-radius: 16px;
-    }
-    .acct-seg-indicator {
-      border-radius: 12px;
-    }
+    // ── Nav tab bar: tighten + swap in the short label ──
+    // The four-up grid layout itself comes from the ≤900px rules above; on
+    // phones we just shrink the cells and swap "Your Recipes" → "Recipes" so a
+    // single line fits.
     .acct-seg {
-      flex-direction: column;
-      gap: 0.32rem;
-      padding: 0.6rem 0.25rem;
       font-size: 0.7rem;
+      padding: 0.55rem 0.2rem;
       line-height: 1;
 
-      .acct-seg-icon {
-        display: flex;
-        font-size: 1.2rem;
-      }
-      // Swap the full label for the short one where a tab defines it.
       .acct-seg-label.has-short {
         display: none;
       }
       .acct-seg-label-short {
         display: inline;
-      }
-      .acct-seg-label {
-        white-space: nowrap;
-      }
-      // Count rides as a small corner badge instead of trailing the label.
-      .acct-seg-count {
-        position: absolute;
-        top: 0.3rem;
-        right: 0.8rem;
-        min-width: 1rem;
-        height: 1rem;
-        padding: 0 0.25rem;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 0.6rem;
-        font-weight: 800;
-        color: #fff;
-        // Muted slate rather than brand orange, so the count doesn't read as a
-        // notification badge.
-        background: s.$secondary-text;
-        border-radius: 999px;
-        opacity: 1;
       }
     }
   }

--- a/src/pages/Account/Account.tsx
+++ b/src/pages/Account/Account.tsx
@@ -164,10 +164,12 @@ const Account: FC = () => {
           </div>
         </header>
 
-        <SegmentedNav counts={counts} />
+        <div className='acct-main'>
+          <SegmentedNav counts={counts} />
 
-        <div className='account-body'>
-          <Outlet />
+          <div className='account-body'>
+            <Outlet />
+          </div>
         </div>
       </div>
 

--- a/src/pages/Account/components/SegmentedNav.tsx
+++ b/src/pages/Account/components/SegmentedNav.tsx
@@ -3,13 +3,15 @@ import { Link, useLocation } from 'react-router-dom'
 import { FiBookmark, FiStar, FiBookOpen, FiFileText } from 'react-icons/fi'
 import { AccountTabCounts } from 'types'
 
-// SegmentedNav — the account sub-route switcher. On desktop it's the centered
-// text segmented control from the P2 header; on phones (≤600px, see Account.scss)
-// it becomes an app-style icon-over-label tab bar. The four tabs are URL routes
-// (so deep-links keep working) and the sliding white indicator follows the active
-// route at every width. Counts come from the aggregate GET /getAccountCounts
-// query (passed in by Account); a tab shows its number only once counts have
-// loaded and the count is non-zero.
+// SegmentedNav — the account sub-route switcher. On desktop (≥900px, see
+// Account.scss) it's a vertical rail sitting beside the sub-page content, turning
+// the account into a two-column dashboard. Below that it collapses to a fixed
+// four-up icon-over-label tab bar — all four destinations stay visible, never a
+// horizontal scroll. The four tabs are URL routes (so deep-links keep working)
+// and the active route gets a tinted background. Counts come from the aggregate
+// GET /getAccountCounts query (passed in by Account); a tab shows its number only
+// once counts have loaded and the count is non-zero. (Named SegmentedNav for
+// history; the control is now a rail.)
 
 type Tab = {
   key: keyof AccountTabCounts
@@ -51,16 +53,7 @@ const SegmentedNav: FC<SegmentedNavProps> = ({ counts }) => {
   )
 
   return (
-    <div
-      className='acct-segment'
-      role='navigation'
-      aria-label='Account sections'
-      style={{
-        ['--seg-i' as string]: activeIndex,
-        ['--seg-n' as string]: tabs.length,
-      }}
-    >
-      <div className='acct-seg-indicator' />
+    <div className='acct-segment' role='navigation' aria-label='Account sections'>
       {tabs.map((t, i) => {
         const count = counts?.[t.key]
         return (

--- a/src/test/SegmentedNav.test.tsx
+++ b/src/test/SegmentedNav.test.tsx
@@ -52,11 +52,11 @@ describe('SegmentedNav', () => {
     expect(screen.getByText('Saved')).toBeInTheDocument()
   })
 
-  it('drives the sliding indicator position from the active index', () => {
-    // tabs: saved=0, ratings=1, recipes(your-recipes)=2, drafts=3
-    const { container } = renderNav('/account/your-recipes')
-    const seg = container.querySelector('.acct-segment') as HTMLElement
-    expect(seg.style.getPropertyValue('--seg-i')).toBe('2')
-    expect(seg.style.getPropertyValue('--seg-n')).toBe('4')
+  it('renders all four tabs as links pointing at their routes', () => {
+    renderNav('/account/saved-recipes')
+    expect(tab('Saved')).toHaveAttribute('href', '/account/saved-recipes')
+    expect(tab('Ratings')).toHaveAttribute('href', '/account/ratings')
+    expect(tab('Your Recipes')).toHaveAttribute('href', '/account/your-recipes')
+    expect(tab('Drafts')).toHaveAttribute('href', '/account/drafts')
   })
 })


### PR DESCRIPTION
## Summary
Replaces the centered segmented control on the account page with a **vertical nav rail** that sits beside the active sub-page, turning `/account` into a two-column dashboard on desktop. Below 900px the rail collapses to a fixed four-up icon-over-label tab bar (no horizontal scroll); on phones (≤600px) cells tighten and swap in short labels.

## Changes
- `Account.scss` — new `.acct-main` two-column grid; rail restyle (sticky, tinted-active, pill count badges); removed the old sliding-indicator styles; consolidated the responsive breakpoints.
- `Account.tsx` — wrap `SegmentedNav` + `.account-body` in `.acct-main`.
- `SegmentedNav.tsx` — drop the sliding white indicator and the `--seg-i`/`--seg-n` CSS vars (no longer needed); the active route now gets a tinted background.
- `SegmentedNav.test.tsx` — replace the indicator-position assertion with route/href coverage.
- Review fix: `min-width:0` on the `.account-body` grid track so non-shrinkable content can't overflow the page horizontally (matches the header grid tracks).

## Testing
- `npx tsc --noEmit` clean
- `SegmentedNav.test.tsx` 6/6 pass

Reviewed locally with /code-review (high) — one finding (grid overflow guard) applied above.