### PR TITLE
docs(moderation): document MODERATION_ALERT_* env vars

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -55,3 +55,12 @@ GOOGLE_VISION_API_KEY=
 # Applies to adult+violence; 'racy' only ever contributes medium (at VERY_LIKELY).
 MODERATION_IMAGE_HIGH=
 MODERATION_IMAGE_MEDIUM=
+
+# Adult-content canary: when an image is flagged adult, a throttled best-effort
+# alert email is sent (only when email is enabled). Leave empty to send to the
+# shared ADMIN_NOTIFY_EMAIL inbox; set to point the safety canary at a different
+# address without a code change. The per-image console.warn fires regardless.
+MODERATION_ALERT_EMAIL=
+# Throttle window for the canary email (ms); at most one send per window so a
+# burst can't flood the inbox. Default 30 min (1800000); 0 disables throttling.
+MODERATION_ALERT_THROTTLE_MS=


### PR DESCRIPTION
Adds the two adult-content canary alert vars (`MODERATION_ALERT_EMAIL`, `MODERATION_ALERT_THROTTLE_MS`) to `server/.env.example` — the only moderation vars the code reads (`server/util/email.js`) that weren't yet documented there. Doc-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)