### PR TITLE
feat(moderation): PR-B robustness hardening

### DIFF
--- a/server/__tests__/automod.test.js
+++ b/server/__tests__/automod.test.js
@@ -226,6 +226,16 @@ describe('respondBlocked — 422 contract + best-effort audit', () => {
     return res
   }
 
+  // The no-context path warns (a wiring bug); spy so it doesn't spam test output
+  // and so the warn-behaviour test can assert on it.
+  let warnSpy
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
   it('returns the 422 CONTENT_BLOCKED contract', () => {
     const res = fakeRes()
     respondBlocked(res)
@@ -253,9 +263,11 @@ describe('respondBlocked — 422 contract + best-effort audit', () => {
     expect(inserts[0].metadata.surface).toBe('displayName')
   })
 
-  it('skips the audit (and never throws) when no context is passed', () => {
+  it('warns loudly (does not silently skip the audit) and never throws when no context is passed', () => {
     const res = fakeRes()
     expect(() => respondBlocked(res)).not.toThrow()
     expect(res.status).toHaveBeenCalledWith(422)
+    // A block with no audit context is a wiring bug — it must be loud, not silent.
+    expect(warnSpy).toHaveBeenCalled()
   })
 })

--- a/server/__tests__/moderation-routes.test.js
+++ b/server/__tests__/moderation-routes.test.js
@@ -435,3 +435,88 @@ describe('PATCH /api/admin/recipes/:id/approve — clear an automated hold', () 
     expect(res.status).toBe(409)
   })
 })
+
+// A recipe hold lives in TWO places — the recipe's 'pending_review' status AND an
+// OPEN automod report. Closing the report directly from the queue (rather than via
+// the approve endpoint) must not strand the recipe invisible forever, so the report
+// routes restore any held recipe whose automod report they close.
+describe('report-close strand guard — closing an automod hold restores the recipe', () => {
+  // Reproduce holdRecipeForReview's output and return the report _id so we can PATCH it.
+  const seedHeld = async (id, status = 'pending_review') => {
+    await seedRecipe({ ...RECIPE_BODY, _id: id, userId: 'owner', status })
+    const { insertedId } = await getDB().collection('reports').insertOne({
+      targetType: 'recipe',
+      recipeId: id,
+      reporterUid: SYSTEM_ACTOR.uid,
+      reason: 'inappropriate',
+      status: 'open',
+      source: 'automod',
+      classifier: { severity: 'medium', category: 'harassment', reason: 'openai:harassment:0.60', source: 'openai' },
+      createdAt: new Date(),
+    })
+    return insertedId
+  }
+
+  beforeEach(() => admin.__setClaims({ admin: true }))
+
+  it('PATCH /reports/:id dismiss of an automod hold restores the recipe to active', async () => {
+    const reportId = await seedHeld('held-1')
+    const res = await request(app)
+      .patch(`/api/reports/${reportId}`)
+      .set(AUTH)
+      .send({ status: 'dismissed' })
+    expect(res.status).toBe(200)
+    const db = getDB()
+    expect((await db.collection('recipes').findOne(recipeIdQuery('held-1'))).status).toBe('active')
+    // The shared restore helper writes the recipe.approve audit row.
+    expect(await db.collection('auditLog').countDocuments({ action: 'recipe.approve', targetId: 'held-1' })).toBe(1)
+  })
+
+  it('PATCH /reports/:id resolve of an automod hold also restores the recipe (no strand on either resolution)', async () => {
+    const reportId = await seedHeld('held-2')
+    const res = await request(app)
+      .patch(`/api/reports/${reportId}`)
+      .set(AUTH)
+      .send({ status: 'resolved' })
+    expect(res.status).toBe(200)
+    expect((await getDB().collection('recipes').findOne(recipeIdQuery('held-2'))).status).toBe('active')
+  })
+
+  it('does NOT restore a recipe an admin separately took down (hidden) — only genuine pending_review strays', async () => {
+    const reportId = await seedHeld('hidden-1', 'hidden')
+    const res = await request(app)
+      .patch(`/api/reports/${reportId}`)
+      .set(AUTH)
+      .send({ status: 'dismissed' })
+    expect(res.status).toBe(200)
+    const db = getDB()
+    expect((await db.collection('recipes').findOne(recipeIdQuery('hidden-1'))).status).toBe('hidden')
+    expect(await db.collection('auditLog').countDocuments({ action: 'recipe.approve' })).toBe(0)
+  })
+
+  it('a user-filed (non-automod) report close touches no recipe status', async () => {
+    await seedRecipe({ ...RECIPE_BODY, _id: 'r-user', userId: 'owner' }) // active (no status)
+    const { insertedId: reportId } = await getDB().collection('reports').insertOne({
+      targetType: 'recipe', recipeId: 'r-user', reporterUid: 'some-user', reason: 'spam', status: 'open', createdAt: new Date(),
+    })
+    const res = await request(app)
+      .patch(`/api/reports/${reportId}`)
+      .set(AUTH)
+      .send({ status: 'dismissed' })
+    expect(res.status).toBe(200)
+    expect(await getDB().collection('auditLog').countDocuments({ action: 'recipe.approve' })).toBe(0)
+  })
+
+  it('PATCH /reports/bulk restores every held recipe whose automod report it closes', async () => {
+    const id1 = await seedHeld('bulk-1')
+    const id2 = await seedHeld('bulk-2')
+    const res = await request(app)
+      .patch('/api/reports/bulk')
+      .set(AUTH)
+      .send({ ids: [String(id1), String(id2)], status: 'dismissed' })
+    expect(res.status).toBe(200)
+    const db = getDB()
+    expect((await db.collection('recipes').findOne(recipeIdQuery('bulk-1'))).status).toBe('active')
+    expect((await db.collection('recipes').findOne(recipeIdQuery('bulk-2'))).status).toBe('active')
+  })
+})

--- a/server/__tests__/writeLimiter.test.js
+++ b/server/__tests__/writeLimiter.test.js
@@ -41,10 +41,12 @@ describe('writeLimiter — per-user content-write cap', () => {
       const res = await request(app).post('/write').set('x-test-uid', uid)
       expect(res.status).toBe(200)
     }
-    // The 31st in the window is throttled with the friendly message.
+    // The 31st in the window is throttled with the friendly message + a stable
+    // code the FE can branch on.
     const blocked = await request(app).post('/write').set('x-test-uid', uid)
     expect(blocked.status).toBe(429)
     expect(blocked.body.error).toMatch(/too quickly/i)
+    expect(blocked.body.code).toBe('RATE_LIMITED')
   })
 
   it('keys per user — one user hitting the cap does not throttle another', async () => {

--- a/server/middleware/writeLimiter.js
+++ b/server/middleware/writeLimiter.js
@@ -24,7 +24,10 @@ const writeLimiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: (req) => req.uid,
   skip: () => process.env.NODE_ENV === 'test',
-  message: { error: 'You’re doing that too quickly — wait a moment and try again.' },
+  // Carry a stable `code` like every other client error (CONTENT_BLOCKED,
+  // ACCOUNT_BANNED, ALREADY_REPORTED) so the FE can branch on the 429 — e.g. show
+  // a dedicated "slow down" affordance — instead of string-matching the message.
+  message: { error: 'You’re doing that too quickly — wait a moment and try again.', code: 'RATE_LIMITED' },
 })
 
 module.exports = { writeLimiter }

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -11,7 +11,7 @@ const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
 const { moderateText } = require('../util/textModeration')
 const { moderateImage } = require('../util/imageModeration')
-const { gatherRecipeText, holdRecipeForReview, respondBlocked, worstVerdict, openAutomodReportQuery } = require('../util/automod')
+const { gatherRecipeText, holdRecipeForReview, respondBlocked, worstVerdict, openAutomodReportQuery, restoreHeldRecipe } = require('../util/automod')
 const { EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 const { teardownRecipeDocs } = require('../util/teardownRecipe')
@@ -469,14 +469,12 @@ router.patch('/admin/recipes/:id/moderation', verifyToken, requireAdmin, asyncHa
 router.patch('/admin/recipes/:id/approve', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
   const db = getDB()
   const recipeId = req.params.id
-  // The status filter scopes this to held recipes only: it makes a double-click
-  // idempotent (a second call finds nothing to flip → 409) and prevents an approve
-  // from silently clobbering a 'hidden'/'unpublished' state into 'active'.
-  const updated = await db.collection('recipes').findOneAndUpdate(
-    { ...recipeIdQuery(recipeId), status: 'pending_review' },
-    { $set: { status: 'active', moderatedBy: req.uid, moderatedAt: new Date() } },
-    { returnDocument: 'after' }
-  )
+  // restoreHeldRecipe scopes to held recipes only (status 'pending_review') and
+  // writes the recipe.approve audit: a double-click is idempotent (a second call
+  // finds nothing to flip → null → 409) and an approve can't clobber a
+  // 'hidden'/'unpublished' state into 'active'. Shared with the report-close strand
+  // guard so both paths clear a hold identically.
+  const updated = await restoreHeldRecipe(db, recipeId, req.uid)
   if (!updated) {
     return res.status(409).json({ error: 'Recipe not found or not pending review' })
   }
@@ -488,14 +486,6 @@ router.patch('/admin/recipes/:id/approve', verifyToken, requireAdmin, asyncHandl
     openAutomodReportQuery(recipeId),
     { $set: { status: 'dismissed', resolvedBy: req.uid, resolvedAt: new Date() } }
   )
-
-  await recordAudit(db, {
-    action: 'recipe.approve',
-    actorUid: req.uid,
-    targetType: 'recipe',
-    targetId: updated._id,
-    targetLabel: updated.title || null,
-  })
 
   res.json({ _id: updated._id, status: updated.status })
 }))

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -5,7 +5,17 @@ const { getDB } = require('../db')
 const { verifyToken, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { recordAudit, recordAuditMany } = require('../util/auditLog')
+const { restoreHeldRecipe } = require('../util/automod')
 const { notifyInBackground, notifyReportResolved, notifyReportResolvedMany } = require('../util/email')
+
+// An OPEN automod report is the queue half of a recipe hold; the other half is the
+// recipe's `pending_review` status. Closing such a report directly (resolve OR
+// dismiss) without restoring the recipe would strand it invisible forever, so any
+// report-close path runs the held recipe back through restoreHeldRecipe. The
+// status filter inside that helper means a recipe an admin has separately taken
+// down ('hidden') is left down — only genuine strays (still 'pending_review') are
+// restored.
+const isAutomodRecipeReport = (r) => r && r.source === 'automod' && r.targetType === 'recipe'
 
 const router = Router()
 
@@ -186,6 +196,13 @@ router.patch('/reports/bulk', verifyToken, requireAdmin, asyncHandler(async (req
     }))
   )
 
+  // Strand guard: any automod recipe report closed in this sweep clears a hold, so
+  // restore those recipes (bounded by MAX_BULK above). Sequential to keep audit
+  // writes orderly; the set is small.
+  for (const r of closed.filter(isAutomodRecipeReport)) {
+    await restoreHeldRecipe(db, r.recipeId, req.uid)
+  }
+
   // Email each affected reporter once per sweep (resolve only; dismiss is
   // silent), in the background so a large sweep never blocks the response.
   if (status === 'resolved') {
@@ -221,6 +238,9 @@ router.patch('/reports/:id', verifyToken, requireAdmin, asyncHandler(async (req,
     targetLabel: updated.reportedUsername ? `@${updated.reportedUsername}` : updated.recipeId,
     metadata: { targetType: updated.targetType, recipeId: updated.recipeId },
   })
+  // Strand guard: if this report was an automod hold, closing it here would leave
+  // the recipe stuck at 'pending_review' — restore it (no-op if already taken down).
+  if (isAutomodRecipeReport(updated)) await restoreHeldRecipe(db, updated.recipeId, req.uid)
   // Notify the reporter that action was taken. Dismiss is intentionally silent.
   if (status === 'resolved') notifyInBackground(notifyReportResolved(updated.reporterUid))
   res.json(updated)

--- a/server/util/automod.js
+++ b/server/util/automod.js
@@ -67,14 +67,25 @@ async function auditContentBlock(db, { uid, surface, verdict } = {}) {
 
 // Single owner of the high-confidence block response, so the 422 contract (status
 // + body shape the FE keys on) lives in one place instead of being re-typed at
-// every write route. When a `context` ({ db, uid, surface, verdict }) is passed,
-// it ALSO drops a best-effort, system-actor audit row so the block is visible to
-// admins — fire-and-forget so it never delays the 422 or turns a block into a
-// 500 (recordAudit already swallows its own errors; the guard covers the rest).
-// Context is optional, so a bare respondBlocked(res) still works.
+// every write route. Returning a block is INSEPARABLE from auditing it here: the
+// audit row is the only trace a write was refused (the content is never persisted)
+// and the sole source of the `autoBlocked` metric, so a block that emits no audit
+// is a silent data loss. The audit is best-effort/fire-and-forget so it never
+// delays the 422 or turns a block into a 500 (recordAudit already swallows its own
+// errors; the guard covers the rest).
+//
+// `context` ({ db, uid, surface, verdict }) is what makes the audit possible, so
+// every real caller passes it. A bare respondBlocked(res) still returns a correct
+// 422 (we never want a logging gap to break the block), but it CANNOT record the
+// block — that's a wiring bug, so we warn loudly rather than dropping the row in
+// silence.
 function respondBlocked(res, context) {
   if (context && context.db) {
     auditContentBlock(context.db, context).catch(() => {})
+  } else {
+    console.warn(
+      'respondBlocked: no audit context supplied — this block will NOT be recorded (missing content.blocked audit + autoBlocked metric). Pass { db, uid, surface, verdict }.'
+    )
   }
   return res.status(422).json({ error: BLOCKED_MESSAGE, code: BLOCKED_CODE })
 }
@@ -151,6 +162,44 @@ function gatherRecipeText(body = {}) {
 // automod hold is keyed.
 function openAutomodReportQuery(recipeId) {
   return { targetType: 'recipe', recipeId: String(recipeId), source: 'automod', status: 'open' }
+}
+
+/**
+ * Restore an auto-held recipe (status 'pending_review') to 'active' and record the
+ * human-decision `recipe.approve` audit row. Returns the updated recipe doc, or
+ * null if nothing was held.
+ *
+ * The `status: 'pending_review'` filter is the safety scope: a recipe that is
+ * already 'active', or that an admin has separately taken down ('hidden'), is left
+ * untouched — so this can never resurrect content an admin meant to keep down, and
+ * a double-call is a harmless no-op.
+ *
+ * Shared by the dedicated approve endpoint AND the report-close strand guard. The
+ * hold lives in two places (the recipe's `pending_review` status + an OPEN automod
+ * report); closing the report directly from the queue would otherwise strand the
+ * recipe invisible forever, so any path that clears the hold restores the recipe
+ * through this one helper.
+ *
+ * @param {import('mongodb').Db} db
+ * @param {string} recipeId
+ * @param {string} actorUid  the admin clearing the hold (audited as the actor)
+ * @returns {Promise<object|null>}
+ */
+async function restoreHeldRecipe(db, recipeId, actorUid) {
+  const updated = await db.collection('recipes').findOneAndUpdate(
+    { ...recipeIdQuery(recipeId), status: 'pending_review' },
+    { $set: { status: 'active', moderatedBy: actorUid, moderatedAt: new Date() } },
+    { returnDocument: 'after' }
+  )
+  if (!updated) return null
+  await recordAudit(db, {
+    action: 'recipe.approve',
+    actorUid,
+    targetType: 'recipe',
+    targetId: updated._id,
+    targetLabel: updated.title || null,
+  })
+  return updated
 }
 
 /**
@@ -233,4 +282,4 @@ async function holdRecipeForReview(db, { recipeId, title, verdict }) {
   return true
 }
 
-module.exports = { BLOCKED_MESSAGE, BLOCKED_CODE, respondBlocked, auditContentBlock, gatherRecipeText, holdRecipeForReview, worstVerdict, openAutomodReportQuery }
+module.exports = { BLOCKED_MESSAGE, BLOCKED_CODE, respondBlocked, auditContentBlock, gatherRecipeText, holdRecipeForReview, worstVerdict, openAutomodReportQuery, restoreHeldRecipe }

--- a/src/pages/Admin/Analytics/Analytics.tsx
+++ b/src/pages/Admin/Analytics/Analytics.tsx
@@ -95,11 +95,11 @@ const Analytics: FC = () => {
               </span>
             </div>
             <div className='stat-card'>
-              <span className='stat-value warn'>{data.totals.moderation.autoBlocked}</span>
+              <span className='stat-value warn'>{data.totals.moderation?.autoBlocked ?? 0}</span>
               <span className='stat-label'>Auto-blocked</span>
               <span className='stat-sub'>
-                {data.totals.moderation.autoHeld} auto-held ·{' '}
-                {data.totals.moderation.autoFlagsDismissed} flags&nbsp;dismissed
+                {data.totals.moderation?.autoHeld ?? 0} auto-held ·{' '}
+                {data.totals.moderation?.autoFlagsDismissed ?? 0} flags&nbsp;dismissed
               </span>
             </div>
           </section>

--- a/src/test/formatClassifier.test.ts
+++ b/src/test/formatClassifier.test.ts
@@ -60,10 +60,10 @@ describe('formatClassifier', () => {
     ).toBe('harassment · 60% confidence')
   })
 
-  // EDGE: every segment absent. Today this yields '' (which renders a dangling
-  // "Auto-flagged:" label at the call sites). Documented here as current
-  // behaviour; the empty-guard fix is tracked as a deferred moderation follow-up.
-  it('returns an empty string when nothing is present (known dangling-label edge)', () => {
+  // EDGE: every renderable segment absent (malformed/partial snapshot). Falls back
+  // to a readable placeholder instead of '' so the call sites never show a dangling
+  // "Auto-flagged: " / "Auto-held … — ." label.
+  it('falls back to a placeholder when nothing renderable is present', () => {
     expect(
       formatClassifier({
         severity: null as unknown as ReportClassifier['severity'],
@@ -71,6 +71,6 @@ describe('formatClassifier', () => {
         reason: null,
         source: 'openai',
       })
-    ).toBe('')
+    ).toBe('details unavailable')
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -393,8 +393,10 @@ export interface AnalyticsTotals {
     resolved: number
     dismissed: number
   }
-  // Automated-moderation activity (all-time).
-  moderation: {
+  // Automated-moderation activity (all-time). Optional: a stale/partial payload
+  // (older server, truncated response) must not crash the admin Overview — the
+  // consumer reads it with `?.x ?? 0`.
+  moderation?: {
     autoHeld: number // recipes the classifier held for review (recipe.autohold)
     autoBlocked: number // writes refused outright (content.blocked)
     autoFlagsDismissed: number // automod reports an admin dismissed (flags cleared, not content restored)

--- a/src/util/formatClassifier.ts
+++ b/src/util/formatClassifier.ts
@@ -15,5 +15,9 @@ export const formatClassifier = (c: ReportClassifier): string => {
   const scoreMatch = c.reason?.match(/:([0-9]*\.?[0-9]+)$/)
   if (scoreMatch) parts.push(`${Math.round(parseFloat(scoreMatch[1]) * 100)}% confidence`)
   if (c.severity) parts.push(`${c.severity} severity`)
-  return parts.join(' · ')
+  // A classifier with no renderable fields would otherwise return '', which leaves
+  // the call sites showing a dangling label ("Auto-flagged: " / "Auto-held … — .").
+  // Real medium holds always carry category + severity + score, so this only fires
+  // on a malformed/partial snapshot — fall back to a readable placeholder.
+  return parts.length ? parts.join(' · ') : 'details unavailable'
 }


### PR DESCRIPTION
PR-B of the content-moderation follow-up series (after PR-A #142). Cheap, defensive hardening — no behavior change for clean content.

## Changes
1. **Server-side strand guard** (fallout from PR-A review). PR-A only kept held recipes out of bulk/dismiss on the *frontend*. A direct `PATCH /reports/:id` or `/reports/bulk` dismissing/resolving a held recipe's open automod report would close the report but leave the recipe stuck at `pending_review` (invisible forever). Both routes now restore the held recipe via a shared `restoreHeldRecipe()` helper. The approve endpoint (`PATCH /admin/recipes/:id/approve`) was refactored to use the same helper, so every hold-clearing path behaves identically. The helper's `status: 'pending_review'` filter means a recipe an admin separately took down (`hidden`) is left down.
2. **Centralize the block-audit invariant.** `respondBlocked` now `console.warn`s when called without an audit context instead of silently emitting zero `content.blocked` rows (the sole source of the `autoBlocked` metric). All real callers pass context; this only fires on a future wiring bug.
3. **Defensive `moderation?.` guard.** `AnalyticsTotals.moderation` is now optional and read with `?. ?? 0` in `Analytics.tsx`, so a stale/partial payload can't white-screen the admin Overview.
4. **`code: 'RATE_LIMITED'`** added to the writeLimiter 429 body, matching the other client-error codes so the FE can branch.
5. **`formatClassifier` empty-case guard.** Falls back to `'details unavailable'` instead of `''`, so call sites never render a dangling "Auto-flagged: " / "Auto-held … — ." label.

## Tests
- New strand-guard route suite (dismiss/resolve restore, hidden recipe not restored, non-automod report untouched, bulk restore).
- `respondBlocked` warn-behaviour assertion; writeLimiter `RATE_LIMITED` assertion; `formatClassifier` fallback assertion (replaces the old `''` pin).
- Full suites green locally: server **547** Jest / FE **391** Vitest / tsc clean / build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)