### PR TITLE
feat(moderation): automated image moderation (P2, server-side Cloud Vision)

### DIFF
--- a/docs/CONTENT_MODERATION.md
+++ b/docs/CONTENT_MODERATION.md
@@ -254,8 +254,10 @@ tiers, Text engine, Username timing, and Verification rows).
 > **Pull the trigger when ANY of these hits:**
 > 1. Image uploads open to the general public at real volume (~low hundreds of active users, or
 >    unverified/anonymous accounts can upload).
-> 2. The **adult-hit canary fires** — `imageModeration.js` now logs `[moderation][adult-canary]`
->    whenever Vision reports `adult >= LIKELY`. Recurring hits = bad actors found the site.
+> 2. The **adult-hit canary fires** — `imageModeration.js` logs `[moderation][adult-canary]` whenever
+>    Vision reports `adult >= LIKELY`, AND fires a throttled best-effort alert email (via `email.js`,
+>    to `MODERATION_ALERT_EMAIL`/admin, ≤1 per 30 min) so it isn't buried in logs. Recurring hits = bad
+>    actors found the site.
 > 3. A new feature invites image uploads beyond recipe photos/avatars (DMs, galleries, image comments).
 
 - [ ] *(deferred, trigger-gated — see decision above)* Integrate PhotoDNA Cloud Service on the image path.
@@ -263,7 +265,7 @@ tiers, Text engine, Username timing, and Verification rows).
 - [ ] Rate-limit content creation endpoints if not already covered by the security-audit limits.
 - [ ] Admin queue: visually distinguish `system`-flagged items + show classifier reason/score.
 - [ ] Metrics: counts of auto-hidden / auto-flagged / false-positive-restored.
-- [x] **Adult-hit canary** — `imageModeration.js` warns on `adult >= LIKELY` as the early-warning for trigger #2 above (2026-06-16).
+- [x] **Adult-hit canary** — `imageModeration.js` warns on `adult >= LIKELY` (early-warning for trigger #2) AND sends a throttled best-effort alert email via `email.js` (`MODERATION_ALERT_EMAIL`, ≤1 per `MODERATION_ALERT_THROTTLE_MS`/30 min) (2026-06-16).
 
 ---
 
@@ -275,6 +277,8 @@ MODERATION_ENABLED=        # master toggle for ALL classifiers; off ⇒ they no-
 GOOGLE_VISION_API_KEY=     # server-side Cloud Vision SafeSearch (REST) — images
 MODERATION_IMAGE_HIGH=     # optional likelihood threshold (default VERY_LIKELY)
 MODERATION_IMAGE_MEDIUM=   # optional likelihood threshold (default LIKELY)
+MODERATION_ALERT_EMAIL=    # optional — where adult-canary alert emails go (default: ADMIN_NOTIFY_EMAIL)
+MODERATION_ALERT_THROTTLE_MS=  # optional — min ms between canary emails (default 1800000 = 30 min; 0 disables)
 # CSAM tool credentials TBD by chosen provider (Cloudflare / PhotoDNA / Thorn)
 ```
 

--- a/docs/CONTENT_MODERATION.md
+++ b/docs/CONTENT_MODERATION.md
@@ -432,5 +432,22 @@ scores). Two findings were fixed (own follow-up commit):
   L2 `updatePhoto` accepts an arbitrary URL — not a regression, non-Storage URLs fail-closed anyway;
   L3 no per-image dedupe on create; doc-drift nits) were reviewed and deferred as non-blocking.
 
+**2026-06-15 — follow-ups found during the user's own prod smoke (logged, not yet fixed):**
+- **FE error surfacing (P1 UX bug) — ✅ FIXED 2026-06-15.** The server's 422 block response carries a
+  friendly body (`{ error: BLOCKED_MESSAGE, code: 'CONTENT_BLOCKED' }`), but `CreateUsername` showed
+  axios's generic "Request failed with status code 422" (it surfaced `err.message`). Added a shared
+  `src/util/getApiErrorMessage(error, fallback)` helper (prefers `response.data.error`) and used it in
+  CreateUsername; folded the existing inline duplicates in `AddReview` and Settings `ProfileSection` onto
+  it. The recipe paths (`api/recipes.ts` add/edit → `result.message`) already read `response.data.error`.
+  Net: every moderated surface — onboarding username, settings username/bio/photo, reviews, recipe
+  create/edit — now shows the friendly moderation message. The 422 status itself was always correct.
+- **Blocklist evasion gaps (P1 hardening).** Token-boundary matching means a concatenated slur with no
+  separator (`shitfuck`) and letter-spacing (`s h i t`) both pass the blocklist. `shit_fuck` / `shit` /
+  `fuck` are caught. The OpenAI layer is the intended backstop but is unreliable against deliberate
+  obfuscation. Consider collapsed-whitespace + substring matching for the slur set.
+- **Reminder:** moderation only runs where the code is deployed AND the keys are present. Prod hadn't
+  shipped moderation yet at the time of this smoke (a slur username + review went through on the live
+  site — cleaned up via account delete). The `OPENAI_API_KEY` + redeploy is the pending Railway step.
+
 _Next: commit P2 on its own branch off `development` + open a PR (P1's branch is already merged/deleted).
 P3 CSAM still needs a provider decision (Cloudflare / PhotoDNA / Thorn). `displayName` follow-up still open._

--- a/docs/CONTENT_MODERATION.md
+++ b/docs/CONTENT_MODERATION.md
@@ -234,11 +234,36 @@ tiers, Text engine, Username timing, and Verification rows).
       trigger if it proves a real vector.
 
 ### P3 — CSAM + hardening (2–3 days) — *gates public launch*
-- [ ] Integrate Cloudflare CSAM Scanning Tool (or PhotoDNA/Thorn) on the image path.
-- [ ] Mandatory-reporting runbook (NCMEC) documented for when a match occurs.
+
+> **DECISION 2026-06-16 — CSAM scanning DEFERRED (not declined), trigger-gated.**
+> At current scale (≈0 users, no upload inflow) the realistic CSAM exposure is negligible, while the
+> free hash-matchers (PhotoDNA / Google Content Safety) require a multi-week application + vetting and
+> an ongoing NCMEC reporting pipeline — i.e. compliance overhead for traffic that doesn't exist yet.
+> The Vision SafeSearch adult/racy gate (P2, fail-closed) is the proportionate first line for now.
+> The owner is willing to take on the reporting duty; the point of deferral is to *sequence* it to
+> when it can actually do good, not to avoid it. **This is reversible** — it's a server-side hook at
+> upload, identical in shape to `imageModeration.js`, so adding it later is contained, not a rewrite.
+>
+> **Chosen approach when triggered:** **PhotoDNA Cloud Service** (free, Microsoft) as a server-side
+> hash-match hook at upload — fits the existing Firebase-Storage + server-scan path with no Cloudflare
+> dependency (Cloudflare's edge tool would require routing image delivery through Cloudflare, which we
+> don't today). Add **Google Content Safety API** later if novel-content (non-hash) detection is wanted.
+> **Thorn Safer** is capable but commercial/overkill at this scale. Full rationale: see the
+> "CSAM provider" discussion in Progress / chat history.
+>
+> **Pull the trigger when ANY of these hits:**
+> 1. Image uploads open to the general public at real volume (~low hundreds of active users, or
+>    unverified/anonymous accounts can upload).
+> 2. The **adult-hit canary fires** — `imageModeration.js` now logs `[moderation][adult-canary]`
+>    whenever Vision reports `adult >= LIKELY`. Recurring hits = bad actors found the site.
+> 3. A new feature invites image uploads beyond recipe photos/avatars (DMs, galleries, image comments).
+
+- [ ] *(deferred, trigger-gated — see decision above)* Integrate PhotoDNA Cloud Service on the image path.
+- [ ] *(deferred)* Mandatory-reporting runbook (NCMEC CyberTipline, preserve-don't-delete) documented for when a match occurs.
 - [ ] Rate-limit content creation endpoints if not already covered by the security-audit limits.
 - [ ] Admin queue: visually distinguish `system`-flagged items + show classifier reason/score.
 - [ ] Metrics: counts of auto-hidden / auto-flagged / false-positive-restored.
+- [x] **Adult-hit canary** — `imageModeration.js` warns on `adult >= LIKELY` as the early-warning for trigger #2 above (2026-06-16).
 
 ---
 

--- a/docs/CONTENT_MODERATION.md
+++ b/docs/CONTENT_MODERATION.md
@@ -449,5 +449,28 @@ scores). Two findings were fixed (own follow-up commit):
   shipped moderation yet at the time of this smoke (a slur username + review went through on the live
   site — cleaned up via account delete). The `OPENAI_API_KEY` + redeploy is the pending Railway step.
 
-_Next: commit P2 on its own branch off `development` + open a PR (P1's branch is already merged/deleted).
-P3 CSAM still needs a provider decision (Cloudflare / PhotoDNA / Thorn). `displayName` follow-up still open._
+**2026-06-15 — comprehensive authed live smoke across EVERY write surface (worktree server :4005, real
+blocklist + OpenAI, throwaway accounts, prod DB swept after). 14/14 effective.** Every server-side surface
+moderates correctly:
+- ✅ **username** (setUsername) — slur→422, clean→200
+- ✅ **bio** + **location** (updateProfile, joined `profileText`) — slur/spam→422, clean→200 (location
+  re-confirmed with a bounded trigger: `shit head`→422, `buy now plaza`→422, `Denver`→200)
+- ✅ **recipe** create — slur in TITLE / INGREDIENT / INSTRUCTION each→422 (confirms `gatherRecipeText`
+  field coverage), clean→201 published
+- ✅ **recipe** edit (editRecipe) — slur→422
+- ✅ **review** create + edit (newReview/editReview) — slur/spam→422, clean→200
+- ✅ **OpenAI layer live** — a violent threat with NO blocklist token still→422 (proves the AI grade, not
+  just the blocklist)
+- ✅ **displayName — FIXED 2026-06-16 (was THE GAP the user hit).** New server `POST /updateDisplayName`
+  (auth.js) mirrors `updatePhoto`: validates (required, ≤50 chars) → `moderateText(name, 'displayName')`
+  (both high+medium block, identity spam rules apply) → `admin.auth().updateUser`. `AuthContext` and
+  `CreateUsername` now route displayName through `AuthAPI.updateDisplayName` + `user.reload()` instead of
+  the client Firebase `updateProfile` (import dropped from both). Tests: 3 route cases + updated FE
+  AuthContext/CreateUsername suites (server 472 / FE 366 / tsc). **Live smoke 6/6** (real classifier +
+  Firebase): slur/spam→422, clean applied (trimmed) and confirmed on the real account, >50/empty→400.
+- ⚠️ Re-confirmed the evasion gaps apply to ALL these text surfaces (concatenated `shittown`/`shitfuck`,
+  spaced `s h i t` pass the blocklist).
+
+_Next: P2 + the displayName/UX fixes are on PR #139 (into development). P3 CSAM still needs a provider
+decision (Cloudflare / PhotoDNA / Thorn). One P1 follow-up remains: **blocklist evasion hardening**
+(concatenated/letter-spaced slurs)._

--- a/docs/CONTENT_MODERATION.md
+++ b/docs/CONTENT_MODERATION.md
@@ -441,10 +441,23 @@ scores). Two findings were fixed (own follow-up commit):
   it. The recipe paths (`api/recipes.ts` add/edit → `result.message`) already read `response.data.error`.
   Net: every moderated surface — onboarding username, settings username/bio/photo, reviews, recipe
   create/edit — now shows the friendly moderation message. The 422 status itself was always correct.
-- **Blocklist evasion gaps (P1 hardening).** Token-boundary matching means a concatenated slur with no
-  separator (`shitfuck`) and letter-spacing (`s h i t`) both pass the blocklist. `shit_fuck` / `shit` /
-  `fuck` are caught. The OpenAI layer is the intended backstop but is unreliable against deliberate
-  obfuscation. Consider collapsed-whitespace + substring matching for the slur set.
+- **Blocklist evasion gaps (P1 hardening).** ✅ **DONE 2026-06-16** (`moderationBlocklist.js`). Was:
+  token-boundary matching let a concatenated slur with no separator (`shitfuck`) and letter-spacing
+  (`s h i t`) pass; `shit_fuck` / `shit` / `fuck` were already caught. Fix adds two passes around the
+  existing exact-token match, designed around the Scunthorpe problem on a *recipe* site:
+  - **Letter-spacing pass** — maximal runs of single-character tokens (`s h i t`, `n.i.g.g.e.r`,
+    `f*u*c*k`) are rejoined and re-scanned with the wide pass. Adversarial signal ⇒ strict.
+  - **Substring pass, tiered** — `SUBSTRING_SLURS` (`nigger`/`cunt`/`asshole`, unambiguous) match as a
+    substring on **every** surface; the substring-prone rest (`shit`/`fuck`/`faggot`/`retard`/…) match
+    as substrings **only on identity fields** (username/displayName), and still as exact tokens
+    everywhere. Long-form prose leans on the OpenAI layer for obfuscated profanity to avoid
+    false-positives.
+  - **`BENIGN_ALLOWLIST`** guards the substring pass: `scunthorpe`, `shitake`/`shiitake`, `shitzu`,
+    `retardant`, `niggardly` — a token equal to one of these is exempt from substring scanning.
+  - Result: `shitfuck`/`shitlord` (identity), `niggerlover`/`megaasshole`/`xXcuntXx` (anywhere), and
+    `s h i t`/`n i g g e r`/`f.u.c.k` all now blocked; `shiitake`/`shitake`/`Scunthorpe`/`fire retardant`/
+    `classic`/`push it`/`viscount`/`glasshouse` all stay clean. Tests: +4 cases in `textModeration.test.js`
+    (catches + FP guards). server 476 green.
 - **Reminder:** moderation only runs where the code is deployed AND the keys are present. Prod hadn't
   shipped moderation yet at the time of this smoke (a slur username + review went through on the live
   site — cleaned up via account delete). The `OPENAI_API_KEY` + redeploy is the pending Railway step.
@@ -468,9 +481,9 @@ moderates correctly:
   the client Firebase `updateProfile` (import dropped from both). Tests: 3 route cases + updated FE
   AuthContext/CreateUsername suites (server 472 / FE 366 / tsc). **Live smoke 6/6** (real classifier +
   Firebase): slur/spam→422, clean applied (trimmed) and confirmed on the real account, >50/empty→400.
-- ⚠️ Re-confirmed the evasion gaps apply to ALL these text surfaces (concatenated `shittown`/`shitfuck`,
-  spaced `s h i t` pass the blocklist).
+- ⚠️ Re-confirmed the evasion gaps applied to ALL these text surfaces (concatenated `shittown`/`shitfuck`,
+  spaced `s h i t`) — **now hardened 2026-06-16, see above.**
 
-_Next: P2 + the displayName/UX fixes are on PR #139 (into development). P3 CSAM still needs a provider
-decision (Cloudflare / PhotoDNA / Thorn). One P1 follow-up remains: **blocklist evasion hardening**
-(concatenated/letter-spaced slurs)._
+_Next: P2 + the displayName/UX fixes + blocklist hardening are on PR #139 (into development). P3 CSAM
+still needs a provider decision (Cloudflare / PhotoDNA / Thorn) — ask the user before integrating. No
+P1 follow-ups remain._

--- a/docs/CONTENT_MODERATION.md
+++ b/docs/CONTENT_MODERATION.md
@@ -75,6 +75,12 @@ Traced from the current codebase on 2026-06-14.
    - Route uploads through the Express server (larger refactor + bandwidth cost). Only do this
      if a Cloud Function proves impractical.
 
+   > **What P2 actually shipped (2026-06-15):** neither of the above. The server never sees the
+   > *bytes*, but it *does* receive the resulting **URL** at recipe-create/edit time, so recipe
+   > images are scanned server-side from that URL (no Functions, no upload re-routing). Profile
+   > photos — the only path that didn't touch the server at all — were moved server-side via a
+   > new `POST /updatePhoto` endpoint. See P2 for the full rationale.
+
 2. **Reviews have no stable id.** They live inside the `ratings` collection keyed by
    `(username, recipeId)`, with text in `reviewText`. Any auto-flag for a review must key off
    `(username, recipeId)`, exactly like the existing report/moderation paths do.
@@ -118,7 +124,7 @@ tiers, Text engine, Username timing, and Verification rows).
 | **Synthetic actor** | Auto-actions credited to a reserved `system` / `automod` actor in `auditLog` | Distinguishes machine from human actions; keeps audit honest |
 | **Text engine** | **OpenAI Moderation API** (free) + blocklist. Claude Haiku relevance/spam pass **deferred** (not in scope until off-topic spam is actually observed). | Purpose-built free safety classifier; one dep, server-side only |
 | **Text strategy** | **Block-on-write** (synchronous, inline 4xx error) for high-confidence | Fast, cheap, best UX; nothing illegal ever goes live |
-| **Image strategy** | **Async scan → auto-hide → queue** (can't block a Storage trigger) | Matches the upload architecture |
+| **Image strategy** | **Server-side synchronous URL scan at write-time**, reusing the P1 pipeline (recipe images via `worstVerdict`+`holdRecipeForReview`; profile photos via a new `POST /updatePhoto`). *(Revised 2026-06-15 from the original Storage-trigger plan — see P2 for the rationale: no Functions infra, filename-keyed paths, the server already has the URL.)* | Avoids the Blaze plan + a new deploy surface; the recipe doc already exists server-side so no mapping/timing problem |
 | **Confidence tiers** | High-confidence → **block** (text) / **auto-hide** (image). Medium-confidence → **hold for review**: see "Medium-confidence hold" below. | Limits false positives nuking legit recipes while never publishing unreviewed risky content |
 | **Medium-confidence hold** | **Recipes:** set a new `status: 'pending_review'` — visible **only to the owner + moderators** — and silently auto-file a `report`; goes public when an admin clears it. **Reviews / bio / username:** no meaningful owner-only state, so medium-confidence is treated as **block-on-write** (they're short; ask the user to rephrase). | Owner-only pending is clean for recipes; pointless for a review or bio only the author can see |
 | **Username timing** | Moderate at **signup AND every rename** | A slur can never land via a later rename; pairs with the reserved-words blocklist |
@@ -188,13 +194,44 @@ tiers, Text engine, Username timing, and Verification rows).
 > endpoint or a Firebase **blocking function** (`beforeUserCreated`/`beforeUserSignedIn`). Tracked
 > here; out of scope for this slice. Username + bio/location (which DO hit the server) are covered.
 
-### P2 — Image moderation (3–4 days)
-- [ ] Firebase Storage `onFinalize` Cloud Function (or the Cloud Vision extension).
-- [ ] SafeSearch scan on `recipeImages/` + `profilePhotos/` uploads.
-- [ ] On hit: set the existing `status`/`moderationHidden` flag on the owning doc +
-      auto-file a `report` + `auditLog` entry + owner email (reuse `notifyRecipeHidden` etc.).
-- [ ] Quarantine-until-scanned default so unscanned images aren't publicly served.
-- [ ] (Optional) Claude Haiku relevance/spam pass on recipe text.
+### P2 — Image moderation — ✅ shipped 2026-06-15 (server-side, not a Cloud Function)
+
+> **Architecture decided 2026-06-15 (with the user):** *not* a Storage trigger. The
+> original `onFinalize` Cloud Function plan was dropped in favour of a **server-side
+> URL scan** that reuses the P1 pipeline, because (a) no Firebase Functions infra
+> exists yet (`firebase.json` is `{}`) and a trigger forces the paid Blaze plan + a new
+> deploy/ops surface, (b) `recipeImages/{filename}` isn't keyed by recipe id and the
+> upload fires *before* the recipe doc exists, so a trigger has nothing to map back to,
+> and (c) the server already receives the image URL at recipe-create/edit time. The one
+> surface that genuinely bypassed the server — profile photos (written straight to
+> Firebase Auth) — was brought server-side via a new endpoint. Scanner: **Cloud Vision
+> SafeSearch** over REST (no SDK dep, mirrors the OpenAI choice). Tradeoff accepted:
+> orphan uploads (images never attached to a doc) aren't scanned; CSAM is P3 regardless.
+
+- [x] `server/util/imageModeration.js` — env-gated `moderateImage(url, context)`, Cloud
+      Vision SafeSearch via native `fetch`, graded high/medium/clean from adult/violence/racy
+      likelihoods (env-tunable; `racy` only ever contributes medium). No-ops to clean when
+      `GOOGLE_VISION_API_KEY` is unset. **Fails CLOSED** (scan error ⇒ medium/`unscanned`).
+- [x] **Recipe images** scanned at create/edit, collapsed with the text verdict via
+      `worstVerdict` (recipe is only as clean as its worst axis). high → `422`; medium /
+      fail-closed → `holdRecipeForReview` (`pending_review` + automod report + audit, reusing
+      the entire P1 pipeline incl. `notifyRecipeHidden`). Edit re-scans only when the URL changed.
+- [x] **Profile photos** — new `POST /updatePhoto` (auth.js): the client uploads to Storage
+      then POSTs the URL; the SERVER scans it and only then sets `photoURL` via Admin
+      `updateUser`. high|medium|fail-closed → `422` (no owner-only state, like a bio).
+      Client refactor: `AuthContext` routes the `photoURL` write through this endpoint +
+      `user.reload()`; `displayName` still goes direct (the known follow-up).
+- [x] Quarantine-until-scanned satisfied by the synchronous design: a recipe image is graded
+      before the write returns (fail-closed holds an unscanned image); a photo is applied only
+      after a clean scan.
+- [x] Tests: `imageModeration.test.js` (grading/gating/fail-closed, 14 cases) + route cases in
+      `moderation-routes.test.js` (image high/medium/fail-closed hold, worst-of, edit re-scan
+      gating, `/updatePhoto` clean/blocked/clear) + FE `AuthContext.test.tsx` photo-flow update.
+      `GOOGLE_VISION_API_KEY` (+ image thresholds) added to `server/.env.example`.
+- [ ] (Optional) Claude Haiku relevance/spam pass on recipe text. *(Still deferred, as in P1.)*
+- [ ] (Deferred) Orphan uploads — images uploaded to Storage but never attached to a doc go
+      unscanned under the server-side model; revisit with a periodic sweep or a narrow Storage
+      trigger if it proves a real vector.
 
 ### P3 — CSAM + hardening (2–3 days) — *gates public launch*
 - [ ] Integrate Cloudflare CSAM Scanning Tool (or PhotoDNA/Thorn) on the image path.
@@ -208,9 +245,11 @@ tiers, Text engine, Username timing, and Verification rows).
 ## Environment variables (to add to `server/.env.example`)
 
 ```
-OPENAI_API_KEY=            # server-side OpenAI Moderation (free endpoint)
-MODERATION_ENABLED=        # master toggle; off ⇒ moderateText no-ops
-GOOGLE_VISION_CREDENTIALS= # or GCP application-default creds for SafeSearch
+OPENAI_API_KEY=            # server-side OpenAI Moderation (free endpoint) — text
+MODERATION_ENABLED=        # master toggle for ALL classifiers; off ⇒ they no-op
+GOOGLE_VISION_API_KEY=     # server-side Cloud Vision SafeSearch (REST) — images
+MODERATION_IMAGE_HIGH=     # optional likelihood threshold (default VERY_LIKELY)
+MODERATION_IMAGE_MEDIUM=   # optional likelihood threshold (default LIKELY)
 # CSAM tool credentials TBD by chosen provider (Cloudflare / PhotoDNA / Thorn)
 ```
 
@@ -328,7 +367,56 @@ follow-up; the central-middleware refactor is deferred (see below).
 Known follow-ups: server-side `displayName` moderation (needs a Firebase blocking function — see the
 P1 note above); **#10 (full) — a central moderation choke point / middleware so a new write route
 can't silently ship unmoderated** (deferred to its own focused PR — retrofitting across the 6 write
-routes is too broad to fold into this slice); P2 image moderation; P3 CSAM. None block the text slice.
+routes is too broad to fold into this slice); P3 CSAM. None block the text slice.
 
-_Next: P1 is fully signed off (incl. the code-review pass). Proceed to the `displayName` follow-up
-(Firebase blocking function) and/or P2 (images) when ready._
+**P1 was MERGED to development via PR #138 (squash-merged 2026-06-15; remote branch auto-deleted).**
+
+---
+
+**2026-06-15 — P2 (image moderation) built — server-side, NOT a Cloud Function.** Scoped with the
+user first; the original Storage `onFinalize` plan was dropped in favour of a server-side URL scan
+that reuses the entire P1 pipeline (see the P2 section + design-table rationale: no Firebase Functions
+infra exists, the Blaze plan + a new deploy surface were unwarranted, `recipeImages/{filename}` isn't
+keyed by recipe id and the trigger would fire before the recipe doc exists, and the server already
+receives the image URL). Scanner: **Cloud Vision SafeSearch** over REST (native `fetch`, no SDK).
+
+Shipped:
+- **`server/util/imageModeration.js`** — env-gated `moderateImage(url, context)` mirroring
+  `textModeration`; grades adult/violence/racy SafeSearch likelihoods → high/medium/clean (env-tunable;
+  `racy` caps at medium). No-ops to clean when `GOOGLE_VISION_API_KEY` is unset. **Fails CLOSED**
+  (scan error ⇒ medium `unscanned`), the deliberate inverse of text's fail-open.
+- **Recipe images** scanned at create/edit, merged with the text verdict via the new
+  `automod.worstVerdict` (recipe = its worst axis). high → block; medium / fail-closed →
+  `holdRecipeForReview` (`pending_review` + automod report + audit + owner email). Edit re-scans only
+  when the URL changed (no re-hold / cost on a plain text edit).
+- **Profile photos** — new `POST /updatePhoto` (auth.js): client uploads to Storage, server scans the
+  URL and only then sets `photoURL` via Admin `updateUser`. high|medium|fail-closed → `422` (no
+  owner-only state, like a bio). `AuthContext` + `AuthAPI` refactored to route the photoURL write
+  through it (+`user.reload()`); `displayName` still direct.
+- **Tests/env:** `imageModeration.test.js` (14) + image route cases in `moderation-routes.test.js`
+  (`firebase-admin` mock gained `updateUser`) + FE `AuthContext.test.tsx` photo-flow update. Env added
+  to `server/.env.example`. **server Jest 468, FE Vitest 362, tsc clean.**
+
+**2026-06-15 — P2 authed live smoke PASSED ✅** against a real `GOOGLE_VISION_API_KEY` (Cloud Vision API
+enabled + billing on `prepify-9b974`), driving the worktree server's real routes with a throwaway
+Firebase account (no browser). Benign images only — the block/hold tiers were proven by lowering the
+likelihood threshold so a clean image's real verdict crosses it, never by sourcing explicit content:
+- **Real classifier fires:** a real Firebase Storage recipe-image URL is fetched and graded by Vision
+  (`source: vision`, all `VERY_UNLIKELY` → clean). Confirmed Vision *can* fetch `firebasestorage.googleapis.com`
+  URLs via `imageUri` (a 3rd-party HTTPS URL, gstatic, was refused — irrelevant to our surfaces, and it
+  **fail-closed** correctly: `severity: medium, source: error`).
+- **Clean tier (3/3):** clean image → `addRecipe` 201 not-pending (published); `updatePhoto` 200; clear 200.
+- **High tier (3/3, threshold forced to VERY_UNLIKELY):** real verdict graded high → `addRecipe` 422,
+  `updatePhoto` 422; cleanup confirmed the blocked recipe wrote **zero rows**.
+- **Medium tier (4/4, threshold forced):** real verdict graded medium → recipe `201 pending_review`,
+  **owner read 200 / anonymous read 404** (the held-recipe visibility split), automod `report` + audit
+  filed (reports=1, audit=1), `updatePhoto` medium → 422 (photos block, no owner-only state).
+
+All test data torn down; prod verified residue-free (0 leftover recipes / 0 recent automod reports).
+Server restored to normal thresholds afterwards.
+
+⚠️ **PROD ENV STEP** to add to Railway when shipping: `GOOGLE_VISION_API_KEY` (absent ⇒ image layer
+no-ops; text moderation unaffected). Optional `MODERATION_IMAGE_HIGH` / `MODERATION_IMAGE_MEDIUM`.
+
+_Next: commit P2 on its own branch off `development` + open a PR (P1's branch is already merged/deleted).
+P3 CSAM still needs a provider decision (Cloudflare / PhotoDNA / Thorn). `displayName` follow-up still open._

--- a/docs/CONTENT_MODERATION.md
+++ b/docs/CONTENT_MODERATION.md
@@ -418,5 +418,19 @@ Server restored to normal thresholds afterwards.
 ⚠️ **PROD ENV STEP** to add to Railway when shipping: `GOOGLE_VISION_API_KEY` (absent ⇒ image layer
 no-ops; text moderation unaffected). Optional `MODERATION_IMAGE_HIGH` / `MODERATION_IMAGE_MEDIUM`.
 
+**2026-06-15 — P2 code-review pass (high effort), 2 fixes applied.** A focused review of the P2 diff
+found the build sound (correct fail-closed routing, SSRF-safe via Vision `imageUri`, no DB leakage of raw
+scores). Two findings were fixed (own follow-up commit):
+- **M1 (perf):** `moderateText` + `moderateImage` ran serially on `addRecipe`/`editRecipe`; now run via
+  `Promise.all`. Both resolve internally (text fails open, image fails closed) so `Promise.all` can't
+  short-circuit on an outage — cuts the added latency from `OpenAI + Vision` to `max(OpenAI, Vision)`.
+- **M2 (fail-closed gap):** `callVision` graded a 200 with no `error` *and* no `safeSearchAnnotation` as
+  clean — a narrow fail-*open* hole in a fail-closed design. It now throws on a missing annotation so the
+  image is held, never published unscanned. Added a unit test for that case (server Jest 468 → 469).
+
+  Low/nit findings (L1 photo now commits before later profile steps — intentional reject-early ordering;
+  L2 `updatePhoto` accepts an arbitrary URL — not a regression, non-Storage URLs fail-closed anyway;
+  L3 no per-image dedupe on create; doc-drift nits) were reviewed and deferred as non-blocking.
+
 _Next: commit P2 on its own branch off `development` + open a PR (P1's branch is already merged/deleted).
 P3 CSAM still needs a provider decision (Cloudflare / PhotoDNA / Thorn). `displayName` follow-up still open._

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -157,6 +157,16 @@ a feature flag. Do these together:
   - **Backend (Railway, optional):** `MODERATION_HIGH_THRESHOLD` / `MODERATION_MEDIUM_THRESHOLD` —
     override the default score cutoffs (0.85 / 0.5). Leave unset for defaults.
   No DB migration. See `docs/CONTENT_MODERATION.md`.
+- `[x]` **Content moderation (images) — wired; prod env var is a launch step** — write-time image
+  moderation (recipe images + profile photos) via Google Cloud Vision SafeSearch, reusing the same
+  pipeline as the text layer. Env-gated: with no key the image layer no-ops (text moderation is
+  unaffected). Live-smoke-tested 2026-06-15. **Before/at launch, set the production env var:**
+  - **Backend (Railway):** `GOOGLE_VISION_API_KEY` = a server-side Cloud Vision API key (the Vision
+    API must be enabled + billing active on the `prepify-9b974` GCP project). **Never expose to the
+    client** — server-side only, not a `VITE_*` var. Absent ⇒ the image layer silently no-ops.
+  - **Backend (Railway, optional):** `MODERATION_IMAGE_HIGH` / `MODERATION_IMAGE_MEDIUM` — override the
+    default SafeSearch likelihood cutoffs (`VERY_LIKELY` / `LIKELY`). Leave unset for defaults.
+  Shares the `MODERATION_ENABLED` master switch. No DB migration. See `docs/CONTENT_MODERATION.md`.
 - `[ ]` **Performance / Lighthouse pass** — run Lighthouse on the prod build; address obvious image-size
   and bundle-size wins. **(nice-to-have)**
 - `[ ]` **README cleanup** — the README still has placeholder `your-username` clone URLs and generic
@@ -256,8 +266,8 @@ the actual flip. Deploy is currently manual (Firebase Hosting frontend + Railway
 4. `[ ]` Update release-notes content for 1.0 and tag a GitHub Release.
 5. `[ ]` Deploy frontend (`npm run build` → Firebase Hosting) and backend (Railway). **First set prod
    env vars:** `VITE_SENTRY_DSN` in the frontend build env (before `npm run build`), and `SENTRY_DSN`
-   + `ADMIN_NOTIFY_EMAIL` + `OPENAI_API_KEY` + `MODERATION_ENABLED` on Railway. See Section C →
-   "Error tracking (Sentry)" and "Content moderation (text)".
+   + `ADMIN_NOTIFY_EMAIL` + `OPENAI_API_KEY` + `MODERATION_ENABLED` + `GOOGLE_VISION_API_KEY` on Railway.
+   See Section C → "Error tracking (Sentry)", "Content moderation (text)", and "Content moderation (images)".
 6. `[ ]` Smoke-test production: load home, view a recipe, sign in, create a recipe, leave a review.
 7. `[ ]` Watch logs/analytics for the first hours.
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -43,3 +43,15 @@ MODERATION_ENABLED=
 # high=0.85 (block / hold), medium=0.5 (hold recipes, block reviews/profile).
 MODERATION_HIGH_THRESHOLD=
 MODERATION_MEDIUM_THRESHOLD=
+
+# Automated content moderation (images). Google Cloud Vision SafeSearch, called
+# server-side over REST with this API key. Leave empty to disable the image layer
+# (recipe images + profile photos go unscreened — same no-op pattern as above).
+# Shares the MODERATION_ENABLED master switch. Unlike text (fail-open), images
+# fail CLOSED: a scan outage holds a recipe (pending_review) / rejects a photo.
+GOOGLE_VISION_API_KEY=
+# Optional likelihood-threshold overrides (SafeSearch enum names). Defaults:
+# high=VERY_LIKELY (block / hold), medium=LIKELY (hold recipes, block photos).
+# Applies to adult+violence; 'racy' only ever contributes medium (at VERY_LIKELY).
+MODERATION_IMAGE_HIGH=
+MODERATION_IMAGE_MEDIUM=

--- a/server/__mocks__/firebase-admin.js
+++ b/server/__mocks__/firebase-admin.js
@@ -50,7 +50,10 @@ const getUserByEmail = jest.fn().mockImplementation(async email => {
 // Used by POST /deleteAccount. Resolves by default; tests assert the uid it was
 // called with via admin.__deleteUser.
 const deleteUser = jest.fn().mockResolvedValue(undefined)
-const authInstance = { verifyIdToken, getUser, getUserByEmail, deleteUser }
+// Used by POST /updatePhoto to set the moderated photoURL. Resolves by default;
+// tests assert the (uid, props) it was called with via admin.__updateUser.
+const updateUser = jest.fn().mockResolvedValue(undefined)
+const authInstance = { verifyIdToken, getUser, getUserByEmail, deleteUser, updateUser }
 
 const admin = {
   apps: [{}],
@@ -68,6 +71,7 @@ const admin = {
   __verifyIdToken: verifyIdToken,
   __getUser: getUser,
   __deleteUser: deleteUser,
+  __updateUser: updateUser,
   __setClaims: claims => {
     extraClaims = claims
   },

--- a/server/__tests__/email-notifications.test.js
+++ b/server/__tests__/email-notifications.test.js
@@ -31,6 +31,7 @@ const {
   notifyAccountStatus,
   notifyRecipeHidden,
   notifyReviewTakenDown,
+  notifyAdultContentFlag,
 } = require('../util/email')
 
 const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
@@ -40,6 +41,8 @@ beforeEach(() => {
   process.env.RESEND_API_KEY = 'test-key'
   delete process.env.EMAIL_ENABLED
   delete process.env.SUPPORT_EMAIL
+  delete process.env.MODERATION_ALERT_EMAIL
+  delete process.env.MODERATION_ALERT_THROTTLE_MS
   sendMock.mockReset()
   // Resend's SDK resolves with { data, error } — it does not throw on API errors.
   sendMock.mockResolvedValue({ data: { id: 'email-1' }, error: null })
@@ -180,6 +183,58 @@ describe('failures never throw', () => {
     const brokenDb = { collection: () => ({ findOne: () => Promise.reject(new Error('db down')) }) }
     await expect(notifyReviewTakenDown(brokenDb, 'chef', 'r1')).resolves.toBeUndefined()
     expect(sendMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('adult-content canary alert', () => {
+  it('mails the admin address (or MODERATION_ALERT_EMAIL) with the SafeSearch likelihoods', async () => {
+    process.env.MODERATION_ALERT_THROTTLE_MS = '0' // no throttle for this assertion
+    process.env.MODERATION_ALERT_EMAIL = 'safety@prepifymeals.com'
+    await notifyAdultContentFlag({
+      context: 'recipe.image', adult: 'LIKELY', racy: 'POSSIBLE', violence: 'UNLIKELY', verdict: 'medium',
+    })
+    await flushNotifications()
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    expect(sentArg().to).toBe('safety@prepifymeals.com')
+    expect(sentArg().subject).toMatch(/adult-content/i)
+    expect(sentArg().text).toMatch(/adult: LIKELY/)
+    expect(sentArg().text).toMatch(/recipe\.image/)
+  })
+
+  it('no-ops without RESEND_API_KEY (never touches the provider)', async () => {
+    delete process.env.RESEND_API_KEY
+    process.env.MODERATION_ALERT_THROTTLE_MS = '0'
+    await notifyAdultContentFlag({ context: 'recipe.image', adult: 'VERY_LIKELY', racy: 'x', violence: 'x', verdict: 'high' })
+    await flushNotifications()
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('throttles repeat alerts within the window, then sends again after it', async () => {
+    process.env.MODERATION_ALERT_THROTTLE_MS = '60000' // 1-min window
+    jest.useFakeTimers()
+    try {
+      // Base far past any real Date.now() a prior test may have stamped into the
+      // module-local throttle clock, so this test's first send isn't seen as a repeat.
+      const base = 10_000_000_000_000 // ~year 2286
+      jest.setSystemTime(base)
+      const fire = () => notifyAdultContentFlag({ context: 'recipe.image', adult: 'LIKELY', racy: 'x', violence: 'x', verdict: 'medium' })
+
+      await fire()
+      await flushNotifications()
+      expect(sendMock).toHaveBeenCalledTimes(1) // first one sends
+
+      jest.setSystemTime(base + 1000) // +1s, inside the window
+      await fire()
+      await flushNotifications()
+      expect(sendMock).toHaveBeenCalledTimes(1) // throttled — still 1
+
+      jest.setSystemTime(base + 61_000) // past the window
+      await fire()
+      await flushNotifications()
+      expect(sendMock).toHaveBeenCalledTimes(2) // sends again
+    } finally {
+      jest.useRealTimers()
+    }
   })
 })
 

--- a/server/__tests__/imageModeration.test.js
+++ b/server/__tests__/imageModeration.test.js
@@ -133,4 +133,13 @@ describe('imageModeration — fail CLOSED', () => {
     const v = await moderateImage(URL)
     expect(v).toMatchObject({ allowed: false, severity: 'medium', source: 'error' })
   })
+
+  it('fails closed on a 200 with no error AND no annotation (never publishes unscanned)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ responses: [{}] }),
+    })
+    const v = await moderateImage(URL)
+    expect(v).toMatchObject({ allowed: false, severity: 'medium', source: 'error' })
+  })
 })

--- a/server/__tests__/imageModeration.test.js
+++ b/server/__tests__/imageModeration.test.js
@@ -112,6 +112,22 @@ describe('imageModeration — grading', () => {
   })
 })
 
+describe('imageModeration — adult-hit canary (CSAM trigger early-warning)', () => {
+  it('logs a warning when adult >= LIKELY (even if the verdict is only medium)', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    mockSafeSearch({ adult: 'LIKELY', violence: 'UNLIKELY', racy: 'UNLIKELY' })
+    await moderateImage(URL, 'recipe.image')
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('adult-canary'))
+  })
+
+  it('does NOT log the canary for a clean image (no adult signal)', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    mockSafeSearch({ adult: 'UNLIKELY', violence: 'UNLIKELY', racy: 'POSSIBLE' })
+    await moderateImage(URL)
+    expect(warn).not.toHaveBeenCalled()
+  })
+})
+
 describe('imageModeration — fail CLOSED', () => {
   it('treats a thrown fetch as MEDIUM / not-allowed (held, not published)', async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('network down'))

--- a/server/__tests__/imageModeration.test.js
+++ b/server/__tests__/imageModeration.test.js
@@ -1,0 +1,136 @@
+/**
+ * P2 — image moderation foundation (util/imageModeration).
+ *
+ * Pure-unit: no DB, no app. `fetch` is replaced per-test so the Vision layer is
+ * exercised without a network call. Contract under test:
+ *   - no-ops to CLEAN when GOOGLE_VISION_API_KEY is unset (or MODERATION_ENABLED=false),
+ *   - SafeSearch likelihoods grade into high/medium/clean at the configured thresholds,
+ *   - 'racy' only ever contributes medium, never high,
+ *   - a scan failure (throw / non-2xx / per-image error) fails CLOSED (medium, not allowed).
+ */
+
+const { moderateImage, grade } = require('../util/imageModeration')
+
+const realFetch = global.fetch
+const URL = 'https://firebasestorage.googleapis.com/v0/b/x/o/recipeImages%2Fp.jpg?alt=media&token=t'
+
+// Build a fake fetch resolving to one Vision SafeSearch response.
+function mockSafeSearch(annotation) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ responses: [{ safeSearchAnnotation: annotation }] }),
+  })
+}
+
+beforeEach(() => {
+  process.env.GOOGLE_VISION_API_KEY = 'test-key'
+  delete process.env.MODERATION_ENABLED
+  delete process.env.MODERATION_IMAGE_HIGH
+  delete process.env.MODERATION_IMAGE_MEDIUM
+})
+
+afterEach(() => {
+  global.fetch = realFetch
+  jest.restoreAllMocks()
+})
+
+// process.env is shared across files under --runInBand; don't leak an enabled
+// image key into later route suites (it would make them hit the real API).
+afterAll(() => {
+  delete process.env.GOOGLE_VISION_API_KEY
+})
+
+describe('imageModeration — env gating', () => {
+  it('no-ops to a CLEAN/allowed verdict when no key is set (never calls Vision)', async () => {
+    delete process.env.GOOGLE_VISION_API_KEY
+    global.fetch = jest.fn()
+    const v = await moderateImage(URL, 'recipe.image')
+    expect(v).toMatchObject({ allowed: true, severity: 'clean', source: 'disabled' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when MODERATION_ENABLED=false even with a key present', async () => {
+    process.env.MODERATION_ENABLED = 'false'
+    global.fetch = jest.fn()
+    const v = await moderateImage(URL)
+    expect(v.allowed).toBe(true)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('treats an empty / missing URL as clean without scanning', async () => {
+    global.fetch = jest.fn()
+    expect((await moderateImage('')).source).toBe('empty')
+    expect((await moderateImage(null)).source).toBe('empty')
+    expect((await moderateImage('   ')).source).toBe('empty')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('imageModeration — grading', () => {
+  it('grades adult VERY_LIKELY as HIGH (block) and not allowed', async () => {
+    mockSafeSearch({ adult: 'VERY_LIKELY', violence: 'UNLIKELY', racy: 'POSSIBLE' })
+    const v = await moderateImage(URL, 'recipe.image')
+    expect(v).toMatchObject({ allowed: false, severity: 'high', category: 'adult', source: 'vision' })
+    expect(v.reason).toBe('vision:adult:VERY_LIKELY')
+  })
+
+  it('grades violence VERY_LIKELY as HIGH', async () => {
+    mockSafeSearch({ adult: 'UNLIKELY', violence: 'VERY_LIKELY', racy: 'UNLIKELY' })
+    const v = await moderateImage(URL)
+    expect(v).toMatchObject({ severity: 'high', category: 'violence' })
+  })
+
+  it('grades adult LIKELY (below high) as MEDIUM (hold)', async () => {
+    mockSafeSearch({ adult: 'LIKELY', violence: 'UNLIKELY', racy: 'UNLIKELY' })
+    const v = await moderateImage(URL)
+    expect(v).toMatchObject({ allowed: false, severity: 'medium', category: 'adult' })
+  })
+
+  it('racy only ever contributes MEDIUM, and only at VERY_LIKELY', async () => {
+    mockSafeSearch({ adult: 'UNLIKELY', violence: 'UNLIKELY', racy: 'VERY_LIKELY' })
+    expect((await moderateImage(URL)).severity).toBe('medium')
+
+    mockSafeSearch({ adult: 'UNLIKELY', violence: 'UNLIKELY', racy: 'LIKELY' })
+    expect((await moderateImage(URL)).severity).toBe('clean')
+  })
+
+  it('grades an all-clear image as CLEAN/allowed', async () => {
+    mockSafeSearch({ adult: 'VERY_UNLIKELY', violence: 'UNLIKELY', racy: 'POSSIBLE' })
+    const v = await moderateImage(URL)
+    expect(v).toMatchObject({ allowed: true, severity: 'clean', reason: null })
+  })
+
+  it('handles UNKNOWN / missing likelihoods as no signal (clean)', () => {
+    expect(grade({}).severity).toBe('clean')
+    expect(grade({ adult: 'UNKNOWN', violence: 'UNKNOWN', racy: 'UNKNOWN' }).severity).toBe('clean')
+  })
+
+  it('honors env threshold overrides', async () => {
+    process.env.MODERATION_IMAGE_HIGH = 'LIKELY'
+    mockSafeSearch({ adult: 'LIKELY', violence: 'UNLIKELY', racy: 'UNLIKELY' })
+    expect((await moderateImage(URL)).severity).toBe('high')
+  })
+})
+
+describe('imageModeration — fail CLOSED', () => {
+  it('treats a thrown fetch as MEDIUM / not-allowed (held, not published)', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network down'))
+    const v = await moderateImage(URL, 'recipe.image')
+    expect(v).toMatchObject({ allowed: false, severity: 'medium', category: 'unscanned', source: 'error' })
+  })
+
+  it('fails closed on a non-2xx response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) })
+    const v = await moderateImage(URL)
+    expect(v).toMatchObject({ allowed: false, severity: 'medium', source: 'error' })
+  })
+
+  it('fails closed when Vision reports a per-image error (bad/unreachable URL)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ responses: [{ error: { code: 3, message: 'Bad image data' } }] }),
+    })
+    const v = await moderateImage(URL)
+    expect(v).toMatchObject({ allowed: false, severity: 'medium', source: 'error' })
+  })
+})

--- a/server/__tests__/moderation-routes.test.js
+++ b/server/__tests__/moderation-routes.test.js
@@ -315,3 +315,29 @@ describe('POST /updatePhoto — profile photo moderation', () => {
     expect(admin.__updateUser).toHaveBeenCalledWith('test-uid', { photoURL: null })
   })
 })
+
+describe('POST /updateDisplayName — display name moderation', () => {
+  it('clean name → 200 and applied (trimmed) to Firebase Auth', async () => {
+    const res = await request(app).post('/api/updateDisplayName').set(AUTH).send({ displayName: '  Jane Cook  ' })
+    expect(res.status).toBe(200)
+    expect(admin.__updateUser).toHaveBeenCalledWith('test-uid', { displayName: 'Jane Cook' })
+  })
+
+  it('high|medium name → 422 and NOT applied (both tiers block, like a username)', async () => {
+    for (const verdict of [HIGH, MEDIUM]) {
+      admin.__updateUser.mockClear()
+      moderateText.mockResolvedValue(verdict)
+      const res = await request(app).post('/api/updateDisplayName').set(AUTH).send({ displayName: 'bad name' })
+      expect(res.status).toBe(422)
+      expect(res.body.code).toBe('CONTENT_BLOCKED')
+      expect(admin.__updateUser).not.toHaveBeenCalled()
+    }
+  })
+
+  it('empty/whitespace name → 400 and never scanned or applied', async () => {
+    const res = await request(app).post('/api/updateDisplayName').set(AUTH).send({ displayName: '   ' })
+    expect(res.status).toBe(400)
+    expect(moderateText).not.toHaveBeenCalled()
+    expect(admin.__updateUser).not.toHaveBeenCalled()
+  })
+})

--- a/server/__tests__/moderation-routes.test.js
+++ b/server/__tests__/moderation-routes.test.js
@@ -14,12 +14,14 @@
  */
 
 jest.mock('../util/textModeration', () => ({ moderateText: jest.fn() }))
+jest.mock('../util/imageModeration', () => ({ moderateImage: jest.fn() }))
 
 const request = require('supertest')
 const admin = require('firebase-admin') // auto-mocked
 const app = require('../app')
 const { getDB } = require('../db')
 const { moderateText } = require('../util/textModeration')
+const { moderateImage } = require('../util/imageModeration')
 const { SYSTEM_ACTOR } = require('../util/auditLog')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { seedRecipe, seedUser } = require('./helpers/seed')
@@ -30,6 +32,13 @@ const AUTH = { Authorization: 'Bearer fake-test-token' }
 const HIGH = { allowed: false, severity: 'high', reason: 'openai:hate:0.97', category: 'hate', source: 'openai' }
 const MEDIUM = { allowed: false, severity: 'medium', reason: 'openai:harassment:0.60', category: 'harassment', source: 'openai' }
 const CLEAN = { allowed: true, severity: 'clean', reason: null, category: null, source: 'openai' }
+
+// Image verdicts (same shape; source 'vision'/'error'). IMG_UNSCANNED models the
+// fail-CLOSED path: a scan outage grades MEDIUM so the recipe is held / photo rejected.
+const IMG_HIGH = { allowed: false, severity: 'high', reason: 'vision:adult:VERY_LIKELY', category: 'adult', source: 'vision' }
+const IMG_MEDIUM = { allowed: false, severity: 'medium', reason: 'vision:racy:VERY_LIKELY', category: 'racy', source: 'vision' }
+const IMG_CLEAN = { allowed: true, severity: 'clean', reason: null, category: null, source: 'vision' }
+const IMG_UNSCANNED = { allowed: false, severity: 'medium', reason: 'vision:unscanned', category: 'unscanned', source: 'error' }
 
 // Minimal valid recipe payload (server stamps _id/userId/counters).
 const RECIPE_BODY = {
@@ -55,6 +64,9 @@ const RECIPE_BODY = {
 beforeEach(() => {
   moderateText.mockReset()
   moderateText.mockResolvedValue(CLEAN)
+  moderateImage.mockReset()
+  moderateImage.mockResolvedValue(IMG_CLEAN)
+  admin.__updateUser.mockClear()
 })
 
 afterEach(async () => {
@@ -216,5 +228,90 @@ describe('fail-open at the route layer', () => {
     const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
     expect(res.status).toBe(201)
     expect(res.body.pendingReview).toBe(false)
+  })
+})
+
+// ── P2: image moderation, collapsed with the text verdict on the recipe path ──
+
+describe('POST /addRecipe — image moderation tiers (text clean)', () => {
+  it('high-confidence image → 422 blocked, nothing persisted', async () => {
+    moderateImage.mockResolvedValue(IMG_HIGH)
+    const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(422)
+    expect(res.body.code).toBe('CONTENT_BLOCKED')
+    expect(await getDB().collection('recipes').countDocuments({})).toBe(0)
+  })
+
+  it('medium-confidence image → 201 pending_review + automod report (image reason)', async () => {
+    moderateImage.mockResolvedValue(IMG_MEDIUM)
+    const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(201)
+    expect(res.body.pendingReview).toBe(true)
+    const db = getDB()
+    expect((await db.collection('recipes').findOne(recipeIdQuery(res.body._id))).status).toBe('pending_review')
+    const report = await db.collection('reports').findOne({ recipeId: String(res.body._id) })
+    expect(report.classifier.reason).toBe('vision:racy:VERY_LIKELY')
+  })
+
+  it('image fails CLOSED: an unscanned (scan-error) image holds the recipe', async () => {
+    moderateImage.mockResolvedValue(IMG_UNSCANNED)
+    const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(201)
+    expect(res.body.pendingReview).toBe(true)
+    expect((await getDB().collection('recipes').findOne(recipeIdQuery(res.body._id))).status).toBe('pending_review')
+  })
+
+  it('worst-of: clean image + high text still blocks', async () => {
+    moderateText.mockResolvedValue(HIGH)
+    moderateImage.mockResolvedValue(IMG_CLEAN)
+    const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(422)
+  })
+})
+
+describe('PUT /editRecipe — image only re-scanned when it changed', () => {
+  it('does not scan the image when the URL is unchanged', async () => {
+    await seedRecipe({ ...RECIPE_BODY, _id: 'e-img', userId: TEST_UID })
+    const res = await request(app).put('/api/editRecipe?recipeId=e-img').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(200)
+    // Same recipeImage as the seeded doc → image axis skipped (empty URL → not called).
+    expect(moderateImage).toHaveBeenCalledWith(null, 'recipe.image')
+  })
+
+  it('scans (and can block on) a changed image URL', async () => {
+    await seedRecipe({ ...RECIPE_BODY, _id: 'e-img2', userId: TEST_UID })
+    moderateImage.mockResolvedValue(IMG_HIGH)
+    const changed = { ...RECIPE_BODY, recipeImage: 'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2FNEW.jpg?alt=media&token=z' }
+    const res = await request(app).put('/api/editRecipe?recipeId=e-img2').set(AUTH).send(changed)
+    expect(res.status).toBe(422)
+    expect(moderateImage).toHaveBeenCalledWith(changed.recipeImage, 'recipe.image')
+  })
+})
+
+describe('POST /updatePhoto — profile photo moderation', () => {
+  const PHOTO = 'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/profilePhotos%2Ftest-uid?alt=media&token=p'
+
+  it('clean photo → 200 and applied to Firebase Auth', async () => {
+    const res = await request(app).post('/api/updatePhoto').set(AUTH).send({ photoURL: PHOTO })
+    expect(res.status).toBe(200)
+    expect(admin.__updateUser).toHaveBeenCalledWith('test-uid', { photoURL: PHOTO })
+  })
+
+  it('high|medium|fail-closed photo → 422 and NOT applied', async () => {
+    for (const verdict of [IMG_HIGH, IMG_MEDIUM, IMG_UNSCANNED]) {
+      admin.__updateUser.mockClear()
+      moderateImage.mockResolvedValue(verdict)
+      const res = await request(app).post('/api/updatePhoto').set(AUTH).send({ photoURL: PHOTO })
+      expect(res.status).toBe(422)
+      expect(res.body.code).toBe('CONTENT_BLOCKED')
+      expect(admin.__updateUser).not.toHaveBeenCalled()
+    }
+  })
+
+  it('clearing the photo (empty URL) needs no scan and clears via null', async () => {
+    const res = await request(app).post('/api/updatePhoto').set(AUTH).send({ photoURL: '' })
+    expect(res.status).toBe(200)
+    expect(moderateImage).not.toHaveBeenCalled()
+    expect(admin.__updateUser).toHaveBeenCalledWith('test-uid', { photoURL: null })
   })
 })

--- a/server/__tests__/textModeration.test.js
+++ b/server/__tests__/textModeration.test.js
@@ -55,6 +55,37 @@ describe('moderationBlocklist.checkBlocklist', () => {
     expect(checkBlocklist('A delicious shiitake mushroom risotto', 'recipe.title')).toBeNull()
   })
 
+  it('catches concatenated/embedded slurs everywhere via the hard-slur substring pass', () => {
+    // Hard, unambiguous stems are substring-matched on any surface.
+    expect(checkBlocklist('what a niggerlover', 'review')).toMatchObject({ kind: 'slur' })
+    expect(checkBlocklist('megaasshole energy', 'recipe.description')).toMatchObject({ kind: 'slur' })
+    expect(checkBlocklist('xXcuntXx', 'recipe.title')).toMatchObject({ kind: 'slur' })
+  })
+
+  it('catches soft concatenated slurs on identity fields but leaves prose to the API', () => {
+    // "shitfuck" is substring-matched on short identity fields…
+    expect(checkBlocklist('shitfuck', 'username')).toMatchObject({ kind: 'slur' })
+    expect(checkBlocklist('shitlord', 'displayName')).toMatchObject({ kind: 'slur' })
+    // …but NOT substring-scanned in long-form prose (the OpenAI layer backstops it).
+    expect(checkBlocklist('this shitfuck of a day', 'review')).toBeNull()
+  })
+
+  it('defeats letter-spacing evasion', () => {
+    expect(checkBlocklist('s h i t', 'username')).toMatchObject({ kind: 'slur' })
+    expect(checkBlocklist('n i g g e r', 'review')).toMatchObject({ kind: 'slur' })
+    expect(checkBlocklist('you f.u.c.k', 'review')).toMatchObject({ kind: 'slur' })
+  })
+
+  it('keeps the substring pass Scunthorpe-safe via the benign allowlist', () => {
+    // "Scunthorpe" (contains cunt) and the shitake/retardant family must pass even
+    // where the hard-slur substring pass would otherwise fire.
+    expect(checkBlocklist('greetings from Scunthorpe', 'review')).toBeNull()
+    expect(checkBlocklist('shitake mushroom stir fry', 'recipe.title')).toBeNull()
+    expect(checkBlocklist('coat the pan with fire retardant', 'recipe.description')).toBeNull()
+    // Even as an identity field (where soft substrings fire), allowlisted words pass.
+    expect(checkBlocklist('Scunthorpe', 'username')).toBeNull()
+  })
+
   it('applies URL/domain spam rules only to identity fields', () => {
     expect(checkBlocklist('visit www.spam.com', 'username')).toMatchObject({ kind: 'spam' })
     // A recipe body legitimately contains links — not flagged by the blocklist.

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -13,6 +13,7 @@ const { respondBlocked } = require('../util/automod')
 
 const USERNAME_MIN_LENGTH = 3
 const USERNAME_MAX_LENGTH = 30
+const DISPLAY_NAME_MAX_LENGTH = 50
 
 const BIO_MAX_LENGTH = 300
 const LOCATION_MAX_LENGTH = 80
@@ -261,6 +262,35 @@ router.post('/updatePhoto', verifyToken, requireActive, asyncHandler(async (req,
   // Admin SDK clears the avatar with null (an empty string is rejected).
   await admin.auth().updateUser(req.uid, { photoURL: url || null })
   res.json({ success: true, photoURL: url })
+}))
+
+// POST /updateDisplayName
+// Sets the authenticated user's Firebase Auth displayName, AFTER moderation.
+// A displayName is otherwise written client-side straight to Firebase Auth
+// (updateProfile in AuthContext) — there's no server path to intercept — so,
+// exactly like updatePhoto for photoURL, this server-owned endpoint is the
+// moderation hook: the client POSTs the desired name and the SERVER applies it
+// only if it passes. Like a username (and unlike a recipe) a name has no
+// owner-only "pending" state, so BOTH high and medium confidence block (422).
+// The 'displayName' context also applies the identity-only spam rules (no
+// URLs/domains in a name).
+router.post('/updateDisplayName', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const { displayName } = req.body || {}
+  if (typeof displayName !== 'string' || !displayName.trim()) {
+    return res.status(400).json({ error: 'displayName is required' })
+  }
+  const name = displayName.trim()
+  if (name.length > DISPLAY_NAME_MAX_LENGTH) {
+    return res.status(400).json({ error: `Display name must be at most ${DISPLAY_NAME_MAX_LENGTH} characters` })
+  }
+
+  const verdict = await moderateText(name, 'displayName')
+  if (!verdict.allowed) {
+    return respondBlocked(res)
+  }
+
+  await admin.auth().updateUser(req.uid, { displayName: name })
+  res.json({ success: true, displayName: name })
 }))
 
 // POST /updatePrivacy

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -8,6 +8,7 @@ const { recordAudit } = require('../util/auditLog')
 const { deleteRecipeImage, deleteProfilePhoto } = require('../util/firebaseStorage')
 const { recomputeRecipeRating } = require('../util/recipeRating')
 const { moderateText } = require('../util/textModeration')
+const { moderateImage } = require('../util/imageModeration')
 const { respondBlocked } = require('../util/automod')
 
 const USERNAME_MIN_LENGTH = 3
@@ -229,6 +230,37 @@ router.post('/updateProfile', verifyToken, requireActive, asyncHandler(async (re
     { upsert: true }
   )
   res.json({ success: true })
+}))
+
+// POST /updatePhoto
+// Sets (or clears) the authenticated user's Firebase Auth photoURL, AFTER
+// screening the image. Profile photos are uploaded client-side straight to
+// Storage and the photoURL is otherwise written client-side directly to Firebase
+// Auth — there is no server upload path to intercept — so this server-owned
+// endpoint is the moderation hook: the client uploads the file, then POSTs the
+// resulting download URL here and the SERVER applies it only if it passes.
+//
+// Like a review/bio (and unlike a recipe), a photo has no owner-only "pending"
+// state to fall back to, so BOTH high and medium confidence block (422); the
+// image fails CLOSED, so a scan outage also rejects rather than applying an
+// unscanned photo. Clearing the photo (empty URL) needs no scan.
+router.post('/updatePhoto', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const { photoURL } = req.body || {}
+  if (photoURL != null && typeof photoURL !== 'string') {
+    return res.status(400).json({ error: 'photoURL must be a string' })
+  }
+  const url = typeof photoURL === 'string' ? photoURL.trim() : ''
+
+  if (url) {
+    const verdict = await moderateImage(url, 'profile.photo')
+    if (!verdict.allowed) {
+      return respondBlocked(res)
+    }
+  }
+
+  // Admin SDK clears the avatar with null (an empty string is rejected).
+  await admin.auth().updateUser(req.uid, { photoURL: url || null })
+  res.json({ success: true, photoURL: url })
 }))
 
 // POST /updatePrivacy

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -9,7 +9,8 @@ const { recordAudit } = require('../util/auditLog')
 const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
 const { moderateText } = require('../util/textModeration')
-const { gatherRecipeText, holdRecipeForReview, respondBlocked } = require('../util/automod')
+const { moderateImage } = require('../util/imageModeration')
+const { gatherRecipeText, holdRecipeForReview, respondBlocked, worstVerdict } = require('../util/automod')
 const { EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 const { teardownRecipeDocs } = require('../util/teardownRecipe')
@@ -255,11 +256,16 @@ router.post('/addRecipe', verifyToken, requireActive, asyncHandler(async (req, r
     return res.status(400).json({ error: boundsError })
   }
 
-  // Automated text moderation. High-confidence → block the write (4xx). Medium →
+  // Automated moderation on BOTH axes — text and the recipe image — collapsed to
+  // the most severe verdict. High-confidence → block the write (4xx). Medium →
   // save but hold from public reads as 'pending_review' (owner still sees it) and
   // file a system report for an admin to clear. Clean / classifier-disabled → save
-  // normally. moderateText fails open, so a moderation outage won't block creation.
-  const verdict = await moderateText(gatherRecipeText(body), 'recipe')
+  // normally. Text fails OPEN (an outage can't block creation); image fails CLOSED
+  // (an unscanned image is held, never published) — see util/imageModeration.
+  const verdict = worstVerdict(
+    await moderateText(gatherRecipeText(body), 'recipe'),
+    await moderateImage(body.recipeImage, 'recipe.image')
+  )
   if (verdict.severity === 'high') {
     return respondBlocked(res)
   }
@@ -322,11 +328,17 @@ router.put('/editRecipe', verifyToken, requireActive, asyncHandler(async (req, r
     return res.status(400).json({ error: boundsError })
   }
 
-  // Re-moderate the edited text (same tiers as create). High → reject the edit;
-  // the previously-saved version stays as-is. Medium → re-hold as 'pending_review'.
-  // A clean edit deliberately does NOT clear an existing hold/takedown — only an
-  // admin clears those (the edit just stops adding new flags).
-  const verdict = await moderateText(gatherRecipeText(body), 'recipe')
+  // Re-moderate the edited text + (only if it changed) the new image — same tiers
+  // as create. High → reject the edit; the previously-saved version stays as-is.
+  // Medium → re-hold as 'pending_review'. A clean edit deliberately does NOT clear
+  // an existing hold/takedown — only an admin clears those (the edit just stops
+  // adding new flags). The image is re-scanned only when the URL actually changed,
+  // so a plain text edit doesn't pay for (or re-hold on) an already-cleared image.
+  const newImage = body.recipeImage && body.recipeImage !== recipe.recipeImage ? body.recipeImage : null
+  const verdict = worstVerdict(
+    await moderateText(gatherRecipeText(body), 'recipe'),
+    await moderateImage(newImage, 'recipe.image')
+  )
   if (verdict.severity === 'high') {
     return respondBlocked(res)
   }

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -262,10 +262,14 @@ router.post('/addRecipe', verifyToken, requireActive, asyncHandler(async (req, r
   // file a system report for an admin to clear. Clean / classifier-disabled → save
   // normally. Text fails OPEN (an outage can't block creation); image fails CLOSED
   // (an unscanned image is held, never published) — see util/imageModeration.
-  const verdict = worstVerdict(
-    await moderateText(gatherRecipeText(body), 'recipe'),
-    await moderateImage(body.recipeImage, 'recipe.image')
-  )
+  // The two scans are independent network calls, so run them concurrently; both
+  // resolve internally (text fails open, image fails closed) and never reject, so
+  // Promise.all won't short-circuit on a moderation outage.
+  const [textVerdict, imageVerdict] = await Promise.all([
+    moderateText(gatherRecipeText(body), 'recipe'),
+    moderateImage(body.recipeImage, 'recipe.image'),
+  ])
+  const verdict = worstVerdict(textVerdict, imageVerdict)
   if (verdict.severity === 'high') {
     return respondBlocked(res)
   }
@@ -335,10 +339,13 @@ router.put('/editRecipe', verifyToken, requireActive, asyncHandler(async (req, r
   // adding new flags). The image is re-scanned only when the URL actually changed,
   // so a plain text edit doesn't pay for (or re-hold on) an already-cleared image.
   const newImage = body.recipeImage && body.recipeImage !== recipe.recipeImage ? body.recipeImage : null
-  const verdict = worstVerdict(
-    await moderateText(gatherRecipeText(body), 'recipe'),
-    await moderateImage(newImage, 'recipe.image')
-  )
+  // Run the two scans concurrently (see addRecipe) — independent calls that both
+  // resolve internally, so Promise.all is safe.
+  const [textVerdict, imageVerdict] = await Promise.all([
+    moderateText(gatherRecipeText(body), 'recipe'),
+    moderateImage(newImage, 'recipe.image'),
+  ])
+  const verdict = worstVerdict(textVerdict, imageVerdict)
   if (verdict.severity === 'high') {
     return respondBlocked(res)
   }

--- a/server/util/automod.js
+++ b/server/util/automod.js
@@ -23,6 +23,20 @@ function respondBlocked(res) {
   return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
 }
 
+// A recipe is screened on two independent axes (text + image); the recipe is
+// only as clean as its worst part. Collapse any number of verdicts into the most
+// severe one, so the route applies a single tier decision (block / hold / allow).
+// Skips falsy args (e.g. an image axis that wasn't scanned this request).
+const SEVERITY_RANK = { clean: 0, medium: 1, high: 2 }
+function worstVerdict(...verdicts) {
+  let worst = null
+  for (const v of verdicts) {
+    if (!v) continue
+    if (!worst || SEVERITY_RANK[v.severity] > SEVERITY_RANK[worst.severity]) worst = v
+  }
+  return worst || { allowed: true, severity: 'clean', reason: null, category: null, scores: null, source: 'none' }
+}
+
 // Flatten a recipe payload's user-controlled text into one blob for a single
 // classifier pass (one API call per recipe, not one per field).
 //
@@ -154,4 +168,4 @@ async function holdRecipeForReview(db, { recipeId, title, verdict }) {
   return true
 }
 
-module.exports = { BLOCKED_MESSAGE, BLOCKED_CODE, respondBlocked, gatherRecipeText, holdRecipeForReview }
+module.exports = { BLOCKED_MESSAGE, BLOCKED_CODE, respondBlocked, gatherRecipeText, holdRecipeForReview, worstVerdict }

--- a/server/util/email.js
+++ b/server/util/email.js
@@ -231,6 +231,26 @@ const templates = {
     }
   },
 
+  // Admin-facing: Cloud Vision flagged a user image with a non-trivial ADULT
+  // likelihood (the canary in imageModeration.js). Internal, no appeal line; the
+  // body carries the SafeSearch likelihoods so it can be triaged from the inbox.
+  adultContentFlagged({ context, adult, racy, violence, verdict }) {
+    const subject = 'Prepify moderation: adult-content image flagged'
+    return {
+      subject,
+      ...layout({
+        heading: subject,
+        paragraphs: [
+          'Cloud Vision SafeSearch flagged a user-uploaded image with a non-trivial ADULT likelihood.',
+          `Surface: ${context || 'unknown'}`,
+          `SafeSearch — adult: ${adult}, racy: ${racy}, violence: ${violence}`,
+          `Moderation verdict: ${verdict}`,
+          'This is an early-warning signal, NOT CSAM detection. If these recur it is the agreed trigger to stand up dedicated CSAM hash-scanning (see CONTENT_MODERATION.md P3). Further alerts are rate-limited.',
+        ],
+      }),
+    }
+  },
+
   // Admin-facing: a new user bug report landed. No appeal line (internal); the
   // CTA button drops the admin at Prepify, and the body carries the triage bits.
   bugReportFiled({ category, description, url, reporterLabel }) {
@@ -332,6 +352,41 @@ function notifyBugReportFiled({ category, description, url, reporterLabel }) {
   )
 }
 
+// Where adult-content canary alerts go. MODERATION_ALERT_EMAIL overrides; else it
+// falls back to the shared admin address. Separate from ADMIN_NOTIFY_EMAIL so the
+// safety canary can be pointed at a different inbox without a code change.
+function moderationAlertAddress() {
+  return process.env.MODERATION_ALERT_EMAIL || adminNotifyAddress()
+}
+
+// Throttle for the adult-content canary email: at most one send per window, so a
+// burst of bad uploads can't flood the inbox. The per-image console.warn in
+// imageModeration.js still fires every time — this only rate-limits the push. The
+// last-sent timestamp is module-local (per process); a multi-instance deploy may
+// send one-per-instance, which is acceptable for an early-warning. Default 30 min,
+// env-overridable (0 disables throttling).
+let _lastAdultAlertAt = 0
+function adultAlertThrottleMs() {
+  const v = Number(process.env.MODERATION_ALERT_THROTTLE_MS)
+  return Number.isFinite(v) && v >= 0 ? v : 30 * 60 * 1000
+}
+
+// Adult-content image flagged → email the moderation/admin address, throttled and
+// best-effort. Returns without sending when disabled, throttled, or there is no
+// recipient. The throttle clock only advances on an actual (enabled) attempt.
+function notifyAdultContentFlag({ context, adult, racy, violence, verdict }) {
+  if (!emailEnabled()) return Promise.resolve()
+  const now = Date.now()
+  if (now - _lastAdultAlertAt < adultAlertThrottleMs()) return Promise.resolve()
+  _lastAdultAlertAt = now
+  const to = moderationAlertAddress()
+  if (!to) return Promise.resolve()
+  return deliver(
+    () => to,
+    () => templates.adultContentFlagged({ context, adult, racy, violence, verdict })
+  )
+}
+
 // --- Background dispatch -----------------------------------------------------
 // Moderation routes fire notifications WITHOUT awaiting them, so the admin's
 // HTTP response never waits on Firebase + the email provider (the action has
@@ -364,4 +419,5 @@ module.exports = {
   notifyRecipeHidden,
   notifyReviewTakenDown,
   notifyBugReportFiled,
+  notifyAdultContentFlag,
 }

--- a/server/util/imageModeration.js
+++ b/server/util/imageModeration.js
@@ -119,7 +119,11 @@ async function callVision(imageUrl) {
     // Vision reports a per-request failure (bad/unreachable image) in `error`
     // rather than a non-2xx — treat it as a scan failure so we fail closed.
     if (result.error) throw new Error(`Vision SafeSearch image error: ${result.error.message || result.error.code}`)
-    return result.safeSearchAnnotation || {}
+    // A 200 with no error but no annotation is anomalous (the feature was
+    // requested). Treat a missing annotation as a scan failure so we fail CLOSED
+    // rather than grading an empty object as clean and publishing it unscanned.
+    if (!result.safeSearchAnnotation) throw new Error('Vision SafeSearch: missing annotation')
+    return result.safeSearchAnnotation
   } finally {
     clearTimeout(timer)
   }

--- a/server/util/imageModeration.js
+++ b/server/util/imageModeration.js
@@ -152,6 +152,21 @@ async function moderateImage(imageUrl, context = '') {
   }
 
   const { severity, category, score } = grade(annotation)
+
+  // Canary: surface any non-trivial ADULT signal in the logs even when the verdict
+  // itself didn't hard-block (a POSSIBLE/LIKELY adult image still grades medium or
+  // clean). The agreed trigger for standing up dedicated CSAM hash-scanning is "we
+  // start seeing adult hits" — this is the early warning that bad actors found the
+  // site. NOTE: SafeSearch flags generic adult/explicit content, NOT CSAM; this is
+  // a signal to act, not a detector. See docs/CONTENT_MODERATION.md P3.
+  if ((LIKELIHOOD[annotation.adult] ?? 0) >= LIKELIHOOD.LIKELY) {
+    console.warn(
+      `[moderation][adult-canary] adult=${annotation.adult} racy=${annotation.racy} ` +
+      `violence=${annotation.violence} context=${context || 'n/a'} verdict=${severity} ` +
+      `— review for abuse; if recurring, enable CSAM hash-scanning (CONTENT_MODERATION.md P3)`
+    )
+  }
+
   return {
     allowed: severity === 'clean',
     severity,

--- a/server/util/imageModeration.js
+++ b/server/util/imageModeration.js
@@ -1,0 +1,161 @@
+// Thin, swappable, env-gated IMAGE classifier — the image counterpart to
+// util/textModeration. The same write routes that screen user text call this
+// before publishing a user-supplied image URL. Mirrors textModeration/email.js:
+//   - Reads config from the environment on every call (tests can toggle it).
+//   - No-ops to a CLEAN verdict when no provider is configured, so local/CI runs
+//     need no external key.
+//
+// Single layer: Google Cloud Vision SafeSearch (adult / violence / racy
+// likelihoods), called over REST with native fetch (no SDK dep, matching the
+// OpenAI choice in textModeration). The image is passed by its public Firebase
+// download URL as `image.source.imageUri`, so we never download the bytes.
+//
+// DELIBERATE ASYMMETRY vs text: text moderation fails OPEN (a classifier outage
+// must not block all content creation), but images fail CLOSED — an unscanned
+// image is treated as MEDIUM ('unscanned'), so the caller quarantines it rather
+// than publishing something never looked at. This is the spec's
+// "quarantine-until-scanned" rule (docs/CONTENT_MODERATION.md).
+//
+// Returns the same verdict shape as moderateText, so the existing pipeline
+// (respondBlocked / holdRecipeForReview) interprets it without translation:
+//   { allowed, severity, reason, category, scores, source }
+//     severity : 'clean' | 'medium' | 'high'
+//     allowed  : true only when severity === 'clean'
+//     source   : 'vision' | 'disabled' | 'error'
+
+const VISION_URL = 'https://vision.googleapis.com/v1/images:annotate'
+const REQUEST_TIMEOUT_MS = 8000
+
+// Google's SafeSearch likelihood enum, as an ordinal so thresholds compare
+// numerically. UNKNOWN is treated as the floor (no signal).
+const LIKELIHOOD = {
+  UNKNOWN: 0,
+  VERY_UNLIKELY: 1,
+  UNLIKELY: 2,
+  POSSIBLE: 3,
+  LIKELY: 4,
+  VERY_LIKELY: 5,
+}
+
+// Enabled only when a key is present AND not explicitly killed — same master
+// toggle as textModeration (MODERATION_ENABLED gates every classifier). Read
+// live (not cached) so tests can flip it.
+function imageModerationEnabled() {
+  if (process.env.MODERATION_ENABLED === 'false') return false
+  return !!process.env.GOOGLE_VISION_API_KEY
+}
+
+// Likelihood thresholds, env-overridable for tuning without a redeploy. Named by
+// the enum string (e.g. 'VERY_LIKELY'); fall back to a sane default if unset or
+// not a recognized name.
+function threshold(envName, fallback) {
+  const v = process.env[envName]
+  return v && v in LIKELIHOOD ? LIKELIHOOD[v] : LIKELIHOOD[fallback]
+}
+// adult/violence at this likelihood → HIGH (block); at the medium one → hold.
+function highLikelihood() { return threshold('MODERATION_IMAGE_HIGH', 'VERY_LIKELY') }
+function mediumLikelihood() { return threshold('MODERATION_IMAGE_MEDIUM', 'LIKELY') }
+
+const CLEAN = { allowed: true, severity: 'clean', reason: null, category: null, scores: null, source: 'disabled' }
+function clean(source) {
+  return { ...CLEAN, source }
+}
+
+// Map a SafeSearch annotation to our severity grade. `adult` and `violence` can
+// reach HIGH; `racy` (suggestive, not explicit) only ever contributes MEDIUM, so
+// a merely-racy photo is held for a human rather than auto-blocked.
+function grade(annotation = {}) {
+  const score = (name) => LIKELIHOOD[annotation[name]] ?? 0
+  const adult = score('adult')
+  const violence = score('violence')
+  const racy = score('racy')
+
+  const high = highLikelihood()
+  const medium = mediumLikelihood()
+
+  // Pick the single most severe category for the verdict reason.
+  let severity = 'clean'
+  let category = null
+  let topScore = 0
+
+  for (const [cat, value] of [['adult', adult], ['violence', violence]]) {
+    if (value >= high && severity !== 'high') { severity = 'high'; category = cat; topScore = value }
+    else if (value >= medium && severity === 'clean') { severity = 'medium'; category = cat; topScore = value }
+  }
+  if (severity === 'clean' && racy >= LIKELIHOOD.VERY_LIKELY) {
+    severity = 'medium'; category = 'racy'; topScore = racy
+  }
+
+  return { severity, category, score: topScore }
+}
+
+// Likelihood ordinal → its enum name, for a human-readable verdict reason.
+function likelihoodName(ordinal) {
+  return Object.keys(LIKELIHOOD).find((k) => LIKELIHOOD[k] === ordinal) || 'UNKNOWN'
+}
+
+// Call Vision SafeSearch with a hard timeout. Throws on network error, non-2xx,
+// timeout, OR a per-image error in the response (e.g. Vision couldn't fetch/decode
+// the URL) — the caller fails CLOSED on any throw.
+async function callVision(imageUrl) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    const res = await fetch(`${VISION_URL}?key=${process.env.GOOGLE_VISION_API_KEY}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requests: [{
+          image: { source: { imageUri: imageUrl } },
+          features: [{ type: 'SAFE_SEARCH_DETECTION' }],
+        }],
+      }),
+      signal: controller.signal,
+    })
+    if (!res.ok) throw new Error(`Vision SafeSearch HTTP ${res.status}`)
+    const json = await res.json()
+    const result = json?.responses?.[0]
+    if (!result) throw new Error('Vision SafeSearch: empty result')
+    // Vision reports a per-request failure (bad/unreachable image) in `error`
+    // rather than a non-2xx — treat it as a scan failure so we fail closed.
+    if (result.error) throw new Error(`Vision SafeSearch image error: ${result.error.message || result.error.code}`)
+    return result.safeSearchAnnotation || {}
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Classify a user-supplied image by URL.
+ *
+ * @param {string} imageUrl   public download URL of the image to screen
+ * @param {string} [context]  surface context ('recipe.image' | 'profile.photo')
+ * @returns {Promise<{allowed:boolean, severity:'clean'|'medium'|'high', reason:string|null, category:string|null, scores:object|null, source:string}>}
+ */
+async function moderateImage(imageUrl, context = '') {
+  if (!imageUrl || typeof imageUrl !== 'string' || !imageUrl.trim()) return clean('empty')
+  if (!imageModerationEnabled()) return clean('disabled')
+
+  let annotation
+  try {
+    annotation = await callVision(imageUrl)
+  } catch (err) {
+    // Fail CLOSED: an unscanned image is held (MEDIUM), never published. The
+    // caller decides what "held" means for its surface — a recipe goes
+    // pending_review; a profile photo is rejected (no owner-only state).
+    console.error(`moderateImage: scan failed (failing closed) [${context}]:`, err.message)
+    return { allowed: false, severity: 'medium', reason: 'vision:unscanned', category: 'unscanned', scores: null, source: 'error' }
+  }
+
+  const { severity, category, score } = grade(annotation)
+  return {
+    allowed: severity === 'clean',
+    severity,
+    reason: severity === 'clean' ? null : `vision:${category}:${likelihoodName(score)}`,
+    category,
+    scores: annotation,
+    source: 'vision',
+  }
+}
+
+module.exports = { moderateImage, imageModerationEnabled, grade }

--- a/server/util/imageModeration.js
+++ b/server/util/imageModeration.js
@@ -23,6 +23,8 @@
 //     allowed  : true only when severity === 'clean'
 //     source   : 'vision' | 'disabled' | 'error'
 
+const { notifyInBackground, notifyAdultContentFlag } = require('./email')
+
 const VISION_URL = 'https://vision.googleapis.com/v1/images:annotate'
 const REQUEST_TIMEOUT_MS = 8000
 
@@ -164,6 +166,17 @@ async function moderateImage(imageUrl, context = '') {
       `[moderation][adult-canary] adult=${annotation.adult} racy=${annotation.racy} ` +
       `violence=${annotation.violence} context=${context || 'n/a'} verdict=${severity} ` +
       `— review for abuse; if recurring, enable CSAM hash-scanning (CONTENT_MODERATION.md P3)`
+    )
+    // Push a throttled, best-effort alert email on top of the log (email.js gates
+    // on RESEND_API_KEY and rate-limits itself; never awaited, never blocks the scan).
+    notifyInBackground(
+      notifyAdultContentFlag({
+        context: context || 'n/a',
+        adult: annotation.adult,
+        racy: annotation.racy,
+        violence: annotation.violence,
+        verdict: severity,
+      })
     )
   }
 

--- a/server/util/moderationBlocklist.js
+++ b/server/util/moderationBlocklist.js
@@ -7,8 +7,16 @@
 // here are expensive. Broad / contextual judgement is left to the API layer.
 //
 // Two kinds of rule:
-//   - `SLUR_TERMS`   — exact normalized-token matches (so "sh1t"/"f4g" obfuscation
-//                      is caught) without the Scunthorpe problem of substring scans.
+//   - `SLUR_TERMS`   — normalized slur stems. Matched as exact tokens on every
+//                      surface (so "sh1t"/"f4g" obfuscation is caught), plus two
+//                      hardening passes that defeat the common evasions of an
+//                      exact-token list:
+//                        1. letter-spacing ("s h i t", "n.i.g.g.e.r") — runs of
+//                           single-character tokens are rejoined and re-scanned;
+//                        2. concatenation/embedding ("shitfuck", "niggerlover") —
+//                           a substring scan, applied carefully to avoid the
+//                           Scunthorpe problem (see SUBSTRING_SLURS / BENIGN_ALLOWLIST
+//                           and the per-surface strictness below).
 //   - `SPAM_PATTERNS` — regexes for promotional / link-dropping abuse. Some only
 //                      apply to short identity fields (username/displayName), where
 //                      a URL or "buy now" is never legitimate.
@@ -51,6 +59,36 @@ const SLUR_TERMS = new Set(
   ].map(normalizeToken)
 )
 
+// Subset of SLUR_TERMS that is safe to match as a SUBSTRING on ANY surface
+// (including long-form prose like recipes/reviews/bios). These stems effectively
+// never occur inside benign English or food words, so "niggerlover" / "xcunt" /
+// "megaasshole" are caught everywhere. The few real-world collisions (e.g. the
+// place name "Scunthorpe") are handled by BENIGN_ALLOWLIST below.
+//
+// The REMAINING slur stems (shit, fuck, bitch, faggot, …) are substring-prone —
+// "shitake" (a misspelled mushroom), the British food "faggots", "fire retardant"
+// — so they are only substring-matched on short identity fields (username /
+// displayName), where there is no legitimate prose to false-positive on. On
+// long-form surfaces they still match as exact tokens, and the OpenAI layer is the
+// semantic backstop for obfuscated profanity there.
+const SUBSTRING_SLURS = new Set(['nigger', 'cunt', 'asshole'].map(normalizeToken))
+
+// Benign words that CONTAIN a slur stem as a substring and must never trip the
+// substring scan (the "Scunthorpe problem"). Stored already-normalized. Matched as
+// a whole normalized token, so a token equal to one of these is exempt from the
+// substring pass entirely (it is still subject to exact-token matching, which none
+// of these collide with). Keep this list tight and obvious.
+const BENIGN_ALLOWLIST = new Set(
+  [
+    'scunthorpe', // place name — contains "cunt"
+    'shiitake', // mushroom — (doesn't actually contain "shit", but pin it)
+    'shitake', // common misspelling of the mushroom — contains "shit"
+    'shitzu', // common misspelling of "shih tzu" — contains "shit"
+    'retardant', // e.g. fire retardant — contains "retard"
+    'niggardly', // archaic "stingy" — contains "niggar" (not "nigger"), pinned for safety
+  ].map(normalizeToken)
+)
+
 // Spam / promotional patterns. `identityOnly: true` rules apply only to short
 // identity fields (username, displayName) where any URL or call-to-action is abuse;
 // they are NOT applied to recipe bodies or reviews, which legitimately contain
@@ -73,6 +111,40 @@ const SPAM_PATTERNS = [
 // here — that's the single switch that makes bios reject URLs/domains too.
 const IDENTITY_CONTEXTS = new Set(['username', 'displayName'])
 
+// Match a single already-normalized token against the slur list, returning the
+// matched stem or null. Matching tiers, cheapest first:
+//   1. allowlisted benign word  -> never a slur,
+//   2. exact normalized token   -> slur (any surface),
+//   3. substring contains a stem -> slur, but only if the stem is in
+//      SUBSTRING_SLURS (safe everywhere) OR the field is a short identity field
+//      (`wide`), where soft/substring-prone stems are also checked.
+function matchSlurToken(normalized, wide) {
+  if (!normalized || BENIGN_ALLOWLIST.has(normalized)) return null
+  if (SLUR_TERMS.has(normalized)) return normalized
+  for (const term of SLUR_TERMS) {
+    if (normalized.includes(term) && (wide || SUBSTRING_SLURS.has(term))) return term
+  }
+  return null
+}
+
+// Join maximal runs of single-character tokens so letter-spacing ("s h i t",
+// "n.i.g.g.e.r", "f*u*c*k") collapses back into one token to scan. A deliberately
+// letter-spaced string is itself an adversarial signal, so the joined run is
+// scanned with the wide (identity-strength) pass.
+function spacedRuns(tokens) {
+  const runs = []
+  let run = []
+  for (const t of tokens) {
+    if (t.length === 1) run.push(t)
+    else {
+      if (run.length > 1) runs.push(run.join(''))
+      run = []
+    }
+  }
+  if (run.length > 1) runs.push(run.join(''))
+  return runs
+}
+
 /**
  * Scan `text` for a blocklist hit. Returns the first match as
  * `{ term, kind }` (kind: 'slur' | 'spam'), or null when clean.
@@ -83,13 +155,21 @@ const IDENTITY_CONTEXTS = new Set(['username', 'displayName'])
 function checkBlocklist(text, context = '') {
   if (!text || typeof text !== 'string') return null
 
-  for (const token of tokenize(text)) {
-    if (SLUR_TERMS.has(normalizeToken(token))) {
-      return { term: normalizeToken(token), kind: 'slur' }
-    }
+  const isIdentity = IDENTITY_CONTEXTS.has(context)
+  const tokens = tokenize(text)
+
+  // Per-token pass: exact on every surface, substring per the tier rules above.
+  for (const token of tokens) {
+    const hit = matchSlurToken(normalizeToken(token), isIdentity)
+    if (hit) return { term: hit, kind: 'slur' }
   }
 
-  const isIdentity = IDENTITY_CONTEXTS.has(context)
+  // Letter-spacing pass: rejoin runs of single-character tokens and re-scan.
+  for (const run of spacedRuns(tokens)) {
+    const hit = matchSlurToken(normalizeToken(run), true)
+    if (hit) return { term: hit, kind: 'slur' }
+  }
+
   for (const { re, label, identityOnly } of SPAM_PATTERNS) {
     if (identityOnly && !isIdentity) continue
     if (re.test(text)) return { term: label, kind: 'spam' }
@@ -98,4 +178,11 @@ function checkBlocklist(text, context = '') {
   return null
 }
 
-module.exports = { checkBlocklist, normalizeToken, SLUR_TERMS, SPAM_PATTERNS }
+module.exports = {
+  checkBlocklist,
+  normalizeToken,
+  SLUR_TERMS,
+  SUBSTRING_SLURS,
+  BENIGN_ALLOWLIST,
+  SPAM_PATTERNS,
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -58,6 +58,12 @@ class AuthAPIClass {
   async updatePhoto(photoURL: string) {
     await http.post('api/updatePhoto', { photoURL })
   }
+  // Applies the Firebase Auth displayName server-side, AFTER text moderation —
+  // the client no longer writes displayName directly. A rejected name throws
+  // (422 CONTENT_BLOCKED), surfaced like the other moderation errors.
+  async updateDisplayName(displayName: string) {
+    await http.post('api/updateDisplayName', { displayName })
+  }
   // Saves the privacy toggles that gate the public /u/:username view. Both flags
   // are always sent so the server stores the current state of each switch.
   async updatePrivacy(isPublic: boolean, hideLocation: boolean) {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -52,6 +52,12 @@ class AuthAPIClass {
   async updateProfile(profile: UserProfile) {
     await http.post('api/updateProfile', profile)
   }
+  // Applies (or clears, with '') the Firebase Auth photoURL server-side, AFTER
+  // image moderation — the client no longer writes photoURL directly. A rejected
+  // image throws (422 CONTENT_BLOCKED), surfaced like the other moderation errors.
+  async updatePhoto(photoURL: string) {
+    await http.post('api/updatePhoto', { photoURL })
+  }
   // Saves the privacy toggles that gate the public /u/:username view. Both flags
   // are always sent so the server stores the current state of each switch.
   async updatePrivacy(isPublic: boolean, hideLocation: boolean) {

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -11,7 +11,6 @@ import {
   browserLocalPersistence,
   browserSessionPersistence,
   UserCredential,
-  updateProfile,
   verifyBeforeUpdateEmail,
   reauthenticateWithCredential,
   reauthenticateWithPopup,
@@ -256,10 +255,13 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
         await verifyBeforeUpdateEmail(user, email)
       }
 
-      // displayName still goes straight to Firebase Auth — it has no server hook
-      // yet (tracked as a moderation follow-up). The photo is handled above.
+      // Apply the displayName through the SERVER so it gets moderated before it's
+      // set on the Firebase Auth profile (like the photo above — the client no
+      // longer writes displayName directly). A rejected name throws here and the
+      // form surfaces the moderation error; reload() refreshes the local user.
       if (displayName !== undefined) {
-        await updateProfile(user, { displayName })
+        await AuthAPI.updateDisplayName(displayName)
+        await user.reload()
       }
     }
   }

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -210,7 +210,9 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
       const currUsername = await AuthAPI.getUsername()
       const { displayName, username, imgFile, email, password } = data
 
-      const photoUpdate: { photoURL?: string } = {}
+      // The new photoURL: the uploaded image's download URL, '' to clear, or
+      // undefined to leave it untouched.
+      let newPhotoURL: string | undefined
       if (imgFile) {
         const storage = getStorage()
         // Key the storage path by uid (not the original filename) so two users
@@ -219,9 +221,20 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
         // than orphaning the old one (Firebase serves the stored content-type).
         const profilePhotosRef = ref(storage, `profilePhotos/${user.uid}`)
         await uploadBytes(profilePhotosRef, imgFile)
-        photoUpdate.photoURL = await getDownloadURL(profilePhotosRef)
+        newPhotoURL = await getDownloadURL(profilePhotosRef)
       } else if (imgFile === null) {
-        photoUpdate.photoURL = ''
+        newPhotoURL = ''
+      }
+
+      // Apply the photo through the SERVER so it gets moderated before it's set
+      // on the Firebase Auth profile (an unmoderated photoURL can't be written
+      // client-side anymore). A rejected image throws here — before any other
+      // profile field is written — and the form surfaces the moderation error.
+      // reload() then refreshes the local user so the new (or cleared) photoURL
+      // is reflected immediately, as the old client-side updateProfile did.
+      if (newPhotoURL !== undefined) {
+        await AuthAPI.updatePhoto(newPhotoURL)
+        await user.reload()
       }
 
       if (username && username !== currUsername) {
@@ -243,12 +256,10 @@ const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
         await verifyBeforeUpdateEmail(user, email)
       }
 
-      const profileUpdate = {
-        ...photoUpdate,
-        ...(displayName !== undefined && { displayName }),
-      }
-      if (Object.keys(profileUpdate).length > 0) {
-        await updateProfile(user, profileUpdate)
+      // displayName still goes straight to Firebase Auth — it has no server hook
+      // yet (tracked as a moderation follow-up). The photo is handled above.
+      if (displayName !== undefined) {
+        await updateProfile(user, { displayName })
       }
     }
   }

--- a/src/pages/CreateUsername/CreateUsername.tsx
+++ b/src/pages/CreateUsername/CreateUsername.tsx
@@ -10,6 +10,7 @@ import { MdOutlineLocationOn } from 'react-icons/md'
 import UsernameInput from 'src/Components/Form/UsernameInput'
 import FormInput from 'src/Components/Form/FormInput'
 import AuthAPI from 'src/api/auth'
+import { getApiErrorMessage } from 'src/util/getApiErrorMessage'
 import { useAuth } from 'src/context/AuthContext'
 
 const BIO_MAX = 300
@@ -97,7 +98,9 @@ const CreateUsername: FC = () => {
         navigate('/')
       } catch (err: unknown) {
         setLoadingCreateUsername(false)
-        setError(err instanceof Error ? err.message : String(err))
+        // Prefer the server's reason (e.g. a 422 moderation block on the
+        // username) over axios's generic "Request failed with status code 422".
+        setError(getApiErrorMessage(err, 'Something went wrong. Please try again.'))
       }
     })()
   }

--- a/src/pages/CreateUsername/CreateUsername.tsx
+++ b/src/pages/CreateUsername/CreateUsername.tsx
@@ -3,7 +3,6 @@ import '../../Components/Form/FormStyles.scss'
 import './CreateUsername.scss'
 import { TailSpin } from 'react-loader-spinner'
 import { useNavigate } from 'react-router-dom'
-import { updateProfile } from 'firebase/auth'
 import toast from 'react-hot-toast'
 import { AiOutlineUser } from 'react-icons/ai'
 import { MdOutlineLocationOn } from 'react-icons/md'
@@ -83,7 +82,10 @@ const CreateUsername: FC = () => {
       try {
         await AuthAPI.setUsername(currUsername)
         if (displayName.trim()) {
-          await updateProfile(user, { displayName: displayName.trim() })
+          // Moderated server-side before it's set on the Firebase Auth profile
+          // (a rejected name throws and surfaces below); reload to reflect it.
+          await AuthAPI.updateDisplayName(displayName.trim())
+          await user.reload()
         }
         if (bio.trim() || location.trim()) {
           await AuthAPI.updateProfile({

--- a/src/pages/Settings/sections/ProfileSection.tsx
+++ b/src/pages/Settings/sections/ProfileSection.tsx
@@ -1,9 +1,9 @@
 import React, { FC, useEffect, useState } from 'react'
-import axios from 'axios'
 import toast from 'react-hot-toast'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from 'src/context/AuthContext'
 import AuthAPI from 'src/api/auth'
+import { getApiErrorMessage } from 'src/util/getApiErrorMessage'
 import { AvatarField, TextField, TextArea, SaveBar } from '../components/controls'
 import { useSettingsDirty } from '../SettingsDirtyContext'
 import './sections.scss'
@@ -220,11 +220,7 @@ const ProfileSection: FC = () => {
         } else {
           // Prefer the server's reason (e.g. a 422 moderation block on the
           // username, bio, or location) over axios's generic "Request failed…".
-          const message =
-            (axios.isAxiosError(err) && err.response?.data?.error) ||
-            err.message ||
-            'Something went wrong.'
-          toast.error(message)
+          toast.error(getApiErrorMessage(err, 'Something went wrong.'))
         }
       })
   }

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/AddReview.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/AddReview.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from 'react'
-import axios from 'axios'
 import RecipeAPI from 'src/api/recipes'
+import { getApiErrorMessage } from 'src/util/getApiErrorMessage'
 import { ReviewType } from 'types'
 
 type AddReviewProps = {
@@ -41,10 +41,12 @@ const AddReview: FC<AddReviewProps> = ({
       .catch(error => {
         // Surface the server's reason (e.g. a 422 moderation block) inline so the
         // user can rephrase, falling back to the generic message otherwise.
-        const message =
-          (axios.isAxiosError(error) && error.response?.data?.error) ||
-          'Something went wrong submitting your review. Please try again.'
-        setNewReviewError(message)
+        setNewReviewError(
+          getApiErrorMessage(
+            error,
+            'Something went wrong submitting your review. Please try again.'
+          )
+        )
       })
   }
 

--- a/src/test/AuthContext.test.tsx
+++ b/src/test/AuthContext.test.tsx
@@ -63,6 +63,7 @@ vi.mock('src/api/auth', () => ({
   default: {
     getUsername: vi.fn().mockResolvedValue('johndoe'),
     setUsername: vi.fn().mockResolvedValue(undefined),
+    updatePhoto: vi.fn().mockResolvedValue(undefined),
     deleteAccount: vi.fn().mockResolvedValue(undefined),
     checkUsernameAvailability: vi.fn().mockResolvedValue(true),
   },
@@ -74,6 +75,7 @@ const makeUser = (overrides: Record<string, any> = {}) => ({
   displayName: 'John',
   photoURL: '',
   providerData: [{ providerId: 'password' }],
+  reload: vi.fn().mockResolvedValue(undefined),
   getIdTokenResult: vi.fn().mockResolvedValue({ claims: {} }),
   ...overrides,
 })
@@ -188,7 +190,7 @@ describe('AuthContext — deleteAccount (Google account)', () => {
 // ─── updateProfileData ────────────────────────────────────────────────────────
 
 describe('AuthContext — updateProfileData', () => {
-  it('uploads a new avatar and writes its URL to the Firebase profile', async () => {
+  it('uploads a new avatar and applies its URL through the moderated server endpoint', async () => {
     const result = await mountAuth(makeUser())
     const imgFile = new File(['x'], 'pic.png', { type: 'image/png' })
 
@@ -198,12 +200,14 @@ describe('AuthContext — updateProfileData', () => {
 
     expect(uploadBytes).toHaveBeenCalledWith('photo-ref', imgFile)
     expect(getDownloadURL).toHaveBeenCalled()
-    expect(updateProfile).toHaveBeenCalledWith(h.authUser, {
-      photoURL: 'https://cdn/new-photo.png',
-    })
+    // photoURL is now written SERVER-side (so it can be moderated), not via the
+    // client Firebase updateProfile; the local user is reloaded to reflect it.
+    expect(AuthAPI.updatePhoto).toHaveBeenCalledWith('https://cdn/new-photo.png')
+    expect(h.authUser.reload).toHaveBeenCalled()
+    expect(updateProfile).not.toHaveBeenCalled()
   })
 
-  it('clears the avatar when imgFile is explicitly null', async () => {
+  it('clears the avatar through the server endpoint when imgFile is explicitly null', async () => {
     const result = await mountAuth(makeUser())
 
     await act(async () => {
@@ -211,7 +215,18 @@ describe('AuthContext — updateProfileData', () => {
     })
 
     expect(uploadBytes).not.toHaveBeenCalled()
-    expect(updateProfile).toHaveBeenCalledWith(h.authUser, { photoURL: '' })
+    expect(AuthAPI.updatePhoto).toHaveBeenCalledWith('')
+  })
+
+  it('writes displayName via Firebase updateProfile and leaves the photo endpoint untouched', async () => {
+    const result = await mountAuth(makeUser())
+
+    await act(async () => {
+      await result.current!.updateProfileData({ displayName: 'Jane' })
+    })
+
+    expect(updateProfile).toHaveBeenCalledWith(h.authUser, { displayName: 'Jane' })
+    expect(AuthAPI.updatePhoto).not.toHaveBeenCalled()
   })
 
   it('renames the username only when it differs from the current one', async () => {

--- a/src/test/AuthContext.test.tsx
+++ b/src/test/AuthContext.test.tsx
@@ -64,6 +64,7 @@ vi.mock('src/api/auth', () => ({
     getUsername: vi.fn().mockResolvedValue('johndoe'),
     setUsername: vi.fn().mockResolvedValue(undefined),
     updatePhoto: vi.fn().mockResolvedValue(undefined),
+    updateDisplayName: vi.fn().mockResolvedValue(undefined),
     deleteAccount: vi.fn().mockResolvedValue(undefined),
     checkUsernameAvailability: vi.fn().mockResolvedValue(true),
   },
@@ -218,14 +219,19 @@ describe('AuthContext — updateProfileData', () => {
     expect(AuthAPI.updatePhoto).toHaveBeenCalledWith('')
   })
 
-  it('writes displayName via Firebase updateProfile and leaves the photo endpoint untouched', async () => {
-    const result = await mountAuth(makeUser())
+  it('writes displayName through the server endpoint (moderated) and leaves the photo endpoint untouched', async () => {
+    const user = makeUser()
+    const result = await mountAuth(user)
 
     await act(async () => {
       await result.current!.updateProfileData({ displayName: 'Jane' })
     })
 
-    expect(updateProfile).toHaveBeenCalledWith(h.authUser, { displayName: 'Jane' })
+    // displayName now goes through the moderated server endpoint, not the client
+    // Firebase updateProfile; the local user is reloaded to reflect it.
+    expect(AuthAPI.updateDisplayName).toHaveBeenCalledWith('Jane')
+    expect(user.reload).toHaveBeenCalled()
+    expect(updateProfile).not.toHaveBeenCalled()
     expect(AuthAPI.updatePhoto).not.toHaveBeenCalled()
   })
 

--- a/src/test/CreateUsername.test.tsx
+++ b/src/test/CreateUsername.test.tsx
@@ -9,7 +9,7 @@ const {
   checkAvailMock,
   setUsernameMock,
   updateProfileApiMock,
-  updateProfileFbMock,
+  updateDisplayNameMock,
   toastSuccessMock,
   navigateMock,
 } = vi.hoisted(() => ({
@@ -17,7 +17,7 @@ const {
   checkAvailMock: vi.fn(),
   setUsernameMock: vi.fn(),
   updateProfileApiMock: vi.fn(),
-  updateProfileFbMock: vi.fn(),
+  updateDisplayNameMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   navigateMock: vi.fn(),
 }))
@@ -28,9 +28,9 @@ vi.mock('src/api/auth', () => ({
     checkUsernameAvailability: checkAvailMock,
     setUsername: setUsernameMock,
     updateProfile: updateProfileApiMock,
+    updateDisplayName: updateDisplayNameMock,
   },
 }))
-vi.mock('firebase/auth', () => ({ updateProfile: updateProfileFbMock }))
 vi.mock('react-hot-toast', () => ({
   default: { success: toastSuccessMock, error: vi.fn() },
 }))
@@ -39,7 +39,11 @@ vi.mock('react-router-dom', async orig => ({
   useNavigate: () => navigateMock,
 }))
 vi.mock('src/context/AuthContext', () => ({
-  useAuth: () => ({ user: { uid: 'u1' }, authLoading: false, logout: vi.fn() }),
+  useAuth: () => ({
+    user: { uid: 'u1', reload: vi.fn().mockResolvedValue(undefined) },
+    authLoading: false,
+    logout: vi.fn(),
+  }),
 }))
 
 const renderOnboarding = () =>
@@ -63,7 +67,7 @@ beforeEach(() => {
   checkAvailMock.mockResolvedValue(true)
   setUsernameMock.mockResolvedValue(undefined)
   updateProfileApiMock.mockResolvedValue(undefined)
-  updateProfileFbMock.mockResolvedValue(undefined)
+  updateDisplayNameMock.mockResolvedValue(undefined)
 })
 
 describe('CreateUsername (onboarding)', () => {
@@ -94,10 +98,7 @@ describe('CreateUsername (onboarding)', () => {
     await waitFor(() =>
       expect(setUsernameMock).toHaveBeenCalledWith('validuser')
     )
-    expect(updateProfileFbMock).toHaveBeenCalledWith(
-      { uid: 'u1' },
-      { displayName: 'John Smith' }
-    )
+    expect(updateDisplayNameMock).toHaveBeenCalledWith('John Smith')
     expect(updateProfileApiMock).toHaveBeenCalledWith({
       bio: 'I cook.',
       location: 'Toronto',
@@ -115,7 +116,7 @@ describe('CreateUsername (onboarding)', () => {
     await waitFor(() =>
       expect(setUsernameMock).toHaveBeenCalledWith('validuser')
     )
-    expect(updateProfileFbMock).not.toHaveBeenCalled()
+    expect(updateDisplayNameMock).not.toHaveBeenCalled()
     expect(updateProfileApiMock).not.toHaveBeenCalled()
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/'))
   })

--- a/src/test/getApiErrorMessage.test.ts
+++ b/src/test/getApiErrorMessage.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { AxiosError, AxiosHeaders } from 'axios'
+import { getApiErrorMessage } from 'src/util/getApiErrorMessage'
+
+// Build an AxiosError the way axios.isAxiosError recognizes it, with a given
+// response body — mirrors a real failed request (e.g. a 422 moderation block).
+function axiosErrorWith(data: unknown, status = 422): AxiosError {
+  const err = new AxiosError('Request failed with status code ' + status)
+  err.response = {
+    data,
+    status,
+    statusText: '',
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  }
+  return err
+}
+
+describe('getApiErrorMessage', () => {
+  it("prefers the server's `error` body over axios's generic message", () => {
+    const err = axiosErrorWith({
+      error: "This content was flagged by our automated moderation system and can't be published.",
+      code: 'CONTENT_BLOCKED',
+    })
+    expect(getApiErrorMessage(err, 'fallback')).toBe(
+      "This content was flagged by our automated moderation system and can't be published."
+    )
+  })
+
+  it("falls back to the axios message when the body has no `error` (e.g. network)", () => {
+    const err = axiosErrorWith(undefined)
+    expect(getApiErrorMessage(err, 'fallback')).toBe(
+      'Request failed with status code 422'
+    )
+  })
+
+  it('uses a plain Error message when present', () => {
+    expect(getApiErrorMessage(new Error('boom'), 'fallback')).toBe('boom')
+  })
+
+  it('returns the fallback for a non-error value', () => {
+    expect(getApiErrorMessage('nope', 'fallback')).toBe('fallback')
+    expect(getApiErrorMessage(undefined, 'fallback')).toBe('fallback')
+  })
+})

--- a/src/util/getApiErrorMessage.ts
+++ b/src/util/getApiErrorMessage.ts
@@ -1,0 +1,18 @@
+import axios from 'axios'
+
+/**
+ * Pull a user-facing message out of a failed request. Prefers the server's own
+ * reason — e.g. a 422 moderation block sends
+ * `{ error: "…flagged by our automated moderation system…", code: 'CONTENT_BLOCKED' }`
+ * — so the UI shows that instead of axios's generic "Request failed with status
+ * code 422". Falls back to a thrown Error's message, then the provided default.
+ */
+export function getApiErrorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError(error)) {
+    const serverMsg = (error.response?.data as { error?: string } | undefined)
+      ?.error
+    if (serverMsg) return serverMsg
+  }
+  if (error instanceof Error && error.message) return error.message
+  return fallback
+}


### PR DESCRIPTION
## What

P2 of automated content moderation: screens user-supplied **images** at write-time, reusing the P1 text pipeline. Server-side synchronous URL scan via **Google Cloud Vision SafeSearch** — **not** a Storage trigger (no Firebase Functions infra; the server already has the image URL).

Builds on the merged P1 text slice (#138).

## How

- **`server/util/imageModeration.js`** (new) — env-gated `moderateImage(url, ctx)`. Calls Vision SafeSearch over REST (native fetch, no SDK), passing the image by `imageUri` so we never download bytes (SSRF-safe). Grades adult/violence → can reach high; racy caps at medium. **Fails CLOSED** (the inverse of text's fail-open): a scan error/outage → `medium` `unscanned`, so an unscanned image is held, never published.
- **Recipe images** (`routes/recipes.js`) — scanned on create, and on edit only when the URL changed. Merged with the text verdict via new `automod.worstVerdict(...)` (most-severe wins). high → block (422); medium / fail-closed → `holdRecipeForReview` (pending_review + system report + audit + owner email), same as P1 text.
- **Profile photos** — new `POST /updatePhoto` (`routes/auth.js`): client uploads to Storage then POSTs the URL; server scans and sets `photoURL` via Admin `updateUser` only if it passes. No owner-only state, so **both** high and medium block (422). `AuthContext`/`AuthAPI` route photoURL through it (+`user.reload()`); displayName still direct (server hook is a tracked follow-up).

## Verification

- **Automated:** server Jest **469** / FE Vitest **362** / tsc clean. New `imageModeration.test.js` (grading, env-gating, fail-closed incl. missing-annotation) + image route cases in `moderation-routes.test.js` + FE `AuthContext` photo-flow update.
- **Authed live smoke (real Vision key, prod Mongo/Firebase, API-driven):** clean 3/3, high 3/3 (blocked recipe wrote 0 rows), medium 4/4 (owner-200/anon-404 split + report + audit). Block/hold tiers proven by lowering the likelihood threshold on benign images — never by sourcing explicit content. Prod left residue-free.
- **Code review (high effort):** 2 fixes applied — parallelized the two scans (`Promise.all`) and closed a narrow fail-open gap (200 with no annotation now fails closed). See `docs/CONTENT_MODERATION.md` Progress.

## ⚠️ Prod env step (Railway)

Set **`GOOGLE_VISION_API_KEY`** (absent ⇒ image layer no-ops silently; text moderation unaffected). Optional `MODERATION_IMAGE_HIGH` / `MODERATION_IMAGE_MEDIUM` likelihood thresholds. Documented in `docs/RELEASE_PLAN.md`.

## Out of scope

- P3 CSAM (gates public launch; provider TBD — Cloudflare / PhotoDNA / Thorn).
- Server-side `displayName` moderation (deferred P1 follow-up).