### PR TITLE
chore(moderation): PR-D polish — classifier score, analytics labels, getRecipe automod fold

### DIFF
--- a/server/__tests__/admin-moderation.test.js
+++ b/server/__tests__/admin-moderation.test.js
@@ -41,38 +41,46 @@ afterEach(async () => {
   ])
 })
 
-describe('GET /api/admin/recipes/:id/automod', () => {
-  it('requires admin', async () => {
-    const res = await request(app).get('/api/admin/recipes/r1/automod').set(AUTH_HEADER)
-    expect(res.status).toBe(403)
-  })
-
-  it('returns the classifier from the open automod report holding the recipe', async () => {
+// The hold reason is carried inline on the admin GET /getRecipe response
+// (recipe.automodClassifier) rather than a dedicated endpoint, so the admin strip
+// explains a pending_review hold without a second round-trip.
+describe('GET /api/getRecipe — admin automodClassifier', () => {
+  it('attaches the open automod report classifier for a pending_review recipe', async () => {
     admin.__setClaims({ admin: true })
+    await seedRecipe({ ...BASE_RECIPE, _id: 'r1', status: 'pending_review' })
     await getDB().collection('reports').insertOne({
       targetType: 'recipe',
       recipeId: 'r1',
       reporterUid: 'system:automod',
       source: 'automod',
       status: 'open',
-      classifier: { severity: 'medium', category: 'harassment', reason: 'openai:harassment:0.60', source: 'openai' },
+      classifier: { severity: 'medium', category: 'harassment', score: 0.6, reason: 'openai:harassment:0.60', source: 'openai' },
       createdAt: new Date(),
     })
-    const res = await request(app).get('/api/admin/recipes/r1/automod').set(AUTH_HEADER)
+    const res = await request(app).get('/api/getRecipe?id=r1').set(AUTH_HEADER)
     expect(res.status).toBe(200)
-    expect(res.body.classifier).toMatchObject({ severity: 'medium', category: 'harassment' })
+    expect(res.body.automodClassifier).toMatchObject({ severity: 'medium', category: 'harassment', score: 0.6 })
   })
 
-  it('returns null classifier when there is no open automod report', async () => {
+  it('attaches null automodClassifier for a pending_review recipe with no open automod report', async () => {
     admin.__setClaims({ admin: true })
+    await seedRecipe({ ...BASE_RECIPE, _id: 'r1', status: 'pending_review' })
     // A user report (no source) and a CLOSED automod report must both be ignored.
     await getDB().collection('reports').insertMany([
       { targetType: 'recipe', recipeId: 'r1', reporterUid: 'u1', status: 'open', createdAt: new Date() },
       { targetType: 'recipe', recipeId: 'r1', reporterUid: 'system:automod', source: 'automod', status: 'dismissed', classifier: { severity: 'medium' }, createdAt: new Date() },
     ])
-    const res = await request(app).get('/api/admin/recipes/r1/automod').set(AUTH_HEADER)
+    const res = await request(app).get('/api/getRecipe?id=r1').set(AUTH_HEADER)
     expect(res.status).toBe(200)
-    expect(res.body.classifier).toBeNull()
+    expect(res.body.automodClassifier).toBeNull()
+  })
+
+  it('does not attach automodClassifier for a non-held (active) recipe', async () => {
+    admin.__setClaims({ admin: true })
+    await seedRecipe({ ...BASE_RECIPE, _id: 'r1', status: 'active' })
+    const res = await request(app).get('/api/getRecipe?id=r1').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.automodClassifier).toBeUndefined()
   })
 })
 

--- a/server/__tests__/automod.test.js
+++ b/server/__tests__/automod.test.js
@@ -121,6 +121,28 @@ describe('holdRecipeForReview — report-gated hold', () => {
     expect(calls.auditLog).toHaveLength(1) // autohold audit appended
   })
 
+  it('stamps the numeric classifier score (0–1) onto the filed report', async () => {
+    const { db, calls } = fakeDb()
+    await holdRecipeForReview(db, {
+      recipeId: 'rec-score',
+      title: 'T',
+      verdict: { ...VERDICT, score: 0.6 },
+    })
+    const setOnInsert = calls.reports[0][1].$setOnInsert
+    expect(setOnInsert.classifier.score).toBe(0.6)
+  })
+
+  it('stores classifier.score as null when the verdict carries no numeric score', async () => {
+    const { db, calls } = fakeDb()
+    await holdRecipeForReview(db, {
+      recipeId: 'rec-noscore',
+      title: 'T',
+      verdict: { severity: 'medium', reason: 'vision:adult:LIKELY', category: 'adult', source: 'vision' },
+    })
+    const setOnInsert = calls.reports[0][1].$setOnInsert
+    expect(setOnInsert.classifier.score).toBeNull()
+  })
+
   it('does NOT hide the recipe when the report write fails (fail-open) and returns false', async () => {
     const { db, calls } = fakeDb({
       reports: { updateOne: async () => { throw new Error('mongo down') } },

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -25,6 +25,20 @@ const TEST_UID = 'test-uid'
 const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
 const RECIPE_ID = 'recipe-001'
 
+// Drive requests through ONE long-lived listening server rather than letting
+// supertest spin up (and tear down) an ephemeral server per `request(server)` call.
+// Under parallel-worker load that per-call churn intermittently surfaced as a
+// "socket hang up" (a transient connection error read as a non-array body), e.g.
+// the `GET /getTrendingRecipes › caps limit at 20` flake. Same approach as
+// writeLimiter.test.js (PR-C).
+let server
+beforeAll(() => {
+  server = app.listen(0)
+})
+afterAll((done) => {
+  server.close(done)
+})
+
 const BASE_RECIPE = {
   _id: RECIPE_ID,
   title: 'Tuscan Chicken Skillet',
@@ -66,7 +80,7 @@ describe('GET /recipes', () => {
   })
 
   it('returns { recipeList, total_results } shape', async () => {
-    const res = await request(app).get('/api/recipes')
+    const res = await request(server).get('/api/recipes')
     expect(res.status).toBe(200)
     expect(res.body).toHaveProperty('recipeList')
     expect(res.body).toHaveProperty('total_results')
@@ -77,14 +91,14 @@ describe('GET /recipes', () => {
   // Browse is intentionally public — anonymous visitors can view recipes.
   // Explicit assertion so a future stray verifyToken doesn't silently break it.
   it('succeeds without an Authorization header (route is public)', async () => {
-    const res = await request(app).get('/api/recipes')
+    const res = await request(server).get('/api/recipes')
     expect(res.status).toBe(200)
     expect(res.body).toHaveProperty('recipeList')
     expect(res.body).toHaveProperty('total_results')
   })
 
   it('filters results by search query (q)', async () => {
-    const res = await request(app).get('/api/recipes?q=chicken')
+    const res = await request(server).get('/api/recipes?q=chicken')
     expect(res.status).toBe(200)
     expect(res.body.recipeList).toHaveLength(1)
     expect(res.body.recipeList[0].title).toBe('Tuscan Chicken Skillet')
@@ -92,28 +106,28 @@ describe('GET /recipes', () => {
   })
 
   it('search is case-insensitive', async () => {
-    const res = await request(app).get('/api/recipes?q=PASTA')
+    const res = await request(server).get('/api/recipes?q=PASTA')
     expect(res.status).toBe(200)
     expect(res.body.recipeList).toHaveLength(1)
     expect(res.body.recipeList[0]._id).toBe('recipe-003')
   })
 
   it('returns empty list when no recipes match query', async () => {
-    const res = await request(app).get('/api/recipes?q=zzznomatch')
+    const res = await request(server).get('/api/recipes?q=zzznomatch')
     expect(res.status).toBe(200)
     expect(res.body.recipeList).toHaveLength(0)
     expect(res.body.total_results).toBe(0)
   })
 
   it('page 0 with recipesPerPage=2 returns first 2 of 3', async () => {
-    const res = await request(app).get('/api/recipes?page=0&recipesPerPage=2')
+    const res = await request(server).get('/api/recipes?page=0&recipesPerPage=2')
     expect(res.status).toBe(200)
     expect(res.body.recipeList).toHaveLength(2)
     expect(res.body.total_results).toBe(3)
   })
 
   it('page 1 with recipesPerPage=2 returns the remaining 1', async () => {
-    const res = await request(app).get('/api/recipes?page=1&recipesPerPage=2')
+    const res = await request(server).get('/api/recipes?page=1&recipesPerPage=2')
     expect(res.status).toBe(200)
     expect(res.body.recipeList).toHaveLength(1)
     expect(res.body.total_results).toBe(3)
@@ -134,7 +148,7 @@ describe('GET /recipes sorting & meal filter', () => {
   })
 
   const firstId = async (order) => {
-    const res = await request(app).get(`/api/recipes?order=${order}`)
+    const res = await request(server).get(`/api/recipes?order=${order}`)
     expect(res.status).toBe(200)
     return res.body.recipeList[0]._id
   }
@@ -162,13 +176,13 @@ describe('GET /recipes sorting & meal filter', () => {
   })
 
   it('mealTypes filters to recipes with that meal', async () => {
-    const res = await request(app).get('/api/recipes?mealTypes=dinner')
+    const res = await request(server).get('/api/recipes?mealTypes=dinner')
     expect(res.status).toBe(200)
     expect(res.body.recipeList.map((r) => r._id).sort()).toEqual(['s-b', 's-c'])
   })
 
   it('mealTypes AND tags (diet) combine', async () => {
-    const res = await request(app).get('/api/recipes?mealTypes=dinner&tags=vegan')
+    const res = await request(server).get('/api/recipes?mealTypes=dinner&tags=vegan')
     expect(res.status).toBe(200)
     expect(res.body.recipeList).toHaveLength(1)
     expect(res.body.recipeList[0]._id).toBe('s-c')
@@ -177,14 +191,14 @@ describe('GET /recipes sorting & meal filter', () => {
   // Hardening: `order` is client-controlled; an inherited-member name must not
   // resolve to a function/object and break the Mongo sort.
   it('ignores a prototype-polluting order value (no 500)', async () => {
-    const res = await request(app).get('/api/recipes?order=constructor')
+    const res = await request(server).get('/api/recipes?order=constructor')
     expect(res.status).toBe(200)
     expect(Array.isArray(res.body.recipeList)).toBe(true)
   })
 
   // Hardening: a repeated list param arrives as an array; must not throw.
   it('handles a repeated mealTypes param as an array', async () => {
-    const res = await request(app).get(
+    const res = await request(server).get(
       '/api/recipes?mealTypes=dinner&mealTypes=lunch'
     )
     expect(res.status).toBe(200)
@@ -205,13 +219,13 @@ describe('GET /recipes diet filter (AND)', () => {
   })
 
   it('a single diet matches any recipe carrying it', async () => {
-    const res = await request(app).get('/api/recipes?diets=vegan')
+    const res = await request(server).get('/api/recipes?diets=vegan')
     expect(res.status).toBe(200)
     expect(res.body.recipeList.map((r) => r._id).sort()).toEqual(['d-1', 'd-2'])
   })
 
   it('multiple diets require ALL labels (AND, not OR)', async () => {
-    const res = await request(app).get('/api/recipes?diets=vegan,gluten-free')
+    const res = await request(server).get('/api/recipes?diets=vegan,gluten-free')
     expect(res.status).toBe(200)
     expect(res.body.recipeList.map((r) => r._id)).toEqual(['d-1'])
   })
@@ -229,7 +243,7 @@ describe('GET /recipes/facets', () => {
   })
 
   it('returns only the distinct, non-empty values present in the catalog', async () => {
-    const res = await request(app).get('/api/recipes/facets')
+    const res = await request(server).get('/api/recipes/facets')
     expect(res.status).toBe(200)
     expect(res.body.cuisines.sort()).toEqual(['Italian', 'Mexican'])
     expect(res.body.diets.sort()).toEqual(['gluten-free', 'vegan'])
@@ -243,12 +257,12 @@ describe('GET /recipes/facets', () => {
 
 describe('POST /addRecipe', () => {
   it('rejects request with no auth token (401)', async () => {
-    const res = await request(app).post('/api/addRecipe').send({})
+    const res = await request(server).post('/api/addRecipe').send({})
     expect(res.status).toBe(401)
   })
 
   it('rejects request with missing required fields (400)', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .post('/api/addRecipe')
       .set(AUTH_HEADER)
       .send({})
@@ -271,7 +285,7 @@ describe('POST /addRecipe', () => {
       views: 500,
     }
 
-    const res = await request(app)
+    const res = await request(server)
       .post('/api/addRecipe')
       .set(AUTH_HEADER)
       .send(payload)
@@ -294,7 +308,7 @@ describe('POST /addRecipe', () => {
   })
 
   it('ignores client-supplied status, featured, and a forged rating on create', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .post('/api/addRecipe')
       .set(AUTH_HEADER)
       .send({
@@ -328,7 +342,7 @@ describe('POST /addRecipe', () => {
     })
 
     const expectRejected = async (overrides, pattern) => {
-      const res = await request(app)
+      const res = await request(server)
         .post('/api/addRecipe')
         .set(AUTH_HEADER)
         .send({ ...validBody(), ...overrides })
@@ -364,7 +378,7 @@ describe('POST /addRecipe', () => {
     })
 
     it('accepts a payload exactly at the limits (201)', async () => {
-      const res = await request(app)
+      const res = await request(server)
         .post('/api/addRecipe')
         .set(AUTH_HEADER)
         .send({
@@ -403,14 +417,14 @@ describe('PUT /editRecipe', () => {
   })
 
   it('rejects request with no auth token (401)', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
       .send(validEdit())
     expect(res.status).toBe(401)
   })
 
   it('returns 400 when recipeId is missing', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .put('/api/editRecipe')
       .set(AUTH_HEADER)
       .send(validEdit())
@@ -418,7 +432,7 @@ describe('PUT /editRecipe', () => {
   })
 
   it('returns 404 if the recipe does not exist', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .put('/api/editRecipe?recipeId=nonexistent')
       .set(AUTH_HEADER)
       .send(validEdit())
@@ -430,7 +444,7 @@ describe('PUT /editRecipe', () => {
     await db.collection('recipes').deleteOne({ _id: RECIPE_ID })
     await seedRecipe({ ...OWNED_RECIPE, userId: 'someone-else' })
 
-    const res = await request(app)
+    const res = await request(server)
       .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
       .send(validEdit())
@@ -442,7 +456,7 @@ describe('PUT /editRecipe', () => {
   })
 
   it('rejects missing required fields (400)', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
       .send({ description: 'no title/ingredients/etc' })
@@ -451,7 +465,7 @@ describe('PUT /editRecipe', () => {
   })
 
   it('enforces input bounds (400)', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
       .send({ ...validEdit(), title: 'A'.repeat(51) })
@@ -460,7 +474,7 @@ describe('PUT /editRecipe', () => {
   })
 
   it('updates editable fields and stamps editedAt', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
       .send(validEdit())
@@ -476,7 +490,7 @@ describe('PUT /editRecipe', () => {
   })
 
   it('never resets ratings, saves, made-count, views, or createdAt on edit', async () => {
-    await request(app)
+    await request(server)
       .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
       .send(validEdit())
@@ -491,7 +505,7 @@ describe('PUT /editRecipe', () => {
   })
 
   it('ignores attempts to overwrite protected fields via the payload', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
       .send({
@@ -528,7 +542,7 @@ describe('POST /recipes/:id/save', () => {
   })
 
   it('saves a recipe and increments numTimesSaved', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .post(`/api/recipes/${RECIPE_ID}/save`)
       .set(AUTH_HEADER)
 
@@ -542,12 +556,12 @@ describe('POST /recipes/:id/save', () => {
 
   it('returns 409 on duplicate save attempt', async () => {
     // first save
-    await request(app)
+    await request(server)
       .post(`/api/recipes/${RECIPE_ID}/save`)
       .set(AUTH_HEADER)
 
     // second save — same recipe, same user
-    const res = await request(app)
+    const res = await request(server)
       .post(`/api/recipes/${RECIPE_ID}/save`)
       .set(AUTH_HEADER)
 
@@ -569,7 +583,7 @@ describe('DELETE /recipes/:id/save', () => {
   })
 
   it('returns 404 if recipe is not in the user\'s saved list', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .delete(`/api/recipes/not-saved-id/save`)
       .set(AUTH_HEADER)
 
@@ -578,7 +592,7 @@ describe('DELETE /recipes/:id/save', () => {
   })
 
   it('unsaves a recipe and decrements numTimesSaved', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .delete(`/api/recipes/${RECIPE_ID}/save`)
       .set(AUTH_HEADER)
 
@@ -595,7 +609,7 @@ describe('DELETE /recipes/:id/save', () => {
     // Force counter to 0 before unsaving (simulates already-corrected data)
     await db.collection('recipes').updateOne({ _id: RECIPE_ID }, { $set: { numTimesSaved: 0 } })
 
-    const res = await request(app)
+    const res = await request(server)
       .delete(`/api/recipes/${RECIPE_ID}/save`)
       .set(AUTH_HEADER)
 
@@ -610,7 +624,7 @@ describe('DELETE /recipes/:id/save', () => {
 
 describe('GET /health', () => {
   it('returns 200 with { status: "ok" }', async () => {
-    const res = await request(app).get('/health')
+    const res = await request(server).get('/health')
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ status: 'ok' })
   })
@@ -624,17 +638,17 @@ describe('GET /getRecipe', () => {
   })
 
   it('returns 400 if id is missing', async () => {
-    const res = await request(app).get('/api/getRecipe')
+    const res = await request(server).get('/api/getRecipe')
     expect(res.status).toBe(400)
   })
 
   it('returns 404 if recipe is not found', async () => {
-    const res = await request(app).get('/api/getRecipe?id=nonexistent')
+    const res = await request(server).get('/api/getRecipe?id=nonexistent')
     expect(res.status).toBe(404)
   })
 
   it('returns the recipe and increments the view count', async () => {
-    const res = await request(app).get(`/api/getRecipe?id=${RECIPE_ID}`)
+    const res = await request(server).get(`/api/getRecipe?id=${RECIPE_ID}`)
     expect(res.status).toBe(200)
     expect(res.body._id).toBe(RECIPE_ID)
     expect(res.body.views).toBe(6)
@@ -673,12 +687,12 @@ describe('DELETE /deleteRecipe', () => {
   })
 
   it('rejects request with no auth token (401)', async () => {
-    const res = await request(app).delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
+    const res = await request(server).delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
     expect(res.status).toBe(401)
   })
 
   it('returns 404 if the recipe does not exist', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .delete(`/api/deleteRecipe?recipeId=nonexistent`)
       .set(AUTH_HEADER)
     expect(res.status).toBe(404)
@@ -690,7 +704,7 @@ describe('DELETE /deleteRecipe', () => {
     await db.collection('recipes').deleteOne({ _id: RECIPE_ID })
     await seedRecipe({ ...BASE_RECIPE, userId: 'someone-else' })
 
-    const res = await request(app)
+    const res = await request(server)
       .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
 
@@ -702,7 +716,7 @@ describe('DELETE /deleteRecipe', () => {
   })
 
   it('deletes the recipe and removes it from the owner\'s created/saved/made lists', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
 
@@ -719,7 +733,7 @@ describe('DELETE /deleteRecipe', () => {
   })
 
   it('removes the recipe\'s ratings/reviews but leaves other recipes\' ratings', async () => {
-    await request(app)
+    await request(server)
       .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
 
@@ -729,7 +743,7 @@ describe('DELETE /deleteRecipe', () => {
   })
 
   it('removes the recipeId from other users\' saved/made lists without touching unrelated entries', async () => {
-    await request(app)
+    await request(server)
       .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
 
@@ -740,7 +754,7 @@ describe('DELETE /deleteRecipe', () => {
   })
 
   it('deletes the recipe image from storage', async () => {
-    await request(app)
+    await request(server)
       .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
 
@@ -751,7 +765,7 @@ describe('DELETE /deleteRecipe', () => {
     const db = getDB()
     await db.collection('recipes').updateOne({ _id: RECIPE_ID }, { $set: { recipeImage: '' } })
 
-    const res = await request(app)
+    const res = await request(server)
       .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
 
@@ -763,7 +777,7 @@ describe('DELETE /deleteRecipe', () => {
   it('succeeds (200) even if storage image deletion fails', async () => {
     admin.__deleteFile.mockRejectedValueOnce(new Error('storage down'))
 
-    const res = await request(app)
+    const res = await request(server)
       .delete(`/api/deleteRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
 
@@ -783,12 +797,12 @@ describe('GET /getSavedRecipe', () => {
   })
 
   it('rejects request with no auth token (401)', async () => {
-    const res = await request(app).get(`/api/getSavedRecipe?recipeId=${RECIPE_ID}`)
+    const res = await request(server).get(`/api/getSavedRecipe?recipeId=${RECIPE_ID}`)
     expect(res.status).toBe(401)
   })
 
   it('returns the saved entry when the recipe is in the saved list', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .get(`/api/getSavedRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
     expect(res.status).toBe(200)
@@ -797,7 +811,7 @@ describe('GET /getSavedRecipe', () => {
   })
 
   it('returns null when the recipe is not in the saved list', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .get(`/api/getSavedRecipe?recipeId=not-saved`)
       .set(AUTH_HEADER)
     expect(res.status).toBe(200)
@@ -809,7 +823,7 @@ describe('GET /getSavedRecipe', () => {
 
 describe('GET /getSavedRecipeIds', () => {
   it('rejects request with no auth token (401)', async () => {
-    const res = await request(app).get('/api/getSavedRecipeIds')
+    const res = await request(server).get('/api/getSavedRecipeIds')
     expect(res.status).toBe(401)
   })
 
@@ -820,7 +834,7 @@ describe('GET /getSavedRecipeIds', () => {
         { recipeId: 'r2', dateSaved: '2' },
       ],
     })
-    const res = await request(app)
+    const res = await request(server)
       .get('/api/getSavedRecipeIds')
       .set(AUTH_HEADER)
     expect(res.status).toBe(200)
@@ -828,7 +842,7 @@ describe('GET /getSavedRecipeIds', () => {
   })
 
   it('returns [] when the user has no saved recipes', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .get('/api/getSavedRecipeIds')
       .set(AUTH_HEADER)
     expect(res.status).toBe(200)
@@ -844,12 +858,12 @@ describe('POST /madeRecipe', () => {
   })
 
   it('rejects request with no auth token (401)', async () => {
-    const res = await request(app).post(`/api/madeRecipe?recipeId=${RECIPE_ID}`)
+    const res = await request(server).post(`/api/madeRecipe?recipeId=${RECIPE_ID}`)
     expect(res.status).toBe(401)
   })
 
   it('increments numTimesMade and adds to madeRecipes', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .post(`/api/madeRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
 
@@ -865,8 +879,8 @@ describe('POST /madeRecipe', () => {
   })
 
   it('does not double-add to madeRecipes on repeated calls ($addToSet)', async () => {
-    await request(app).post(`/api/madeRecipe?recipeId=${RECIPE_ID}`).set(AUTH_HEADER)
-    await request(app).post(`/api/madeRecipe?recipeId=${RECIPE_ID}`).set(AUTH_HEADER)
+    await request(server).post(`/api/madeRecipe?recipeId=${RECIPE_ID}`).set(AUTH_HEADER)
+    await request(server).post(`/api/madeRecipe?recipeId=${RECIPE_ID}`).set(AUTH_HEADER)
 
     const db = getDB()
     const userData = await db.collection('userRecipeData').findOne({ _id: TEST_UID })
@@ -879,12 +893,12 @@ describe('POST /madeRecipe', () => {
 
 describe('GET /checkMadeRecipe', () => {
   it('rejects request with no auth token (401)', async () => {
-    const res = await request(app).get(`/api/checkMadeRecipe?recipeId=${RECIPE_ID}`)
+    const res = await request(server).get(`/api/checkMadeRecipe?recipeId=${RECIPE_ID}`)
     expect(res.status).toBe(401)
   })
 
   it('returns { made: false } when user has not made the recipe', async () => {
-    const res = await request(app)
+    const res = await request(server)
       .get(`/api/checkMadeRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
     expect(res.status).toBe(200)
@@ -894,7 +908,7 @@ describe('GET /checkMadeRecipe', () => {
   it('returns { made: true } when user has made the recipe', async () => {
     await seedUserRecipeData(TEST_UID, { madeRecipes: [{ recipeId: RECIPE_ID }] })
 
-    const res = await request(app)
+    const res = await request(server)
       .get(`/api/checkMadeRecipe?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
     expect(res.status).toBe(200)
@@ -914,7 +928,7 @@ describe('GET /searchAutoCompleteRecipes', () => {
   })
 
   it('returns recipes matching the title search', async () => {
-    const res = await request(app).get('/api/searchAutoCompleteRecipes?title=apple')
+    const res = await request(server).get('/api/searchAutoCompleteRecipes?title=apple')
     expect(res.status).toBe(200)
     expect(res.body).toHaveLength(2)
     const titles = res.body.map((r) => r.title)
@@ -937,7 +951,7 @@ describe('GET /searchAutoCompleteRecipes', () => {
       ingredients: [],
       instructions: [],
     })
-    const res = await request(app).get('/api/searchAutoCompleteRecipes?title=Full')
+    const res = await request(server).get('/api/searchAutoCompleteRecipes?title=Full')
     expect(res.status).toBe(200)
     expect(res.body).toHaveLength(1)
     expect(Object.keys(res.body[0]).sort()).toEqual([
@@ -954,7 +968,7 @@ describe('GET /searchAutoCompleteRecipes', () => {
   })
 
   it('is case-insensitive', async () => {
-    const res = await request(app).get('/api/searchAutoCompleteRecipes?title=APPLE')
+    const res = await request(server).get('/api/searchAutoCompleteRecipes?title=APPLE')
     expect(res.status).toBe(200)
     expect(res.body).toHaveLength(2)
   })
@@ -963,7 +977,7 @@ describe('GET /searchAutoCompleteRecipes', () => {
     await seedRecipes(
       Array.from({ length: 10 }, (_, i) => ({ _id: `extra-${i}`, title: `apple-extra-${i}` }))
     )
-    const res = await request(app).get('/api/searchAutoCompleteRecipes?title=apple')
+    const res = await request(server).get('/api/searchAutoCompleteRecipes?title=apple')
     expect(res.status).toBe(200)
     expect(res.body.length).toBeLessThanOrEqual(8)
   })
@@ -983,14 +997,14 @@ describe('GET /getTrendingRecipes', () => {
   })
 
   it('returns 4 recipes sorted by views descending by default', async () => {
-    const res = await request(app).get('/api/getTrendingRecipes')
+    const res = await request(server).get('/api/getTrendingRecipes')
     expect(res.status).toBe(200)
     expect(res.body).toHaveLength(4)
     expect(res.body[0]._id).toBe('tr-1')
   })
 
   it('respects the limit query param', async () => {
-    const res = await request(app).get('/api/getTrendingRecipes?limit=2')
+    const res = await request(server).get('/api/getTrendingRecipes?limit=2')
     expect(res.status).toBe(200)
     expect(res.body).toHaveLength(2)
     expect(res.body[0]._id).toBe('tr-1')
@@ -1000,9 +1014,10 @@ describe('GET /getTrendingRecipes', () => {
     await seedRecipes(
       Array.from({ length: 20 }, (_, i) => ({ _id: `cap-${i}`, title: `Recipe ${i}`, views: i }))
     )
-    const res = await request(app).get('/api/getTrendingRecipes?limit=100')
+    const res = await request(server).get('/api/getTrendingRecipes?limit=100')
     expect(res.status).toBe(200)
-    expect(res.body.length).toBeLessThanOrEqual(20)
+    expect(Array.isArray(res.body)).toBe(true)
+    expect(res.body).toHaveLength(20)
   })
 })
 
@@ -1016,7 +1031,7 @@ describe('Phase 5-D — recipeIdQuery coercion', () => {
     const hex = oid.toHexString()
     await seedRecipe({ ...BASE_RECIPE, _id: oid, views: 5 })
 
-    const res = await request(app).get(`/api/getRecipe?id=${hex}`)
+    const res = await request(server).get(`/api/getRecipe?id=${hex}`)
     expect(res.status).toBe(200)
     // BSON ObjectId serialises to its hex string over JSON
     expect(res.body._id).toBe(hex)
@@ -1038,7 +1053,7 @@ describe('Phase 5-D — recipeIdQuery coercion', () => {
       ],
     })
 
-    const res = await request(app)
+    const res = await request(server)
       .get('/api/getSavedRecipes?page=0&recipesPerPage=10&order=new')
       .set(AUTH_HEADER)
 

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -6,7 +6,6 @@ const { verifyToken, requireAdmin } = require('../middleware/auth')
 const { USER_STATUSES } = require('../util/userStatus')
 const { recordAudit, AUDIT_ACTIONS, AUDIT_TARGET_TYPES } = require('../util/auditLog')
 const { notifyInBackground, notifyAccountStatus } = require('../util/email')
-const { openAutomodReportQuery } = require('../util/automod')
 
 const router = Router()
 
@@ -338,21 +337,6 @@ router.get('/admin/audit', verifyToken, requireAdmin, asyncHandler(async (req, r
   const enriched = await enrichActors(db, entries)
 
   res.json({ entries: enriched, totalCount })
-}))
-
-// GET /admin/recipes/:id/automod — the classifier snapshot from the OPEN
-// automated-moderation report that put this recipe into pending_review, so the
-// recipe page's admin strip can show WHY it was held inline (not only in the
-// reports queue). The reason lives on the report, not the recipe doc, hence this
-// targeted lookup. Returns { classifier: null } when no open automod report
-// exists (e.g. a human takedown, or the hold was already cleared).
-router.get('/admin/recipes/:id/automod', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
-  const db = getDB()
-  const report = await db.collection('reports').findOne(
-    openAutomodReportQuery(req.params.id),
-    { sort: { createdAt: -1 }, projection: { classifier: 1, createdAt: 1 } }
-  )
-  res.json({ classifier: report?.classifier || null, createdAt: report?.createdAt || null })
 }))
 
 // GET /admin/analytics?days= — single overview payload for the admin dashboard:

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -247,6 +247,7 @@ router.post('/updateProfile', verifyToken, requireActive, profileWriteLimiter, a
 // image fails CLOSED, so a scan outage also rejects rather than applying an
 // unscanned photo. Clearing the photo (empty URL) needs no scan.
 router.post('/updatePhoto', verifyToken, requireActive, profileWriteLimiter, asyncHandler(async (req, res) => {
+  const db = getDB()
   const { photoURL } = req.body || {}
   if (photoURL != null && typeof photoURL !== 'string') {
     return res.status(400).json({ error: 'photoURL must be a string' })
@@ -256,7 +257,7 @@ router.post('/updatePhoto', verifyToken, requireActive, profileWriteLimiter, asy
   if (url) {
     const verdict = await moderateImage(url, 'profile.photo')
     if (!verdict.allowed) {
-      return respondBlocked(res, { db: getDB(), uid: req.uid, surface: 'profile.photo', verdict })
+      return respondBlocked(res, { db, uid: req.uid, surface: 'profile.photo', verdict })
     }
   }
 
@@ -276,6 +277,7 @@ router.post('/updatePhoto', verifyToken, requireActive, profileWriteLimiter, asy
 // The 'displayName' context also applies the identity-only spam rules (no
 // URLs/domains in a name).
 router.post('/updateDisplayName', verifyToken, requireActive, profileWriteLimiter, asyncHandler(async (req, res) => {
+  const db = getDB()
   const { displayName } = req.body || {}
   if (typeof displayName !== 'string' || !displayName.trim()) {
     return res.status(400).json({ error: 'displayName is required' })
@@ -287,7 +289,7 @@ router.post('/updateDisplayName', verifyToken, requireActive, profileWriteLimite
 
   const verdict = await moderateText(name, 'displayName')
   if (!verdict.allowed) {
-    return respondBlocked(res, { db: getDB(), uid: req.uid, surface: 'displayName', verdict })
+    return respondBlocked(res, { db, uid: req.uid, surface: 'displayName', verdict })
   }
 
   await admin.auth().updateUser(req.uid, { displayName: name })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -209,6 +209,16 @@ router.get('/getRecipe', optionalAuth, asyncHandler(async (req, res) => {
   if (req.isAdmin) {
     const recipe = await db.collection('recipes').findOne(recipeIdQuery(id))
     if (!recipe) return res.status(404).json({ error: 'Not found' })
+    // For an auto-held recipe, attach WHY (the open automod report's classifier)
+    // so the admin strip can explain the hold inline without a second round-trip.
+    // Only an extra lookup on the (rare) pending_review path, admins only.
+    if (recipe.status === 'pending_review') {
+      const report = await db.collection('reports').findOne(
+        openAutomodReportQuery(id),
+        { sort: { createdAt: -1 }, projection: { classifier: 1 } }
+      )
+      recipe.automodClassifier = report?.classifier || null
+    }
     return res.json(recipe)
   }
 

--- a/server/util/auditLog.js
+++ b/server/util/auditLog.js
@@ -33,6 +33,17 @@ const AUDIT_ACTIONS = [
   'bugReport.dismiss',
 ]
 
+const AUDIT_ACTION_SET = new Set(AUDIT_ACTIONS)
+
+// A typo'd action still persists (best-effort: never drop an audit row) but is
+// invisible to the Audit page's action filter, which keys off AUDIT_ACTIONS. Warn
+// loudly so the mismatch surfaces in dev/logs instead of silently disappearing.
+function warnUnknownAction(action) {
+  if (!AUDIT_ACTION_SET.has(action)) {
+    console.warn(`recordAudit: unknown action '${action}' — add it to AUDIT_ACTIONS or it won't be filterable`)
+  }
+}
+
 const AUDIT_TARGET_TYPES = ['recipe', 'review', 'user', 'report', 'bugReport']
 
 // Reserved synthetic actor for automated (non-human) moderation actions. Stamped
@@ -59,6 +70,7 @@ const SYSTEM_ACTOR = { uid: 'system:automod', type: 'system' }
  * @param {object} [entry.metadata]   any extra structured context (e.g. { from, to })
  */
 async function recordAudit(db, entry) {
+  warnUnknownAction(entry.action)
   try {
     await db.collection('auditLog').insertOne({
       _id: new ObjectId(),
@@ -87,6 +99,7 @@ async function recordAudit(db, entry) {
  */
 async function recordAuditMany(db, entries) {
   if (!Array.isArray(entries) || entries.length === 0) return
+  entries.forEach((entry) => warnUnknownAction(entry.action))
   try {
     await db.collection('auditLog').insertMany(
       entries.map((entry) => ({

--- a/server/util/automod.js
+++ b/server/util/automod.js
@@ -244,6 +244,9 @@ async function holdRecipeForReview(db, { recipeId, title, verdict }) {
           classifier: {
             severity: verdict.severity,
             category: verdict.category || null,
+            // Numeric confidence (0–1) when the classifier produced one; the FE
+            // reads this directly instead of regex-parsing it out of `reason`.
+            score: typeof verdict.score === 'number' ? verdict.score : null,
             reason: verdict.reason || null,
             source: verdict.source || null,
           },

--- a/server/util/imageModeration.js
+++ b/server/util/imageModeration.js
@@ -58,7 +58,7 @@ function threshold(envName, fallback) {
 function highLikelihood() { return threshold('MODERATION_IMAGE_HIGH', 'VERY_LIKELY') }
 function mediumLikelihood() { return threshold('MODERATION_IMAGE_MEDIUM', 'LIKELY') }
 
-const CLEAN = { allowed: true, severity: 'clean', reason: null, category: null, scores: null, source: 'disabled' }
+const CLEAN = { allowed: true, severity: 'clean', reason: null, category: null, score: null, scores: null, source: 'disabled' }
 function clean(source) {
   return { ...CLEAN, source }
 }
@@ -136,7 +136,12 @@ async function callVision(imageUrl) {
  *
  * @param {string} imageUrl   public download URL of the image to screen
  * @param {string} [context]  surface context ('recipe.image' | 'profile.photo')
- * @returns {Promise<{allowed:boolean, severity:'clean'|'medium'|'high', reason:string|null, category:string|null, scores:object|null, source:string}>}
+ * @returns {Promise<{allowed:boolean, severity:'clean'|'medium'|'high', reason:string|null, category:string|null, score:number|null, scores:object|null, source:string}>}
+ *
+ * `score` mirrors the text moderator's field for a uniform verdict shape, but is
+ * always null here: Vision SafeSearch returns a coarse likelihood bucket
+ * (UNLIKELY…VERY_LIKELY), not a 0–1 probability, so there's no honest numeric
+ * confidence to surface. The bucket name lives in `reason` for human readers.
  */
 async function moderateImage(imageUrl, context = '') {
   if (!imageUrl || typeof imageUrl !== 'string' || !imageUrl.trim()) return clean('empty')
@@ -150,7 +155,7 @@ async function moderateImage(imageUrl, context = '') {
     // caller decides what "held" means for its surface — a recipe goes
     // pending_review; a profile photo is rejected (no owner-only state).
     console.error(`moderateImage: scan failed (failing closed) [${context}]:`, err.message)
-    return { allowed: false, severity: 'medium', reason: 'vision:unscanned', category: 'unscanned', scores: null, source: 'error' }
+    return { allowed: false, severity: 'medium', reason: 'vision:unscanned', category: 'unscanned', score: null, scores: null, source: 'error' }
   }
 
   const { severity, category, score } = grade(annotation)
@@ -185,6 +190,8 @@ async function moderateImage(imageUrl, context = '') {
     severity,
     reason: severity === 'clean' ? null : `vision:${category}:${likelihoodName(score)}`,
     category,
+    // Always null — Vision yields a likelihood bucket, not a 0–1 probability.
+    score: null,
     scores: annotation,
     source: 'vision',
   }

--- a/server/util/textModeration.js
+++ b/server/util/textModeration.js
@@ -45,7 +45,7 @@ function mediumThreshold() {
 // review" judgement call. (`sexual/minors` is the omni-moderation category name.)
 const ALWAYS_HIGH_CATEGORIES = new Set(['sexual/minors'])
 
-const CLEAN = { allowed: true, severity: 'clean', reason: null, category: null, scores: null, source: 'disabled' }
+const CLEAN = { allowed: true, severity: 'clean', reason: null, category: null, score: null, scores: null, source: 'disabled' }
 
 // A clean verdict tagged with its source (so logs/tests can tell disabled from
 // classifier-said-clean from failed-open).
@@ -113,7 +113,12 @@ async function callOpenAI(text) {
  *
  * @param {string} text       the content to screen
  * @param {string} [context]  field context ('username' | 'recipe.title' | 'review' | 'bio' | ...)
- * @returns {Promise<{allowed:boolean, severity:'clean'|'medium'|'high', reason:string|null, category:string|null, scores:object|null, source:string}>}
+ * @returns {Promise<{allowed:boolean, severity:'clean'|'medium'|'high', reason:string|null, category:string|null, score:number|null, scores:object|null, source:string}>}
+ *
+ * `score` is the top category's confidence as a 0–1 probability (the same value
+ * embedded in `reason`), exposed as a numeric field so consumers don't have to
+ * regex-parse it back out. null when there is no probabilistic signal
+ * (blocklist hit, disabled, clean, or a failed-open error).
  */
 async function moderateText(text, context = '') {
   if (!text || typeof text !== 'string' || !text.trim()) return clean('empty')
@@ -126,6 +131,7 @@ async function moderateText(text, context = '') {
       severity: 'high',
       reason: `blocklist:${hit.kind}:${hit.term}`,
       category: hit.kind,
+      score: null,
       scores: null,
       source: 'blocklist',
     }
@@ -150,6 +156,9 @@ async function moderateText(text, context = '') {
     severity,
     reason: severity === 'clean' ? null : `openai:${category}:${score.toFixed(2)}`,
     category,
+    // Surfaced numerically (0–1) so the admin UI reads confidence off a field
+    // rather than regex-parsing it back out of `reason`. Null on a clean verdict.
+    score: severity === 'clean' ? null : score,
     scores: result.category_scores || null,
     source: 'openai',
   }

--- a/src/Components/AdminRecipeControls/AdminRecipeControls.tsx
+++ b/src/Components/AdminRecipeControls/AdminRecipeControls.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import { RecipeType } from 'types'
 import { useAuth } from 'src/context/AuthContext'
@@ -24,22 +24,17 @@ const AdminRecipeControls: FC<AdminRecipeControlsProps> = ({ recipe }) => {
   const queryClient = useQueryClient()
 
   const invalidate = () => {
+    // Refetching the recipe also refreshes recipe.automodClassifier (the admin
+    // getRecipe attaches it for held recipes); approving clears the hold so it
+    // drops out on its own.
     queryClient.invalidateQueries({ queryKey: ['recipe', recipe._id] })
-    // The automod note keys off the OPEN report; approving dismisses it, so drop
-    // the stale classifier snapshot too.
-    queryClient.invalidateQueries({ queryKey: ['recipe-automod', recipe._id] })
   }
 
   const isPendingReview = recipe.status === 'pending_review'
 
-  // For an auto-held recipe, fetch WHY (the open automod report's classifier) so
-  // the admin sees the reason inline. Only runs for an admin viewing a held
-  // recipe — never on the public path.
-  const { data: automod } = useQuery({
-    queryKey: ['recipe-automod', recipe._id],
-    queryFn: () => AdminAPI.getRecipeAutomod(recipe._id),
-    enabled: isAdmin && isPendingReview,
-  })
+  // For an auto-held recipe, the admin getRecipe response carries the open automod
+  // report's classifier so the strip can explain the hold inline.
+  const automodClassifier = recipe.automodClassifier
 
   const featureMutation = useMutation({
     mutationFn: (featured: boolean) =>
@@ -105,7 +100,7 @@ const AdminRecipeControls: FC<AdminRecipeControlsProps> = ({ recipe }) => {
       {isPendingReview && (
         <p className='arc-automod-note'>
           Auto-held for moderation review
-          {automod?.classifier ? ` — ${formatClassifier(automod.classifier)}` : ''}.
+          {automodClassifier ? ` — ${formatClassifier(automodClassifier)}` : ''}.
         </p>
       )}
 

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -6,7 +6,6 @@ import {
   AuditAction,
   AuditTargetType,
   AnalyticsResponse,
-  ReportClassifier,
 } from 'types'
 import { http } from 'src/api/http-common'
 
@@ -91,21 +90,10 @@ class AdminAPIClass {
     return result.data
   }
 
-  // Why a recipe was auto-held (its open automod report's classifier), so the
-  // recipe page's admin strip can explain a pending_review hold inline.
-  async getRecipeAutomod(
-    recipeId: string
-  ): Promise<{ classifier: ReportClassifier | null; createdAt: string | null }> {
-    const result = await http.get<{
-      classifier: ReportClassifier | null
-      createdAt: string | null
-    }>(`api/admin/recipes/${recipeId}/automod`)
-    return result.data
-  }
-
   // Clear an automated hold: restore a pending_review recipe to active AND dismiss
-  // its open automod report in one server-side action. Pairs with getRecipeAutomod
-  // (which explains the hold). Errors if the recipe isn't currently pending review.
+  // its open automod report in one server-side action. The hold reason itself is
+  // carried inline on the admin GET /getRecipe (recipe.automodClassifier). Errors
+  // if the recipe isn't currently pending review.
   async approveRecipe(
     recipeId: string
   ): Promise<{ _id: string; status: string }> {

--- a/src/pages/Admin/Analytics/Analytics.scss
+++ b/src/pages/Admin/Analytics/Analytics.scss
@@ -50,6 +50,15 @@
     }
   }
 
+  .section-eyebrow {
+    margin: 0 0 0.6rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #9ca3af;
+  }
+
   .stat-cards {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/src/pages/Admin/Analytics/Analytics.scss
+++ b/src/pages/Admin/Analytics/Analytics.scss
@@ -13,30 +13,46 @@
       margin: 0;
       font-size: 1.6rem;
     }
+  }
 
-    .range-toggle {
-      display: flex;
-      gap: 0.3rem;
+  // Header row for the windowed trends: the "Last N days" eyebrow paired with the
+  // range toggle that actually drives it (kept out of the page header so it sits
+  // next to the only section it affects).
+  .trends-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.6rem;
+    flex-wrap: wrap;
 
-      .range {
-        border: 1px solid #d8dbe0;
-        background: #fff;
-        color: #4b5563;
-        padding: 0.35rem 0.75rem;
-        border-radius: 999px;
-        font-size: 0.82rem;
-        cursor: pointer;
-        transition: all 0.15s;
+    .section-eyebrow {
+      margin: 0;
+    }
+  }
 
-        &:hover {
-          border-color: #9ca3af;
-        }
+  .range-toggle {
+    display: flex;
+    gap: 0.3rem;
 
-        &.active {
-          background: #1f2430;
-          border-color: #1f2430;
-          color: #fff;
-        }
+    .range {
+      border: 1px solid #d8dbe0;
+      background: #fff;
+      color: #4b5563;
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      font-size: 0.82rem;
+      cursor: pointer;
+      transition: all 0.15s;
+
+      &:hover {
+        border-color: #9ca3af;
+      }
+
+      &.active {
+        background: #1f2430;
+        border-color: #1f2430;
+        color: #fff;
       }
     }
   }

--- a/src/pages/Admin/Analytics/Analytics.tsx
+++ b/src/pages/Admin/Analytics/Analytics.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { AuditEntryType, TimeBucket } from 'types'
 import AdminAPI from 'src/api/admin'
 import { ACTION_META, formatAuditActor } from 'src/pages/Admin/auditMeta'
@@ -45,23 +45,32 @@ const Analytics: FC = () => {
   const { data, isPending, isError } = useQuery({
     queryKey: ['admin-analytics', days],
     queryFn: () => AdminAPI.getAnalytics({ days }),
+    // Keep the previous window's data on screen while a new range loads, so the
+    // range toggle (which lives down in the trends section) doesn't blink the
+    // whole page back to "Loading…" — and stays mounted — on every switch.
+    placeholderData: keepPreviousData,
   })
+
+  // The range toggle only drives the windowed trends, so it lives with them
+  // rather than in the page header (the all-time totals never react to it).
+  const rangeToggle = (
+    <div className='range-toggle' role='group' aria-label='Time range'>
+      {DAY_OPTIONS.map(d => (
+        <button
+          key={d}
+          className={days === d ? 'range active' : 'range'}
+          onClick={() => setDays(d)}
+        >
+          {d}d
+        </button>
+      ))}
+    </div>
+  )
 
   return (
     <div className='admin-analytics'>
       <header className='admin-analytics-head'>
         <h1>Overview</h1>
-        <div className='range-toggle' role='group' aria-label='Time range'>
-          {DAY_OPTIONS.map(d => (
-            <button
-              key={d}
-              className={days === d ? 'range active' : 'range'}
-              onClick={() => setDays(d)}
-            >
-              {d}d
-            </button>
-          ))}
-        </div>
       </header>
 
       {isPending ? (
@@ -105,7 +114,10 @@ const Analytics: FC = () => {
             </div>
           </section>
 
-          <p className='section-eyebrow'>Last {data.days} days</p>
+          <div className='trends-head'>
+            <p className='section-eyebrow'>Last {data.days} days</p>
+            {rangeToggle}
+          </div>
           <section className='trends'>
             <div className='trend-card'>
               <h2>Reports filed</h2>

--- a/src/pages/Admin/Analytics/Analytics.tsx
+++ b/src/pages/Admin/Analytics/Analytics.tsx
@@ -70,6 +70,7 @@ const Analytics: FC = () => {
         <p className='analytics-state error'>Failed to load analytics.</p>
       ) : (
         <>
+          <p className='section-eyebrow'>All-time totals</p>
           <section className='stat-cards'>
             <div className='stat-card'>
               <span className='stat-value'>{data.totals.users}</span>
@@ -104,6 +105,7 @@ const Analytics: FC = () => {
             </div>
           </section>
 
+          <p className='section-eyebrow'>Last {data.days} days</p>
           <section className='trends'>
             <div className='trend-card'>
               <h2>Reports filed</h2>

--- a/src/test/AdminRecipeControls.test.tsx
+++ b/src/test/AdminRecipeControls.test.tsx
@@ -20,7 +20,6 @@ vi.mock('src/api/admin', () => ({
   default: {
     setRecipeFeatured: vi.fn().mockResolvedValue({ _id: 'r1', featured: true }),
     setRecipePublished: vi.fn().mockResolvedValue({ _id: 'r1', status: 'unpublished' }),
-    getRecipeAutomod: vi.fn(),
     approveRecipe: vi.fn().mockResolvedValue({ _id: 'r1', status: 'active' }),
   },
 }))
@@ -37,7 +36,6 @@ const mockedUseAuth = useAuth as unknown as Mock
 const mockedFeature = AdminAPI.setRecipeFeatured as unknown as Mock
 const mockedPublish = AdminAPI.setRecipePublished as unknown as Mock
 const mockedModeration = ReportAPI.setRecipeModeration as unknown as Mock
-const mockedAutomod = AdminAPI.getRecipeAutomod as unknown as Mock
 const mockedApprove = AdminAPI.approveRecipe as unknown as Mock
 
 const recipe = { _id: 'r1', title: 'T', status: 'active', featured: false } as RecipeType
@@ -100,49 +98,46 @@ describe('AdminRecipeControls', () => {
     expect(screen.getByRole('button', { name: /^publish$/i })).toBeEnabled()
   })
 
-  it('shows the Pending review pill + auto-held note with the classifier reason', async () => {
+  it('shows the Pending review pill + auto-held note with the classifier reason', () => {
     mockedUseAuth.mockReturnValue({ isAdmin: true })
-    mockedAutomod.mockResolvedValue({
-      classifier: {
+    // The hold reason now rides inline on the recipe (admin getRecipe attaches it).
+    renderControls({
+      ...recipe,
+      status: 'pending_review',
+      automodClassifier: {
         severity: 'medium',
         category: 'harassment',
+        score: 0.6,
         reason: 'openai:harassment:0.60',
         source: 'openai',
       },
-      createdAt: new Date('2026-06-01').toISOString(),
-    })
-    renderControls({ ...recipe, status: 'pending_review' } as RecipeType)
+    } as RecipeType)
 
     expect(screen.getByText('Pending review')).toBeInTheDocument()
-    // The note fills in once the classifier query resolves.
     expect(
-      await screen.findByText(
+      screen.getByText(
         /auto-held for moderation review — harassment · 60% confidence · medium severity/i
       )
     ).toBeInTheDocument()
-    expect(mockedAutomod).toHaveBeenCalledWith('r1')
   })
 
-  it('renders a held recipe without a classifier as a plain auto-held note', async () => {
+  it('renders a held recipe without a classifier as a plain auto-held note', () => {
     mockedUseAuth.mockReturnValue({ isAdmin: true })
-    mockedAutomod.mockResolvedValue({ classifier: null, createdAt: null })
-    renderControls({ ...recipe, status: 'pending_review' } as RecipeType)
+    renderControls({ ...recipe, status: 'pending_review', automodClassifier: null } as RecipeType)
 
-    expect(await screen.findByText(/auto-held for moderation review\.$/i)).toBeInTheDocument()
+    expect(screen.getByText(/auto-held for moderation review\.$/i)).toBeInTheDocument()
   })
 
-  it('does not query automod or show held UI for an active recipe', () => {
+  it('does not show held UI for an active recipe', () => {
     mockedUseAuth.mockReturnValue({ isAdmin: true })
     renderControls() // active
     expect(screen.queryByText('Pending review')).not.toBeInTheDocument()
     expect(screen.queryByText(/auto-held/i)).not.toBeInTheDocument()
-    expect(mockedAutomod).not.toHaveBeenCalled()
   })
 
   it('approves (publishes + clears the hold) a pending_review recipe', async () => {
     mockedUseAuth.mockReturnValue({ isAdmin: true })
-    mockedAutomod.mockResolvedValue({ classifier: null, createdAt: null })
-    renderControls({ ...recipe, status: 'pending_review' } as RecipeType)
+    renderControls({ ...recipe, status: 'pending_review', automodClassifier: null } as RecipeType)
 
     fireEvent.click(screen.getByRole('button', { name: /approve & publish/i }))
     await waitFor(() => expect(mockedApprove).toHaveBeenCalledWith('r1'))

--- a/src/test/formatClassifier.test.ts
+++ b/src/test/formatClassifier.test.ts
@@ -26,7 +26,26 @@ describe('formatClassifier', () => {
     )
   })
 
-  it('parses the score from the END of reason and rounds to a whole percent', () => {
+  it('renders confidence from the numeric score field when present', () => {
+    expect(
+      formatClassifier(classifier({ score: 0.6, reason: null }))
+    ).toBe('harassment · 60% confidence · medium severity')
+  })
+
+  it('prefers the numeric score over a (legacy) score embedded in reason', () => {
+    // score wins even if reason still carries an older trailing number.
+    expect(
+      formatClassifier(classifier({ score: 0.42, reason: 'openai:harassment:0.99' }))
+    ).toContain('42% confidence')
+  })
+
+  it('omits the confidence segment when score is null and reason carries none', () => {
+    const out = formatClassifier(classifier({ score: null, reason: 'vision:adult:VERY_LIKELY' }))
+    expect(out).not.toMatch(/confidence/)
+    expect(out).toBe('harassment · medium severity')
+  })
+
+  it('falls back to the legacy reason-embedded score when score is absent', () => {
     expect(formatClassifier(classifier({ reason: 'openai:violence:0.07' }))).toContain(
       '7% confidence'
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,10 @@ export type RecipeType = {
   // public reads until an admin clears it.
   status?: 'active' | 'hidden' | 'unpublished' | 'pending_review'
   featured?: boolean
+  // Admin-only: the open automod report's classifier, attached by GET /getRecipe
+  // for an admin viewing a 'pending_review' recipe so the admin strip can explain
+  // the hold inline. null when held by a non-automod path; absent otherwise.
+  automodClassifier?: ReportClassifier | null
 }
 export type RecipeFormType = {
   title: string
@@ -204,9 +208,13 @@ export interface NewReportType {
 export interface ReportClassifier {
   severity: 'clean' | 'medium' | 'high'
   category: string | null
-  // e.g. 'openai:harassment:0.60' — the numeric score lives here. Medium holds
-  // are openai-only (blocklist hits are always high-blocked, never held), so this
-  // never carries raw user content.
+  // Confidence as a 0–1 probability (openai medium holds). null when the source
+  // has no probabilistic score (e.g. Vision likelihood buckets). Optional because
+  // reports filed before this field existed don't carry it — formatClassifier
+  // falls back to parsing the legacy score embedded in `reason`.
+  score?: number | null
+  // e.g. 'openai:harassment:0.60'. Medium holds are openai-only (blocklist hits
+  // are always high-blocked, never held), so this never carries raw user content.
   reason: string | null
   source: string | null
 }

--- a/src/util/formatClassifier.ts
+++ b/src/util/formatClassifier.ts
@@ -4,20 +4,27 @@ import { ReportClassifier } from 'types'
 // string, e.g. "harassment · 60% confidence · medium severity". Shared by the
 // Reports queue and the recipe page's admin strip so they read identically.
 //
-// The numeric score (when present) is embedded in `reason`, e.g.
-// 'openai:harassment:0.60' — parse it out rather than show the raw token. No raw
-// user content is shown: the only reports filed are medium holds, which are
-// openai-only (blocklist hits are always high-blocked, never held), so `reason`
-// never carries a matched term.
+// Confidence comes from the numeric `score` field (0–1). No raw user content is
+// shown: the only reports filed are medium holds, which are openai-only
+// (blocklist hits are always high-blocked, never held), so `reason` never
+// carries a matched term.
 export const formatClassifier = (c: ReportClassifier): string => {
   const parts: string[] = []
   if (c.category) parts.push(c.category)
-  const scoreMatch = c.reason?.match(/:([0-9]*\.?[0-9]+)$/)
-  if (scoreMatch) parts.push(`${Math.round(parseFloat(scoreMatch[1]) * 100)}% confidence`)
+  const score = classifierScore(c)
+  if (score !== null) parts.push(`${Math.round(score * 100)}% confidence`)
   if (c.severity) parts.push(`${c.severity} severity`)
   // A classifier with no renderable fields would otherwise return '', which leaves
   // the call sites showing a dangling label ("Auto-flagged: " / "Auto-held … — .").
   // Real medium holds always carry category + severity + score, so this only fires
   // on a malformed/partial snapshot — fall back to a readable placeholder.
   return parts.length ? parts.join(' · ') : 'details unavailable'
+}
+
+// Prefer the persisted numeric score; fall back to the score embedded in `reason`
+// (e.g. 'openai:harassment:0.60') for legacy reports filed before `score` existed.
+const classifierScore = (c: ReportClassifier): number | null => {
+  if (typeof c.score === 'number') return c.score
+  const match = c.reason?.match(/:([0-9]*\.?[0-9]+)$/)
+  return match ? parseFloat(match[1]) : null
 }


### PR DESCRIPTION
## PR-D — moderation follow-up polish (lowest-priority cleanup batch)

Last of the content-moderation follow-up PRs (A/B/C merged). Opportunistic polish + one flaky-test fix. No new product surface; net-removes an endpoint and a per-view round-trip.

### Changes
- **#9 Persist numeric classifier `score` (0–1).** `moderateText` now exposes `score` (openai probability; `null` for blocklist/clean/disabled/error). `moderateImage` exposes `score: null` deliberately — Vision SafeSearch returns a likelihood *bucket* (`UNLIKELY…VERY_LIKELY`), not a probability, so there's no honest numeric confidence to surface (bucket name stays in `reason` for humans). `holdRecipeForReview` stamps `classifier.score`. `formatClassifier` reads the field and **keeps the legacy `reason`-regex as a fallback** so reports filed before this field render confidence unchanged.
- **#6 Fold the automod classifier into admin `GET /getRecipe`.** The admin branch attaches `recipe.automodClassifier` (the open automod report's classifier) for a `pending_review` recipe, so the admin strip explains the hold inline. Drops the dedicated `GET /admin/recipes/:id/automod` endpoint, `AdminAPI.getRecipeAutomod`, and the `recipe-automod` query key — one fetch instead of two.
- **#4 Analytics scope labels.** "All-time totals" eyebrow above the stat cards, "Last N days" above the trend bars, so the day-range toggle's scope is unambiguous.
- **Flaky `getTrendingRecipes › caps limit at 20`.** Root cause was per-call `request(app)` server churn under parallel-worker load (socket hang up → non-array body). Fixed per the PR-C precedent: one reused `app.listen(0)` server in `recipes.test.js`; all 71 `request(app)`→`request(server)`; tightened the assertion to `toHaveLength(20)`.
- **Tail.** `recordAudit`/`recordAuditMany` `console.warn` on an action ∉ `AUDIT_ACTIONS` (still persists — best-effort); hoisted `getDB()` in `updatePhoto`/`updateDisplayName`.

### Verification
- tsc clean · server **557** pass · FE **394** pass · production build OK.
- Local high-effort code review (8 angles): zero correctness defects. Verified `recipes.js` still imports `openAutomodReportQuery`, no stale refs to the removed endpoint/method/query-key, no duplicate `const db`, `score === 0` handled via `!== null`.

### Deferred (noted, intentionally out of scope)
- `auditContentBlock` `targetLabel` for fresh-account blocks (bare uid when no usernames doc yet).
- Shared `<ClassifierNote>` component for the duplicated classifier markup/SCSS across Reports + AdminRecipeControls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)