### PR TITLE
feat(moderation): PR-C rate-limiter correctness — per-surface buckets + makeUserLimiter factory

### DIFF
--- a/server/__tests__/writeLimiter.test.js
+++ b/server/__tests__/writeLimiter.test.js
@@ -1,7 +1,8 @@
 /**
- * middleware/writeLimiter — the shared per-user cap on moderated content writes.
+ * middleware/writeLimiter — the per-user cap factory + per-surface instances on
+ * moderated content writes.
  *
- * The limiter `skip`s when NODE_ENV === 'test' (so the rest of the suite, which
+ * The limiters `skip` when NODE_ENV === 'test' (so the rest of the suite, which
  * fires many requests per user via supertest, isn't throttled). `skip` is read
  * per-request, so we flip NODE_ENV for THIS file to exercise the real behaviour,
  * then restore it.
@@ -9,67 +10,133 @@
 
 const express = require('express')
 const request = require('supertest')
-const { writeLimiter } = require('../middleware/writeLimiter')
+const {
+  makeUserLimiter,
+  recipeWriteLimiter,
+  reviewWriteLimiter,
+  profileWriteLimiter,
+} = require('../middleware/writeLimiter')
 
 const ORIGINAL_NODE_ENV = process.env.NODE_ENV
 
-// Tiny app: stamp a uid (writeLimiter keys on req.uid, normally set by
-// verifyToken) from a header so each test can drive a distinct user.
-const makeApp = () => {
+// Tiny app: stamp a uid (the limiters key on req.uid, normally set by
+// verifyToken) from a header so each test can drive a distinct user. Each call
+// mounts the supplied limiter(s) on their own path so a test can hit two
+// surfaces independently, and LISTENS once — reused for every request in the
+// test. (Passing the bare app to supertest spins up + tears down a fresh
+// ephemeral server per request; at 30+ rapid requests that occasionally ECONNRESETs
+// as "socket hang up". One long-lived server avoids the churn.) Servers are
+// tracked and closed in afterAll.
+const servers = []
+const start = (routes) => {
   const app = express()
   app.use((req, _res, next) => {
     req.uid = req.headers['x-test-uid']
     next()
   })
-  app.post('/write', writeLimiter, (_req, res) => res.json({ ok: true }))
-  return app
+  for (const [path, limiter] of Object.entries(routes)) {
+    app.post(path, limiter, (_req, res) => res.json({ ok: true }))
+  }
+  const server = app.listen(0)
+  servers.push(server)
+  return server
 }
 
 beforeAll(() => {
-  process.env.NODE_ENV = 'development' // un-skip the limiter
+  process.env.NODE_ENV = 'development' // un-skip the limiters
 })
 afterAll(() => {
   process.env.NODE_ENV = ORIGINAL_NODE_ENV
+  servers.forEach((s) => s.close())
 })
 
-describe('writeLimiter — per-user content-write cap', () => {
+describe('makeUserLimiter — per-user content-write cap', () => {
   it('allows up to the limit then returns 429 for the same user', async () => {
-    const app = makeApp()
+    const server = start({ '/write': makeUserLimiter({ limit: 30 }) })
     const uid = 'user-a'
     // The first 30 succeed.
     for (let i = 0; i < 30; i++) {
-      const res = await request(app).post('/write').set('x-test-uid', uid)
+      const res = await request(server).post('/write').set('x-test-uid', uid)
       expect(res.status).toBe(200)
     }
     // The 31st in the window is throttled with the friendly message + a stable
     // code the FE can branch on.
-    const blocked = await request(app).post('/write').set('x-test-uid', uid)
+    const blocked = await request(server).post('/write').set('x-test-uid', uid)
     expect(blocked.status).toBe(429)
     expect(blocked.body.error).toMatch(/too quickly/i)
     expect(blocked.body.code).toBe('RATE_LIMITED')
   })
 
   it('keys per user — one user hitting the cap does not throttle another', async () => {
-    const app = makeApp()
+    const server = start({ '/write': makeUserLimiter({ limit: 30 }) })
     // Exhaust user-b.
     for (let i = 0; i < 30; i++) {
-      await request(app).post('/write').set('x-test-uid', 'user-b')
+      await request(server).post('/write').set('x-test-uid', 'user-b')
     }
-    const bBlocked = await request(app).post('/write').set('x-test-uid', 'user-b')
+    const bBlocked = await request(server).post('/write').set('x-test-uid', 'user-b')
     expect(bBlocked.status).toBe(429)
     // A different user is unaffected.
-    const cOk = await request(app).post('/write').set('x-test-uid', 'user-c')
+    const cOk = await request(server).post('/write').set('x-test-uid', 'user-c')
     expect(cOk.status).toBe(200)
+  })
+
+  it('honours a custom message while still carrying the RATE_LIMITED code', async () => {
+    const server = start({
+      '/write': makeUserLimiter({ limit: 1, message: 'slow your roll' }),
+    })
+    await request(server).post('/write').set('x-test-uid', 'user-msg')
+    const blocked = await request(server).post('/write').set('x-test-uid', 'user-msg')
+    expect(blocked.status).toBe(429)
+    expect(blocked.body.error).toBe('slow your roll')
+    expect(blocked.body.code).toBe('RATE_LIMITED')
+  })
+
+  it('resets the bucket after the window elapses', async () => {
+    // Short window so the test doesn't wait a real minute, but wide enough that
+    // the two in-window requests can't straddle it even when parallel jest
+    // workers starve the event loop.
+    const server = start({ '/write': makeUserLimiter({ limit: 1, windowMs: 1000 }) })
+    const uid = 'user-window'
+    expect((await request(server).post('/write').set('x-test-uid', uid)).status).toBe(200)
+    expect((await request(server).post('/write').set('x-test-uid', uid)).status).toBe(429)
+    // After the window passes the same user is allowed again.
+    await new Promise((r) => setTimeout(r, 1200))
+    expect((await request(server).post('/write').set('x-test-uid', uid)).status).toBe(200)
   })
 
   it('is bypassed entirely under NODE_ENV=test', async () => {
     process.env.NODE_ENV = 'test'
-    const app = makeApp()
+    const server = start({ '/write': makeUserLimiter({ limit: 5 }) })
     // Far more than the limit, all allowed because skip() short-circuits.
     for (let i = 0; i < 40; i++) {
-      const res = await request(app).post('/write').set('x-test-uid', 'user-d')
+      const res = await request(server).post('/write').set('x-test-uid', 'user-d')
       expect(res.status).toBe(200)
     }
     process.env.NODE_ENV = 'development' // restore for any later tests in this file
+  })
+})
+
+describe('per-surface limiters are independent buckets', () => {
+  // The whole point of #3: exhausting one surface must NOT throttle another, so a
+  // legit cross-surface burst can't 429. Each exported limiter is its own
+  // instance with its own store, so a single uid gets a separate 30/min budget on
+  // recipes vs reviews vs profile.
+  it('exhausting the recipe surface leaves review + profile untouched for the same user', async () => {
+    const server = start({
+      '/recipe': recipeWriteLimiter,
+      '/review': reviewWriteLimiter,
+      '/profile': profileWriteLimiter,
+    })
+    const uid = 'cross-surface-user'
+
+    // Burn the full recipe budget.
+    for (let i = 0; i < 30; i++) {
+      expect((await request(server).post('/recipe').set('x-test-uid', uid)).status).toBe(200)
+    }
+    expect((await request(server).post('/recipe').set('x-test-uid', uid)).status).toBe(429)
+
+    // The other surfaces still have their own full budget.
+    expect((await request(server).post('/review').set('x-test-uid', uid)).status).toBe(200)
+    expect((await request(server).post('/profile').set('x-test-uid', uid)).status).toBe(200)
   })
 })

--- a/server/__tests__/writeLimiter.wiring.test.js
+++ b/server/__tests__/writeLimiter.wiring.test.js
@@ -1,0 +1,75 @@
+/**
+ * writeLimiter wiring — proves each moderated write route actually mounts its
+ * per-surface limiter, in the right order.
+ *
+ * The limiters `skip` under NODE_ENV=test, so a supertest request can never
+ * produce a real 429 here. Instead we inspect the routers' middleware stacks by
+ * REFERENCE: each route file imports the same singleton limiter we import below,
+ * so the exact function must appear in the route's handler chain, after
+ * verifyToken + requireActive (a limiter keyed on req.uid is meaningless before
+ * verifyToken populates it, and we only want to spend the budget on requests
+ * from active accounts). This is what catches a future route being added — or an
+ * existing one reordered — without its limiter.
+ */
+
+const { verifyToken, requireActive } = require('../middleware/auth')
+const {
+  recipeWriteLimiter,
+  reviewWriteLimiter,
+  profileWriteLimiter,
+} = require('../middleware/writeLimiter')
+
+const recipesRouter = require('../routes/recipes')
+const reviewsRouter = require('../routes/reviews')
+const authRouter = require('../routes/auth')
+const ingredientsRouter = require('../routes/ingredients')
+
+// Ordered handler chain for a single route on a router, or throws if missing.
+const routeHandlers = (router, method, path) => {
+  const layer = router.stack.find(
+    (l) => l.route && l.route.path === path && l.route.methods[method]
+  )
+  if (!layer) throw new Error(`route ${method.toUpperCase()} ${path} not found`)
+  return layer.route.stack.map((s) => s.handle)
+}
+
+describe('per-surface write limiters are wired onto every moderated write route', () => {
+  const cases = [
+    ['recipes', recipesRouter, 'post', '/addRecipe', recipeWriteLimiter],
+    ['recipes', recipesRouter, 'put', '/editRecipe', recipeWriteLimiter],
+    ['reviews', reviewsRouter, 'post', '/newReview', reviewWriteLimiter],
+    ['reviews', reviewsRouter, 'post', '/editReview', reviewWriteLimiter],
+    ['auth', authRouter, 'post', '/setUsername', profileWriteLimiter],
+    ['auth', authRouter, 'post', '/updateProfile', profileWriteLimiter],
+    ['auth', authRouter, 'post', '/updatePhoto', profileWriteLimiter],
+    ['auth', authRouter, 'post', '/updateDisplayName', profileWriteLimiter],
+  ]
+
+  it.each(cases)(
+    '%s %s %s mounts its limiter after verifyToken + requireActive',
+    (_group, router, method, path, limiter) => {
+      const handlers = routeHandlers(router, method, path)
+      expect(handlers).toContain(verifyToken)
+      expect(handlers).toContain(requireActive)
+      expect(handlers).toContain(limiter)
+      // verifyToken → requireActive → limiter, in that order.
+      expect(handlers.indexOf(verifyToken)).toBeLessThan(handlers.indexOf(requireActive))
+      expect(handlers.indexOf(requireActive)).toBeLessThan(handlers.indexOf(limiter))
+    }
+  )
+
+  it('recipe / review / profile each use a DISTINCT limiter instance', () => {
+    // Independent instances ⇒ independent buckets (the #3 fix). If two surfaces
+    // ever collapsed back onto one shared limiter this would catch it.
+    const limiters = new Set([recipeWriteLimiter, reviewWriteLimiter, profileWriteLimiter])
+    expect(limiters.size).toBe(3)
+  })
+
+  it('ingredients POST /parse mounts a user limiter right after verifyToken', () => {
+    // parseLimiter is internal to the route file (not exported), so assert
+    // structurally: verifyToken first, exactly one middleware before the handler.
+    const handlers = routeHandlers(ingredientsRouter, 'post', '/parse')
+    expect(handlers[0]).toBe(verifyToken)
+    expect(handlers).toHaveLength(3) // verifyToken, parseLimiter, handler
+  })
+})

--- a/server/middleware/writeLimiter.js
+++ b/server/middleware/writeLimiter.js
@@ -1,33 +1,66 @@
 const { rateLimit } = require('express-rate-limit')
 
-// Per-USER limiter shared across the moderated content-write routes (recipe,
-// review, profile, username, displayName, photo). It complements — does not
-// replace — the coarse global per-IP backstop in app.js:
-//   - The global limit is per-IP, so it's shared across everyone behind one NAT
-//     and evadable by rotating IPs; it can't bound a single account.
-//   - Every one of these writes now triggers a paid classifier call (OpenAI, plus
-//     Cloud Vision on recipe images), so write-spam directly burns moderation
-//     quota. This is the same reason /api/ingredients/parse got a per-user cap —
-//     the moderated writes need the equivalent.
-//
-// ONE shared instance ⇒ one bucket per user across ALL these endpoints (e.g. a
-// user can't dodge it by spreading 30 writes across recipes + reviews + profile).
-// Keyed by req.uid, so it MUST be mounted after verifyToken. The window is sized
-// well above any plausible human cadence — a real user never approaches 30 content
-// writes in a minute — so only scripted abuse hits it. Skipped under Jest, where
-// supertest fires many requests from one user in seconds (same as the global
-// limiter); Cypress E2E stays well under the cap.
-const writeLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  limit: 30,
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: (req) => req.uid,
-  skip: () => process.env.NODE_ENV === 'test',
-  // Carry a stable `code` like every other client error (CONTENT_BLOCKED,
-  // ACCOUNT_BANNED, ALREADY_REPORTED) so the FE can branch on the 429 — e.g. show
-  // a dedicated "slow down" affordance — instead of string-matching the message.
-  message: { error: 'You’re doing that too quickly — wait a moment and try again.', code: 'RATE_LIMITED' },
-})
+// Shared "slow down" copy for the content-write surfaces. parseLimiter
+// (routes/ingredients.js) builds its own limiter from the same factory but keeps
+// its own wording.
+const WRITE_LIMIT_MESSAGE =
+  'You’re doing that too quickly — wait a moment and try again.'
 
-module.exports = { writeLimiter }
+// Factory for a per-USER rate limiter. Each call returns an INDEPENDENT limiter
+// with its own in-memory bucket, so mounting one instance per surface gives each
+// surface its own budget (see the per-surface instances below). Keyed by
+// req.uid, so each instance MUST be mounted after verifyToken. It complements —
+// does not replace — the coarse global per-IP backstop in app.js: that one is
+// per-IP (shared behind a NAT, evadable by rotating IPs) and can't bound a
+// single account; every one of these writes also triggers a paid classifier
+// call (OpenAI, plus Cloud Vision on recipe images), so write-spam directly
+// burns moderation quota.
+//
+// Skipped under Jest, where supertest fires many requests per user in seconds;
+// the dedicated writeLimiter.test.js flips NODE_ENV to exercise the real
+// behaviour. Cypress E2E stays well under the cap.
+//
+// NOTE (multi-instance): the default store is in-memory and per-process. On a
+// multi-replica deploy the effective cap is limit×replicas/min and it resets on
+// restart — an acceptable abuse backstop (it still bounds a single account hard
+// on any one instance), but move to a shared store (Redis) if we ever need an
+// exact global cap. windowMs is a param only so the tests can exercise window
+// reset with a short window; production always uses the 60s default.
+function makeUserLimiter({
+  limit = 30,
+  windowMs = 60 * 1000,
+  message = WRITE_LIMIT_MESSAGE,
+} = {}) {
+  return rateLimit({
+    windowMs,
+    limit,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (req) => req.uid,
+    skip: () => process.env.NODE_ENV === 'test',
+    // Carry a stable `code` like every other client error (CONTENT_BLOCKED,
+    // ACCOUNT_BANNED, ALREADY_REPORTED) so the FE can branch on the 429 — e.g.
+    // show a dedicated "slow down" affordance — instead of string-matching the
+    // message.
+    message: { error: message, code: 'RATE_LIMITED' },
+  })
+}
+
+// ONE limiter PER surface rather than a single shared bucket. Previously all
+// content writes (recipe + review + profile) drew from ONE 30/min/user bucket,
+// so a legitimate cross-surface burst — publish a recipe, fix a few reviews,
+// then tweak your profile — could 429 even though no single surface was abused.
+// Separate instances ⇒ separate buckets, so each surface is bounded on its own
+// and normal mixed activity never trips the limit; scripted spam of any one
+// surface still hits its cap at 30/min. A real user never approaches 30 writes
+// to a single surface in a minute, so only abuse is affected.
+const recipeWriteLimiter = makeUserLimiter()
+const reviewWriteLimiter = makeUserLimiter()
+const profileWriteLimiter = makeUserLimiter()
+
+module.exports = {
+  makeUserLimiter,
+  recipeWriteLimiter,
+  reviewWriteLimiter,
+  profileWriteLimiter,
+}

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -4,7 +4,7 @@ const { asyncHandler } = require('../util/asyncHandler')
 const router = express.Router()
 const { getDB, getClient } = require('../db')
 const { verifyToken, requireActive } = require('../middleware/auth')
-const { writeLimiter } = require('../middleware/writeLimiter')
+const { profileWriteLimiter } = require('../middleware/writeLimiter')
 const { recordAudit } = require('../util/auditLog')
 const { deleteRecipeImage, deleteProfilePhoto } = require('../util/firebaseStorage')
 const { recomputeRecipeRating } = require('../util/recipeRating')
@@ -114,7 +114,7 @@ router.get('/getMyStatus', verifyToken, asyncHandler(async (req, res) => {
 
 // POST /setUsername?username=...
 // Creates or updates the username for the authenticated user
-router.post('/setUsername', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
+router.post('/setUsername', verifyToken, requireActive, profileWriteLimiter, asyncHandler(async (req, res) => {
   const { username } = req.query
   const validationError = validateUsername(username)
   if (validationError) {
@@ -206,7 +206,7 @@ router.get('/getProfile', verifyToken, asyncHandler(async (req, res) => {
 // POST /updateProfile
 // Upserts the authenticated user's bio + location. Empty strings are allowed
 // and clear the field. Values are trimmed before storage.
-router.post('/updateProfile', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
+router.post('/updateProfile', verifyToken, requireActive, profileWriteLimiter, asyncHandler(async (req, res) => {
   const { bio, location } = req.body || {}
   const validationError = validateProfile(bio, location)
   if (validationError) {
@@ -246,7 +246,7 @@ router.post('/updateProfile', verifyToken, requireActive, writeLimiter, asyncHan
 // state to fall back to, so BOTH high and medium confidence block (422); the
 // image fails CLOSED, so a scan outage also rejects rather than applying an
 // unscanned photo. Clearing the photo (empty URL) needs no scan.
-router.post('/updatePhoto', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
+router.post('/updatePhoto', verifyToken, requireActive, profileWriteLimiter, asyncHandler(async (req, res) => {
   const { photoURL } = req.body || {}
   if (photoURL != null && typeof photoURL !== 'string') {
     return res.status(400).json({ error: 'photoURL must be a string' })
@@ -275,7 +275,7 @@ router.post('/updatePhoto', verifyToken, requireActive, writeLimiter, asyncHandl
 // owner-only "pending" state, so BOTH high and medium confidence block (422).
 // The 'displayName' context also applies the identity-only spam rules (no
 // URLs/domains in a name).
-router.post('/updateDisplayName', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
+router.post('/updateDisplayName', verifyToken, requireActive, profileWriteLimiter, asyncHandler(async (req, res) => {
   const { displayName } = req.body || {}
   if (typeof displayName !== 'string' || !displayName.trim()) {
     return res.status(400).json({ error: 'displayName is required' })

--- a/server/routes/ingredients.js
+++ b/server/routes/ingredients.js
@@ -1,24 +1,19 @@
 const { Router } = require('express')
-const { rateLimit } = require('express-rate-limit')
 const { ingredientParser } = require('@jclind/ingredient-parser')
 const { verifyToken } = require('../middleware/auth')
+const { makeUserLimiter } = require('../middleware/writeLimiter')
 const { GENERIC_500_MESSAGE } = require('../util/respondServerError')
 
 const router = Router()
 
-// Every call spends paid Spoonacular quota, so this is the one route with a
-// tight per-user limit. Keyed by req.uid (set by verifyToken, which runs
+// Every call spends paid Spoonacular quota, so this route gets its own tight
+// per-user limit — an independent bucket from the content-write limiters (see
+// middleware/writeLimiter), keyed by req.uid (set by verifyToken, which runs
 // first), not IP, so shared NATs don't collide. 30/min comfortably covers the
 // add-recipe flow — one parse per ingredient added, max 50 per recipe.
 // Skipped under Jest along with the global limiter (see app.js).
-const parseLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  limit: 30,
-  standardHeaders: true,
-  legacyHeaders: false,
-  keyGenerator: (req) => req.uid,
-  skip: () => process.env.NODE_ENV === 'test',
-  message: { error: 'Too many ingredient lookups — wait a minute and try again.' },
+const parseLimiter = makeUserLimiter({
+  message: 'Too many ingredient lookups — wait a minute and try again.',
 })
 
 router.post('/parse', verifyToken, parseLimiter, async (req, res) => {

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -3,7 +3,7 @@ const { asyncHandler } = require('../util/asyncHandler')
 const { ObjectId } = require('mongodb')
 const { getDB, getClient } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
-const { writeLimiter } = require('../middleware/writeLimiter')
+const { recipeWriteLimiter } = require('../middleware/writeLimiter')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { RECIPE_VISIBLE, RECIPE_OWNER_VISIBLE } = require('../util/moderation')
 const { recordAudit } = require('../util/auditLog')
@@ -244,7 +244,7 @@ router.get('/getRecipe', optionalAuth, asyncHandler(async (req, res) => {
 }))
 
 // POST /addRecipe
-router.post('/addRecipe', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
+router.post('/addRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncHandler(async (req, res) => {
   const db = getDB()
   const body = req.body
   const uid = req.uid
@@ -308,7 +308,7 @@ router.post('/addRecipe', verifyToken, requireActive, writeLimiter, asyncHandler
 // metadata are never writable here (only EDITABLE_RECIPE_FIELDS are copied), so
 // an edit can never reset a recipe's ratings, saves, or made-count. editedAt is
 // stamped so the UI can surface that the recipe changed after people saved it.
-router.put('/editRecipe', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
+router.put('/editRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncHandler(async (req, res) => {
   const db = getDB()
   const { recipeId } = req.query
   if (!recipeId) {

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -2,7 +2,7 @@ const { Router } = require('express')
 const { asyncHandler } = require('../util/asyncHandler')
 const { getDB } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
-const { writeLimiter } = require('../middleware/writeLimiter')
+const { reviewWriteLimiter } = require('../middleware/writeLimiter')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { REVIEW_VISIBLE, RECIPE_VISIBLE } = require('../util/moderation')
 const { DESCRIPTION_MAX_LENGTH } = require('../util/recipeLimits')
@@ -64,7 +64,7 @@ router.post('/addRating', verifyToken, requireActive, asyncHandler(async (req, r
 }))
 
 // POST /newReview
-router.post('/newReview', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
+router.post('/newReview', verifyToken, requireActive, reviewWriteLimiter, asyncHandler(async (req, res) => {
   const db = getDB()
   const { recipeId, reviewText } = req.body
   const userId = req.uid
@@ -125,7 +125,7 @@ router.get('/checkIfReviewed', verifyToken, asyncHandler(async (req, res) => {
 }))
 
 // POST /editReview
-router.post('/editReview', verifyToken, requireActive, writeLimiter, asyncHandler(async (req, res) => {
+router.post('/editReview', verifyToken, requireActive, reviewWriteLimiter, asyncHandler(async (req, res) => {
   const { recipeId, text } = req.query
   const db = getDB()
   if (!recipeId || typeof recipeId !== 'string' || text == null || typeof text !== 'string') {


### PR DESCRIPTION
## PR-C — Rate-limiter correctness (content-moderation follow-up)

Third in the moderation P3 follow-up series (after #142 PR-A, #143 PR-B). Fixes the two rate-limiter findings from the P3 review.

### What & why
Previously **all** moderated content writes (recipe + review + profile/username/displayName/photo) drew from **one** shared `30/min/user` bucket. A legitimate cross-surface burst — publish a recipe, fix a few reviews, then tweak your profile — could `429` even though no single surface was abused.

- **#3 Per-surface buckets.** Split into three independent `30/min/user` limiters — `recipeWriteLimiter`, `reviewWriteLimiter`, `profileWriteLimiter`. Separate `rateLimit()` instances ⇒ separate in-memory buckets, so normal mixed activity never trips the limit while scripted spam of any one surface still hits its cap at 30/min.
- **#8 `makeUserLimiter({ limit, windowMs, message })` factory** in `middleware/writeLimiter.js`. The three per-surface instances + `parseLimiter` (ingredients) are all built from it; the old single `writeLimiter` export is gone.

### Notes for the reviewer
- **Quota ceiling, by design:** a single account can now drive up to **90 moderated writes/min** (3 × 30, each a paid OpenAI/Vision call) before a per-user cap trips, vs 30 before. This is the intended trade for #3; the coarse global per-IP backstop in `app.js` still sits above it. A code comment documents the multi-replica caveat (in-memory store → effective cap is `limit × replicas`; Redis if an exact global cap is ever needed).
- **Minor consistency change:** the `/api/ingredients/parse` 429 body now also carries `code: 'RATE_LIMITED'` (was message-only), matching the content-write limiters.

### Tests
- Rewrote `__tests__/writeLimiter.test.js` against the factory (cap / per-user keying / custom-message+code / window reset / skip-under-test) + a behavioral **per-surface independence** test.
- New `__tests__/writeLimiter.wiring.test.js` — table-driven proof that each moderated write route mounts its limiter after `verifyToken → requireActive`, that the three instances are distinct, and that `/parse` is wired structurally.
- 16/16 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
