### PR TITLE
feat(moderation): P3 — write rate-limiting, block audit log, admin queue UX + metrics

### DIFF
--- a/server/__tests__/admin-analytics.test.js
+++ b/server/__tests__/admin-analytics.test.js
@@ -81,6 +81,37 @@ describe('GET /api/admin/analytics', () => {
     })
     expect(totals.reviews).toBe(2) // bare star-only excluded
     expect(totals.reports).toEqual({ open: 2, resolved: 1, dismissed: 1 })
+    // No automod activity seeded here → all zero, all-time.
+    expect(totals.moderation).toEqual({ autoHeld: 0, autoBlocked: 0, autoFlagsDismissed: 0 })
+  })
+
+  it('tallies automated-moderation activity from the audit log + dismissed automod reports', async () => {
+    admin.__setClaims({ admin: true })
+    const db = getDB()
+    await db.collection('auditLog').insertMany([
+      { action: 'recipe.autohold', actorType: 'system', targetType: 'recipe', targetId: 'r1', createdAt: daysAgo(1) },
+      { action: 'recipe.autohold', actorType: 'system', targetType: 'recipe', targetId: 'r2', createdAt: daysAgo(2) },
+      { action: 'content.blocked', actorType: 'system', targetType: 'user', targetId: 'u1', createdAt: daysAgo(1) },
+      { action: 'content.blocked', actorType: 'system', targetType: 'user', targetId: 'u2', createdAt: daysAgo(3) },
+      { action: 'content.blocked', actorType: 'system', targetType: 'user', targetId: 'u3', createdAt: daysAgo(3) },
+      // A human admin action must NOT be counted as automated.
+      { action: 'recipe.hide', actorType: 'admin', targetType: 'recipe', targetId: 'r3', createdAt: daysAgo(1) },
+    ])
+    await db.collection('reports').insertMany([
+      { targetType: 'recipe', recipeId: 'r1', source: 'automod', status: 'dismissed', createdAt: daysAgo(1) },
+      // A dismissed USER report (no source) is not a false-positive restore.
+      { targetType: 'recipe', recipeId: 'r2', status: 'dismissed', createdAt: daysAgo(1) },
+      // An open automod report is not a restore either.
+      { targetType: 'recipe', recipeId: 'r3', source: 'automod', status: 'open', createdAt: daysAgo(1) },
+    ])
+
+    const res = await request(app).get('/api/admin/analytics').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.totals.moderation).toEqual({
+      autoHeld: 2,
+      autoBlocked: 3,
+      autoFlagsDismissed: 1,
+    })
   })
 
   it('returns a zero-filled, date-bounded daily series', async () => {

--- a/server/__tests__/admin-moderation.test.js
+++ b/server/__tests__/admin-moderation.test.js
@@ -37,7 +37,43 @@ afterEach(async () => {
     db.collection('userRecipeData').deleteMany({}),
     db.collection('usernames').deleteMany({}),
     db.collection('stats').deleteMany({}),
+    db.collection('reports').deleteMany({}),
   ])
+})
+
+describe('GET /api/admin/recipes/:id/automod', () => {
+  it('requires admin', async () => {
+    const res = await request(app).get('/api/admin/recipes/r1/automod').set(AUTH_HEADER)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns the classifier from the open automod report holding the recipe', async () => {
+    admin.__setClaims({ admin: true })
+    await getDB().collection('reports').insertOne({
+      targetType: 'recipe',
+      recipeId: 'r1',
+      reporterUid: 'system:automod',
+      source: 'automod',
+      status: 'open',
+      classifier: { severity: 'medium', category: 'harassment', reason: 'openai:harassment:0.60', source: 'openai' },
+      createdAt: new Date(),
+    })
+    const res = await request(app).get('/api/admin/recipes/r1/automod').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.classifier).toMatchObject({ severity: 'medium', category: 'harassment' })
+  })
+
+  it('returns null classifier when there is no open automod report', async () => {
+    admin.__setClaims({ admin: true })
+    // A user report (no source) and a CLOSED automod report must both be ignored.
+    await getDB().collection('reports').insertMany([
+      { targetType: 'recipe', recipeId: 'r1', reporterUid: 'u1', status: 'open', createdAt: new Date() },
+      { targetType: 'recipe', recipeId: 'r1', reporterUid: 'system:automod', source: 'automod', status: 'dismissed', classifier: { severity: 'medium' }, createdAt: new Date() },
+    ])
+    const res = await request(app).get('/api/admin/recipes/r1/automod').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.classifier).toBeNull()
+  })
 })
 
 describe('PATCH /api/admin/recipes/:id/moderation', () => {

--- a/server/__tests__/automod.test.js
+++ b/server/__tests__/automod.test.js
@@ -9,7 +9,8 @@
  * unmoderated. Assert the real keys make it into the blob.
  */
 
-const { gatherRecipeText, holdRecipeForReview } = require('../util/automod')
+const { gatherRecipeText, holdRecipeForReview, auditContentBlock, respondBlocked } = require('../util/automod')
+const { SYSTEM_ACTOR } = require('../util/auditLog')
 
 // A parsed-ingredient row exactly as src/api/recipes.ts builds it.
 const parsedIngredient = (originalIngredientString, ingredient) => ({
@@ -128,5 +129,133 @@ describe('holdRecipeForReview — report-gated hold', () => {
     expect(held).toBe(false)
     // Crucial invariant: a recipe is never hidden without a queue entry to clear it.
     expect(calls.recipes).toHaveLength(0)
+  })
+})
+
+describe('auditContentBlock — system-actor trail for a refused write', () => {
+  // Fake Db capturing the auditLog insert and serving a usernames lookup.
+  const fakeDb = ({ username, findThrows, insertThrows } = {}) => {
+    const inserts = []
+    return {
+      inserts,
+      db: {
+        collection: (name) => {
+          if (name === 'usernames') {
+            return {
+              findOne: async () => {
+                if (findThrows) throw new Error('lookup down')
+                return username ? { username } : null
+              },
+            }
+          }
+          return {
+            insertOne: async (doc) => {
+              if (insertThrows) throw new Error('insert down')
+              inserts.push(doc)
+              return { acknowledged: true }
+            },
+          }
+        },
+      },
+    }
+  }
+
+  const VERDICT = { allowed: false, severity: 'high', reason: 'blocklist:slur:SLURWORD', category: 'slur', source: 'blocklist' }
+
+  it('writes a system-actor content.blocked row targeting the offending user', async () => {
+    const { db, inserts } = fakeDb({ username: 'baduser' })
+    await auditContentBlock(db, { uid: 'uid-1', surface: 'review', verdict: VERDICT })
+    expect(inserts).toHaveLength(1)
+    const row = inserts[0]
+    expect(row.action).toBe('content.blocked')
+    expect(row.actorUid).toBe(SYSTEM_ACTOR.uid)
+    expect(row.actorType).toBe('system')
+    expect(row.targetType).toBe('user')
+    expect(row.targetId).toBe('uid-1')
+    expect(row.targetLabel).toBe('@baduser')
+    expect(row.metadata).toEqual({
+      surface: 'review',
+      category: 'slur',
+      severity: 'high',
+      source: 'blocklist',
+    })
+  })
+
+  it('stores NO raw content — never the verdict.reason (which embeds the matched term) or the text', async () => {
+    const { db, inserts } = fakeDb({ username: 'baduser' })
+    await auditContentBlock(db, { uid: 'uid-1', surface: 'username', verdict: VERDICT })
+    const serialized = JSON.stringify(inserts[0])
+    expect(serialized).not.toContain('SLURWORD') // the matched term must not leak
+    expect(serialized).not.toContain('blocklist:slur:') // nor the reason string that carries it
+    expect(inserts[0].reason).toBeFalsy()
+  })
+
+  it('falls back to a null targetLabel (→ bare uid at render) when the username lookup misses', async () => {
+    const { db, inserts } = fakeDb({ username: null })
+    await auditContentBlock(db, { uid: 'uid-2', surface: 'profile', verdict: VERDICT })
+    expect(inserts[0].targetLabel).toBeNull()
+    expect(inserts[0].targetId).toBe('uid-2')
+  })
+
+  it('is best-effort: a username-lookup failure still records the row', async () => {
+    const { db, inserts } = fakeDb({ findThrows: true })
+    await expect(
+      auditContentBlock(db, { uid: 'uid-3', surface: 'recipe', verdict: VERDICT })
+    ).resolves.toBeUndefined()
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0].targetLabel).toBeNull()
+  })
+
+  it('is best-effort: an audit-insert failure never throws', async () => {
+    const { db } = fakeDb({ username: 'baduser', insertThrows: true })
+    await expect(
+      auditContentBlock(db, { uid: 'uid-4', surface: 'recipe', verdict: VERDICT })
+    ).resolves.toBeUndefined()
+  })
+
+  it('no-ops when given no db', async () => {
+    await expect(auditContentBlock(undefined, { uid: 'x' })).resolves.toBeUndefined()
+  })
+})
+
+describe('respondBlocked — 422 contract + best-effort audit', () => {
+  const fakeRes = () => {
+    const res = {}
+    res.status = jest.fn(() => res)
+    res.json = jest.fn(() => res)
+    return res
+  }
+
+  it('returns the 422 CONTENT_BLOCKED contract', () => {
+    const res = fakeRes()
+    respondBlocked(res)
+    expect(res.status).toHaveBeenCalledWith(422)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'CONTENT_BLOCKED' })
+    )
+  })
+
+  it('drops a content.blocked audit row when context is supplied, without blocking the response', async () => {
+    const inserts = []
+    const db = {
+      collection: (name) =>
+        name === 'usernames'
+          ? { findOne: async () => ({ username: 'baduser' }) }
+          : { insertOne: async (doc) => { inserts.push(doc); return { acknowledged: true } } },
+    }
+    const res = fakeRes()
+    respondBlocked(res, { db, uid: 'uid-9', surface: 'displayName', verdict: { severity: 'high', category: 'harassment', source: 'openai' } })
+    // Response is sent synchronously; the audit is fire-and-forget.
+    expect(res.status).toHaveBeenCalledWith(422)
+    await new Promise((r) => setImmediate(r)) // let the fire-and-forget settle
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0].action).toBe('content.blocked')
+    expect(inserts[0].metadata.surface).toBe('displayName')
+  })
+
+  it('skips the audit (and never throws) when no context is passed', () => {
+    const res = fakeRes()
+    expect(() => respondBlocked(res)).not.toThrow()
+    expect(res.status).toHaveBeenCalledWith(422)
   })
 })

--- a/server/__tests__/writeLimiter.test.js
+++ b/server/__tests__/writeLimiter.test.js
@@ -1,0 +1,73 @@
+/**
+ * middleware/writeLimiter — the shared per-user cap on moderated content writes.
+ *
+ * The limiter `skip`s when NODE_ENV === 'test' (so the rest of the suite, which
+ * fires many requests per user via supertest, isn't throttled). `skip` is read
+ * per-request, so we flip NODE_ENV for THIS file to exercise the real behaviour,
+ * then restore it.
+ */
+
+const express = require('express')
+const request = require('supertest')
+const { writeLimiter } = require('../middleware/writeLimiter')
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV
+
+// Tiny app: stamp a uid (writeLimiter keys on req.uid, normally set by
+// verifyToken) from a header so each test can drive a distinct user.
+const makeApp = () => {
+  const app = express()
+  app.use((req, _res, next) => {
+    req.uid = req.headers['x-test-uid']
+    next()
+  })
+  app.post('/write', writeLimiter, (_req, res) => res.json({ ok: true }))
+  return app
+}
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'development' // un-skip the limiter
+})
+afterAll(() => {
+  process.env.NODE_ENV = ORIGINAL_NODE_ENV
+})
+
+describe('writeLimiter — per-user content-write cap', () => {
+  it('allows up to the limit then returns 429 for the same user', async () => {
+    const app = makeApp()
+    const uid = 'user-a'
+    // The first 30 succeed.
+    for (let i = 0; i < 30; i++) {
+      const res = await request(app).post('/write').set('x-test-uid', uid)
+      expect(res.status).toBe(200)
+    }
+    // The 31st in the window is throttled with the friendly message.
+    const blocked = await request(app).post('/write').set('x-test-uid', uid)
+    expect(blocked.status).toBe(429)
+    expect(blocked.body.error).toMatch(/too quickly/i)
+  })
+
+  it('keys per user — one user hitting the cap does not throttle another', async () => {
+    const app = makeApp()
+    // Exhaust user-b.
+    for (let i = 0; i < 30; i++) {
+      await request(app).post('/write').set('x-test-uid', 'user-b')
+    }
+    const bBlocked = await request(app).post('/write').set('x-test-uid', 'user-b')
+    expect(bBlocked.status).toBe(429)
+    // A different user is unaffected.
+    const cOk = await request(app).post('/write').set('x-test-uid', 'user-c')
+    expect(cOk.status).toBe(200)
+  })
+
+  it('is bypassed entirely under NODE_ENV=test', async () => {
+    process.env.NODE_ENV = 'test'
+    const app = makeApp()
+    // Far more than the limit, all allowed because skip() short-circuits.
+    for (let i = 0; i < 40; i++) {
+      const res = await request(app).post('/write').set('x-test-uid', 'user-d')
+      expect(res.status).toBe(200)
+    }
+    process.env.NODE_ENV = 'development' // restore for any later tests in this file
+  })
+})

--- a/server/middleware/writeLimiter.js
+++ b/server/middleware/writeLimiter.js
@@ -1,0 +1,30 @@
+const { rateLimit } = require('express-rate-limit')
+
+// Per-USER limiter shared across the moderated content-write routes (recipe,
+// review, profile, username, displayName, photo). It complements — does not
+// replace — the coarse global per-IP backstop in app.js:
+//   - The global limit is per-IP, so it's shared across everyone behind one NAT
+//     and evadable by rotating IPs; it can't bound a single account.
+//   - Every one of these writes now triggers a paid classifier call (OpenAI, plus
+//     Cloud Vision on recipe images), so write-spam directly burns moderation
+//     quota. This is the same reason /api/ingredients/parse got a per-user cap —
+//     the moderated writes need the equivalent.
+//
+// ONE shared instance ⇒ one bucket per user across ALL these endpoints (e.g. a
+// user can't dodge it by spreading 30 writes across recipes + reviews + profile).
+// Keyed by req.uid, so it MUST be mounted after verifyToken. The window is sized
+// well above any plausible human cadence — a real user never approaches 30 content
+// writes in a minute — so only scripted abuse hits it. Skipped under Jest, where
+// supertest fires many requests from one user in seconds (same as the global
+// limiter); Cypress E2E stays well under the cap.
+const writeLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.uid,
+  skip: () => process.env.NODE_ENV === 'test',
+  message: { error: 'You’re doing that too quickly — wait a moment and try again.' },
+})
+
+module.exports = { writeLimiter }

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -339,6 +339,21 @@ router.get('/admin/audit', verifyToken, requireAdmin, asyncHandler(async (req, r
   res.json({ entries: enriched, totalCount })
 }))
 
+// GET /admin/recipes/:id/automod — the classifier snapshot from the OPEN
+// automated-moderation report that put this recipe into pending_review, so the
+// recipe page's admin strip can show WHY it was held inline (not only in the
+// reports queue). The reason lives on the report, not the recipe doc, hence this
+// targeted lookup. Returns { classifier: null } when no open automod report
+// exists (e.g. a human takedown, or the hold was already cleared).
+router.get('/admin/recipes/:id/automod', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const report = await db.collection('reports').findOne(
+    { targetType: 'recipe', recipeId: String(req.params.id), source: 'automod', status: 'open' },
+    { sort: { createdAt: -1 }, projection: { classifier: 1, createdAt: 1 } }
+  )
+  res.json({ classifier: report?.classifier || null, createdAt: report?.createdAt || null })
+}))
+
 // GET /admin/analytics?days= — single overview payload for the admin dashboard:
 // headline totals, daily over-time series (reports filed / recipes / signups),
 // and the most recent admin actions. `days` is clamped to [MIN_DAYS, MAX_DAYS].
@@ -364,6 +379,8 @@ router.get('/admin/analytics', verifyToken, requireAdmin, asyncHandler(async (re
     featuredCount,
     reviewCount,
     reportStatusAgg,
+    moderationActionAgg,
+    autoDismissedCount,
     reportsDaily,
     recipesDaily,
     usersDaily,
@@ -385,6 +402,20 @@ router.get('/admin/analytics', verifyToken, requireAdmin, asyncHandler(async (re
       .collection('reports')
       .aggregate([{ $group: { _id: '$status', count: { $sum: 1 } } }])
       .toArray(),
+    // Automated-moderation tallies (all-time, like the other totals). autohold =
+    // recipes the classifier held for review; content.blocked = writes it refused
+    // outright. One aggregation over the two system actions (uses the action index).
+    db
+      .collection('auditLog')
+      .aggregate([
+        { $match: { action: { $in: ['recipe.autohold', 'content.blocked'] } } },
+        { $group: { _id: '$action', count: { $sum: 1 } } },
+      ])
+      .toArray(),
+    // Automod-filed reports an admin later dismissed. NOTE: dismissing does not
+    // (yet) restore a held recipe's status — this counts flags cleared, not
+    // content republished. See moderation follow-ups (approve/restore path).
+    db.collection('reports').countDocuments({ source: 'automod', status: 'dismissed' }),
     dailyCreatedAgg(db, 'reports', cutoff),
     dailyCreatedAgg(db, 'recipes', cutoff),
     dailyCreatedAgg(db, 'usernames', cutoff),
@@ -399,6 +430,7 @@ router.get('/admin/analytics', verifyToken, requireAdmin, asyncHandler(async (re
   const recipeByStatus = Object.fromEntries(recipeStatusAgg.map((r) => [r._id, r.count]))
   const recipeTotal = recipeStatusAgg.reduce((sum, r) => sum + r.count, 0)
   const reportByStatus = Object.fromEntries(reportStatusAgg.map((r) => [r._id, r.count]))
+  const modByAction = Object.fromEntries(moderationActionAgg.map((r) => [r._id, r.count]))
 
   const recentActions = await enrichActors(db, recentRaw)
 
@@ -418,6 +450,13 @@ router.get('/admin/analytics', verifyToken, requireAdmin, asyncHandler(async (re
         open: reportByStatus.open || 0,
         resolved: reportByStatus.resolved || 0,
         dismissed: reportByStatus.dismissed || 0,
+      },
+      // Automated-moderation activity (all-time). See the audit actions
+      // recipe.autohold / content.blocked and dismissed automod reports.
+      moderation: {
+        autoHeld: modByAction['recipe.autohold'] || 0,
+        autoBlocked: modByAction['content.blocked'] || 0,
+        autoFlagsDismissed: autoDismissedCount,
       },
     },
     reportsOverTime: buildDailySeries(reportsDaily, days, now),

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -4,6 +4,7 @@ const { asyncHandler } = require('../util/asyncHandler')
 const router = express.Router()
 const { getDB, getClient } = require('../db')
 const { verifyToken, requireActive } = require('../middleware/auth')
+const { writeLimiter } = require('../middleware/writeLimiter')
 const { recordAudit } = require('../util/auditLog')
 const { deleteRecipeImage, deleteProfilePhoto } = require('../util/firebaseStorage')
 const { recomputeRecipeRating } = require('../util/recipeRating')
@@ -113,7 +114,7 @@ router.get('/getMyStatus', verifyToken, asyncHandler(async (req, res) => {
 
 // POST /setUsername?username=...
 // Creates or updates the username for the authenticated user
-router.post('/setUsername', verifyToken, requireActive, asyncHandler(async (req, res) => {
+router.post('/setUsername', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
   const { username } = req.query
   const validationError = validateUsername(username)
   if (validationError) {
@@ -122,13 +123,13 @@ router.post('/setUsername', verifyToken, requireActive, asyncHandler(async (req,
   // A username is high-visibility (it lands in the URL), so both high and medium
   // confidence block at signup AND on every rename. The 'username' context also
   // applies the identity-only spam rules (no URLs/domains in a handle).
+  const db = getDB()
   const usernameVerdict = await moderateText(username, 'username')
   if (!usernameVerdict.allowed) {
-    return respondBlocked(res)
+    return respondBlocked(res, { db, uid: req.uid, surface: 'username', verdict: usernameVerdict })
   }
   const usernameLower = username.toLowerCase()
   const uid = req.uid
-  const db = getDB()
 
   // Check the name isn't already taken by someone else (case-insensitive).
   const existing = await db
@@ -205,7 +206,7 @@ router.get('/getProfile', verifyToken, asyncHandler(async (req, res) => {
 // POST /updateProfile
 // Upserts the authenticated user's bio + location. Empty strings are allowed
 // and clear the field. Values are trimmed before storage.
-router.post('/updateProfile', verifyToken, requireActive, asyncHandler(async (req, res) => {
+router.post('/updateProfile', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
   const { bio, location } = req.body || {}
   const validationError = validateProfile(bio, location)
   if (validationError) {
@@ -214,11 +215,11 @@ router.post('/updateProfile', verifyToken, requireActive, asyncHandler(async (re
   // Profile text is short and only the author benefits from it, so (like reviews)
   // both high and medium confidence block inline rather than holding for review.
   const profileText = [bio, location].filter((s) => typeof s === 'string' && s.trim()).join('\n')
+  const db = getDB()
   const profileVerdict = await moderateText(profileText, 'profile')
   if (!profileVerdict.allowed) {
-    return respondBlocked(res)
+    return respondBlocked(res, { db, uid: req.uid, surface: 'profile', verdict: profileVerdict })
   }
-  const db = getDB()
   await db.collection('userProfiles').updateOne(
     { _id: req.uid },
     {
@@ -245,7 +246,7 @@ router.post('/updateProfile', verifyToken, requireActive, asyncHandler(async (re
 // state to fall back to, so BOTH high and medium confidence block (422); the
 // image fails CLOSED, so a scan outage also rejects rather than applying an
 // unscanned photo. Clearing the photo (empty URL) needs no scan.
-router.post('/updatePhoto', verifyToken, requireActive, asyncHandler(async (req, res) => {
+router.post('/updatePhoto', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
   const { photoURL } = req.body || {}
   if (photoURL != null && typeof photoURL !== 'string') {
     return res.status(400).json({ error: 'photoURL must be a string' })
@@ -255,7 +256,7 @@ router.post('/updatePhoto', verifyToken, requireActive, asyncHandler(async (req,
   if (url) {
     const verdict = await moderateImage(url, 'profile.photo')
     if (!verdict.allowed) {
-      return respondBlocked(res)
+      return respondBlocked(res, { db: getDB(), uid: req.uid, surface: 'profile.photo', verdict })
     }
   }
 
@@ -274,7 +275,7 @@ router.post('/updatePhoto', verifyToken, requireActive, asyncHandler(async (req,
 // owner-only "pending" state, so BOTH high and medium confidence block (422).
 // The 'displayName' context also applies the identity-only spam rules (no
 // URLs/domains in a name).
-router.post('/updateDisplayName', verifyToken, requireActive, asyncHandler(async (req, res) => {
+router.post('/updateDisplayName', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
   const { displayName } = req.body || {}
   if (typeof displayName !== 'string' || !displayName.trim()) {
     return res.status(400).json({ error: 'displayName is required' })
@@ -286,7 +287,7 @@ router.post('/updateDisplayName', verifyToken, requireActive, asyncHandler(async
 
   const verdict = await moderateText(name, 'displayName')
   if (!verdict.allowed) {
-    return respondBlocked(res)
+    return respondBlocked(res, { db: getDB(), uid: req.uid, surface: 'displayName', verdict })
   }
 
   await admin.auth().updateUser(req.uid, { displayName: name })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -3,6 +3,7 @@ const { asyncHandler } = require('../util/asyncHandler')
 const { ObjectId } = require('mongodb')
 const { getDB, getClient } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
+const { writeLimiter } = require('../middleware/writeLimiter')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { RECIPE_VISIBLE, RECIPE_OWNER_VISIBLE } = require('../util/moderation')
 const { recordAudit } = require('../util/auditLog')
@@ -243,7 +244,7 @@ router.get('/getRecipe', optionalAuth, asyncHandler(async (req, res) => {
 }))
 
 // POST /addRecipe
-router.post('/addRecipe', verifyToken, requireActive, asyncHandler(async (req, res) => {
+router.post('/addRecipe', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
   const db = getDB()
   const body = req.body
   const uid = req.uid
@@ -271,7 +272,7 @@ router.post('/addRecipe', verifyToken, requireActive, asyncHandler(async (req, r
   ])
   const verdict = worstVerdict(textVerdict, imageVerdict)
   if (verdict.severity === 'high') {
-    return respondBlocked(res)
+    return respondBlocked(res, { db, uid, surface: 'recipe', verdict })
   }
 
   // Whitelist the insert (mirrors the edit path): only creatable fields are
@@ -307,7 +308,7 @@ router.post('/addRecipe', verifyToken, requireActive, asyncHandler(async (req, r
 // metadata are never writable here (only EDITABLE_RECIPE_FIELDS are copied), so
 // an edit can never reset a recipe's ratings, saves, or made-count. editedAt is
 // stamped so the UI can surface that the recipe changed after people saved it.
-router.put('/editRecipe', verifyToken, requireActive, asyncHandler(async (req, res) => {
+router.put('/editRecipe', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
   const db = getDB()
   const { recipeId } = req.query
   if (!recipeId) {
@@ -347,7 +348,7 @@ router.put('/editRecipe', verifyToken, requireActive, asyncHandler(async (req, r
   ])
   const verdict = worstVerdict(textVerdict, imageVerdict)
   if (verdict.severity === 'high') {
-    return respondBlocked(res)
+    return respondBlocked(res, { db, uid, surface: 'recipe', verdict })
   }
 
   // Whitelist: copy only editable fields from the client payload. Anything

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -2,6 +2,7 @@ const { Router } = require('express')
 const { asyncHandler } = require('../util/asyncHandler')
 const { getDB } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
+const { writeLimiter } = require('../middleware/writeLimiter')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { REVIEW_VISIBLE, RECIPE_VISIBLE } = require('../util/moderation')
 const { DESCRIPTION_MAX_LENGTH } = require('../util/recipeLimits')
@@ -63,7 +64,7 @@ router.post('/addRating', verifyToken, requireActive, asyncHandler(async (req, r
 }))
 
 // POST /newReview
-router.post('/newReview', verifyToken, requireActive, asyncHandler(async (req, res) => {
+router.post('/newReview', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
   const db = getDB()
   const { recipeId, reviewText } = req.body
   const userId = req.uid
@@ -79,7 +80,7 @@ router.post('/newReview', verifyToken, requireActive, asyncHandler(async (req, r
   // `allowed` is true only for a clean verdict.
   const verdict = await moderateText(reviewText, 'review')
   if (!verdict.allowed) {
-    return respondBlocked(res)
+    return respondBlocked(res, { db, uid: userId, surface: 'review', verdict })
   }
 
   const usernameDoc = await db.collection('usernames').findOne({ _id: userId })
@@ -124,7 +125,7 @@ router.get('/checkIfReviewed', verifyToken, asyncHandler(async (req, res) => {
 }))
 
 // POST /editReview
-router.post('/editReview', verifyToken, requireActive, asyncHandler(async (req, res) => {
+router.post('/editReview', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
   const { recipeId, text } = req.query
   const db = getDB()
   if (!recipeId || typeof recipeId !== 'string' || text == null || typeof text !== 'string') {
@@ -135,7 +136,7 @@ router.post('/editReview', verifyToken, requireActive, asyncHandler(async (req, 
   }
   const verdict = await moderateText(text, 'review')
   if (!verdict.allowed) {
-    return respondBlocked(res)
+    return respondBlocked(res, { db, uid: req.uid, surface: 'review', verdict })
   }
   // Keyed by the stable uid (D1): only the author (req.uid) can match their own
   // doc, so a non-author falls through to matchedCount 0 → 403 below.

--- a/server/util/auditLog.js
+++ b/server/util/auditLog.js
@@ -15,6 +15,10 @@ const AUDIT_ACTIONS = [
   // Automated moderation: a classifier put a recipe into pending_review (held
   // from public reads until a human clears it). Credited to the system actor.
   'recipe.autohold',
+  // Automated moderation: a high/medium-confidence classifier verdict refused a
+  // write outright (the content was never persisted). Credited to the system
+  // actor; the target is the offending user. See util/automod.auditContentBlock.
+  'content.blocked',
   'user.suspend',
   'user.ban',
   'user.activate',

--- a/server/util/automod.js
+++ b/server/util/automod.js
@@ -16,10 +16,66 @@ const BLOCKED_MESSAGE =
   "This content was flagged by our automated moderation system and can't be published. Please review our content guidelines and edit your submission."
 const BLOCKED_CODE = 'CONTENT_BLOCKED'
 
+/**
+ * Best-effort audit row for a block that was returned to a user. Without it a
+ * block leaves NO trace: the refused content is never persisted, so an admin
+ * could not otherwise tell the automated system is rejecting submissions — from
+ * whom, on which surface, or in what category. Credited to the system actor (a
+ * machine decision, like recipe.autohold), with the OFFENDING user as the target.
+ *
+ * Stores ONLY structured signal — surface + classifier category/severity/source
+ * + the offender's uid. It deliberately never stores verdict.reason (a blocklist
+ * reason embeds the matched term, i.e. the very content we refuse to echo) nor
+ * any of the submitted text.
+ *
+ * @param {import('mongodb').Db} db
+ * @param {object} args
+ * @param {string} args.uid       offending user's uid
+ * @param {string} args.surface   where the block happened ('recipe' | 'review' | 'username' | 'displayName' | 'profile' | 'profile.photo')
+ * @param {object} args.verdict   the moderate{Text,Image} result
+ */
+async function auditContentBlock(db, { uid, surface, verdict } = {}) {
+  if (!db) return
+  let targetLabel = null
+  try {
+    // Best-effort handle so the queue reads "@user" not a bare uid. A miss
+    // (legacy user, lookup hiccup) just falls back to the uid at render time.
+    if (uid) {
+      const doc = await db
+        .collection('usernames')
+        .findOne({ _id: uid }, { projection: { username: 1 } })
+      if (doc?.username) targetLabel = `@${doc.username}`
+    }
+  } catch (_) {
+    // ignore — targetLabel stays null
+  }
+  await recordAudit(db, {
+    action: 'content.blocked',
+    actorUid: SYSTEM_ACTOR.uid,
+    actorType: SYSTEM_ACTOR.type,
+    targetType: 'user',
+    targetId: uid || null,
+    targetLabel,
+    metadata: {
+      surface: surface || null,
+      category: verdict?.category || null,
+      severity: verdict?.severity || null,
+      source: verdict?.source || null,
+    },
+  })
+}
+
 // Single owner of the high-confidence block response, so the 422 contract (status
 // + body shape the FE keys on) lives in one place instead of being re-typed at
-// every write route.
-function respondBlocked(res) {
+// every write route. When a `context` ({ db, uid, surface, verdict }) is passed,
+// it ALSO drops a best-effort, system-actor audit row so the block is visible to
+// admins — fire-and-forget so it never delays the 422 or turns a block into a
+// 500 (recordAudit already swallows its own errors; the guard covers the rest).
+// Context is optional, so a bare respondBlocked(res) still works.
+function respondBlocked(res, context) {
+  if (context && context.db) {
+    auditContentBlock(context.db, context).catch(() => {})
+  }
   return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
 }
 
@@ -168,4 +224,4 @@ async function holdRecipeForReview(db, { recipeId, title, verdict }) {
   return true
 }
 
-module.exports = { BLOCKED_MESSAGE, BLOCKED_CODE, respondBlocked, gatherRecipeText, holdRecipeForReview, worstVerdict }
+module.exports = { BLOCKED_MESSAGE, BLOCKED_CODE, respondBlocked, auditContentBlock, gatherRecipeText, holdRecipeForReview, worstVerdict }

--- a/src/Components/AdminRecipeControls/AdminRecipeControls.scss
+++ b/src/Components/AdminRecipeControls/AdminRecipeControls.scss
@@ -42,6 +42,21 @@
       background: #fef3c7;
       color: #b45309;
     }
+
+    &.pending {
+      background: #e0e7ff;
+      color: #3730a3;
+    }
+  }
+
+  // Auto-hold explanation; wraps to its own line under the strip.
+  .arc-automod-note {
+    flex-basis: 100%;
+    margin: 0;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #4338ca;
+    text-transform: capitalize;
   }
 
   .arc-btn {

--- a/src/Components/AdminRecipeControls/AdminRecipeControls.tsx
+++ b/src/Components/AdminRecipeControls/AdminRecipeControls.tsx
@@ -1,10 +1,11 @@
 import React, { FC } from 'react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import { RecipeType } from 'types'
 import { useAuth } from 'src/context/AuthContext'
 import AdminAPI from 'src/api/admin'
 import ReportAPI from 'src/api/reports'
+import { formatClassifier } from 'src/util/formatClassifier'
 import './AdminRecipeControls.scss'
 
 interface AdminRecipeControlsProps {
@@ -24,6 +25,17 @@ const AdminRecipeControls: FC<AdminRecipeControlsProps> = ({ recipe }) => {
 
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: ['recipe', recipe._id] })
+
+  const isPendingReview = recipe.status === 'pending_review'
+
+  // For an auto-held recipe, fetch WHY (the open automod report's classifier) so
+  // the admin sees the reason inline. Only runs for an admin viewing a held
+  // recipe — never on the public path.
+  const { data: automod } = useQuery({
+    queryKey: ['recipe-automod', recipe._id],
+    queryFn: () => AdminAPI.getRecipeAutomod(recipe._id),
+    enabled: isAdmin && isPendingReview,
+  })
 
   const featureMutation = useMutation({
     mutationFn: (featured: boolean) =>
@@ -71,7 +83,15 @@ const AdminRecipeControls: FC<AdminRecipeControlsProps> = ({ recipe }) => {
 
       {isHidden && <span className='arc-pill hidden'>Hidden</span>}
       {isUnpublished && <span className='arc-pill unpublished'>Unpublished</span>}
+      {isPendingReview && <span className='arc-pill pending'>Pending review</span>}
       {isFeatured && <span className='arc-pill featured'>Featured</span>}
+
+      {isPendingReview && (
+        <p className='arc-automod-note'>
+          Auto-held for moderation review
+          {automod?.classifier ? ` — ${formatClassifier(automod.classifier)}` : ''}.
+        </p>
+      )}
 
       <button
         type='button'

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -6,6 +6,7 @@ import {
   AuditAction,
   AuditTargetType,
   AnalyticsResponse,
+  ReportClassifier,
 } from 'types'
 import { http } from 'src/api/http-common'
 
@@ -87,6 +88,18 @@ class AdminAPIClass {
     const result = await http.get<AnalyticsResponse>('api/admin/analytics', {
       params,
     })
+    return result.data
+  }
+
+  // Why a recipe was auto-held (its open automod report's classifier), so the
+  // recipe page's admin strip can explain a pending_review hold inline.
+  async getRecipeAutomod(
+    recipeId: string
+  ): Promise<{ classifier: ReportClassifier | null; createdAt: string | null }> {
+    const result = await http.get<{
+      classifier: ReportClassifier | null
+      createdAt: string | null
+    }>(`api/admin/recipes/${recipeId}/automod`)
     return result.data
   }
 }

--- a/src/pages/Admin/Analytics/Analytics.scss
+++ b/src/pages/Admin/Analytics/Analytics.scss
@@ -74,6 +74,10 @@
         &.danger {
           color: #b91c1c;
         }
+
+        &.warn {
+          color: #b45309;
+        }
       }
 
       .stat-label {

--- a/src/pages/Admin/Analytics/Analytics.tsx
+++ b/src/pages/Admin/Analytics/Analytics.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { AuditEntryType, TimeBucket } from 'types'
 import AdminAPI from 'src/api/admin'
-import { ACTION_META } from 'src/pages/Admin/auditMeta'
+import { ACTION_META, formatAuditActor } from 'src/pages/Admin/auditMeta'
 import './Analytics.scss'
 
 // Day windows offered by the toggle. Server clamps to 7–90 regardless.
@@ -94,6 +94,14 @@ const Analytics: FC = () => {
                 {data.totals.reports.resolved} resolved · {data.totals.reports.dismissed} dismissed
               </span>
             </div>
+            <div className='stat-card'>
+              <span className='stat-value warn'>{data.totals.moderation.autoBlocked}</span>
+              <span className='stat-label'>Auto-blocked</span>
+              <span className='stat-sub'>
+                {data.totals.moderation.autoHeld} auto-held ·{' '}
+                {data.totals.moderation.autoFlagsDismissed} flags&nbsp;dismissed
+              </span>
+            </div>
           </section>
 
           <section className='trends'>
@@ -126,7 +134,7 @@ const Analytics: FC = () => {
                       <div className='action-body'>
                         <p className='action-line'>
                           <strong className='actor'>
-                            {entry.actorUsername ? `@${entry.actorUsername}` : 'An admin'}
+                            {formatAuditActor(entry)}
                           </strong>{' '}
                           {meta?.label || entry.action}{' '}
                           <span className='target'>{entry.targetLabel || entry.targetId}</span>

--- a/src/pages/Admin/Audit/Audit.tsx
+++ b/src/pages/Admin/Audit/Audit.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { AuditAction, AuditEntryType, AuditTargetType } from 'types'
 import AdminAPI from 'src/api/admin'
-import { ACTION_META } from 'src/pages/Admin/auditMeta'
+import { ACTION_META, formatAuditActor } from 'src/pages/Admin/auditMeta'
 import SavedFilterBar from 'src/Components/SavedFilters/SavedFilterBar'
 import './Audit.scss'
 
@@ -29,6 +29,8 @@ const ACTION_FILTERS: { value: AuditAction | 'all'; label: string }[] = [
   { value: 'user.activate', label: 'User reactivated' },
   { value: 'report.resolve', label: 'Report resolved' },
   { value: 'report.dismiss', label: 'Report dismissed' },
+  { value: 'recipe.autohold', label: 'Recipe auto-held (auto)' },
+  { value: 'content.blocked', label: 'Content blocked (auto)' },
 ]
 
 const TARGET_TABS: { value: AuditTargetType | 'all'; label: string }[] = [
@@ -125,7 +127,7 @@ const Audit: FC = () => {
                   <div className='audit-body'>
                     <p className='audit-line'>
                       <strong className='actor'>
-                        {entry.actorUsername ? `@${entry.actorUsername}` : 'An admin'}
+                        {formatAuditActor(entry)}
                       </strong>{' '}
                       {meta?.label || entry.action}{' '}
                       <span className='target'>{entry.targetLabel || entry.targetId}</span>

--- a/src/pages/Admin/Reports/Reports.scss
+++ b/src/pages/Admin/Reports/Reports.scss
@@ -190,6 +190,21 @@
           color: #6b7280;
         }
       }
+
+      // Machine-filed report — visually set apart from human reports.
+      .automod-pill {
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+    }
+
+    // Why the system held this content (automod reports only).
+    .report-classifier {
+      margin: 0 0 0.65rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #4338ca;
+      text-transform: capitalize;
     }
 
     .preview {

--- a/src/pages/Admin/Reports/Reports.tsx
+++ b/src/pages/Admin/Reports/Reports.tsx
@@ -5,6 +5,7 @@ import toast from 'react-hot-toast'
 import { AdminReportType, ReportStatus } from 'types'
 import ReportAPI from 'src/api/reports'
 import SavedFilterBar from 'src/Components/SavedFilters/SavedFilterBar'
+import { formatClassifier } from 'src/util/formatClassifier'
 import './Reports.scss'
 
 type StatusFilter = ReportStatus | 'all'
@@ -265,7 +266,21 @@ const Reports: FC = () => {
                   <span className={`status-pill ${report.status}`}>
                     {report.status}
                   </span>
+                  {report.source === 'automod' && (
+                    <span
+                      className='automod-pill'
+                      title='Filed automatically by the content-moderation system'
+                    >
+                      Automod
+                    </span>
+                  )}
                 </div>
+
+                {report.classifier && (
+                  <p className='report-classifier'>
+                    Auto-flagged: {formatClassifier(report.classifier)}
+                  </p>
+                )}
 
                 {renderPreview(report)}
 

--- a/src/pages/Admin/auditMeta.ts
+++ b/src/pages/Admin/auditMeta.ts
@@ -1,4 +1,16 @@
-import { AuditAction } from 'types'
+import { AuditAction, AuditEntryType } from 'types'
+
+// Display name for the actor of an audit row, shared by the Audit log and the
+// Analytics "recent actions" feed so they stay in sync. Automated actions
+// (autohold, content.blocked) are credited to the synthetic system actor, whose
+// uid never resolves to a username — show "Automod" instead of the misleading
+// "An admin" fallback. Human admins show their @handle (or a generic fallback).
+export const formatAuditActor = (
+  entry: Pick<AuditEntryType, 'actorType' | 'actorUsername'>
+): string => {
+  if (entry.actorType === 'system') return 'Automod'
+  return entry.actorUsername ? `@${entry.actorUsername}` : 'An admin'
+}
 
 // Short human phrasing + a colour tone per audit action, used for the row label
 // in both the Audit log and the Analytics "recent actions" feed. Kept here so
@@ -21,4 +33,9 @@ export const ACTION_META: Record<AuditAction, { label: string; tone: string }> =
   'report.dismiss': { label: 'dismissed report', tone: 'neutral' },
   'bugReport.resolve': { label: 'resolved bug report', tone: 'good' },
   'bugReport.dismiss': { label: 'dismissed bug report', tone: 'neutral' },
+  // Automated moderation (system actor). autohold = held a borderline recipe for
+  // review; content.blocked = refused a write outright (never persisted, target
+  // is the offending user; surface/category live in metadata).
+  'recipe.autohold': { label: 'auto-held recipe', tone: 'warn' },
+  'content.blocked': { label: 'blocked content from', tone: 'warn' },
 }

--- a/src/test/AdminAnalytics.test.tsx
+++ b/src/test/AdminAnalytics.test.tsx
@@ -29,6 +29,7 @@ const sample = {
     recipes: { total: 100, active: 90, hidden: 5, unpublished: 5, featured: 3 },
     reviews: 17,
     reports: { open: 4, resolved: 8, dismissed: 2 },
+    moderation: { autoHeld: 6, autoBlocked: 11, autoFlagsDismissed: 2 },
   },
   reportsOverTime: series(1, 0, 2),
   recipesOverTime: series(3, 1, 0),
@@ -72,6 +73,11 @@ describe('Admin Analytics page', () => {
     expect(screen.getByText('17')).toBeInTheDocument() // reviews
     expect(screen.getByText('4')).toBeInTheDocument() // open reports
     expect(screen.getByText(/3 featured/)).toBeInTheDocument()
+
+    // Moderation card: auto-blocked headline + the auto-held / false-positive sub.
+    expect(screen.getByText('11')).toBeInTheDocument() // auto-blocked
+    expect(screen.getByText('Auto-blocked')).toBeInTheDocument()
+    expect(screen.getByText(/6 auto-held/)).toBeInTheDocument()
 
     // Recent action row reuses the audit phrasing.
     expect(screen.getByText('@mod')).toBeInTheDocument()

--- a/src/test/AdminRecipeControls.test.tsx
+++ b/src/test/AdminRecipeControls.test.tsx
@@ -20,6 +20,7 @@ vi.mock('src/api/admin', () => ({
   default: {
     setRecipeFeatured: vi.fn().mockResolvedValue({ _id: 'r1', featured: true }),
     setRecipePublished: vi.fn().mockResolvedValue({ _id: 'r1', status: 'unpublished' }),
+    getRecipeAutomod: vi.fn(),
   },
 }))
 vi.mock('src/api/reports', () => ({
@@ -35,6 +36,7 @@ const mockedUseAuth = useAuth as unknown as Mock
 const mockedFeature = AdminAPI.setRecipeFeatured as unknown as Mock
 const mockedPublish = AdminAPI.setRecipePublished as unknown as Mock
 const mockedModeration = ReportAPI.setRecipeModeration as unknown as Mock
+const mockedAutomod = AdminAPI.getRecipeAutomod as unknown as Mock
 
 const recipe = { _id: 'r1', title: 'T', status: 'active', featured: false } as RecipeType
 
@@ -94,5 +96,44 @@ describe('AdminRecipeControls', () => {
     renderControls({ ...recipe, status: 'unpublished' } as RecipeType)
     expect(screen.getByRole('button', { name: /take down/i })).toBeDisabled()
     expect(screen.getByRole('button', { name: /^publish$/i })).toBeEnabled()
+  })
+
+  it('shows the Pending review pill + auto-held note with the classifier reason', async () => {
+    mockedUseAuth.mockReturnValue({ isAdmin: true })
+    mockedAutomod.mockResolvedValue({
+      classifier: {
+        severity: 'medium',
+        category: 'harassment',
+        reason: 'openai:harassment:0.60',
+        source: 'openai',
+      },
+      createdAt: new Date('2026-06-01').toISOString(),
+    })
+    renderControls({ ...recipe, status: 'pending_review' } as RecipeType)
+
+    expect(screen.getByText('Pending review')).toBeInTheDocument()
+    // The note fills in once the classifier query resolves.
+    expect(
+      await screen.findByText(
+        /auto-held for moderation review — harassment · 60% confidence · medium severity/i
+      )
+    ).toBeInTheDocument()
+    expect(mockedAutomod).toHaveBeenCalledWith('r1')
+  })
+
+  it('renders a held recipe without a classifier as a plain auto-held note', async () => {
+    mockedUseAuth.mockReturnValue({ isAdmin: true })
+    mockedAutomod.mockResolvedValue({ classifier: null, createdAt: null })
+    renderControls({ ...recipe, status: 'pending_review' } as RecipeType)
+
+    expect(await screen.findByText(/auto-held for moderation review\.$/i)).toBeInTheDocument()
+  })
+
+  it('does not query automod or show held UI for an active recipe', () => {
+    mockedUseAuth.mockReturnValue({ isAdmin: true })
+    renderControls() // active
+    expect(screen.queryByText('Pending review')).not.toBeInTheDocument()
+    expect(screen.queryByText(/auto-held/i)).not.toBeInTheDocument()
+    expect(mockedAutomod).not.toHaveBeenCalled()
   })
 })

--- a/src/test/Reports.test.tsx
+++ b/src/test/Reports.test.tsx
@@ -85,4 +85,43 @@ describe('Admin Reports bulk actions', () => {
     await screen.findByText('Dish r1')
     expect(screen.queryByText(/select all/i)).not.toBeInTheDocument()
   })
+
+  it('flags an automod report with the Automod pill + the classifier reason', async () => {
+    mockedList.mockResolvedValue({
+      reports: [
+        {
+          ...openReport('r1', 'rec1'),
+          source: 'automod',
+          classifier: {
+            severity: 'medium',
+            category: 'harassment',
+            reason: 'openai:harassment:0.60',
+            source: 'openai',
+          },
+        },
+      ],
+      totalCount: 1,
+      openCount: 1,
+    })
+    renderReports()
+    await screen.findByText('Dish r1')
+
+    expect(screen.getByText('Automod')).toBeInTheDocument()
+    expect(
+      screen.getByText(/auto-flagged: harassment · 60% confidence · medium severity/i)
+    ).toBeInTheDocument()
+  })
+
+  it('shows no Automod pill or classifier line for a plain user report', async () => {
+    mockedList.mockResolvedValue({
+      reports: [openReport('r1', 'rec1')], // no source / classifier
+      totalCount: 1,
+      openCount: 1,
+    })
+    renderReports()
+    await screen.findByText('Dish r1')
+
+    expect(screen.queryByText('Automod')).not.toBeInTheDocument()
+    expect(screen.queryByText(/auto-flagged/i)).not.toBeInTheDocument()
+  })
 })

--- a/src/test/auditMeta.test.ts
+++ b/src/test/auditMeta.test.ts
@@ -1,0 +1,37 @@
+/**
+ * auditMeta — shared actor labelling + action metadata for the Audit log and the
+ * Analytics "recent actions" feed. Asserts the behaviour we want: automated
+ * (system-actor) rows read "Automod" rather than the misleading admin fallback,
+ * and the two automod actions have display metadata (a missing key would be a
+ * compile error, but this pins the labels callers render).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { formatAuditActor, ACTION_META } from 'src/pages/Admin/auditMeta'
+
+describe('formatAuditActor', () => {
+  it('labels a system-actor row "Automod"', () => {
+    expect(formatAuditActor({ actorType: 'system', actorUsername: null })).toBe('Automod')
+  })
+
+  it('ignores any username on a system row (never shows a handle for Automod)', () => {
+    expect(formatAuditActor({ actorType: 'system', actorUsername: 'system:automod' })).toBe(
+      'Automod'
+    )
+  })
+
+  it('shows a human admin by @handle', () => {
+    expect(formatAuditActor({ actorType: 'admin', actorUsername: 'mod' })).toBe('@mod')
+  })
+
+  it('falls back to "An admin" for a human row with no resolved username', () => {
+    expect(formatAuditActor({ actorType: 'admin', actorUsername: null })).toBe('An admin')
+  })
+})
+
+describe('ACTION_META — automated-moderation actions', () => {
+  it('has display metadata for the automod actions', () => {
+    expect(ACTION_META['recipe.autohold']).toEqual({ label: 'auto-held recipe', tone: 'warn' })
+    expect(ACTION_META['content.blocked']).toEqual({ label: 'blocked content from', tone: 'warn' })
+  })
+})

--- a/src/test/formatClassifier.test.ts
+++ b/src/test/formatClassifier.test.ts
@@ -1,0 +1,76 @@
+/**
+ * formatClassifier — renders an automod classifier snapshot as the short
+ * admin-facing string shown in the Reports queue and the recipe admin strip.
+ *
+ * These assert the SHAPE WE WANT rendered for each real combination of fields,
+ * not just the happy path: the score is parsed out of `reason` (never shown
+ * raw), and each segment drops out cleanly when its field is absent.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { formatClassifier } from 'src/util/formatClassifier'
+import { ReportClassifier } from 'types'
+
+const classifier = (over: Partial<ReportClassifier> = {}): ReportClassifier => ({
+  severity: 'medium',
+  category: 'harassment',
+  reason: 'openai:harassment:0.60',
+  source: 'openai',
+  ...over,
+})
+
+describe('formatClassifier', () => {
+  it('renders category · confidence · severity for a full classifier', () => {
+    expect(formatClassifier(classifier())).toBe(
+      'harassment · 60% confidence · medium severity'
+    )
+  })
+
+  it('parses the score from the END of reason and rounds to a whole percent', () => {
+    expect(formatClassifier(classifier({ reason: 'openai:violence:0.07' }))).toContain(
+      '7% confidence'
+    )
+    expect(formatClassifier(classifier({ reason: 'openai:hate:1' }))).toContain(
+      '100% confidence'
+    )
+  })
+
+  it('omits the confidence segment when reason carries no trailing score', () => {
+    // A reason without a trailing number (the regex anchors on end-of-string).
+    const out = formatClassifier(classifier({ reason: 'vision:adult:VERY_LIKELY' }))
+    expect(out).not.toMatch(/confidence/)
+    expect(out).toBe('harassment · medium severity')
+  })
+
+  it('omits the confidence segment when reason is null', () => {
+    const out = formatClassifier(classifier({ reason: null }))
+    expect(out).not.toMatch(/confidence/)
+    expect(out).toBe('harassment · medium severity')
+  })
+
+  it('drops the category segment when category is null', () => {
+    expect(formatClassifier(classifier({ category: null }))).toBe(
+      '60% confidence · medium severity'
+    )
+  })
+
+  it('drops the severity segment when severity is falsy', () => {
+    expect(
+      formatClassifier(classifier({ severity: null as unknown as ReportClassifier['severity'] }))
+    ).toBe('harassment · 60% confidence')
+  })
+
+  // EDGE: every segment absent. Today this yields '' (which renders a dangling
+  // "Auto-flagged:" label at the call sites). Documented here as current
+  // behaviour; the empty-guard fix is tracked as a deferred moderation follow-up.
+  it('returns an empty string when nothing is present (known dangling-label edge)', () => {
+    expect(
+      formatClassifier({
+        severity: null as unknown as ReportClassifier['severity'],
+        category: null,
+        reason: null,
+        source: 'openai',
+      })
+    ).toBe('')
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,6 +199,18 @@ export interface NewReportType {
   details?: string
 }
 
+// Classifier snapshot stamped onto an automated (source: 'automod') report by
+// holdRecipeForReview, so the admin queue can show WHY the system held it.
+export interface ReportClassifier {
+  severity: 'clean' | 'medium' | 'high'
+  category: string | null
+  // e.g. 'openai:harassment:0.60' — the numeric score lives here. Medium holds
+  // are openai-only (blocklist hits are always high-blocked, never held), so this
+  // never carries raw user content.
+  reason: string | null
+  source: string | null
+}
+
 export interface ReportType {
   _id: string
   targetType: ReportTargetType
@@ -211,6 +223,9 @@ export interface ReportType {
   createdAt: string
   resolvedBy?: string
   resolvedAt?: string
+  // Present only on machine-filed reports. User reports leave these undefined.
+  source?: 'automod'
+  classifier?: ReportClassifier
 }
 
 // Report enriched with a snapshot of the reported content, as returned by the
@@ -328,6 +343,9 @@ export type AuditAction =
   | 'report.dismiss'
   | 'bugReport.resolve'
   | 'bugReport.dismiss'
+  // Automated moderation actions (system actor).
+  | 'recipe.autohold'
+  | 'content.blocked'
 
 export type AuditTargetType =
   | 'recipe'
@@ -340,6 +358,9 @@ export interface AuditEntryType {
   _id: string
   action: AuditAction
   actorUid: string
+  // 'system' marks an automated (non-human) action — autohold, content.blocked.
+  // 'admin' (or absent, for legacy rows) is a human admin.
+  actorType?: 'admin' | 'system'
   actorUsername: string | null
   targetType: AuditTargetType
   targetId: string | null
@@ -370,6 +391,12 @@ export interface AnalyticsTotals {
     open: number
     resolved: number
     dismissed: number
+  }
+  // Automated-moderation activity (all-time).
+  moderation: {
+    autoHeld: number // recipes the classifier held for review (recipe.autohold)
+    autoBlocked: number // writes refused outright (content.blocked)
+    autoFlagsDismissed: number // automod reports an admin dismissed (flags cleared, not content restored)
   }
 }
 

--- a/src/util/formatClassifier.ts
+++ b/src/util/formatClassifier.ts
@@ -1,0 +1,19 @@
+import { ReportClassifier } from 'types'
+
+// Render an automated-moderation classifier snapshot as a short admin-facing
+// string, e.g. "harassment · 60% confidence · medium severity". Shared by the
+// Reports queue and the recipe page's admin strip so they read identically.
+//
+// The numeric score (when present) is embedded in `reason`, e.g.
+// 'openai:harassment:0.60' — parse it out rather than show the raw token. No raw
+// user content is shown: the only reports filed are medium holds, which are
+// openai-only (blocklist hits are always high-blocked, never held), so `reason`
+// never carries a matched term.
+export const formatClassifier = (c: ReportClassifier): string => {
+  const parts: string[] = []
+  if (c.category) parts.push(c.category)
+  const scoreMatch = c.reason?.match(/:([0-9]*\.?[0-9]+)$/)
+  if (scoreMatch) parts.push(`${Math.round(parseFloat(scoreMatch[1]) * 100)}% confidence`)
+  if (c.severity) parts.push(`${c.severity} severity`)
+  return parts.join(' · ')
+}


### PR DESCRIPTION
## What

Builds out the rest of content-moderation **P3** (CSAM excluded; deferred to PhotoDNA).

### Server
- **Per-user write rate-limiter** (`server/middleware/writeLimiter.js`) on the moderated write routes (recipe / review / profile / username / displayName / photo) — each refused write no longer costs an unbounded paid OpenAI/Vision call.
- **`*.blocked` audit logging** — `respondBlocked` now records a best-effort **system-actor** `content.blocked` audit row (surface + category + severity + source; **no content stored**) so outright blocks are visible to admins. New audit actions `content.blocked` and `recipe.autohold`.
- **`GET /admin/recipes/:id/automod`** — returns the classifier of the open automod report holding a recipe (admin-gated).
- **Moderation metrics** on `/admin/analytics`: `autoHeld` / `autoBlocked` / `autoFlagsDismissed` (+ an Auto-blocked Overview card).

### Frontend
- **Reports queue**: Automod badge + classifier reason/score on auto-flagged reports.
- **Audit + Analytics**: render **"Automod"** as the system actor.
- **Recipe admin strip**: Pending-review pill + auto-held reason inline.

## Notes / known follow-ups
- `autoFlagsDismissed` counts **dismissed automod reports** — it does **not** yet restore a held (`pending_review`) recipe. The approve/restore path is the tracked HIGH follow-up; the metric was deliberately renamed (was a misleading "false-positives restored") so it states what it actually counts.
- Code-reviewed at high effort; #1 (lying metric label) fixed pre-merge, the rest logged for the next PR (limiter per-surface bucket + 429 code, opt-in-audit invariant, all-time-vs-windowed totals, defensive `moderation?` guard, persist score field, empty-classifier guard).

## Tests
- New: `formatClassifier` + `auditMeta` unit suites; extended Reports + AdminRecipeControls FE suites for the automod UX.
- **Server 532 passed · FE 387 passed / 2 skipped · tsc clean.**
- Authed live smoke (real Firebase admin token + Mongo) confirmed the renamed analytics field end-to-end.