### PR TITLE
feat(moderation): automated text moderation P0+P1 (write-time)

### DIFF
--- a/docs/CONTENT_MODERATION.md
+++ b/docs/CONTENT_MODERATION.md
@@ -255,10 +255,26 @@ recipes / block for reviews+bio+username**; verification = **tests + authed live
 ## Progress
 
 **2026-06-14 — P0 + P1 (text) shipped.** The independently-shippable text slice is complete and
-fully tested (server Jest **431/431**, frontend Vitest **361/361**, `tsc` clean). Awaiting an
-**authed live smoke test** against a real `.env` with `OPENAI_API_KEY` set (step 2 under "How to
-verify") before this is considered signed off — the automated suite mocks the classifier, so the
-real OpenAI call has not yet been exercised end-to-end.
+fully tested (server Jest **431/431**, frontend Vitest **361/361**, `tsc` clean).
+
+**2026-06-15 — P1 authed live smoke test PASSED ✅ — P1 is now signed off.** Ran against a real
+`.env` (prod Mongo + Firebase) with a live `OPENAI_API_KEY`, driving the API directly with a
+throwaway Firebase account (no browser — the moderation logic is all server-side):
+- **Blocklist layer (7/7):** recipe/review/bio blocklist-spam → `422 CONTENT_BLOCKED`; clean
+  recipe → 201, clean review/bio → 2xx, clean username → 200. (Proves `verdict=high → 422` on
+  every surface; needs no OpenAI key.)
+- **OpenAI grading (real classifier):** violent-threat recipe/review/bio → `422 CONTENT_BLOCKED`;
+  clean recipe → 201; clean bio → 200.
+- **Medium-confidence hold (6/6) — the distinctive `pending_review` state:** harassment-band text
+  (score 0.649) → `201 pendingReview:true`, recipe saved `status:'pending_review'`, automod
+  `report` filed (open/medium) + `recipe.autohold` audit by the `system` actor, **owner read
+  returns it (200) while the public read 404s it.** Owner-vs-public split confirmed end-to-end.
+- **Fail-open verified for real:** before account credits were loaded the key returned a persistent
+  account-level `429`; the classifier failed open exactly as designed (logged, content allowed) —
+  no writes blocked by the outage.
+
+All test data torn down; prod verified residue-free. (Cleanup gotcha logged: `updateProfile`
+writes bio/location to the `userProfiles` collection — easy to miss when purging test data.)
 
 Shipped:
 - **P0 foundation** — `server/util/textModeration.js` (env-gated `moderateText`, blocklist →
@@ -273,7 +289,46 @@ Shipped:
 - **Frontend** — moderation `422` surfaced on the recipe / review / profile forms; a non-error
   "pending review" toast when a recipe is held. Env vars added to `server/.env.example`.
 
-Known follow-ups: server-side `displayName` moderation (needs a Firebase blocking function — see the
-P1 note above); P2 image moderation; P3 CSAM. None block the text slice.
+**2026-06-15 — P1 code-review pass (high effort), 9 findings fixed.** A multi-angle review of
+the branch surfaced one critical gap and several integrity/robustness issues; all fixed with
+regression tests (server Jest **446** green). One finding (`displayName`) was already a known
+follow-up; the central-middleware refactor is deferred (see below).
 
-_Next: run the authed live smoke test, then proceed to P2 (images) when ready._
+- **#1 (critical) — ingredient + instruction text bypassed moderation.** `gatherRecipeText` read
+  keys that don't exist on real payloads (`ing.ingredient`/`.name`, `step.step`), so only
+  `title`/`description` were ever screened. Now reads the real shapes
+  (`parsedIngredient.originalIngredientString` + `ingredient`/`comment`, instruction `.content`,
+  and `LabelType` `.label` section headers). New `__tests__/automod.test.js` uses the real client
+  shapes — the route tests mock `moderateText`, so this was previously untestable.
+- **#2 — edit no longer downgrades an admin takedown.** A medium-confidence owner edit of a
+  `hidden`/`unpublished` recipe no longer lifts it to the weaker, owner-visible `pending_review`
+  (only an admin clears a takedown); the automod report is gated on the same condition.
+- **#3 — `addRecipe` whitelists the insert.** Replaced the raw `{ ...body }` spread with
+  `pickFields(body, CREATABLE_RECIPE_FIELDS)`; the server stamps `_id`/`userId`/zeroed
+  `rating`+counters, so a client can't inject `status`, `featured`, or a forged rating on create
+  (symmetric with the edit whitelist).
+- **#4 — public-profile count matches the visible list.** `recipesTotalCount` now counts with
+  `RECIPE_VISIBLE` instead of the unfiltered account total, so held/hidden recipes no longer
+  inflate the number or leak their existence.
+- **#7 — `editRecipe` race guard.** A `null` `findOneAndUpdate` result (recipe deleted mid-edit)
+  returns `404` instead of `200`-with-null, and skips the hold (no orphan report).
+- **#8 — report-gated hold.** `holdRecipeForReview` now files the queue report FIRST, then flips
+  the recipe to `pending_review`, then audits — returning a boolean. If the report write fails the
+  recipe is left visible (fail-open) rather than disappearing with nothing for an admin to clear.
+  The routes no longer stamp `pending_review` inline; the helper is the single owner.
+- **#9 — classifier reason fallback.** `flagged: true` with empty category scores now grades
+  `medium` with category `flagged` (reason `openai:flagged:0.00`) instead of `openai:null:0.00`.
+- **#10 (partial) — `respondBlocked(res)` helper.** The `422 {error, code}` block contract was
+  hand-typed at 6 sites across 3 route files; now one helper in `automod.js`.
+- **#6 — bio/`profile` spam rules: deliberate decision, no behavior change.** Bios stay on the
+  non-identity ruleset (a recipe author linking their own blog is legitimate; promo-phrase patterns
+  + OpenAI still apply). `IDENTITY_CONTEXTS` carries a note: adding `'profile'` is the single switch
+  that makes bios reject URLs/domains, if bio link-spam is ever observed.
+
+Known follow-ups: server-side `displayName` moderation (needs a Firebase blocking function — see the
+P1 note above); **#10 (full) — a central moderation choke point / middleware so a new write route
+can't silently ship unmoderated** (deferred to its own focused PR — retrofitting across the 6 write
+routes is too broad to fold into this slice); P2 image moderation; P3 CSAM. None block the text slice.
+
+_Next: P1 is fully signed off (incl. the code-review pass). Proceed to the `displayName` follow-up
+(Firebase blocking function) and/or P2 (images) when ready._

--- a/docs/CONTENT_MODERATION.md
+++ b/docs/CONTENT_MODERATION.md
@@ -149,29 +149,44 @@ tiers, Text engine, Username timing, and Verification rows).
 
 ## Phases
 
-### P0 — Foundation + text blocklist (½–1 day)
-- [ ] `server/util/moderation.js` — thin, swappable, env-gated wrapper (mirror `email.js`):
-      exports `moderateText(text, context)` → `{ allowed, reason, severity }`. No-ops to
-      `{ allowed: true }` when no provider configured.
-- [ ] Curated blocklist (slurs + spam patterns) as the zeroth pass inside `moderateText`.
-- [ ] Reserved `system`/`automod` actor constant + helper for `recordAudit`.
-- [ ] Unit tests for the blocklist + no-op behavior.
+### P0 — Foundation + text blocklist (½–1 day) — ✅ shipped 2026-06-14
+- [x] `server/util/textModeration.js` — thin, swappable, env-gated wrapper (mirrors `email.js`):
+      exports `moderateText(text, context)` → `{ allowed, severity, reason, category, source }`.
+      No-ops to a clean verdict when no provider configured. *(Lives in its own file rather than
+      the existing `server/util/moderation.js`, which already holds the visibility predicates.)*
+- [x] Curated blocklist (`server/util/moderationBlocklist.js`) — slur stems (leet/repeat-normalized,
+      Scunthorpe-safe) + identity-only spam patterns, as the zeroth pass inside `moderateText`.
+- [x] Reserved `SYSTEM_ACTOR` constant + optional `actorType` on `recordAudit` (default `'admin'`)
+      + new `recipe.autohold` audit action.
+- [x] Unit tests for the blocklist + no-op gating + severity grading + fail-open (15 cases).
 
-### P1 — Text moderation at write-time (2–3 days) — *primary value*
-- [ ] Wire OpenAI Moderation into `moderateText`, returning a `severity` (high / medium / clean).
-- [ ] Apply at recipe create/edit (`recipes.js`), review create/edit (`reviews.js`),
-      profile bio/location (`users.js`), and username/displayName at **signup AND rename**.
-- [ ] **High-confidence** → return inline 4xx with a friendly message (FE surfaces it on the form).
-- [ ] **Medium-confidence handling (per surface):**
-  - [ ] Recipes → save with `status: 'pending_review'` (owner + mod visible only) + silent
-        auto-`report`; clears to public on admin approval. Owner-facing reads must still show it.
-  - [ ] Reviews / bio / username → treat as a block (4xx, ask to rephrase) — no owner-only state.
-- [ ] Public read paths exclude `pending_review`; owner read paths include it (see gotcha #3).
-- [ ] Fail-open on transient API errors (log, don't block); fail-closed on blocklist.
-- [ ] Tests: high → 4xx; medium recipe → `pending_review` + queued; medium review → 4xx;
-      clean → 200 (and visible publicly); API-down → allowed + logged; owner-sees-own-pending.
-- [ ] Surface the inline 4xx in the FE: recipe form (`src/pages/AddRecipe*`), review form, and
-      profile/settings forms — locate the existing form error handling before adding new UI.
+### P1 — Text moderation at write-time (2–3 days) — *primary value* — ✅ shipped 2026-06-14
+- [x] Wire OpenAI Moderation into `moderateText` (native `fetch`, no SDK dep), grading a
+      `severity` (high / medium / clean) via env-tunable thresholds.
+- [x] Apply at recipe create/edit (`recipes.js`), review create/edit (`reviews.js`),
+      profile bio/location (`auth.js` `updateProfile`), and **username at signup AND rename**
+      (`auth.js` `setUsername`).
+- [x] **High-confidence** → inline `422` with a friendly `CONTENT_BLOCKED` message (FE surfaces it).
+- [x] **Medium-confidence handling (per surface):**
+  - [x] Recipes → save with `status: 'pending_review'` (owner + mod visible only) + silent
+        auto-`report` (idempotent) + `recipe.autohold` audit; clears to public on admin approval.
+        Owner-facing reads (`getCreatedRecipes`, own single-recipe `getRecipe`) still show it.
+  - [x] Reviews / bio / username → treated as a block (`422`, ask to rephrase) — no owner-only state.
+- [x] Public read paths exclude `pending_review` (`RECIPE_VISIBLE`); owner reads use
+      `RECIPE_OWNER_VISIBLE` (see gotcha #3). **Also fixed the pre-existing `publicProfile.js` leak**
+      (it filtered nothing, so it had been exposing `hidden`/`unpublished` recipes too).
+- [x] Fail-open on transient API errors (log, don't block); fail-closed on blocklist.
+- [x] Tests: high → 422; medium recipe → `pending_review` + queued report + system audit; medium
+      review → 422; clean → 201/visible; classifier-disabled/error → allowed; owner-sees-own-pending;
+      public-hides-pending (11 route cases, all green).
+- [x] Surfaced in the FE: recipe form (`AddRecipe.tsx` — block message + a "pending review" notice
+      on hold), review form (`AddReview.tsx`), and profile/settings (`ProfileSection.tsx`) — all reuse
+      the existing react-hot-toast / inline-error patterns and `error.response.data.error`.
+
+> **P1 follow-up (not shipped):** `displayName` is set client-side straight to Firebase Auth with
+> no server route, so it has no server-side moderation hook. Covering it needs a new server rename
+> endpoint or a Firebase **blocking function** (`beforeUserCreated`/`beforeUserSignedIn`). Tracked
+> here; out of scope for this slice. Username + bio/location (which DO hit the server) are covered.
 
 ### P2 — Image moderation (3–4 days)
 - [ ] Firebase Storage `onFinalize` Cloud Function (or the Cloud Vision extension).
@@ -239,5 +254,26 @@ recipes / block for reviews+bio+username**; verification = **tests + authed live
 
 ## Progress
 
-_Not started (scoped 2026-06-14; all P0–P2 decisions resolved same day). Update this section as
-phases ship — mirror the format used in `docs/ADMIN_FUNCTIONALITY.md`._
+**2026-06-14 — P0 + P1 (text) shipped.** The independently-shippable text slice is complete and
+fully tested (server Jest **431/431**, frontend Vitest **361/361**, `tsc` clean). Awaiting an
+**authed live smoke test** against a real `.env` with `OPENAI_API_KEY` set (step 2 under "How to
+verify") before this is considered signed off — the automated suite mocks the classifier, so the
+real OpenAI call has not yet been exercised end-to-end.
+
+Shipped:
+- **P0 foundation** — `server/util/textModeration.js` (env-gated `moderateText`, blocklist →
+  OpenAI grading, fail-open/fail-closed), `server/util/moderationBlocklist.js`, `SYSTEM_ACTOR` +
+  `actorType` + `recipe.autohold` in `auditLog.js`.
+- **P1 write-time wiring** — recipe add/edit (high→block / medium→`pending_review`+report+audit),
+  review add/edit + username + bio/location (high|medium→block). `server/util/automod.js` holds the
+  shared `gatherRecipeText` + idempotent `holdRecipeForReview`.
+- **Visibility** — `pending_review` added to `RECIPE_VISIBLE` (excluded from all public reads) +
+  new `RECIPE_OWNER_VISIBLE`; `getCreatedRecipes` and owner `getRecipe` show the owner their own
+  held recipe; **fixed the pre-existing `publicProfile.js` visibility leak**.
+- **Frontend** — moderation `422` surfaced on the recipe / review / profile forms; a non-error
+  "pending review" toast when a recipe is held. Env vars added to `server/.env.example`.
+
+Known follow-ups: server-side `displayName` moderation (needs a Firebase blocking function — see the
+P1 note above); P2 image moderation; P3 CSAM. None block the text slice.
+
+_Next: run the authed live smoke test, then proceed to P2 (images) when ready._

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -146,6 +146,17 @@ a feature flag. Do these together:
     defaults to `jesselindcs@gmail.com`. Only sends when `RESEND_API_KEY` is configured.
   DSNs are public (safe to ship in the client bundle). No DB migration — `bugReports` indexes
   auto-build at startup. **(was: needs decision → done; the env vars are the remaining launch task)**
+- `[x]` **Content moderation (text) — wired; prod env vars are a launch step** — write-time text
+  moderation is implemented (PR #138; blocklist + OpenAI Moderation API). Env-gated: with no key the
+  curated blocklist still fires, but the OpenAI layer no-ops to "clean".
+  **Before/at launch, set the production env vars or the OpenAI layer stays off:**
+  - **Backend (Railway):** `OPENAI_API_KEY` = OpenAI key (server-side only; the moderation endpoint
+    is free). **Never expose to the client** — it must not be a `VITE_*` var.
+  - **Backend (Railway):** `MODERATION_ENABLED` = `true` (master kill switch; `false` disables the
+    OpenAI layer even when a key is set).
+  - **Backend (Railway, optional):** `MODERATION_HIGH_THRESHOLD` / `MODERATION_MEDIUM_THRESHOLD` —
+    override the default score cutoffs (0.85 / 0.5). Leave unset for defaults.
+  No DB migration. See `docs/CONTENT_MODERATION.md`.
 - `[ ]` **Performance / Lighthouse pass** — run Lighthouse on the prod build; address obvious image-size
   and bundle-size wins. **(nice-to-have)**
 - `[ ]` **README cleanup** — the README still has placeholder `your-username` clone URLs and generic
@@ -245,7 +256,8 @@ the actual flip. Deploy is currently manual (Firebase Hosting frontend + Railway
 4. `[ ]` Update release-notes content for 1.0 and tag a GitHub Release.
 5. `[ ]` Deploy frontend (`npm run build` → Firebase Hosting) and backend (Railway). **First set prod
    env vars:** `VITE_SENTRY_DSN` in the frontend build env (before `npm run build`), and `SENTRY_DSN`
-   + `ADMIN_NOTIFY_EMAIL` on Railway. See Section C → "Error tracking (Sentry)".
+   + `ADMIN_NOTIFY_EMAIL` + `OPENAI_API_KEY` + `MODERATION_ENABLED` on Railway. See Section C →
+   "Error tracking (Sentry)" and "Content moderation (text)".
 6. `[ ]` Smoke-test production: load home, view a recipe, sign in, create a recipe, leave a review.
 7. `[ ]` Watch logs/analytics for the first hours.
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -29,3 +29,17 @@ SUPPORT_EMAIL=
 # (jesselindcs@gmail.com). Only used when email is enabled (RESEND_API_KEY set).
 ADMIN_NOTIFY_EMAIL=
 # EMAIL_ENABLED=true   # optional kill switch; an empty RESEND_API_KEY already disables sending
+
+# Automated content moderation (text). Leave OPENAI_API_KEY empty to disable the
+# OpenAI Moderation layer — the wrapper no-ops to a "clean" verdict, so dev/CI
+# without a key let all writes through (the curated blocklist still runs). The
+# free OpenAI Moderation endpoint is used server-side only; never expose this key
+# to the client. See docs/CONTENT_MODERATION.md.
+OPENAI_API_KEY=
+# Master kill switch. Set to 'false' to disable the OpenAI layer even when a key
+# is present (the blocklist still runs). Any other value (or unset) = enabled.
+MODERATION_ENABLED=
+# Optional score-threshold overrides for tuning without a redeploy. Defaults:
+# high=0.85 (block / hold), medium=0.5 (hold recipes, block reviews/profile).
+MODERATION_HIGH_THRESHOLD=
+MODERATION_MEDIUM_THRESHOLD=

--- a/server/__tests__/automod.test.js
+++ b/server/__tests__/automod.test.js
@@ -9,7 +9,7 @@
  * unmoderated. Assert the real keys make it into the blob.
  */
 
-const { gatherRecipeText } = require('../util/automod')
+const { gatherRecipeText, holdRecipeForReview } = require('../util/automod')
 
 // A parsed-ingredient row exactly as src/api/recipes.ts builds it.
 const parsedIngredient = (originalIngredientString, ingredient) => ({
@@ -92,5 +92,41 @@ describe('gatherRecipeText — real client payload shapes', () => {
     expect(
       gatherRecipeText({ title: 'T', ingredients: [null], instructions: [null] })
     ).toBe('T')
+  })
+})
+
+describe('holdRecipeForReview — report-gated hold', () => {
+  const VERDICT = { severity: 'medium', reason: 'openai:harassment:0.60', category: 'harassment', source: 'openai' }
+
+  // Minimal fake Db that records calls and lets a collection's updateOne be
+  // overridden (to simulate a failing report write).
+  const fakeDb = (overrides = {}) => {
+    const calls = { reports: [], recipes: [], auditLog: [] }
+    const coll = (name) => ({
+      updateOne: overrides[name]?.updateOne || (async (...args) => { calls[name].push(args); return { acknowledged: true } }),
+      insertOne: overrides[name]?.insertOne || (async (...args) => { calls[name].push(args); return { acknowledged: true } }),
+    })
+    return { db: { collection: coll }, calls }
+  }
+
+  it('files the report, THEN hides the recipe, and returns true', async () => {
+    const { db, calls } = fakeDb()
+    const held = await holdRecipeForReview(db, { recipeId: 'rec-1', title: 'T', verdict: VERDICT })
+    expect(held).toBe(true)
+    expect(calls.reports).toHaveLength(1) // queue entry filed
+    expect(calls.recipes).toHaveLength(1) // recipe hidden
+    // The recipe is flipped to pending_review.
+    expect(calls.recipes[0][1]).toEqual({ $set: { status: 'pending_review' } })
+    expect(calls.auditLog).toHaveLength(1) // autohold audit appended
+  })
+
+  it('does NOT hide the recipe when the report write fails (fail-open) and returns false', async () => {
+    const { db, calls } = fakeDb({
+      reports: { updateOne: async () => { throw new Error('mongo down') } },
+    })
+    const held = await holdRecipeForReview(db, { recipeId: 'rec-2', title: 'T', verdict: VERDICT })
+    expect(held).toBe(false)
+    // Crucial invariant: a recipe is never hidden without a queue entry to clear it.
+    expect(calls.recipes).toHaveLength(0)
   })
 })

--- a/server/__tests__/automod.test.js
+++ b/server/__tests__/automod.test.js
@@ -1,0 +1,96 @@
+/**
+ * util/automod.gatherRecipeText — flattens a recipe payload into one blob for the
+ * classifier. Pure-unit (no DB, no app).
+ *
+ * REGRESSION GUARD: these cases use the shapes the CLIENT ACTUALLY SENDS
+ * (src/types.ts IngredientsType/InstructionsType), not hand-simplified stand-ins.
+ * The earlier implementation read `ingredient`/`name` and `step.step`, which do
+ * not exist on real payloads, so all ingredient + instruction text silently went
+ * unmoderated. Assert the real keys make it into the blob.
+ */
+
+const { gatherRecipeText } = require('../util/automod')
+
+// A parsed-ingredient row exactly as src/api/recipes.ts builds it.
+const parsedIngredient = (originalIngredientString, ingredient) => ({
+  parsedIngredient: {
+    quantity: 2,
+    unit: 'cups',
+    unitPlural: 'cups',
+    symbol: null,
+    ingredient,
+    originalIngredientString,
+    minQty: 2,
+    maxQty: null,
+    comment: null,
+  },
+  ingredientData: { name: ingredient },
+  id: 'ing-id',
+})
+
+describe('gatherRecipeText — real client payload shapes', () => {
+  it('includes the verbatim ingredient line (parsedIngredient.originalIngredientString)', () => {
+    const blob = gatherRecipeText({
+      title: 'Soup',
+      ingredients: [parsedIngredient('2 cups SLURWORD onions', 'onions')],
+      instructions: [],
+    })
+    expect(blob).toContain('2 cups SLURWORD onions')
+  })
+
+  it('includes instruction step text (InstructionsType.content)', () => {
+    const blob = gatherRecipeText({
+      title: 'Soup',
+      ingredients: [],
+      instructions: [{ content: 'Stir in the SLURWORD and simmer', index: 0, id: 's1' }],
+    })
+    expect(blob).toContain('Stir in the SLURWORD and simmer')
+  })
+
+  it('includes section-header labels in both ingredient and instruction lists (LabelType)', () => {
+    const blob = gatherRecipeText({
+      title: 'Soup',
+      ingredients: [{ label: 'For the SLURWORD sauce', id: 'l1' }],
+      instructions: [{ label: 'SLURWORD prep steps', id: 'l2' }],
+    })
+    expect(blob).toContain('For the SLURWORD sauce')
+    expect(blob).toContain('SLURWORD prep steps')
+  })
+
+  it('gathers a full mixed recipe (title, description, parsed ingredients, labels, steps)', () => {
+    const blob = gatherRecipeText({
+      title: 'Title TOK1',
+      description: 'Description TOK2',
+      ingredients: [
+        { label: 'Section TOK3', id: 'l1' },
+        parsedIngredient('1 tbsp TOK4 oil', 'oil'),
+      ],
+      instructions: [
+        { label: 'Steps TOK5', id: 'l2' },
+        { content: 'Heat TOK6 gently', index: 0, id: 's1' },
+      ],
+    })
+    for (const tok of ['TOK1', 'TOK2', 'TOK3', 'TOK4', 'TOK5', 'TOK6']) {
+      expect(blob).toContain(tok)
+    }
+  })
+
+  it('still accepts the legacy/defensive shapes (string steps, ingredient/name, step.step)', () => {
+    const blob = gatherRecipeText({
+      title: 'T',
+      ingredients: [{ ingredient: 'ING_A' }, { name: 'ING_B' }, 'ING_C'],
+      instructions: ['STEP_X', { step: 'STEP_Y' }],
+    })
+    for (const tok of ['ING_A', 'ING_B', 'ING_C', 'STEP_X', 'STEP_Y']) {
+      expect(blob).toContain(tok)
+    }
+  })
+
+  it('is defensive against empty/missing arrays and null rows', () => {
+    expect(gatherRecipeText({})).toBe('')
+    expect(gatherRecipeText({ title: 'Only Title' })).toBe('Only Title')
+    expect(
+      gatherRecipeText({ title: 'T', ingredients: [null], instructions: [null] })
+    ).toBe('T')
+  })
+})

--- a/server/__tests__/moderation-routes.test.js
+++ b/server/__tests__/moderation-routes.test.js
@@ -1,0 +1,190 @@
+/**
+ * P1 — automated text moderation wired into the write routes.
+ *
+ * util/textModeration.moderateText is mocked so each test drives a deterministic
+ * verdict (high / medium / clean) without an API call; the REAL automod helper,
+ * routes, visibility predicates, audit log and reports collection are exercised.
+ *
+ * Contract under test, per the design doc:
+ *   - recipe  high   → 422 blocked, nothing persisted
+ *   - recipe  medium → 201 saved as 'pending_review' + open automod report + audit
+ *   - recipe  clean  → 201 normal, publicly visible
+ *   - review / username / profile  high|medium → 422 blocked
+ *   - public reads exclude 'pending_review'; the owner's own list includes it
+ */
+
+jest.mock('../util/textModeration', () => ({ moderateText: jest.fn() }))
+
+const request = require('supertest')
+const admin = require('firebase-admin') // auto-mocked
+const app = require('../app')
+const { getDB } = require('../db')
+const { moderateText } = require('../util/textModeration')
+const { SYSTEM_ACTOR } = require('../util/auditLog')
+const { recipeIdQuery } = require('../util/recipeIdQuery')
+const { seedRecipe, seedUser } = require('./helpers/seed')
+
+const TEST_UID = 'test-uid'
+const AUTH = { Authorization: 'Bearer fake-test-token' }
+
+const HIGH = { allowed: false, severity: 'high', reason: 'openai:hate:0.97', category: 'hate', source: 'openai' }
+const MEDIUM = { allowed: false, severity: 'medium', reason: 'openai:harassment:0.60', category: 'harassment', source: 'openai' }
+const CLEAN = { allowed: true, severity: 'clean', reason: null, category: null, source: 'openai' }
+
+// Minimal valid recipe payload (server stamps _id/userId/counters).
+const RECIPE_BODY = {
+  title: 'Tuscan Chicken Skillet',
+  description: 'A great dish',
+  cuisine: 'Italian',
+  mealTypes: ['dinner'],
+  nutritionLabels: ['low-carb'],
+  rating: { rateCount: 0, rateValue: 0 },
+  createdAt: '1000000',
+  ingredients: [{ id: 'i1', name: 'chicken' }],
+  instructions: [{ step: 'Cook the chicken' }],
+  recipeImage: 'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ft.jpg?alt=media&token=abc',
+}
+
+beforeEach(() => {
+  moderateText.mockReset()
+  moderateText.mockResolvedValue(CLEAN)
+})
+
+afterEach(async () => {
+  admin.__resetClaims()
+  admin.__resetUsers()
+  const db = getDB()
+  await Promise.all([
+    db.collection('recipes').deleteMany({}),
+    db.collection('ratings').deleteMany({}),
+    db.collection('reports').deleteMany({}),
+    db.collection('auditLog').deleteMany({}),
+    db.collection('usernames').deleteMany({}),
+    db.collection('userRecipeData').deleteMany({}),
+    db.collection('userProfiles').deleteMany({}),
+  ])
+})
+
+describe('POST /addRecipe — moderation tiers', () => {
+  it('high confidence → 422 blocked, nothing persisted', async () => {
+    moderateText.mockResolvedValue(HIGH)
+    const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(422)
+    expect(res.body.code).toBe('CONTENT_BLOCKED')
+    expect(await getDB().collection('recipes').countDocuments({})).toBe(0)
+  })
+
+  it('medium confidence → 201 pending_review + open automod report + system audit', async () => {
+    moderateText.mockResolvedValue(MEDIUM)
+    const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(201)
+    expect(res.body.pendingReview).toBe(true)
+
+    const db = getDB()
+    const recipe = await db.collection('recipes').findOne(recipeIdQuery(res.body._id))
+    expect(recipe.status).toBe('pending_review')
+
+    const report = await db.collection('reports').findOne({ recipeId: String(res.body._id) })
+    expect(report).toMatchObject({
+      targetType: 'recipe',
+      reporterUid: SYSTEM_ACTOR.uid,
+      status: 'open',
+      source: 'automod',
+    })
+
+    const audit = await db.collection('auditLog').findOne({ action: 'recipe.autohold' })
+    expect(audit).toMatchObject({ actorType: 'system', actorUid: SYSTEM_ACTOR.uid, targetType: 'recipe' })
+  })
+
+  it('clean → 201 normal (no pending flag, no report)', async () => {
+    const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(201)
+    expect(res.body.pendingReview).toBe(false)
+    const recipe = await getDB().collection('recipes').findOne(recipeIdQuery(res.body._id))
+    expect(recipe.status).toBeUndefined()
+    expect(await getDB().collection('reports').countDocuments({})).toBe(0)
+  })
+})
+
+describe('pending_review visibility split', () => {
+  beforeEach(async () => {
+    await seedRecipe({ ...RECIPE_BODY, _id: 'r-public', userId: TEST_UID, title: 'Public Pasta' })
+    await seedRecipe({ ...RECIPE_BODY, _id: 'r-pending', userId: TEST_UID, title: 'Held Pasta', status: 'pending_review' })
+  })
+
+  it('public GET /recipes excludes pending_review', async () => {
+    const res = await request(app).get('/api/recipes')
+    const ids = res.body.recipeList.map((r) => r._id)
+    expect(ids).toContain('r-public')
+    expect(ids).not.toContain('r-pending')
+  })
+
+  it("owner GET /getCreatedRecipes includes their own pending_review", async () => {
+    const res = await request(app).get('/api/getCreatedRecipes').set(AUTH)
+    const ids = res.body.recipes.map((r) => r._id)
+    expect(ids).toContain('r-public')
+    expect(ids).toContain('r-pending')
+  })
+
+  it('owner GET /getRecipe can view their own pending_review recipe', async () => {
+    const res = await request(app).get('/api/getRecipe?id=r-pending').set(AUTH)
+    expect(res.status).toBe(200)
+    expect(res.body._id).toBe('r-pending')
+  })
+
+  it('anonymous GET /getRecipe on a pending_review recipe is 404', async () => {
+    const res = await request(app).get('/api/getRecipe?id=r-pending')
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('reviews — high|medium both block', () => {
+  beforeEach(async () => {
+    await seedUser(TEST_UID, 'chef_test')
+    await seedRecipe({ ...RECIPE_BODY, _id: 'r-1', userId: 'someone-else' })
+  })
+
+  it('medium review → 422 (no owner-only state)', async () => {
+    moderateText.mockResolvedValue(MEDIUM)
+    const res = await request(app).post('/api/newReview').set(AUTH).send({ recipeId: 'r-1', reviewText: 'borderline' })
+    expect(res.status).toBe(422)
+    expect(res.body.code).toBe('CONTENT_BLOCKED')
+    expect(await getDB().collection('ratings').countDocuments({})).toBe(0)
+  })
+
+  it('clean review → 200 persisted', async () => {
+    const res = await request(app).post('/api/newReview').set(AUTH).send({ recipeId: 'r-1', reviewText: 'lovely dish' })
+    expect(res.status).toBe(200)
+    expect(await getDB().collection('ratings').countDocuments({ userId: TEST_UID, recipeId: 'r-1' })).toBe(1)
+  })
+})
+
+describe('username + profile blocking', () => {
+  it('high-confidence username → 422', async () => {
+    moderateText.mockResolvedValue(HIGH)
+    const res = await request(app).post('/api/setUsername?username=badword').set(AUTH)
+    expect(res.status).toBe(422)
+    expect(res.body.code).toBe('CONTENT_BLOCKED')
+  })
+
+  it('medium-confidence bio → 422', async () => {
+    moderateText.mockResolvedValue(MEDIUM)
+    const res = await request(app).post('/api/updateProfile').set(AUTH).send({ bio: 'borderline bio', location: 'NY' })
+    expect(res.status).toBe(422)
+    expect(await getDB().collection('userProfiles').countDocuments({})).toBe(0)
+  })
+
+  it('clean username → 200', async () => {
+    const res = await request(app).post('/api/setUsername?username=cleanchef').set(AUTH)
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('fail-open at the route layer', () => {
+  it('classifier-disabled/error verdict (clean) lets the recipe save', async () => {
+    moderateText.mockResolvedValue({ ...CLEAN, source: 'error' })
+    const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(201)
+    expect(res.body.pendingReview).toBe(false)
+  })
+})

--- a/server/__tests__/moderation-routes.test.js
+++ b/server/__tests__/moderation-routes.test.js
@@ -40,8 +40,15 @@ const RECIPE_BODY = {
   nutritionLabels: ['low-carb'],
   rating: { rateCount: 0, rateValue: 0 },
   createdAt: '1000000',
-  ingredients: [{ id: 'i1', name: 'chicken' }],
-  instructions: [{ step: 'Cook the chicken' }],
+  // Real client shapes (src/types.ts): parsed-ingredient row + step row.
+  ingredients: [
+    {
+      id: 'i1',
+      parsedIngredient: { ingredient: 'chicken', originalIngredientString: '1 lb chicken', comment: null },
+      ingredientData: { name: 'chicken' },
+    },
+  ],
+  instructions: [{ content: 'Cook the chicken', index: 0, id: 's1' }],
   recipeImage: 'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ft.jpg?alt=media&token=abc',
 }
 
@@ -103,6 +110,29 @@ describe('POST /addRecipe — moderation tiers', () => {
     const recipe = await getDB().collection('recipes').findOne(recipeIdQuery(res.body._id))
     expect(recipe.status).toBeUndefined()
     expect(await getDB().collection('reports').countDocuments({})).toBe(0)
+  })
+})
+
+describe('PUT /editRecipe — medium hold never downgrades an admin takedown', () => {
+  it('medium edit of an active recipe → pending_review + automod report', async () => {
+    await seedRecipe({ ...RECIPE_BODY, _id: 'e-active', userId: TEST_UID })
+    moderateText.mockResolvedValue(MEDIUM)
+    const res = await request(app).put('/api/editRecipe?recipeId=e-active').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(200)
+    const db = getDB()
+    expect((await db.collection('recipes').findOne(recipeIdQuery('e-active'))).status).toBe('pending_review')
+    expect(await db.collection('reports').countDocuments({ recipeId: 'e-active', source: 'automod' })).toBe(1)
+  })
+
+  it('medium edit of an admin-hidden recipe keeps it hidden and files no automod report', async () => {
+    await seedRecipe({ ...RECIPE_BODY, _id: 'e-hidden', userId: TEST_UID, status: 'hidden' })
+    moderateText.mockResolvedValue(MEDIUM)
+    const res = await request(app).put('/api/editRecipe?recipeId=e-hidden').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(200)
+    const db = getDB()
+    // Admin takedown preserved — not lifted to the weaker owner-visible pending state.
+    expect((await db.collection('recipes').findOne(recipeIdQuery('e-hidden'))).status).toBe('hidden')
+    expect(await db.collection('reports').countDocuments({ recipeId: 'e-hidden' })).toBe(0)
   })
 })
 

--- a/server/__tests__/publicProfile.test.js
+++ b/server/__tests__/publicProfile.test.js
@@ -86,6 +86,23 @@ describe('GET /getPublicProfile', () => {
     expect(res.body.recipesTotalCount).toBe(2)
   })
 
+  it('excludes held / hidden recipes from both the list and the total count', async () => {
+    await seedUser(PUB_UID, 'CoolUser')
+    await seedRecipes([
+      { _id: 'v1', userId: PUB_UID, createdAt: '4000' },
+      { _id: 'v2', userId: PUB_UID, createdAt: '3000' },
+      { _id: 'held', userId: PUB_UID, createdAt: '2000', status: 'pending_review' },
+      { _id: 'hid', userId: PUB_UID, createdAt: '1000', status: 'hidden' },
+    ])
+
+    const res = await request(app).get('/api/getPublicProfile?username=CoolUser')
+    expect(res.status).toBe(200)
+    // The list shows only visible recipes…
+    expect(res.body.recipes.map(r => r._id)).toEqual(['v1', 'v2'])
+    // …and the reported total agrees with it (no leak of held/hidden existence).
+    expect(res.body.recipesTotalCount).toBe(2)
+  })
+
   it('caps recipes at 12 but reports the full total', async () => {
     await seedUser(PUB_UID, 'CoolUser')
     await seedRecipes(

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -293,6 +293,31 @@ describe('POST /addRecipe', () => {
     expect(stored.userId).toBe(TEST_UID)
   })
 
+  it('ignores client-supplied status, featured, and a forged rating on create', async () => {
+    const res = await request(app)
+      .post('/api/addRecipe')
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Test Recipe',
+        description: 'A test recipe',
+        ingredients: [{ id: 'i1', name: 'salt' }],
+        instructions: [{ content: 'Add salt', index: 1, id: 's1' }],
+        mealTypes: ['dinner'],
+        // Curation / moderation flags a client must never be able to set on create.
+        status: 'active',
+        featured: true,
+        // A forged rating to fake social proof on a brand-new recipe.
+        rating: { rateCount: 99, rateValue: 5 },
+      })
+
+    expect(res.status).toBe(201)
+    const { ObjectId } = require('mongodb')
+    const stored = await getDB().collection('recipes').findOne({ _id: new ObjectId(res.body._id) })
+    expect(stored.status).toBeUndefined()
+    expect(stored.featured).toBeUndefined()
+    expect(stored.rating).toEqual({ rateCount: 0, rateValue: 0 })
+  })
+
   describe('input bounds (defense-in-depth)', () => {
     const validBody = () => ({
       title: 'Test Recipe',

--- a/server/__tests__/textModeration.test.js
+++ b/server/__tests__/textModeration.test.js
@@ -1,0 +1,140 @@
+/**
+ * P0 — text moderation foundation (util/textModeration + util/moderationBlocklist).
+ *
+ * Pure-unit: no DB, no app. `fetch` is replaced per-test so the OpenAI layer is
+ * exercised without a network call. Contract under test:
+ *   - blocklist hits are high-confidence and fire even with the API disabled,
+ *   - the wrapper no-ops to CLEAN when OPENAI_API_KEY is unset,
+ *   - API scores grade into high/medium/clean at the configured thresholds,
+ *   - a transient API failure fails OPEN (clean), never throwing.
+ */
+
+const { moderateText } = require('../util/textModeration')
+const { checkBlocklist, normalizeToken } = require('../util/moderationBlocklist')
+
+const realFetch = global.fetch
+
+// Build a fake fetch resolving to one OpenAI moderation result.
+function mockModeration({ flagged = false, categories = {}, category_scores = {} }) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ results: [{ flagged, categories, category_scores }] }),
+  })
+}
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = 'test-key'
+  delete process.env.MODERATION_ENABLED
+  delete process.env.MODERATION_HIGH_THRESHOLD
+  delete process.env.MODERATION_MEDIUM_THRESHOLD
+})
+
+afterEach(() => {
+  global.fetch = realFetch
+  jest.restoreAllMocks()
+})
+
+// process.env is shared across files under --runInBand; don't leak an enabled
+// moderation key (or it would make later route suites hit the real API).
+afterAll(() => {
+  delete process.env.OPENAI_API_KEY
+})
+
+describe('moderationBlocklist.checkBlocklist', () => {
+  it('catches an exact slur token', () => {
+    expect(checkBlocklist('you are a bitch', 'review')).toMatchObject({ kind: 'slur' })
+  })
+
+  it('catches leetspeak / obfuscated slurs', () => {
+    expect(checkBlocklist('f4ggot', 'review')).toMatchObject({ kind: 'slur' })
+    expect(checkBlocklist('sh1t', 'review')).toMatchObject({ kind: 'slur' })
+  })
+
+  it('does not false-positive on clean text (Scunthorpe-safe)', () => {
+    expect(checkBlocklist('Scunthorpe assistant classic recipe', 'recipe.title')).toBeNull()
+    expect(checkBlocklist('A delicious shiitake mushroom risotto', 'recipe.title')).toBeNull()
+  })
+
+  it('applies URL/domain spam rules only to identity fields', () => {
+    expect(checkBlocklist('visit www.spam.com', 'username')).toMatchObject({ kind: 'spam' })
+    // A recipe body legitimately contains links — not flagged by the blocklist.
+    expect(checkBlocklist('adapted from www.spam.com', 'recipe.description')).toBeNull()
+  })
+
+  it('normalizeToken folds case, leet, and repeats', () => {
+    expect(normalizeToken('Fuuuck')).toBe('fuck')
+    expect(normalizeToken('SH!T')).toBe('sht')
+  })
+})
+
+describe('moderateText — gating', () => {
+  it('no-ops to clean when OPENAI_API_KEY is absent (and no blocklist hit)', async () => {
+    delete process.env.OPENAI_API_KEY
+    global.fetch = jest.fn()
+    const v = await moderateText('a perfectly normal sentence', 'review')
+    expect(v).toMatchObject({ allowed: true, severity: 'clean', source: 'disabled' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('still blocks blocklist hits even when the API is disabled', async () => {
+    delete process.env.OPENAI_API_KEY
+    const v = await moderateText('total bitch move', 'review')
+    expect(v).toMatchObject({ allowed: false, severity: 'high', source: 'blocklist' })
+  })
+
+  it('treats empty/blank text as clean without calling the API', async () => {
+    global.fetch = jest.fn()
+    expect(await moderateText('', 'bio')).toMatchObject({ allowed: true, severity: 'clean' })
+    expect(await moderateText('   ', 'bio')).toMatchObject({ allowed: true, severity: 'clean' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('moderateText — OpenAI grading', () => {
+  it('grades a high score as high', async () => {
+    mockModeration({ flagged: true, category_scores: { hate: 0.97 } })
+    const v = await moderateText('borderline content', 'review')
+    expect(v).toMatchObject({ allowed: false, severity: 'high', source: 'openai' })
+  })
+
+  it('grades a mid score as medium', async () => {
+    mockModeration({ flagged: true, category_scores: { harassment: 0.6 } })
+    const v = await moderateText('borderline content', 'recipe.description')
+    expect(v).toMatchObject({ allowed: false, severity: 'medium', source: 'openai' })
+  })
+
+  it('grades a low score as clean', async () => {
+    mockModeration({ flagged: false, category_scores: { harassment: 0.01 } })
+    const v = await moderateText('a wholesome lasagna recipe', 'recipe.description')
+    expect(v).toMatchObject({ allowed: true, severity: 'clean', source: 'openai' })
+  })
+
+  it('treats sexual/minors as high regardless of score', async () => {
+    mockModeration({ flagged: true, categories: { 'sexual/minors': true }, category_scores: { 'sexual/minors': 0.2 } })
+    const v = await moderateText('borderline content', 'review')
+    expect(v).toMatchObject({ severity: 'high', category: 'sexual/minors' })
+  })
+
+  it('respects env-tuned thresholds', async () => {
+    process.env.MODERATION_HIGH_THRESHOLD = '0.5'
+    mockModeration({ flagged: true, category_scores: { hate: 0.55 } })
+    const v = await moderateText('borderline content', 'review')
+    expect(v.severity).toBe('high')
+  })
+})
+
+describe('moderateText — fail-open', () => {
+  it('returns clean (failing open) when the API call rejects', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network down'))
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    const v = await moderateText('a perfectly normal sentence', 'review')
+    expect(v).toMatchObject({ allowed: true, severity: 'clean', source: 'error' })
+  })
+
+  it('returns clean (failing open) on a non-2xx response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) })
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    const v = await moderateText('a perfectly normal sentence', 'review')
+    expect(v).toMatchObject({ allowed: true, severity: 'clean', source: 'error' })
+  })
+})

--- a/server/__tests__/textModeration.test.js
+++ b/server/__tests__/textModeration.test.js
@@ -121,6 +121,15 @@ describe('moderateText — OpenAI grading', () => {
     const v = await moderateText('borderline content', 'review')
     expect(v.severity).toBe('high')
   })
+
+  it('flagged with no usable category scores → medium with a non-null reason', async () => {
+    mockModeration({ flagged: true, category_scores: {} })
+    const v = await moderateText('borderline content', 'recipe.description')
+    expect(v.severity).toBe('medium')
+    expect(v.category).toBe('flagged')
+    // Never the meaningless 'openai:null:0.00'.
+    expect(v.reason).toBe('openai:flagged:0.00')
+  })
 })
 
 describe('moderateText — fail-open', () => {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -7,6 +7,8 @@ const { verifyToken, requireActive } = require('../middleware/auth')
 const { recordAudit } = require('../util/auditLog')
 const { deleteRecipeImage, deleteProfilePhoto } = require('../util/firebaseStorage')
 const { recomputeRecipeRating } = require('../util/recipeRating')
+const { moderateText } = require('../util/textModeration')
+const { BLOCKED_MESSAGE, BLOCKED_CODE } = require('../util/automod')
 
 const USERNAME_MIN_LENGTH = 3
 const USERNAME_MAX_LENGTH = 30
@@ -115,6 +117,13 @@ router.post('/setUsername', verifyToken, requireActive, asyncHandler(async (req,
   if (validationError) {
     return res.status(400).json({ error: validationError })
   }
+  // A username is high-visibility (it lands in the URL), so both high and medium
+  // confidence block at signup AND on every rename. The 'username' context also
+  // applies the identity-only spam rules (no URLs/domains in a handle).
+  const usernameVerdict = await moderateText(username, 'username')
+  if (!usernameVerdict.allowed) {
+    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
+  }
   const usernameLower = username.toLowerCase()
   const uid = req.uid
   const db = getDB()
@@ -199,6 +208,13 @@ router.post('/updateProfile', verifyToken, requireActive, asyncHandler(async (re
   const validationError = validateProfile(bio, location)
   if (validationError) {
     return res.status(400).json({ error: validationError })
+  }
+  // Profile text is short and only the author benefits from it, so (like reviews)
+  // both high and medium confidence block inline rather than holding for review.
+  const profileText = [bio, location].filter((s) => typeof s === 'string' && s.trim()).join('\n')
+  const profileVerdict = await moderateText(profileText, 'profile')
+  if (!profileVerdict.allowed) {
+    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
   }
   const db = getDB()
   await db.collection('userProfiles').updateOne(

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -8,7 +8,7 @@ const { recordAudit } = require('../util/auditLog')
 const { deleteRecipeImage, deleteProfilePhoto } = require('../util/firebaseStorage')
 const { recomputeRecipeRating } = require('../util/recipeRating')
 const { moderateText } = require('../util/textModeration')
-const { BLOCKED_MESSAGE, BLOCKED_CODE } = require('../util/automod')
+const { respondBlocked } = require('../util/automod')
 
 const USERNAME_MIN_LENGTH = 3
 const USERNAME_MAX_LENGTH = 30
@@ -122,7 +122,7 @@ router.post('/setUsername', verifyToken, requireActive, asyncHandler(async (req,
   // applies the identity-only spam rules (no URLs/domains in a handle).
   const usernameVerdict = await moderateText(username, 'username')
   if (!usernameVerdict.allowed) {
-    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
+    return respondBlocked(res)
   }
   const usernameLower = username.toLowerCase()
   const uid = req.uid
@@ -214,7 +214,7 @@ router.post('/updateProfile', verifyToken, requireActive, asyncHandler(async (re
   const profileText = [bio, location].filter((s) => typeof s === 'string' && s.trim()).join('\n')
   const profileVerdict = await moderateText(profileText, 'profile')
   if (!profileVerdict.allowed) {
-    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
+    return respondBlocked(res)
   }
   const db = getDB()
   await db.collection('userProfiles').updateOne(

--- a/server/routes/publicProfile.js
+++ b/server/routes/publicProfile.js
@@ -45,9 +45,15 @@ router.get('/getPublicProfile', asyncHandler(async (req, res) => {
     }
   }
 
-  const [profile, counts, recipes, authRecord] = await Promise.all([
+  const [profile, counts, visibleRecipeCount, recipes, authRecord] = await Promise.all([
     db.collection('userProfiles').findOne({ _id: uid }),
     getAccountCountsFor(db, uid),
+    // The displayed total must match what the list shows: count only publicly
+    // visible recipes, not every recipe the user owns (getAccountCountsFor is
+    // unfiltered — correct for the owner's own account page, but it would
+    // otherwise inflate the public total and leak the existence of held/hidden
+    // recipes here).
+    db.collection('recipes').countDocuments({ userId: uid, ...RECIPE_VISIBLE }),
     db
       // Public surface: exclude hidden / unpublished / pending_review recipes so
       // a held or taken-down recipe never appears on someone's public profile.
@@ -84,7 +90,7 @@ router.get('/getPublicProfile', asyncHandler(async (req, res) => {
     pct: gamification.pct,
     achievements: earnedAchievements,
     recipes,
-    recipesTotalCount: counts.recipes,
+    recipesTotalCount: visibleRecipeCount,
   })
 }))
 

--- a/server/routes/publicProfile.js
+++ b/server/routes/publicProfile.js
@@ -5,6 +5,7 @@ const admin = require('firebase-admin')
 const { getDB } = require('../db')
 const { getAccountCountsFor } = require('../util/accountCounts')
 const { computeGamification } = require('../util/gamification')
+const { RECIPE_VISIBLE } = require('../util/moderation')
 
 const PROFILE_RECIPE_LIMIT = 12
 
@@ -48,8 +49,10 @@ router.get('/getPublicProfile', asyncHandler(async (req, res) => {
     db.collection('userProfiles').findOne({ _id: uid }),
     getAccountCountsFor(db, uid),
     db
+      // Public surface: exclude hidden / unpublished / pending_review recipes so
+      // a held or taken-down recipe never appears on someone's public profile.
       .collection('recipes')
-      .find({ userId: uid })
+      .find({ userId: uid, ...RECIPE_VISIBLE })
       .sort({ createdAt: -1 })
       .limit(PROFILE_RECIPE_LIMIT)
       .toArray(),

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -4,10 +4,12 @@ const { ObjectId } = require('mongodb')
 const { getDB, getClient } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
-const { RECIPE_VISIBLE } = require('../util/moderation')
+const { RECIPE_VISIBLE, RECIPE_OWNER_VISIBLE } = require('../util/moderation')
 const { recordAudit } = require('../util/auditLog')
 const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
+const { moderateText } = require('../util/textModeration')
+const { gatherRecipeText, holdRecipeForReview, BLOCKED_MESSAGE, BLOCKED_CODE } = require('../util/automod')
 const { EDITABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 const { teardownRecipeDocs } = require('../util/teardownRecipe')
@@ -216,7 +218,19 @@ router.get('/getRecipe', optionalAuth, asyncHandler(async (req, res) => {
     { returnDocument: 'after' }
   )
 
-  if (!recipe) return res.status(404).json({ error: 'Not found' })
+  if (!recipe) {
+    // The author can still view their OWN recipe while it's held in
+    // 'pending_review' (it's withheld from the public, not from its owner). Don't
+    // inflate views for this owner preview. Takedowns ('hidden'/'unpublished')
+    // are excluded by RECIPE_OWNER_VISIBLE, so this only surfaces a pending hold.
+    if (req.uid) {
+      const own = await db
+        .collection('recipes')
+        .findOne({ ...recipeIdQuery(id), userId: req.uid, ...RECIPE_OWNER_VISIBLE })
+      if (own) return res.json(own)
+    }
+    return res.status(404).json({ error: 'Not found' })
+  }
 
   // Fire-and-forget global stats increment
   db.collection('stats').updateOne(
@@ -240,16 +254,31 @@ router.post('/addRecipe', verifyToken, requireActive, asyncHandler(async (req, r
   if (boundsError) {
     return res.status(400).json({ error: boundsError })
   }
+
+  // Automated text moderation. High-confidence → block the write (4xx). Medium →
+  // save but hold from public reads as 'pending_review' (owner still sees it) and
+  // file a system report for an admin to clear. Clean / classifier-disabled → save
+  // normally. moderateText fails open, so a moderation outage won't block creation.
+  const verdict = await moderateText(gatherRecipeText(body), 'recipe')
+  if (verdict.severity === 'high') {
+    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
+  }
+  const pendingReview = verdict.severity === 'medium'
+
   // Server stamps _id, userId, and counters — client-supplied values are discarded
   const newId = new ObjectId()
   const docToInsert = { ...body, _id: newId, userId: uid, numTimesSaved: 0, numTimesMade: 0, views: 0 }
+  if (pendingReview) docToInsert.status = 'pending_review'
   await db.collection('recipes').insertOne(docToInsert)
   await db.collection('userRecipeData').updateOne(
     { _id: uid },
     { $push: { userRecipes: { recipeId: newId } } },
     { upsert: true }
   )
-  res.status(201).json({ _id: newId })
+  if (pendingReview) {
+    await holdRecipeForReview(db, { recipeId: newId, title: body.title, verdict })
+  }
+  res.status(201).json({ _id: newId, pendingReview })
 }))
 
 // PUT /editRecipe — owner-only edit. Social/derived counters and immutable
@@ -281,6 +310,15 @@ router.put('/editRecipe', verifyToken, requireActive, asyncHandler(async (req, r
     return res.status(400).json({ error: boundsError })
   }
 
+  // Re-moderate the edited text (same tiers as create). High → reject the edit;
+  // the previously-saved version stays as-is. Medium → re-hold as 'pending_review'.
+  // A clean edit deliberately does NOT clear an existing hold/takedown — only an
+  // admin clears those (the edit just stops adding new flags).
+  const verdict = await moderateText(gatherRecipeText(body), 'recipe')
+  if (verdict.severity === 'high') {
+    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
+  }
+
   // Whitelist: copy only editable fields from the client payload. Anything
   // else the client sends (rating, numTimesSaved, views, userId, _id, …) is
   // ignored.
@@ -288,12 +326,16 @@ router.put('/editRecipe', verifyToken, requireActive, asyncHandler(async (req, r
     ...pickFields(body, EDITABLE_RECIPE_FIELDS),
     editedAt: Date.now().toString(),
   }
+  if (verdict.severity === 'medium') update.status = 'pending_review'
 
   const updated = await db.collection('recipes').findOneAndUpdate(
     recipeIdQuery(recipeId),
     { $set: update },
     { returnDocument: 'after' }
   )
+  if (verdict.severity === 'medium') {
+    await holdRecipeForReview(db, { recipeId, title: body.title, verdict })
+  }
   res.json(updated)
 }))
 

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -9,7 +9,7 @@ const { recordAudit } = require('../util/auditLog')
 const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
 const { moderateText } = require('../util/textModeration')
-const { gatherRecipeText, holdRecipeForReview, BLOCKED_MESSAGE, BLOCKED_CODE } = require('../util/automod')
+const { gatherRecipeText, holdRecipeForReview, respondBlocked } = require('../util/automod')
 const { EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 const { teardownRecipeDocs } = require('../util/teardownRecipe')
@@ -261,15 +261,15 @@ router.post('/addRecipe', verifyToken, requireActive, asyncHandler(async (req, r
   // normally. moderateText fails open, so a moderation outage won't block creation.
   const verdict = await moderateText(gatherRecipeText(body), 'recipe')
   if (verdict.severity === 'high') {
-    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
+    return respondBlocked(res)
   }
-  const pendingReview = verdict.severity === 'medium'
 
   // Whitelist the insert (mirrors the edit path): only creatable fields are
   // copied from the client, and the server stamps _id, userId, a zeroed rating
   // and counters. Anything else the client sends — `status`, `featured`, a
   // forged rating/counter — is ignored, so a recipe can never be born hidden,
-  // featured, or pre-rated.
+  // featured, or pre-rated. The medium-hold status is NOT set here; holdRecipeForReview
+  // owns it (and only flips it once the admin-queue report is filed).
   const newId = new ObjectId()
   const docToInsert = {
     ...pickFields(body, CREATABLE_RECIPE_FIELDS),
@@ -280,15 +280,15 @@ router.post('/addRecipe', verifyToken, requireActive, asyncHandler(async (req, r
     numTimesMade: 0,
     views: 0,
   }
-  if (pendingReview) docToInsert.status = 'pending_review'
   await db.collection('recipes').insertOne(docToInsert)
   await db.collection('userRecipeData').updateOne(
     { _id: uid },
     { $push: { userRecipes: { recipeId: newId } } },
     { upsert: true }
   )
-  if (pendingReview) {
-    await holdRecipeForReview(db, { recipeId: newId, title: body.title, verdict })
+  let pendingReview = false
+  if (verdict.severity === 'medium') {
+    pendingReview = await holdRecipeForReview(db, { recipeId: newId, title: body.title, verdict })
   }
   res.status(201).json({ _id: newId, pendingReview })
 }))
@@ -328,12 +328,13 @@ router.put('/editRecipe', verifyToken, requireActive, asyncHandler(async (req, r
   // admin clears those (the edit just stops adding new flags).
   const verdict = await moderateText(gatherRecipeText(body), 'recipe')
   if (verdict.severity === 'high') {
-    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
+    return respondBlocked(res)
   }
 
   // Whitelist: copy only editable fields from the client payload. Anything
   // else the client sends (rating, numTimesSaved, views, userId, _id, …) is
-  // ignored.
+  // ignored. The hold status is NOT set here — holdRecipeForReview owns it, so
+  // the recipe is only hidden once its admin-queue report exists.
   const update = {
     ...pickFields(body, EDITABLE_RECIPE_FIELDS),
     editedAt: Date.now().toString(),
@@ -343,16 +344,21 @@ router.put('/editRecipe', verifyToken, requireActive, asyncHandler(async (req, r
   // it back to the weaker, owner-visible pending state (only an admin clears a
   // takedown). Re-holding an already-pending/active recipe is fine.
   const TAKEDOWN_STATUSES = ['hidden', 'unpublished']
-  const hold = verdict.severity === 'medium' && !TAKEDOWN_STATUSES.includes(recipe.status)
-  if (hold) update.status = 'pending_review'
+  const shouldHold = verdict.severity === 'medium' && !TAKEDOWN_STATUSES.includes(recipe.status)
 
   const updated = await db.collection('recipes').findOneAndUpdate(
     recipeIdQuery(recipeId),
     { $set: update },
     { returnDocument: 'after' }
   )
-  if (hold) {
-    await holdRecipeForReview(db, { recipeId, title: body.title, verdict })
+  // The recipe can be deleted between the ownership check and this update; don't
+  // 200 with a null body (and don't file a report against a recipe that's gone).
+  if (!updated) {
+    return res.status(404).json({ error: 'Recipe not found' })
+  }
+  if (shouldHold) {
+    const held = await holdRecipeForReview(db, { recipeId, title: body.title, verdict })
+    if (held) updated.status = 'pending_review'
   }
   res.json(updated)
 }))

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -10,7 +10,7 @@ const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
 const { moderateText } = require('../util/textModeration')
 const { gatherRecipeText, holdRecipeForReview, BLOCKED_MESSAGE, BLOCKED_CODE } = require('../util/automod')
-const { EDITABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
+const { EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 const { teardownRecipeDocs } = require('../util/teardownRecipe')
 
@@ -265,9 +265,21 @@ router.post('/addRecipe', verifyToken, requireActive, asyncHandler(async (req, r
   }
   const pendingReview = verdict.severity === 'medium'
 
-  // Server stamps _id, userId, and counters — client-supplied values are discarded
+  // Whitelist the insert (mirrors the edit path): only creatable fields are
+  // copied from the client, and the server stamps _id, userId, a zeroed rating
+  // and counters. Anything else the client sends — `status`, `featured`, a
+  // forged rating/counter — is ignored, so a recipe can never be born hidden,
+  // featured, or pre-rated.
   const newId = new ObjectId()
-  const docToInsert = { ...body, _id: newId, userId: uid, numTimesSaved: 0, numTimesMade: 0, views: 0 }
+  const docToInsert = {
+    ...pickFields(body, CREATABLE_RECIPE_FIELDS),
+    _id: newId,
+    userId: uid,
+    rating: { rateCount: 0, rateValue: 0 },
+    numTimesSaved: 0,
+    numTimesMade: 0,
+    views: 0,
+  }
   if (pendingReview) docToInsert.status = 'pending_review'
   await db.collection('recipes').insertOne(docToInsert)
   await db.collection('userRecipeData').updateOne(
@@ -326,14 +338,20 @@ router.put('/editRecipe', verifyToken, requireActive, asyncHandler(async (req, r
     ...pickFields(body, EDITABLE_RECIPE_FIELDS),
     editedAt: Date.now().toString(),
   }
-  if (verdict.severity === 'medium') update.status = 'pending_review'
+  // Medium → re-hold as 'pending_review', BUT never downgrade an admin takedown:
+  // if the recipe is already 'hidden'/'unpublished', an owner edit must not lift
+  // it back to the weaker, owner-visible pending state (only an admin clears a
+  // takedown). Re-holding an already-pending/active recipe is fine.
+  const TAKEDOWN_STATUSES = ['hidden', 'unpublished']
+  const hold = verdict.severity === 'medium' && !TAKEDOWN_STATUSES.includes(recipe.status)
+  if (hold) update.status = 'pending_review'
 
   const updated = await db.collection('recipes').findOneAndUpdate(
     recipeIdQuery(recipeId),
     { $set: update },
     { returnDocument: 'after' }
   )
-  if (verdict.severity === 'medium') {
+  if (hold) {
     await holdRecipeForReview(db, { recipeId, title: body.title, verdict })
   }
   res.json(updated)

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -10,7 +10,7 @@ const { recomputeRecipeRating } = require('../util/recipeRating')
 const { upsertWithDupRetry } = require('../util/upsertWithDupRetry')
 const { notifyInBackground, notifyReviewTakenDown } = require('../util/email')
 const { moderateText } = require('../util/textModeration')
-const { BLOCKED_MESSAGE, BLOCKED_CODE } = require('../util/automod')
+const { respondBlocked } = require('../util/automod')
 
 const router = Router()
 
@@ -79,7 +79,7 @@ router.post('/newReview', verifyToken, requireActive, asyncHandler(async (req, r
   // `allowed` is true only for a clean verdict.
   const verdict = await moderateText(reviewText, 'review')
   if (!verdict.allowed) {
-    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
+    return respondBlocked(res)
   }
 
   const usernameDoc = await db.collection('usernames').findOne({ _id: userId })
@@ -135,7 +135,7 @@ router.post('/editReview', verifyToken, requireActive, asyncHandler(async (req, 
   }
   const verdict = await moderateText(text, 'review')
   if (!verdict.allowed) {
-    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
+    return respondBlocked(res)
   }
   // Keyed by the stable uid (D1): only the author (req.uid) can match their own
   // doc, so a non-author falls through to matchedCount 0 → 403 below.

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -9,6 +9,8 @@ const { recordAudit } = require('../util/auditLog')
 const { recomputeRecipeRating } = require('../util/recipeRating')
 const { upsertWithDupRetry } = require('../util/upsertWithDupRetry')
 const { notifyInBackground, notifyReviewTakenDown } = require('../util/email')
+const { moderateText } = require('../util/textModeration')
+const { BLOCKED_MESSAGE, BLOCKED_CODE } = require('../util/automod')
 
 const router = Router()
 
@@ -72,6 +74,14 @@ router.post('/newReview', verifyToken, requireActive, asyncHandler(async (req, r
     return res.status(400).json({ error: `Review cannot exceed ${DESCRIPTION_MAX_LENGTH} characters` })
   }
 
+  // Reviews are short and author-only; there's no useful owner-only "pending"
+  // state, so BOTH high and medium confidence block inline (ask to rephrase).
+  // `allowed` is true only for a clean verdict.
+  const verdict = await moderateText(reviewText, 'review')
+  if (!verdict.allowed) {
+    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
+  }
+
   const usernameDoc = await db.collection('usernames').findOne({ _id: userId })
   if (!usernameDoc) return res.status(400).json({ error: 'Username not found for this user' })
   const { username } = usernameDoc
@@ -122,6 +132,10 @@ router.post('/editReview', verifyToken, requireActive, asyncHandler(async (req, 
   }
   if (text.length > DESCRIPTION_MAX_LENGTH) {
     return res.status(400).json({ error: `Review cannot exceed ${DESCRIPTION_MAX_LENGTH} characters` })
+  }
+  const verdict = await moderateText(text, 'review')
+  if (!verdict.allowed) {
+    return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
   }
   // Keyed by the stable uid (D1): only the author (req.uid) can match their own
   // doc, so a non-author falls through to matchedCount 0 → 403 below.

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -4,7 +4,7 @@ const { getDB } = require('../db')
 const { verifyToken } = require('../middleware/auth')
 const { recipeIdInQuery } = require('../util/recipeIdQuery')
 const { getAccountCountsFor } = require('../util/accountCounts')
-const { RECIPE_VISIBLE } = require('../util/moderation')
+const { RECIPE_VISIBLE, RECIPE_OWNER_VISIBLE } = require('../util/moderation')
 
 const router = Router()
 
@@ -23,8 +23,10 @@ router.get('/getCreatedRecipes', verifyToken, asyncHandler(async (req, res) => {
   const perPage = Math.min(parseInt(recipesPerPage) || 6, MAX_PER_PAGE)
 
   const collection = db.collection('recipes')
-  // Don't surface soft-hidden recipes in the author's own created list.
-  const filter = { userId: uid, ...RECIPE_VISIBLE }
+  // The author's own created list: exclude takedowns/de-publishes, but DO show
+  // their own 'pending_review' recipes (owner-visible) so a held recipe isn't
+  // silently missing from their account while it awaits moderation.
+  const filter = { userId: uid, ...RECIPE_OWNER_VISIBLE }
   const [recipes, totalCount] = await Promise.all([
     collection
       .find(filter)

--- a/server/util/auditLog.js
+++ b/server/util/auditLog.js
@@ -12,6 +12,9 @@ const AUDIT_ACTIONS = [
   'recipe.unfeature',
   'review.takedown',
   'review.restore',
+  // Automated moderation: a classifier put a recipe into pending_review (held
+  // from public reads until a human clears it). Credited to the system actor.
+  'recipe.autohold',
   'user.suspend',
   'user.ban',
   'user.activate',
@@ -25,6 +28,12 @@ const AUDIT_ACTIONS = [
 
 const AUDIT_TARGET_TYPES = ['recipe', 'review', 'user', 'report', 'bugReport']
 
+// Reserved synthetic actor for automated (non-human) moderation actions. Stamped
+// into auditLog/reports so the queue can visually distinguish a machine decision
+// from a human admin's, and so `actorUid` analytics never attribute an automod
+// action to a real admin. The uid is an obviously-non-Firebase sentinel.
+const SYSTEM_ACTOR = { uid: 'system:automod', type: 'system' }
+
 /**
  * Append one immutable entry to the `auditLog` collection describing an admin
  * action. Deliberately best-effort: a logging failure must never break the
@@ -34,7 +43,8 @@ const AUDIT_TARGET_TYPES = ['recipe', 'review', 'user', 'report', 'bugReport']
  * @param {import('mongodb').Db} db
  * @param {object} entry
  * @param {string} entry.action       one of AUDIT_ACTIONS
- * @param {string} entry.actorUid     admin uid performing the action
+ * @param {string} entry.actorUid     admin uid performing the action (or SYSTEM_ACTOR.uid)
+ * @param {string} [entry.actorType]  'admin' (default) | 'system' — machine vs human
  * @param {string} entry.targetType   one of AUDIT_TARGET_TYPES
  * @param {string} entry.targetId     recipeId / uid / reportId (or username+recipeId for reviews)
  * @param {string} [entry.targetLabel] human-readable label captured at action time (recipe title, @username)
@@ -47,6 +57,7 @@ async function recordAudit(db, entry) {
       _id: new ObjectId(),
       action: entry.action,
       actorUid: entry.actorUid,
+      actorType: entry.actorType || 'admin',
       targetType: entry.targetType,
       targetId: entry.targetId != null ? String(entry.targetId) : null,
       targetLabel: entry.targetLabel || null,
@@ -75,6 +86,7 @@ async function recordAuditMany(db, entries) {
         _id: new ObjectId(),
         action: entry.action,
         actorUid: entry.actorUid,
+        actorType: entry.actorType || 'admin',
         targetType: entry.targetType,
         targetId: entry.targetId != null ? String(entry.targetId) : null,
         targetLabel: entry.targetLabel || null,
@@ -88,4 +100,4 @@ async function recordAuditMany(db, entries) {
   }
 }
 
-module.exports = { recordAudit, recordAuditMany, AUDIT_ACTIONS, AUDIT_TARGET_TYPES }
+module.exports = { recordAudit, recordAuditMany, AUDIT_ACTIONS, AUDIT_TARGET_TYPES, SYSTEM_ACTOR }

--- a/server/util/automod.js
+++ b/server/util/automod.js
@@ -16,22 +16,53 @@ const BLOCKED_MESSAGE =
 const BLOCKED_CODE = 'CONTENT_BLOCKED'
 
 // Flatten a recipe payload's user-controlled text into one blob for a single
-// classifier pass (one API call per recipe, not one per field). Defensive about
-// shape: ingredients may carry `ingredient` or `name`; instructions may be
-// strings or `{ step }`; tags may be strings or `{ text }`.
+// classifier pass (one API call per recipe, not one per field).
+//
+// Must match the SHAPES THE CLIENT ACTUALLY SENDS (src/types.ts), or whole
+// fields silently go unmoderated:
+//   - ingredients[] are parsed rows ({ parsedIngredient: { originalIngredientString,
+//     ingredient, comment, … }, ingredientData, id }) OR section-header labels
+//     ({ label, id }). The verbatim line the user typed lives in
+//     `parsedIngredient.originalIngredientString`.
+//   - instructions[] are step rows ({ content, index, id }) OR labels ({ label, id }).
+//   - There is no `tags` field on recipes today; the loop is kept for forward-compat.
+// Older/test shapes (`ingredient`/`name`, `step`, plain strings, `text`) are still
+// accepted defensively, but the real keys above are what production exercises.
 function gatherRecipeText(body = {}) {
   const parts = []
-  if (typeof body.title === 'string') parts.push(body.title)
-  if (typeof body.description === 'string') parts.push(body.description)
+  const push = (v) => { if (typeof v === 'string') parts.push(v) }
+
+  push(body.title)
+  push(body.description)
+
   for (const ing of body.ingredients || []) {
-    parts.push((ing && (ing.ingredient || ing.name)) || '')
+    if (!ing) continue
+    if (typeof ing === 'string') { parts.push(ing); continue }
+    push(ing.label) // section-header row (LabelType)
+    if (ing.parsedIngredient) {
+      push(ing.parsedIngredient.originalIngredientString) // the verbatim typed line
+      push(ing.parsedIngredient.ingredient)
+      push(ing.parsedIngredient.comment)
+    }
+    push(ing.ingredient) // defensive (older/alternate shapes)
+    push(ing.name)
   }
+
   for (const step of body.instructions || []) {
-    parts.push(typeof step === 'string' ? step : (step && step.step) || '')
+    if (!step) continue
+    if (typeof step === 'string') { parts.push(step); continue }
+    push(step.content) // step row (InstructionsType)
+    push(step.label) // section-header row (LabelType)
+    push(step.step) // defensive
   }
+
   for (const tag of body.tags || []) {
-    parts.push(typeof tag === 'string' ? tag : (tag && tag.text) || '')
+    if (!tag) continue
+    if (typeof tag === 'string') { parts.push(tag); continue }
+    push(tag.label)
+    push(tag.text)
   }
+
   return parts.filter(Boolean).join('\n')
 }
 

--- a/server/util/automod.js
+++ b/server/util/automod.js
@@ -1,0 +1,99 @@
+// Route-facing helpers that connect the text classifier (util/textModeration) to
+// the EXISTING reactive moderation pipeline (reports + status + auditLog), so an
+// automated decision does exactly what an admin action does today — no parallel
+// state. Used by the recipe write routes; reviews/profile block inline and need
+// none of this.
+
+const { ObjectId } = require('mongodb')
+const { recordAudit, SYSTEM_ACTOR } = require('./auditLog')
+
+// Friendly, surface-agnostic message returned on a high-confidence block. It
+// deliberately does NOT echo the matched term/category (don't coach evasion, and
+// don't repeat a slur back to the user). Routes pair it with `code` so the FE can
+// branch without string-matching.
+const BLOCKED_MESSAGE =
+  "This content was flagged by our automated moderation system and can't be published. Please review our content guidelines and edit your submission."
+const BLOCKED_CODE = 'CONTENT_BLOCKED'
+
+// Flatten a recipe payload's user-controlled text into one blob for a single
+// classifier pass (one API call per recipe, not one per field). Defensive about
+// shape: ingredients may carry `ingredient` or `name`; instructions may be
+// strings or `{ step }`; tags may be strings or `{ text }`.
+function gatherRecipeText(body = {}) {
+  const parts = []
+  if (typeof body.title === 'string') parts.push(body.title)
+  if (typeof body.description === 'string') parts.push(body.description)
+  for (const ing of body.ingredients || []) {
+    parts.push((ing && (ing.ingredient || ing.name)) || '')
+  }
+  for (const step of body.instructions || []) {
+    parts.push(typeof step === 'string' ? step : (step && step.step) || '')
+  }
+  for (const tag of body.tags || []) {
+    parts.push(typeof tag === 'string' ? tag : (tag && tag.text) || '')
+  }
+  return parts.filter(Boolean).join('\n')
+}
+
+/**
+ * Record a medium-confidence automated hold on a recipe: file an OPEN report into
+ * the admin queue (credited to the system actor) and append an audit entry. The
+ * caller is responsible for stamping `status: 'pending_review'` on the recipe doc
+ * itself — this only writes the queue/audit side effects.
+ *
+ * Idempotent on the report: re-holding the same recipe (e.g. owner re-edits while
+ * still pending) upserts the single open automod report instead of stacking
+ * duplicates, mirroring the one-open-report-per-(reporter,target) rule in
+ * routes/reports.js.
+ *
+ * Best-effort, like recordAudit/email: never throws into the write route.
+ *
+ * @param {import('mongodb').Db} db
+ * @param {object} args
+ * @param {string} args.recipeId
+ * @param {string} [args.title]   recipe title, for the audit label
+ * @param {object} args.verdict   the moderateText() result (severity/reason/category/source)
+ */
+async function holdRecipeForReview(db, { recipeId, title, verdict }) {
+  const id = String(recipeId)
+  try {
+    await db.collection('reports').updateOne(
+      { targetType: 'recipe', recipeId: id, reporterUid: SYSTEM_ACTOR.uid, status: 'open' },
+      {
+        $setOnInsert: {
+          _id: new ObjectId(),
+          targetType: 'recipe',
+          recipeId: id,
+          reporterUid: SYSTEM_ACTOR.uid,
+          reason: 'inappropriate',
+          details: `Automated moderation hold (${verdict.reason || verdict.severity}).`,
+          status: 'open',
+          source: 'automod',
+          classifier: {
+            severity: verdict.severity,
+            category: verdict.category || null,
+            reason: verdict.reason || null,
+            source: verdict.source || null,
+          },
+          createdAt: new Date(),
+        },
+      },
+      { upsert: true }
+    )
+  } catch (err) {
+    console.error('holdRecipeForReview: failed to file automod report:', err.message)
+  }
+
+  await recordAudit(db, {
+    action: 'recipe.autohold',
+    actorUid: SYSTEM_ACTOR.uid,
+    actorType: SYSTEM_ACTOR.type,
+    targetType: 'recipe',
+    targetId: id,
+    targetLabel: title || null,
+    reason: verdict.reason || null,
+    metadata: { severity: verdict.severity, category: verdict.category || null, source: verdict.source || null },
+  })
+}
+
+module.exports = { BLOCKED_MESSAGE, BLOCKED_CODE, gatherRecipeText, holdRecipeForReview }

--- a/server/util/automod.js
+++ b/server/util/automod.js
@@ -6,6 +6,7 @@
 
 const { ObjectId } = require('mongodb')
 const { recordAudit, SYSTEM_ACTOR } = require('./auditLog')
+const { recipeIdQuery } = require('./recipeIdQuery')
 
 // Friendly, surface-agnostic message returned on a high-confidence block. It
 // deliberately does NOT echo the matched term/category (don't coach evasion, and
@@ -14,6 +15,13 @@ const { recordAudit, SYSTEM_ACTOR } = require('./auditLog')
 const BLOCKED_MESSAGE =
   "This content was flagged by our automated moderation system and can't be published. Please review our content guidelines and edit your submission."
 const BLOCKED_CODE = 'CONTENT_BLOCKED'
+
+// Single owner of the high-confidence block response, so the 422 contract (status
+// + body shape the FE keys on) lives in one place instead of being re-typed at
+// every write route.
+function respondBlocked(res) {
+  return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
+}
 
 // Flatten a recipe payload's user-controlled text into one blob for a single
 // classifier pass (one API call per recipe, not one per field).
@@ -67,23 +75,28 @@ function gatherRecipeText(body = {}) {
 }
 
 /**
- * Record a medium-confidence automated hold on a recipe: file an OPEN report into
- * the admin queue (credited to the system actor) and append an audit entry. The
- * caller is responsible for stamping `status: 'pending_review'` on the recipe doc
- * itself — this only writes the queue/audit side effects.
+ * Place a medium-confidence automated hold on a recipe, as one report-gated unit:
+ *   1. file the OPEN admin-queue report (credited to the system actor),
+ *   2. only then flip the recipe to `status: 'pending_review'`,
+ *   3. append the `recipe.autohold` audit entry.
+ *
+ * Ordering matters: the recipe is hidden from public reads ONLY after its queue
+ * entry exists, so we can never end up with a recipe that has silently vanished
+ * with nothing for an admin to clear. If the report write fails the recipe is
+ * left visible (fail-open, consistent with the text classifier) and the caller
+ * is told the hold did not take.
  *
  * Idempotent on the report: re-holding the same recipe (e.g. owner re-edits while
  * still pending) upserts the single open automod report instead of stacking
  * duplicates, mirroring the one-open-report-per-(reporter,target) rule in
  * routes/reports.js.
  *
- * Best-effort, like recordAudit/email: never throws into the write route.
- *
  * @param {import('mongodb').Db} db
  * @param {object} args
  * @param {string} args.recipeId
  * @param {string} [args.title]   recipe title, for the audit label
  * @param {object} args.verdict   the moderateText() result (severity/reason/category/source)
+ * @returns {Promise<boolean>}    true if the recipe was actually held
  */
 async function holdRecipeForReview(db, { recipeId, title, verdict }) {
   const id = String(recipeId)
@@ -112,7 +125,20 @@ async function holdRecipeForReview(db, { recipeId, title, verdict }) {
       { upsert: true }
     )
   } catch (err) {
-    console.error('holdRecipeForReview: failed to file automod report:', err.message)
+    // Queue entry could not be created → do NOT hide the recipe. Better to leave
+    // a borderline recipe momentarily visible than to disappear it with no way
+    // for an admin to find and clear it.
+    console.error('holdRecipeForReview: failed to file automod report — leaving recipe visible:', err.message)
+    return false
+  }
+
+  // The queue entry now exists, so it is safe to withhold the recipe from public
+  // reads. A failure here leaves the report in place (an admin can still act), so
+  // it's logged but not fatal.
+  try {
+    await db.collection('recipes').updateOne(recipeIdQuery(id), { $set: { status: 'pending_review' } })
+  } catch (err) {
+    console.error('holdRecipeForReview: report filed but failed to set pending_review:', err.message)
   }
 
   await recordAudit(db, {
@@ -125,6 +151,7 @@ async function holdRecipeForReview(db, { recipeId, title, verdict }) {
     reason: verdict.reason || null,
     metadata: { severity: verdict.severity, category: verdict.category || null, source: verdict.source || null },
   })
+  return true
 }
 
-module.exports = { BLOCKED_MESSAGE, BLOCKED_CODE, gatherRecipeText, holdRecipeForReview }
+module.exports = { BLOCKED_MESSAGE, BLOCKED_CODE, respondBlocked, gatherRecipeText, holdRecipeForReview }

--- a/server/util/moderation.js
+++ b/server/util/moderation.js
@@ -11,17 +11,25 @@
 // The keys (`status` / `moderationHidden`) never collide with query fields used
 // elsewhere, so the spread ANDs cleanly.
 
-// Recipes: non-public via the `status` enum. 'hidden' = a P1 moderation takedown
-// (reported/policy); 'unpublished' = a P2 admin de-publish that is deliberately
-// NOT framed as a moderation action. Both are filtered from every public read
-// path identically; they differ only in intent and which admin field is stamped.
-// $nin (not $eq 'active') keeps this legacy-safe — a doc with no status field
-// isn't matched, so the existing catalog stays visible on deploy.
-const RECIPE_VISIBLE = { status: { $nin: ['hidden', 'unpublished'] } }
+// Recipes: non-public via the `status` enum. 'hidden' = a moderation takedown
+// (reported/policy); 'unpublished' = an admin de-publish that is deliberately
+// NOT framed as a moderation action; 'pending_review' = an automated-moderation
+// hold (owner + moderator can see it, the public cannot) awaiting a human clear.
+// All three are filtered from every PUBLIC read path identically; they differ
+// only in intent and which field is stamped. $nin (not $eq 'active') keeps this
+// legacy-safe — a doc with no status field isn't matched, so the existing catalog
+// stays visible on deploy.
+const RECIPE_VISIBLE = { status: { $nin: ['hidden', 'unpublished', 'pending_review'] } }
+
+// Owner-facing variant: the author still sees their own 'pending_review' recipe
+// (e.g. in their created list / own recipe view) while it is withheld from every
+// public surface above. 'hidden'/'unpublished' remain excluded even for the owner.
+// Use this ONLY on reads already scoped to the owning user (userId === req.uid).
+const RECIPE_OWNER_VISIBLE = { status: { $nin: ['hidden', 'unpublished'] } }
 
 // Reviews live in the `ratings` collection and are hidden via a distinct
 // `moderationHidden` flag — kept separate from the user's own delete (which
 // blanks reviewText) so a takedown is reversible and auditable.
 const REVIEW_VISIBLE = { moderationHidden: { $ne: true } }
 
-module.exports = { RECIPE_VISIBLE, REVIEW_VISIBLE }
+module.exports = { RECIPE_VISIBLE, RECIPE_OWNER_VISIBLE, REVIEW_VISIBLE }

--- a/server/util/moderationBlocklist.js
+++ b/server/util/moderationBlocklist.js
@@ -1,0 +1,93 @@
+// Curated zeroth-pass blocklist for text moderation.
+//
+// This runs BEFORE (and independently of) the OpenAI Moderation API, so it still
+// catches the most blatant content when the classifier is disabled or down. It is
+// deliberately small and high-precision: a blocklist hit is treated as
+// high-confidence and FAIL-CLOSED (blocked even on API error), so false positives
+// here are expensive. Broad / contextual judgement is left to the API layer.
+//
+// Two kinds of rule:
+//   - `SLUR_TERMS`   — exact normalized-token matches (so "sh1t"/"f4g" obfuscation
+//                      is caught) without the Scunthorpe problem of substring scans.
+//   - `SPAM_PATTERNS` — regexes for promotional / link-dropping abuse. Some only
+//                      apply to short identity fields (username/displayName), where
+//                      a URL or "buy now" is never legitimate.
+//
+// Extend the lists in place; the matching logic below should not need to change.
+
+// Normalize a single token for slur matching: lowercase, fold common leetspeak,
+// collapse 3+ repeated chars to one, and drop anything non-alphanumeric. This
+// makes "F.U.C.K", "fuuuck", and "f4ck" all normalize to the same stem.
+const LEET_MAP = { '0': 'o', '1': 'i', '3': 'e', '4': 'a', '5': 's', '7': 't', '@': 'a', $: 's' }
+
+function normalizeToken(token) {
+  return String(token)
+    .toLowerCase()
+    .replace(/[01345 7@$]/g, (c) => LEET_MAP[c] || c)
+    .replace(/(.)\1{2,}/g, '$1')
+    .replace(/[^a-z0-9]/g, '')
+}
+
+// Split arbitrary text into candidate tokens on any non-alphanumeric run.
+function tokenize(text) {
+  return String(text).split(/[^a-zA-Z0-9@$]+/).filter(Boolean)
+}
+
+// Slur stems, stored already-normalized. Keep this list tight and obvious; the
+// API layer handles the long tail and anything context-dependent. (Starter set —
+// extend with the product's policy list.)
+const SLUR_TERMS = new Set(
+  [
+    'fuck',
+    'shit',
+    'bitch',
+    'cunt',
+    'asshole',
+    'nigger',
+    'faggot',
+    'retard',
+    'whore',
+    'slut',
+  ].map(normalizeToken)
+)
+
+// Spam / promotional patterns. `identityOnly: true` rules apply only to short
+// identity fields (username, displayName) where any URL or call-to-action is abuse;
+// they are NOT applied to recipe bodies or reviews, which legitimately contain
+// links and prose.
+const SPAM_PATTERNS = [
+  { re: /\bhttps?:\/\/|www\.[a-z0-9-]+\.[a-z]{2,}/i, label: 'url', identityOnly: true },
+  { re: /[a-z0-9-]+\.(com|net|org|io|ru|xyz|shop)\b/i, label: 'domain', identityOnly: true },
+  { re: /\b(buy|order|shop)\s+now\b/i, label: 'buy-now', identityOnly: false },
+  { re: /\b(free|cheap)\s+(viagra|cialis|crypto|bitcoin|followers)\b/i, label: 'spam-offer', identityOnly: false },
+]
+
+// Short identity fields get the stricter (identityOnly) spam rules too.
+const IDENTITY_CONTEXTS = new Set(['username', 'displayName'])
+
+/**
+ * Scan `text` for a blocklist hit. Returns the first match as
+ * `{ term, kind }` (kind: 'slur' | 'spam'), or null when clean.
+ *
+ * @param {string} text
+ * @param {string} [context]  field context, e.g. 'username' | 'recipe.title' | 'review'
+ */
+function checkBlocklist(text, context = '') {
+  if (!text || typeof text !== 'string') return null
+
+  for (const token of tokenize(text)) {
+    if (SLUR_TERMS.has(normalizeToken(token))) {
+      return { term: normalizeToken(token), kind: 'slur' }
+    }
+  }
+
+  const isIdentity = IDENTITY_CONTEXTS.has(context)
+  for (const { re, label, identityOnly } of SPAM_PATTERNS) {
+    if (identityOnly && !isIdentity) continue
+    if (re.test(text)) return { term: label, kind: 'spam' }
+  }
+
+  return null
+}
+
+module.exports = { checkBlocklist, normalizeToken, SLUR_TERMS, SPAM_PATTERNS }

--- a/server/util/moderationBlocklist.js
+++ b/server/util/moderationBlocklist.js
@@ -62,7 +62,15 @@ const SPAM_PATTERNS = [
   { re: /\b(free|cheap)\s+(viagra|cialis|crypto|bitcoin|followers)\b/i, label: 'spam-offer', identityOnly: false },
 ]
 
-// Short identity fields get the stricter (identityOnly) spam rules too.
+// Short identity fields get the stricter (identityOnly) spam rules too: a URL or
+// bare domain in a username/displayName is never legitimate.
+//
+// `bio`/`location` (context 'profile') are DELIBERATELY excluded. A bio is prose,
+// and a recipe author linking their own blog/socials is legitimate, so blocking
+// every URL there would be user-hostile. Bios are still covered by the
+// non-identity spam patterns (promotional "buy now" / "free crypto" phrasing) and
+// by the OpenAI layer. If bio link-spam becomes a real problem, add 'profile'
+// here — that's the single switch that makes bios reject URLs/domains too.
 const IDENTITY_CONTEXTS = new Set(['username', 'displayName'])
 
 /**

--- a/server/util/recipeFields.js
+++ b/server/util/recipeFields.js
@@ -27,6 +27,18 @@ const EDITABLE_RECIPE_FIELDS = [
   'totalTime',
 ]
 
+// Creating a recipe additionally accepts the author snapshot and timestamps the
+// client supplies. The server still stamps _id/userId, zeroes the social
+// counters, and seeds the rating itself — so curation/moderation flags
+// (`status`, `featured`) and any other unlisted key the client sends are
+// ignored on create, exactly as the edit whitelist ignores them on update.
+const CREATABLE_RECIPE_FIELDS = [
+  ...EDITABLE_RECIPE_FIELDS,
+  'authorUsername',
+  'createdAt',
+  'editedAt',
+]
+
 // Copy only the whitelisted keys that are present in `body`. Absent keys are
 // left out (callers merge via $set), so a field the client doesn't send is
 // untouched rather than overwritten.
@@ -38,4 +50,4 @@ function pickFields(body, fields) {
   return out
 }
 
-module.exports = { RECIPE_CONTENT_FIELDS, EDITABLE_RECIPE_FIELDS, pickFields }
+module.exports = { RECIPE_CONTENT_FIELDS, EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields }

--- a/server/util/textModeration.js
+++ b/server/util/textModeration.js
@@ -75,7 +75,10 @@ function grade(result) {
 
   if (topScore >= highThreshold()) return { severity: 'high', category: topCategory, score: topScore }
   if (result.flagged || topScore >= mediumThreshold()) {
-    return { severity: 'medium', category: topCategory, score: topScore }
+    // `flagged` can be true with no usable per-category score (empty/zero
+    // category_scores). Fall back to a non-null category so the verdict reason
+    // never reads `openai:null:0.00`.
+    return { severity: 'medium', category: topCategory || 'flagged', score: topScore }
   }
   return { severity: 'clean', category: topCategory, score: topScore }
 }

--- a/server/util/textModeration.js
+++ b/server/util/textModeration.js
@@ -1,0 +1,155 @@
+// Thin, swappable, env-gated text classifier — the single entry point every
+// write route calls before persisting user text. Mirrors util/email.js:
+//   - Reads config from the environment on every call (tests can toggle it).
+//   - No-ops to a CLEAN verdict when no provider is configured, so local/CI runs
+//     need no external key.
+//
+// Two layers, cheapest first:
+//   1. Curated blocklist (util/moderationBlocklist) — always runs, even when the
+//      API is disabled or down. A hit is HIGH severity and FAIL-CLOSED.
+//   2. OpenAI Moderation API (free, purpose-built) — graded into high/medium/clean.
+//      Transient failures FAIL-OPEN (logged, treated as clean) so a moderation
+//      outage can't block all content creation.
+//
+// Returns a verdict the route interprets per surface:
+//   { allowed, severity, reason, category, scores, source }
+//     severity : 'clean' | 'medium' | 'high'
+//     allowed  : true only when severity === 'clean'
+//     source   : 'blocklist' | 'openai' | 'disabled' | 'error'
+
+const { checkBlocklist } = require('./moderationBlocklist')
+
+const MODERATION_URL = 'https://api.openai.com/v1/moderations'
+const MODERATION_MODEL = 'omni-moderation-latest'
+const REQUEST_TIMEOUT_MS = 5000
+
+// Enabled only when a key is present AND not explicitly killed — same shape as
+// email.js's emailEnabled(). Read live (not cached) so tests can flip it.
+function moderationEnabled() {
+  if (process.env.MODERATION_ENABLED === 'false') return false
+  return !!process.env.OPENAI_API_KEY
+}
+
+// Score thresholds, env-overridable for tuning without a redeploy.
+function highThreshold() {
+  const v = parseFloat(process.env.MODERATION_HIGH_THRESHOLD)
+  return Number.isFinite(v) ? v : 0.85
+}
+function mediumThreshold() {
+  const v = parseFloat(process.env.MODERATION_MEDIUM_THRESHOLD)
+  return Number.isFinite(v) ? v : 0.5
+}
+
+// Categories that are treated as HIGH the moment the API flags them at all,
+// regardless of score — sexual content involving minors is never a "hold for
+// review" judgement call. (`sexual/minors` is the omni-moderation category name.)
+const ALWAYS_HIGH_CATEGORIES = new Set(['sexual/minors'])
+
+const CLEAN = { allowed: true, severity: 'clean', reason: null, category: null, scores: null, source: 'disabled' }
+
+// A clean verdict tagged with its source (so logs/tests can tell disabled from
+// classifier-said-clean from failed-open).
+function clean(source) {
+  return { ...CLEAN, source }
+}
+
+// Map an OpenAI moderation result to our severity grade.
+function grade(result) {
+  const scores = result.category_scores || {}
+  const categories = result.categories || {}
+
+  for (const cat of ALWAYS_HIGH_CATEGORIES) {
+    if (categories[cat]) {
+      return { severity: 'high', category: cat, score: scores[cat] ?? 1 }
+    }
+  }
+
+  let topCategory = null
+  let topScore = 0
+  for (const [cat, score] of Object.entries(scores)) {
+    if (score > topScore) {
+      topScore = score
+      topCategory = cat
+    }
+  }
+
+  if (topScore >= highThreshold()) return { severity: 'high', category: topCategory, score: topScore }
+  if (result.flagged || topScore >= mediumThreshold()) {
+    return { severity: 'medium', category: topCategory, score: topScore }
+  }
+  return { severity: 'clean', category: topCategory, score: topScore }
+}
+
+// Call the OpenAI Moderation endpoint with a hard timeout. Throws on network
+// error, non-2xx, or timeout — the caller fails open on any throw.
+async function callOpenAI(text) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    const res = await fetch(MODERATION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({ model: MODERATION_MODEL, input: text }),
+      signal: controller.signal,
+    })
+    if (!res.ok) throw new Error(`OpenAI moderation HTTP ${res.status}`)
+    const json = await res.json()
+    const result = json?.results?.[0]
+    if (!result) throw new Error('OpenAI moderation: empty result')
+    return result
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Classify a piece of user text.
+ *
+ * @param {string} text       the content to screen
+ * @param {string} [context]  field context ('username' | 'recipe.title' | 'review' | 'bio' | ...)
+ * @returns {Promise<{allowed:boolean, severity:'clean'|'medium'|'high', reason:string|null, category:string|null, scores:object|null, source:string}>}
+ */
+async function moderateText(text, context = '') {
+  if (!text || typeof text !== 'string' || !text.trim()) return clean('empty')
+
+  // Layer 1 — blocklist. Runs unconditionally; fail-closed.
+  const hit = checkBlocklist(text, context)
+  if (hit) {
+    return {
+      allowed: false,
+      severity: 'high',
+      reason: `blocklist:${hit.kind}:${hit.term}`,
+      category: hit.kind,
+      scores: null,
+      source: 'blocklist',
+    }
+  }
+
+  // Layer 2 — OpenAI. Skipped (clean) when disabled.
+  if (!moderationEnabled()) return clean('disabled')
+
+  let result
+  try {
+    result = await callOpenAI(text)
+  } catch (err) {
+    // Fail-open on transient classifier errors: log and allow. An outage in the
+    // moderation provider must not block all content creation.
+    console.error(`moderateText: classifier error (failing open) [${context}]:`, err.message)
+    return clean('error')
+  }
+
+  const { severity, category, score } = grade(result)
+  return {
+    allowed: severity === 'clean',
+    severity,
+    reason: severity === 'clean' ? null : `openai:${category}:${score.toFixed(2)}`,
+    category,
+    scores: result.category_scores || null,
+    source: 'openai',
+  }
+}
+
+module.exports = { moderateText, moderationEnabled, grade }

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -28,6 +28,15 @@ type EditRecipeResult =
   | { status: 'auth-error' }
   | { status: 'error'; message: string }
 
+// addRecipe mirrors EditRecipeResult so the create path can surface the same
+// things an edit can: a server moderation block (status: 'error', message) and a
+// medium-confidence hold (status: 'success', pendingReview: true) where the recipe
+// saved but is withheld from public reads until an admin clears it.
+export type AddRecipeResult =
+  | { status: 'success'; id: string; pendingReview: boolean }
+  | { status: 'auth-error' }
+  | { status: 'error'; message: string }
+
 type GetAllRecipesParams = {
   page?: number
   order?: string
@@ -198,7 +207,7 @@ class RecipeAPIClass {
   async addRecipe(
     recipeData: RecipeFormType,
     setProgress: (val: number) => void
-  ): Promise<string | null> {
+  ): Promise<AddRecipeResult> {
     try {
       setProgress(10)
       const authorUsername: string | null = await AuthAPI.getUsername()
@@ -238,14 +247,27 @@ class RecipeAPIClass {
         numTimesMade: 0,
       }
       setProgress(90)
-      const result = await http.post<{ _id: string }>('api/addRecipe', returnRecipeData)
-      return result.data._id
+      const result = await http.post<{ _id: string; pendingReview?: boolean }>(
+        'api/addRecipe',
+        returnRecipeData
+      )
+      return {
+        status: 'success',
+        id: result.data._id,
+        pendingReview: !!result.data.pendingReview,
+      }
     } catch (error: unknown) {
       console.error('addRecipe failed:', error)
-      if (axios.isAxiosError(error) && error.response?.status === 401) {
-        return ADD_RECIPE_AUTH_ERROR
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 401) return { status: 'auth-error' }
+        // Surface the server's reason (e.g. a 422 moderation block) so the user
+        // sees why the recipe was rejected instead of a generic "try again".
+        const message =
+          error.response?.data?.error ??
+          'Failed to create recipe. Please try again.'
+        return { status: 'error', message }
       }
-      return null
+      return { status: 'error', message: 'Failed to create recipe. Please try again.' }
     }
   }
 

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -33,7 +33,7 @@ import {
   MAX_INGREDIENTS,
   MAX_INSTRUCTIONS,
 } from 'src/util/recipeLimits'
-import RecipeAPI, { ADD_RECIPE_AUTH_ERROR } from 'src/api/recipes'
+import RecipeAPI from 'src/api/recipes'
 import styles from 'src/_exports.module.scss'
 import AddRecipeFormError from 'src/pages/AddRecipe/AddRecipeFormError'
 import SectionHeader from 'src/pages/AddRecipe/SectionHeader'
@@ -46,6 +46,15 @@ import DraftSaveStatus from 'src/pages/AddRecipe/DraftSaveStatus'
 import DraftResumeBanner from 'src/pages/AddRecipe/DraftResumeBanner'
 
 type TimeVal = { hours: number; minutes: number } | null
+
+// Shown when a recipe saves but is held by automated moderation for an admin to
+// review before it appears publicly. Longer-lived than a normal toast (and not
+// styled as an error — nothing went wrong) so the owner doesn't miss it.
+const notifyPendingReview = () =>
+  toast(
+    'Your recipe was submitted and is pending review. It will appear publicly once approved.',
+    { icon: '⏳', duration: 7000 }
+  )
 
 // When `initialRecipe` is supplied the form runs in edit mode: every field is
 // pre-populated from the existing recipe and submitting updates it (preserving
@@ -336,25 +345,36 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
         // list still needs a refetch to reorder/relabel.
         queryClient.setQueryData(['recipe', initialRecipe._id], result.recipe)
         queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
-        toast.success('Recipe updated!')
+        // A medium-confidence moderation hold saves the edit but withholds it from
+        // public reads until an admin clears it; tell the owner instead of the
+        // usual "updated!" so a silently-hidden recipe isn't a surprise.
+        if (result.recipe.status === 'pending_review') {
+          notifyPendingReview()
+        } else {
+          toast.success('Recipe updated!')
+        }
         navigate(`/recipes/${initialRecipe._id}`)
       } else {
         toast.error(result.message)
       }
     } else {
       const recipeData: RecipeFormType = { ...formData, recipeImage: recipeImage! }
-      const newId = await RecipeAPI.addRecipe(recipeData, setLoadingProgress)
-      if (newId === ADD_RECIPE_AUTH_ERROR) {
+      const result = await RecipeAPI.addRecipe(recipeData, setLoadingProgress)
+      if (result.status === 'auth-error') {
         toast.error('Your session has expired — please sign in again and retry.')
-      } else if (newId) {
-        // Recipe is live — remove the now-redundant draft (and stop autosave
+      } else if (result.status === 'success') {
+        // Recipe is saved — remove the now-redundant draft (and stop autosave
         // from recreating it on unmount) before navigating away.
         await clearDraft()
         queryClient.invalidateQueries({ queryKey: ['drafts'] })
-        toast.success('Recipe published!')
-        navigate(`/recipes/${newId}`)
+        if (result.pendingReview) {
+          notifyPendingReview()
+        } else {
+          toast.success('Recipe published!')
+        }
+        navigate(`/recipes/${result.id}`)
       } else {
-        toast.error('Failed to create recipe. Please try again.')
+        toast.error(result.message)
       }
     }
     setAddRecipeLoading(false)

--- a/src/pages/Settings/sections/ProfileSection.tsx
+++ b/src/pages/Settings/sections/ProfileSection.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect, useState } from 'react'
+import axios from 'axios'
 import toast from 'react-hot-toast'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from 'src/context/AuthContext'
@@ -217,7 +218,13 @@ const ProfileSection: FC = () => {
         if (err.code === 'auth/email-already-in-use') {
           toast.error('Email already in use.')
         } else {
-          toast.error(err.message || 'Something went wrong.')
+          // Prefer the server's reason (e.g. a 422 moderation block on the
+          // username, bio, or location) over axios's generic "Request failed…".
+          const message =
+            (axios.isAxiosError(err) && err.response?.data?.error) ||
+            err.message ||
+            'Something went wrong.'
+          toast.error(message)
         }
       })
   }

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/AddReview.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/AddReview.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useState } from 'react'
+import axios from 'axios'
 import RecipeAPI from 'src/api/recipes'
 import { ReviewType } from 'types'
 
@@ -37,10 +38,13 @@ const AddReview: FC<AddReviewProps> = ({
       .then(res => {
         setCurrUserReview(res ?? null)
       })
-      .catch(() => {
-        setNewReviewError(
+      .catch(error => {
+        // Surface the server's reason (e.g. a 422 moderation block) inline so the
+        // user can rephrase, falling back to the generic message otherwise.
+        const message =
+          (axios.isAxiosError(error) && error.response?.data?.error) ||
           'Something went wrong submitting your review. Please try again.'
-        )
+        setNewReviewError(message)
       })
   }
 

--- a/src/test/AddRecipe.test.tsx
+++ b/src/test/AddRecipe.test.tsx
@@ -8,10 +8,12 @@ import { MemoryRouter } from 'react-router-dom'
 import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
 import RecipeAPI from 'src/api/recipes'
 
-const { navigateFn, toastSuccess, toastError } = vi.hoisted(() => ({
+const { navigateFn, toastSuccess, toastError, toastBase } = vi.hoisted(() => ({
   navigateFn: vi.fn(),
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
+  // The base callable toast() — used for the neutral "pending review" notice.
+  toastBase: vi.fn(),
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -21,10 +23,10 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useNavigate: () => navigateFn }
 })
 
-vi.mock('react-hot-toast', () => ({
-  toast: { success: toastSuccess, error: toastError },
-  default: { success: toastSuccess, error: toastError },
-}))
+vi.mock('react-hot-toast', () => {
+  const toast = Object.assign(toastBase, { success: toastSuccess, error: toastError })
+  return { toast, default: toast }
+})
 
 vi.mock('src/api/recipes', () => ({
   default: { addRecipe: vi.fn() },
@@ -168,6 +170,7 @@ describe('AddRecipe form', () => {
     navigateFn.mockReset()
     toastSuccess.mockReset()
     toastError.mockReset()
+    toastBase.mockReset()
   })
 
   it('submit button has the "invalid" CSS class on initial empty render', () => {
@@ -279,7 +282,7 @@ describe('AddRecipe form', () => {
 
   it('clicking "Create Recipe" when valid calls RecipeAPI.addRecipe', async () => {
     const user = userEvent.setup()
-    mockAddRecipe.mockResolvedValue('new-1')
+    mockAddRecipe.mockResolvedValue({ status: 'success', id: 'new-1', pendingReview: false })
     renderAddRecipe()
     await fillAllFields(user)
     await waitFor(() =>
@@ -291,7 +294,7 @@ describe('AddRecipe form', () => {
 
   it('navigates to the new recipe page after a successful submission', async () => {
     const user = userEvent.setup()
-    mockAddRecipe.mockResolvedValue('new-1')
+    mockAddRecipe.mockResolvedValue({ status: 'success', id: 'new-1', pendingReview: false })
     renderAddRecipe()
     await fillAllFields(user)
     await waitFor(() =>
@@ -304,9 +307,28 @@ describe('AddRecipe form', () => {
     expect(toastSuccess).toHaveBeenCalledWith('Recipe published!')
   })
 
+  it('shows a pending-review notice (not "published") when the recipe is held for review', async () => {
+    const user = userEvent.setup()
+    mockAddRecipe.mockResolvedValue({ status: 'success', id: 'new-1', pendingReview: true })
+    renderAddRecipe()
+    await fillAllFields(user)
+    await waitFor(() =>
+      expect(screen.getByText('Create Recipe').closest('button')).toHaveClass('valid')
+    )
+    await user.click(screen.getByText('Create Recipe'))
+    // Still navigates to the (owner-visible) recipe, but the notice replaces the
+    // usual success toast so the owner knows it isn't public yet.
+    await waitFor(() => expect(navigateFn).toHaveBeenCalledWith('/recipes/new-1'))
+    expect(toastSuccess).not.toHaveBeenCalledWith('Recipe published!')
+    expect(toastBase).toHaveBeenCalledWith(
+      expect.stringMatching(/pending review/i),
+      expect.anything()
+    )
+  })
+
   it('shows error message when addRecipe returns null', async () => {
     const user = userEvent.setup()
-    mockAddRecipe.mockResolvedValue(null)
+    mockAddRecipe.mockResolvedValue({ status: 'error', message: 'Failed to create recipe. Please try again.' })
     renderAddRecipe()
     await fillAllFields(user)
     await waitFor(() =>
@@ -330,7 +352,7 @@ describe('AddRecipe form', () => {
     await user.click(screen.getByText('Create Recipe'))
     // After clicking, handleAddRecipe awaits addRecipe — "Create Recipe" text is replaced
     expect(screen.queryByText('Create Recipe')).toBeNull()
-    resolveAddRecipe!('new-1')
+    resolveAddRecipe!({ status: 'success', id: 'new-1', pendingReview: false })
     await waitFor(() => expect(screen.getByText('Create Recipe')).toBeInTheDocument())
   })
 
@@ -344,7 +366,7 @@ describe('AddRecipe form', () => {
 
   it('does not block submission when cookTime is absent', async () => {
     const user = userEvent.setup()
-    mockAddRecipe.mockResolvedValue('new-1')
+    mockAddRecipe.mockResolvedValue({ status: 'success', id: 'new-1', pendingReview: false })
     renderAddRecipe()
     await fillAllFields(user) // fillAllFields does not set cookTime
     await waitFor(() =>
@@ -409,7 +431,7 @@ describe('AddRecipe form', () => {
       // Loading in-flight: button should be disabled
       await waitFor(() => expect(submitBtn).toBeDisabled())
 
-      resolveAddRecipe!('new-1')
+      resolveAddRecipe!({ status: 'success', id: 'new-1', pendingReview: false })
       await waitFor(() => expect(submitBtn).not.toBeDisabled())
     })
   })
@@ -418,7 +440,7 @@ describe('AddRecipe form', () => {
   describe('error discrimination', () => {
     it('shows session-expired message on the AUTH_ERROR sentinel and does not navigate', async () => {
       const user = userEvent.setup()
-      mockAddRecipe.mockResolvedValue('AUTH_ERROR')
+      mockAddRecipe.mockResolvedValue({ status: 'auth-error' })
       renderAddRecipe()
       await fillAllFields(user)
       await waitFor(() =>
@@ -434,7 +456,7 @@ describe('AddRecipe form', () => {
 
     it('does not navigate when addRecipe returns null', async () => {
       const user = userEvent.setup()
-      mockAddRecipe.mockResolvedValue(null)
+      mockAddRecipe.mockResolvedValue({ status: 'error', message: 'Failed to create recipe. Please try again.' })
       renderAddRecipe()
       await fillAllFields(user)
       await waitFor(() =>

--- a/src/test/RecipesApi.test.ts
+++ b/src/test/RecipesApi.test.ts
@@ -79,7 +79,7 @@ describe('RecipeAPI.addRecipe — nutrition soft-fail (High #4)', () => {
 
     const result = await RecipeAPI.addRecipe(makeFormData(), () => {})
 
-    expect(result).toBe('srv-1')
+    expect(result).toEqual({ status: 'success', id: 'srv-1', pendingReview: false })
     // The recipe POST fires even though nutrition failed
     expect(httpPost).toHaveBeenCalledTimes(1)
     expect(httpPost.mock.calls[0][0]).toBe('api/addRecipe')
@@ -96,7 +96,7 @@ describe('RecipeAPI.addRecipe — nutrition soft-fail (High #4)', () => {
 
     const result = await RecipeAPI.addRecipe(makeFormData(), () => {})
 
-    expect(result).toBe('srv-2')
+    expect(result).toEqual({ status: 'success', id: 'srv-2', pendingReview: false })
     expect(httpPost).toHaveBeenCalledWith('api/addRecipe', expect.any(Object))
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,9 @@ export type RecipeType = {
   numTimesSaved: number
   numTimesMade: number
   // Moderation/curation state (P1/P2). Absent on legacy recipes = public/active.
-  status?: 'active' | 'hidden' | 'unpublished'
+  // 'pending_review' = an automated-moderation hold: owner-visible, withheld from
+  // public reads until an admin clears it.
+  status?: 'active' | 'hidden' | 'unpublished' | 'pending_review'
   featured?: boolean
 }
 export type RecipeFormType = {


### PR DESCRIPTION
## Automated content moderation — P0 + P1 (write-time text)

Implements the text-moderation slice from `docs/CONTENT_MODERATION.md`, feeding classifier signals into the existing reports / auditLog / status pipeline. This is the first phase; P2 (images) and P3 (CSAM) will follow as separate PRs.

### What it does
- **Two-layer classifier** (`util/textModeration.js`): a curated blocklist zeroth-pass (leet/repeat-normalized, Scunthorpe-safe, **fail-closed**, runs even with no API key) → OpenAI Moderation API (`omni-moderation-latest`, **fail-open** on transient error). Graded high / medium / clean. No-ops to clean when `OPENAI_API_KEY` is unset.
- **Confidence tiers by surface**: HIGH → `422 { code: CONTENT_BLOCKED }` everywhere; MEDIUM recipe → `pending_review` hold + automod report + audit; MEDIUM review/username/bio → blocked inline.
- **Wired into** recipe create/edit, reviews, username (signup + rename), and bio/location.
- **Visibility**: `RECIPE_VISIBLE` now excludes `pending_review`; owners still see their own held recipe. Fixed a pre-existing `publicProfile.js` count leak along the way.
- **Frontend**: 422 surfaced on recipe/review/profile forms; friendly "pending review" toast on hold.

### Code-review fixes folded in (2 batches)
- **#1 (critical)** `gatherRecipeText` was reading keys that don't exist on real payloads, so **all ingredient + instruction text bypassed moderation** — now reads the real client shapes, with a regression unit suite.
- **#2** editRecipe medium verdict no longer overwrites an admin takedown with the weaker `pending_review`.
- **#3** addRecipe whitelists creatable fields (`CREATABLE_RECIPE_FIELDS`) — client can no longer inject `status`/`featured`/forged rating.
- **#4** public-profile total count uses `RECIPE_VISIBLE` (no longer leaks held/hidden recipe existence).
- **#7** editRecipe returns 404 (not 200-with-null) on a delete race.
- **#8** `holdRecipeForReview` is report-gated: files the queue entry first, only then flips to `pending_review` (a recipe is never hidden with nothing for an admin to clear).
- **#9** flagged-with-empty-scores grades to `medium` / `flagged` instead of a meaningless reason.
- **#10** shared `respondBlocked(res)` centralizes the 422 contract across 6 sites.

### Verification
- `/verify` PASS against a live worktree server + a real minted Firebase token: HIGH slur in ingredient/instruction text → 422 (proves the #1 fix end-to-end); forged create fields stripped (#3); live OpenAI layer catches a violent threat with no blocklist token; blocked creates write zero rows. Test data torn down, no prod pollution.
- server Jest 446 green; frontend tests + tsc clean.

### ⚠️ Prod deploy step
Set `OPENAI_API_KEY` (and `MODERATION_ENABLED=true`) on Railway. Without the key the OpenAI layer no-ops to clean — the blocklist still fires, but the live classifier won't.

### Deferred
- `displayName` moderation (needs a Firebase blocking function — no server hook today), tracked in the doc.
- Full central block middleware (#10 partial).
- P2 images / P3 CSAM (separate PRs).
