### PR TITLE
feat(moderation): approve/restore path for auto-held recipes (PR-A)

### DIFF
--- a/server/__tests__/moderation-routes.test.js
+++ b/server/__tests__/moderation-routes.test.js
@@ -61,6 +61,18 @@ const RECIPE_BODY = {
   recipeImage: 'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ft.jpg?alt=media&token=abc',
 }
 
+// content.blocked audit rows are written fire-and-forget by respondBlocked (so a
+// logging hiccup can never turn a block into a 500), so poll briefly for the row
+// rather than asserting synchronously the instant the 422 lands.
+const waitFor = async (fn, { tries = 50, gap = 10 } = {}) => {
+  for (let i = 0; i < tries; i++) {
+    const v = await fn()
+    if (v) return v
+    await new Promise((r) => setTimeout(r, gap))
+  }
+  return null
+}
+
 beforeEach(() => {
   moderateText.mockReset()
   moderateText.mockResolvedValue(CLEAN)
@@ -91,6 +103,26 @@ describe('POST /addRecipe — moderation tiers', () => {
     expect(res.status).toBe(422)
     expect(res.body.code).toBe('CONTENT_BLOCKED')
     expect(await getDB().collection('recipes').countDocuments({})).toBe(0)
+  })
+
+  it('high block leaves a content.blocked audit row (system actor, offender as target)', async () => {
+    moderateText.mockResolvedValue(HIGH)
+    const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
+    expect(res.status).toBe(422)
+
+    const db = getDB()
+    const audit = await waitFor(() =>
+      db.collection('auditLog').findOne({ action: 'content.blocked', 'metadata.surface': 'recipe' })
+    )
+    expect(audit).toMatchObject({
+      action: 'content.blocked',
+      actorType: 'system',
+      actorUid: SYSTEM_ACTOR.uid,
+      targetType: 'user',
+      targetId: TEST_UID,
+    })
+    // Structured signal only — never the matched term / submitted text.
+    expect(audit.metadata).toMatchObject({ surface: 'recipe', category: 'hate', severity: 'high', source: 'openai' })
   })
 
   it('medium confidence → 201 pending_review + open automod report + system audit', async () => {
@@ -339,5 +371,67 @@ describe('POST /updateDisplayName — display name moderation', () => {
     expect(res.status).toBe(400)
     expect(moderateText).not.toHaveBeenCalled()
     expect(admin.__updateUser).not.toHaveBeenCalled()
+  })
+})
+
+describe('PATCH /api/admin/recipes/:id/approve — clear an automated hold', () => {
+  // Reproduce the exact state holdRecipeForReview leaves behind: a pending_review
+  // recipe with one OPEN system-filed automod report.
+  const seedHeld = async (id = 'held') => {
+    await seedRecipe({ ...RECIPE_BODY, _id: id, userId: 'owner', status: 'pending_review' })
+    await getDB().collection('reports').insertOne({
+      targetType: 'recipe',
+      recipeId: id,
+      reporterUid: SYSTEM_ACTOR.uid,
+      reason: 'inappropriate',
+      status: 'open',
+      source: 'automod',
+      classifier: { severity: 'medium', category: 'harassment', reason: 'openai:harassment:0.60', source: 'openai' },
+      createdAt: new Date(),
+    })
+  }
+
+  it('requires admin', async () => {
+    await seedHeld()
+    const res = await request(app).patch('/api/admin/recipes/held/approve').set(AUTH)
+    expect(res.status).toBe(403)
+  })
+
+  it('publishes the held recipe, dismisses its open automod report, and audits the approval', async () => {
+    admin.__setClaims({ admin: true })
+    await seedHeld()
+
+    const res = await request(app).patch('/api/admin/recipes/held/approve').set(AUTH)
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('active')
+
+    const db = getDB()
+    const recipe = await db.collection('recipes').findOne(recipeIdQuery('held'))
+    expect(recipe.status).toBe('active')
+    expect(recipe.moderatedBy).toBe(TEST_UID)
+
+    const report = await db.collection('reports').findOne({ recipeId: 'held', source: 'automod' })
+    expect(report.status).toBe('dismissed')
+    expect(report.resolvedBy).toBe(TEST_UID)
+
+    const audit = await db.collection('auditLog').findOne({ action: 'recipe.approve' })
+    expect(audit).toMatchObject({ actorUid: TEST_UID, targetType: 'recipe', targetId: 'held' })
+  })
+
+  it('is 409 and a no-op when the recipe is not pending_review (never clobbers active/hidden)', async () => {
+    admin.__setClaims({ admin: true })
+    await seedRecipe({ ...RECIPE_BODY, _id: 'live', userId: 'owner' }) // no status field = active
+
+    const res = await request(app).patch('/api/admin/recipes/live/approve').set(AUTH)
+    expect(res.status).toBe(409)
+    const recipe = await getDB().collection('recipes').findOne(recipeIdQuery('live'))
+    expect(recipe.status).toBeUndefined() // untouched
+    expect(await getDB().collection('auditLog').countDocuments({ action: 'recipe.approve' })).toBe(0)
+  })
+
+  it('is 409 for a recipe that does not exist', async () => {
+    admin.__setClaims({ admin: true })
+    const res = await request(app).patch('/api/admin/recipes/nope/approve').set(AUTH)
+    expect(res.status).toBe(409)
   })
 })

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -6,6 +6,7 @@ const { verifyToken, requireAdmin } = require('../middleware/auth')
 const { USER_STATUSES } = require('../util/userStatus')
 const { recordAudit, AUDIT_ACTIONS, AUDIT_TARGET_TYPES } = require('../util/auditLog')
 const { notifyInBackground, notifyAccountStatus } = require('../util/email')
+const { openAutomodReportQuery } = require('../util/automod')
 
 const router = Router()
 
@@ -348,7 +349,7 @@ router.get('/admin/audit', verifyToken, requireAdmin, asyncHandler(async (req, r
 router.get('/admin/recipes/:id/automod', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
   const db = getDB()
   const report = await db.collection('reports').findOne(
-    { targetType: 'recipe', recipeId: String(req.params.id), source: 'automod', status: 'open' },
+    openAutomodReportQuery(req.params.id),
     { sort: { createdAt: -1 }, projection: { classifier: 1, createdAt: 1 } }
   )
   res.json({ classifier: report?.classifier || null, createdAt: report?.createdAt || null })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -11,7 +11,7 @@ const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
 const { moderateText } = require('../util/textModeration')
 const { moderateImage } = require('../util/imageModeration')
-const { gatherRecipeText, holdRecipeForReview, respondBlocked, worstVerdict } = require('../util/automod')
+const { gatherRecipeText, holdRecipeForReview, respondBlocked, worstVerdict, openAutomodReportQuery } = require('../util/automod')
 const { EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 const { teardownRecipeDocs } = require('../util/teardownRecipe')
@@ -450,6 +450,53 @@ router.patch('/admin/recipes/:id/moderation', verifyToken, requireAdmin, asyncHa
   })
   // Notify the owner on a takedown (background). Unhide is silent.
   if (status === 'hidden') notifyInBackground(notifyRecipeHidden(updated.userId, updated.title))
+  res.json({ _id: updated._id, status: updated.status })
+}))
+
+// PATCH /admin/recipes/:id/approve — clear an AUTOMATED hold. An auto-held recipe
+// sits at status 'pending_review' (owner-visible, withheld from public reads) with
+// an OPEN system-filed automod report. Dismissing that report from the queue alone
+// only flips the report and strands the recipe invisible forever; this is the path
+// that actually publishes it. Restores the recipe to 'active' AND closes the open
+// automod report(s) as 'dismissed' in one action.
+//
+// Ordering is deliberate (mirrors holdRecipeForReview's fail-safe reasoning): flip
+// the recipe live FIRST, then close the report. If the second write fails the
+// recipe is already public (the goal) and the report just stays open for a manual
+// dismiss — strictly better than the reverse, which could re-strand a recipe that
+// should be live. Only one audit row is written (recipe.approve, the human
+// decision); the report's status flip records its own resolution.
+router.patch('/admin/recipes/:id/approve', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const recipeId = req.params.id
+  // The status filter scopes this to held recipes only: it makes a double-click
+  // idempotent (a second call finds nothing to flip → 409) and prevents an approve
+  // from silently clobbering a 'hidden'/'unpublished' state into 'active'.
+  const updated = await db.collection('recipes').findOneAndUpdate(
+    { ...recipeIdQuery(recipeId), status: 'pending_review' },
+    { $set: { status: 'active', moderatedBy: req.uid, moderatedAt: new Date() } },
+    { returnDocument: 'after' }
+  )
+  if (!updated) {
+    return res.status(409).json({ error: 'Recipe not found or not pending review' })
+  }
+
+  // Close the open automod report(s) for this recipe so the queue item resolves and
+  // the autoFlagsDismissed metric counts it. holdRecipeForReview keeps at most one
+  // open automod report per recipe, but updateMany is safe for 0..n.
+  await db.collection('reports').updateMany(
+    openAutomodReportQuery(recipeId),
+    { $set: { status: 'dismissed', resolvedBy: req.uid, resolvedAt: new Date() } }
+  )
+
+  await recordAudit(db, {
+    action: 'recipe.approve',
+    actorUid: req.uid,
+    targetType: 'recipe',
+    targetId: updated._id,
+    targetLabel: updated.title || null,
+  })
+
   res.json({ _id: updated._id, status: updated.status })
 }))
 

--- a/server/util/auditLog.js
+++ b/server/util/auditLog.js
@@ -10,6 +10,9 @@ const AUDIT_ACTIONS = [
   'recipe.unpublish',
   'recipe.feature',
   'recipe.unfeature',
+  // An admin cleared an automated hold: a pending_review recipe was approved back
+  // to public (and its open automod report dismissed). See recipes.js approve route.
+  'recipe.approve',
   'review.takedown',
   'review.restore',
   // Automated moderation: a classifier put a recipe into pending_review (held

--- a/server/util/automod.js
+++ b/server/util/automod.js
@@ -144,6 +144,15 @@ function gatherRecipeText(body = {}) {
   return parts.filter(Boolean).join('\n')
 }
 
+// The single OPEN automated-moderation report for a recipe — the queue entry that
+// represents an active hold. holdRecipeForReview keeps at most one (it upserts on
+// the system reporter), so this both reads "why is it held" (admin.js) and clears
+// the hold (recipes.js approve). Kept here so those callers can't drift on how an
+// automod hold is keyed.
+function openAutomodReportQuery(recipeId) {
+  return { targetType: 'recipe', recipeId: String(recipeId), source: 'automod', status: 'open' }
+}
+
 /**
  * Place a medium-confidence automated hold on a recipe, as one report-gated unit:
  *   1. file the OPEN admin-queue report (credited to the system actor),
@@ -224,4 +233,4 @@ async function holdRecipeForReview(db, { recipeId, title, verdict }) {
   return true
 }
 
-module.exports = { BLOCKED_MESSAGE, BLOCKED_CODE, respondBlocked, auditContentBlock, gatherRecipeText, holdRecipeForReview, worstVerdict }
+module.exports = { BLOCKED_MESSAGE, BLOCKED_CODE, respondBlocked, auditContentBlock, gatherRecipeText, holdRecipeForReview, worstVerdict, openAutomodReportQuery }

--- a/src/Components/AdminRecipeControls/AdminRecipeControls.scss
+++ b/src/Components/AdminRecipeControls/AdminRecipeControls.scss
@@ -88,5 +88,18 @@
       border-color: #d64545;
       color: #b91c1c;
     }
+
+    // Primary action for an auto-held recipe — filled green so it reads as the
+    // recommended way out of pending_review.
+    &.approve {
+      border-color: #15803d;
+      background: #16a34a;
+      color: #fff;
+
+      &:hover:not(:disabled) {
+        background: #15803d;
+        border-color: #166534;
+      }
+    }
   }
 }

--- a/src/Components/AdminRecipeControls/AdminRecipeControls.tsx
+++ b/src/Components/AdminRecipeControls/AdminRecipeControls.tsx
@@ -23,8 +23,12 @@ const AdminRecipeControls: FC<AdminRecipeControlsProps> = ({ recipe }) => {
   const isAdmin = authRes?.isAdmin === true
   const queryClient = useQueryClient()
 
-  const invalidate = () =>
+  const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ['recipe', recipe._id] })
+    // The automod note keys off the OPEN report; approving dismisses it, so drop
+    // the stale classifier snapshot too.
+    queryClient.invalidateQueries({ queryKey: ['recipe-automod', recipe._id] })
+  }
 
   const isPendingReview = recipe.status === 'pending_review'
 
@@ -67,6 +71,17 @@ const AdminRecipeControls: FC<AdminRecipeControlsProps> = ({ recipe }) => {
     onError: () => toast.error('Could not update moderation state.'),
   })
 
+  // Clear an automated hold: publish the recipe and dismiss its automod report in
+  // one call. Only meaningful (and only shown) while the recipe is pending_review.
+  const approveMutation = useMutation({
+    mutationFn: () => AdminAPI.approveRecipe(recipe._id),
+    onSuccess: () => {
+      toast.success('Recipe approved and published.')
+      invalidate()
+    },
+    onError: () => toast.error('Could not approve the recipe.'),
+  })
+
   if (!isAdmin) return null
 
   const isHidden = recipe.status === 'hidden'
@@ -75,7 +90,8 @@ const AdminRecipeControls: FC<AdminRecipeControlsProps> = ({ recipe }) => {
   const busy =
     featureMutation.isPending ||
     publishMutation.isPending ||
-    takedownMutation.isPending
+    takedownMutation.isPending ||
+    approveMutation.isPending
 
   return (
     <div className='admin-recipe-controls' role='group' aria-label='Admin recipe controls'>
@@ -93,6 +109,17 @@ const AdminRecipeControls: FC<AdminRecipeControlsProps> = ({ recipe }) => {
         </p>
       )}
 
+      {isPendingReview && (
+        <button
+          type='button'
+          className='arc-btn approve'
+          disabled={busy}
+          onClick={() => approveMutation.mutate()}
+        >
+          Approve &amp; publish
+        </button>
+      )}
+
       <button
         type='button'
         className='arc-btn feature'
@@ -105,11 +132,18 @@ const AdminRecipeControls: FC<AdminRecipeControlsProps> = ({ recipe }) => {
       <button
         type='button'
         className='arc-btn publish'
-        // `status` is a single field shared with the moderation takedown, so
-        // unpublishing a taken-down recipe would silently clear the `hidden`
-        // state (and its moderation stamp). Force the admin to Restore first.
-        disabled={busy || isHidden}
-        title={isHidden ? 'Restore this recipe before changing its publish state' : undefined}
+        // `status` is a single field shared with the moderation/hold states, so
+        // unpublishing a taken-down OR auto-held recipe would silently clear that
+        // state (and orphan its open automod report). Force the admin to resolve
+        // the hold (Approve/Take down) or Restore first.
+        disabled={busy || isHidden || isPendingReview}
+        title={
+          isHidden
+            ? 'Restore this recipe before changing its publish state'
+            : isPendingReview
+            ? 'Approve or take down this held recipe before changing its publish state'
+            : undefined
+        }
         onClick={() => publishMutation.mutate(isUnpublished)}
       >
         {isUnpublished ? 'Publish' : 'Unpublish'}

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -102,6 +102,18 @@ class AdminAPIClass {
     }>(`api/admin/recipes/${recipeId}/automod`)
     return result.data
   }
+
+  // Clear an automated hold: restore a pending_review recipe to active AND dismiss
+  // its open automod report in one server-side action. Pairs with getRecipeAutomod
+  // (which explains the hold). Errors if the recipe isn't currently pending review.
+  async approveRecipe(
+    recipeId: string
+  ): Promise<{ _id: string; status: string }> {
+    const result = await http.patch<{ _id: string; status: string }>(
+      `api/admin/recipes/${recipeId}/approve`
+    )
+    return result.data
+  }
 }
 
 const AdminAPI = new AdminAPIClass()

--- a/src/pages/Admin/Reports/Reports.scss
+++ b/src/pages/Admin/Reports/Reports.scss
@@ -303,7 +303,8 @@
           color: #fff;
         }
 
-        &.restore {
+        &.restore,
+        &.approve {
           background: #16a34a;
           border-color: #16a34a;
           color: #fff;

--- a/src/pages/Admin/Reports/Reports.tsx
+++ b/src/pages/Admin/Reports/Reports.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import { AdminReportType, ReportStatus } from 'types'
 import ReportAPI from 'src/api/reports'
+import AdminAPI from 'src/api/admin'
 import SavedFilterBar from 'src/Components/SavedFilters/SavedFilterBar'
 import { formatClassifier } from 'src/util/formatClassifier'
 import './Reports.scss'
@@ -49,7 +50,19 @@ const Reports: FC = () => {
       return next
     })
 
-  const openReports = (data?.reports || []).filter(r => r.status === 'open')
+  // Whether the reported recipe is sitting on an automated hold (pending_review).
+  // These need Approve/Take down, NOT a bare Resolve/Dismiss (which would strand
+  // the recipe invisible — the bug this action fixes), so they're also excluded
+  // from the bulk-action selection below.
+  const isTargetPendingReview = (report: AdminReportType) =>
+    report.targetType === 'recipe' &&
+    report.target.recipe?.status === 'pending_review'
+
+  // Only non-held open reports are bulk-selectable; a bulk Dismiss must never be
+  // able to strand an auto-held recipe.
+  const openReports = (data?.reports || []).filter(
+    r => r.status === 'open' && !isTargetPendingReview(r)
+  )
   const allOpenSelected =
     openReports.length > 0 && openReports.every(r => selected.has(r._id))
 
@@ -58,10 +71,16 @@ const Reports: FC = () => {
       allOpenSelected ? new Set() : new Set(openReports.map(r => r._id))
     )
 
-  // Resolve/dismiss every selected report in one request.
+  // Resolve/dismiss every selected report in one request. Re-derive the ids from
+  // the CURRENT selectable set rather than the raw `selected` snapshot: a report
+  // selected while active but auto-held since (its checkbox is now hidden) would
+  // otherwise still ride along and let a bulk dismiss strand the held recipe.
   const bulkMutation = useMutation({
     mutationFn: ({ status }: { status: 'resolved' | 'dismissed' }) =>
-      ReportAPI.bulkResolve(Array.from(selected), status),
+      ReportAPI.bulkResolve(
+        openReports.filter(r => selected.has(r._id)).map(r => r._id),
+        status
+      ),
     onSuccess: (res, vars) => {
       toast.success(`${res.updated} report${res.updated === 1 ? '' : 's'} ${vars.status}.`)
       setSelected(new Set())
@@ -122,16 +141,41 @@ const Reports: FC = () => {
     onError: () => toast.error('Could not restore the content.'),
   })
 
+  // Approve an auto-held recipe: publish it AND dismiss its open automod report in
+  // one server call. The only path that actually clears a pending_review hold — a
+  // bare Dismiss would close the report but leave the recipe invisible forever.
+  const approveMutation = useMutation({
+    mutationFn: (report: AdminReportType) => AdminAPI.approveRecipe(report.recipeId),
+    onSuccess: () => {
+      toast.success('Recipe approved and published.')
+      invalidate()
+    },
+    onError: () => toast.error('Could not approve the recipe.'),
+  })
+
   // Whether the reported target is currently hidden (from the queue's snapshot).
   const isTargetHidden = (report: AdminReportType) =>
     report.targetType === 'recipe'
       ? report.target.recipe?.status === 'hidden'
       : report.target.review?.moderationHidden === true
 
+  // Take-down button is offered both for a held recipe and a plain open report, so
+  // render it once here rather than duplicating the markup across both branches.
+  const takedownButton = (report: AdminReportType) => (
+    <button
+      className='action takedown'
+      disabled={busy}
+      onClick={() => takedownMutation.mutate(report)}
+    >
+      Take down
+    </button>
+  )
+
   const busy =
     resolveMutation.isPending ||
     takedownMutation.isPending ||
     restoreMutation.isPending ||
+    approveMutation.isPending ||
     bulkMutation.isPending
 
   const renderPreview = (report: AdminReportType) => {
@@ -248,7 +292,7 @@ const Reports: FC = () => {
         <ul className='reports-list'>
           {data.reports.map(report => (
             <li key={report._id} className='report-card'>
-              {report.status === 'open' && (
+              {report.status === 'open' && !isTargetPendingReview(report) && (
                 <input
                   type='checkbox'
                   className='report-select'
@@ -294,45 +338,56 @@ const Reports: FC = () => {
 
               {(report.status === 'open' || isTargetHidden(report)) && (
                 <div className='report-actions'>
-                  {isTargetHidden(report) ? (
-                    <button
-                      className='action restore'
-                      disabled={busy}
-                      onClick={() => restoreMutation.mutate(report)}
-                    >
-                      Restore
-                    </button>
-                  ) : (
-                    report.status === 'open' && (
-                      <button
-                        className='action takedown'
-                        disabled={busy}
-                        onClick={() => takedownMutation.mutate(report)}
-                      >
-                        Take down
-                      </button>
-                    )
-                  )}
-                  {report.status === 'open' && (
+                  {isTargetPendingReview(report) ? (
+                    // Auto-held recipe: the two terminal choices are publish or
+                    // hide, both of which close the report. A bare Resolve/Dismiss
+                    // is intentionally omitted — it would strand the recipe in
+                    // pending_review (invisible to the public) forever.
                     <>
                       <button
-                        className='action resolve'
+                        className='action approve'
                         disabled={busy}
-                        onClick={() =>
-                          resolveMutation.mutate({ id: report._id, status: 'resolved' })
-                        }
+                        onClick={() => approveMutation.mutate(report)}
                       >
-                        Resolve
+                        Approve
                       </button>
-                      <button
-                        className='action dismiss'
-                        disabled={busy}
-                        onClick={() =>
-                          resolveMutation.mutate({ id: report._id, status: 'dismissed' })
-                        }
-                      >
-                        Dismiss
-                      </button>
+                      {takedownButton(report)}
+                    </>
+                  ) : (
+                    <>
+                      {isTargetHidden(report) ? (
+                        <button
+                          className='action restore'
+                          disabled={busy}
+                          onClick={() => restoreMutation.mutate(report)}
+                        >
+                          Restore
+                        </button>
+                      ) : (
+                        report.status === 'open' && takedownButton(report)
+                      )}
+                      {report.status === 'open' && (
+                        <>
+                          <button
+                            className='action resolve'
+                            disabled={busy}
+                            onClick={() =>
+                              resolveMutation.mutate({ id: report._id, status: 'resolved' })
+                            }
+                          >
+                            Resolve
+                          </button>
+                          <button
+                            className='action dismiss'
+                            disabled={busy}
+                            onClick={() =>
+                              resolveMutation.mutate({ id: report._id, status: 'dismissed' })
+                            }
+                          >
+                            Dismiss
+                          </button>
+                        </>
+                      )}
                     </>
                   )}
                 </div>

--- a/src/pages/Admin/auditMeta.ts
+++ b/src/pages/Admin/auditMeta.ts
@@ -23,6 +23,7 @@ export const ACTION_META: Record<AuditAction, { label: string; tone: string }> =
   'recipe.unpublish': { label: 'unpublished recipe', tone: 'warn' },
   'recipe.feature': { label: 'featured recipe', tone: 'good' },
   'recipe.unfeature': { label: 'unfeatured recipe', tone: 'neutral' },
+  'recipe.approve': { label: 'approved held recipe', tone: 'good' },
   'review.takedown': { label: 'took down review by', tone: 'danger' },
   'review.restore': { label: 'restored review by', tone: 'good' },
   'user.suspend': { label: 'suspended', tone: 'warn' },

--- a/src/test/AdminRecipeControls.test.tsx
+++ b/src/test/AdminRecipeControls.test.tsx
@@ -21,6 +21,7 @@ vi.mock('src/api/admin', () => ({
     setRecipeFeatured: vi.fn().mockResolvedValue({ _id: 'r1', featured: true }),
     setRecipePublished: vi.fn().mockResolvedValue({ _id: 'r1', status: 'unpublished' }),
     getRecipeAutomod: vi.fn(),
+    approveRecipe: vi.fn().mockResolvedValue({ _id: 'r1', status: 'active' }),
   },
 }))
 vi.mock('src/api/reports', () => ({
@@ -37,6 +38,7 @@ const mockedFeature = AdminAPI.setRecipeFeatured as unknown as Mock
 const mockedPublish = AdminAPI.setRecipePublished as unknown as Mock
 const mockedModeration = ReportAPI.setRecipeModeration as unknown as Mock
 const mockedAutomod = AdminAPI.getRecipeAutomod as unknown as Mock
+const mockedApprove = AdminAPI.approveRecipe as unknown as Mock
 
 const recipe = { _id: 'r1', title: 'T', status: 'active', featured: false } as RecipeType
 
@@ -135,5 +137,20 @@ describe('AdminRecipeControls', () => {
     expect(screen.queryByText('Pending review')).not.toBeInTheDocument()
     expect(screen.queryByText(/auto-held/i)).not.toBeInTheDocument()
     expect(mockedAutomod).not.toHaveBeenCalled()
+  })
+
+  it('approves (publishes + clears the hold) a pending_review recipe', async () => {
+    mockedUseAuth.mockReturnValue({ isAdmin: true })
+    mockedAutomod.mockResolvedValue({ classifier: null, createdAt: null })
+    renderControls({ ...recipe, status: 'pending_review' } as RecipeType)
+
+    fireEvent.click(screen.getByRole('button', { name: /approve & publish/i }))
+    await waitFor(() => expect(mockedApprove).toHaveBeenCalledWith('r1'))
+  })
+
+  it('shows no Approve button on a non-held recipe', () => {
+    mockedUseAuth.mockReturnValue({ isAdmin: true })
+    renderControls() // active
+    expect(screen.queryByRole('button', { name: /approve/i })).not.toBeInTheDocument()
   })
 })

--- a/src/test/Reports.test.tsx
+++ b/src/test/Reports.test.tsx
@@ -10,6 +10,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import Reports from 'src/pages/Admin/Reports/Reports'
 import ReportAPI from 'src/api/reports'
+import AdminAPI from 'src/api/admin'
 
 vi.mock('src/api/reports', () => ({
   __esModule: true,
@@ -21,6 +22,10 @@ vi.mock('src/api/reports', () => ({
     setReviewModeration: vi.fn(),
   },
 }))
+vi.mock('src/api/admin', () => ({
+  __esModule: true,
+  default: { approveRecipe: vi.fn().mockResolvedValue({ _id: 'rec1', status: 'active' }) },
+}))
 vi.mock('react-hot-toast', () => ({
   __esModule: true,
   default: { success: vi.fn(), error: vi.fn() },
@@ -28,6 +33,7 @@ vi.mock('react-hot-toast', () => ({
 
 const mockedList = ReportAPI.listReports as unknown as Mock
 const mockedBulk = ReportAPI.bulkResolve as unknown as Mock
+const mockedApprove = AdminAPI.approveRecipe as unknown as Mock
 
 const openReport = (id: string, recipeId: string) => ({
   _id: id,
@@ -38,6 +44,13 @@ const openReport = (id: string, recipeId: string) => ({
   status: 'open' as const,
   createdAt: new Date('2026-06-01').toISOString(),
   target: { recipe: { title: `Dish ${id}`, recipeImage: '', status: 'active' }, review: null },
+})
+
+// An auto-held report: open automod report whose target recipe is pending_review.
+const heldReport = (id: string, recipeId: string) => ({
+  ...openReport(id, recipeId),
+  source: 'automod' as const,
+  target: { recipe: { title: `Dish ${id}`, recipeImage: '', status: 'pending_review' }, review: null },
 })
 
 const renderReports = () =>
@@ -123,5 +136,33 @@ describe('Admin Reports bulk actions', () => {
 
     expect(screen.queryByText('Automod')).not.toBeInTheDocument()
     expect(screen.queryByText(/auto-flagged/i)).not.toBeInTheDocument()
+  })
+
+  it('approves an auto-held recipe straight from the queue (publishes + clears the report)', async () => {
+    mockedList.mockResolvedValue({
+      reports: [heldReport('h1', 'rec1')],
+      totalCount: 1,
+      openCount: 1,
+    })
+    renderReports()
+    await screen.findByText('Dish h1')
+
+    fireEvent.click(screen.getByRole('button', { name: /^approve$/i }))
+    await waitFor(() => expect(mockedApprove).toHaveBeenCalledWith('rec1'))
+  })
+
+  it('keeps an auto-held report out of bulk select (a bulk dismiss must not strand it)', async () => {
+    mockedList.mockResolvedValue({
+      reports: [heldReport('h1', 'rec1'), openReport('r2', 'rec2')],
+      totalCount: 2,
+      openCount: 2,
+    })
+    renderReports()
+    await screen.findByText('Dish h1')
+
+    // Only the plain open report is selectable, so the bulk bar counts 1, not 2.
+    expect(screen.getByText(/select all 1 open/i)).toBeInTheDocument()
+    // The held report offers Approve, never a bare Dismiss.
+    expect(screen.getByRole('button', { name: /^approve$/i })).toBeInTheDocument()
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -333,6 +333,7 @@ export type AuditAction =
   | 'recipe.unpublish'
   | 'recipe.feature'
   | 'recipe.unfeature'
+  | 'recipe.approve'
   | 'review.takedown'
   | 'review.restore'
   | 'user.suspend'


### PR DESCRIPTION
## What & why

First of the post-P3 moderation follow-up PRs (PR-A in the A→B→C→D plan).

**The bug:** when the classifier auto-holds a recipe it sets `status: 'pending_review'` (withheld from public) and files an OPEN system automod report. Dismissing that report from the queue only flipped the *report* — the recipe stayed `pending_review` **invisible forever**. The queue's "Restore" only rendered for `status === 'hidden'`, never `pending_review`, so there was no action that actually published a held recipe.

## Server

- **`PATCH /admin/recipes/:id/approve`** — atomically restores a `pending_review` recipe to `active` **and** dismisses its open automod report(s). Recipe is flipped live *first*, then the report is closed (a failed second write leaves it public, not stranded — mirrors `holdRecipeForReview`'s fail-safe ordering). Returns **409** when the recipe isn't `pending_review` (idempotent; never clobbers `active`/`hidden`). New `recipe.approve` audit action.
- Extracted **`openAutomodReportQuery()`** into `util/automod.js`, shared by the new route and `admin.js` `getRecipeAutomod`, so the "which report is the hold" key can't drift across call sites.

## Frontend

- **Approve** action on both admin surfaces: the recipe-page `AdminRecipeControls` strip ("Approve & publish") and the Reports queue (held recipes show **Approve** / **Take down**, not a bare Resolve/Dismiss).
- Held automod reports are **excluded from bulk-select**, and the bulk action re-derives ids from the current selectable set — a bulk dismiss can't strand a recipe that became held *after* selection.
- **Publish/Unpublish disabled** on a held recipe (extends the existing clobber-guard): unpublishing would silently clear the hold and orphan its report.

## Tests

- Server: approve route (publish + report dismissal + audit; 409 guards for non-held / missing) and a `content.blocked` audit-row assertion on a blocked write.
- FE: Approve buttons on both surfaces + bulk-exclusion coverage.

Local: tsc clean · FE 391 pass · server 537 pass · build OK · `/code-review` (high) run, 4 findings applied (publish clobber-guard, bulk stale-selection race, shared query extraction, dup-button hoist).

## Deferred to PR-B (robustness)
Server-side guard so a *direct* `PATCH /reports/:id` or `/reports/bulk` dismiss can't strand a held recipe — today the protection is FE-only. Fits PR-B's "centralize the block/hold invariant" item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)