### PR TITLE
fix(moderation): label self-service account deletion correctly in audit feed

### DIFF
--- a/server/__tests__/audit-log.test.js
+++ b/server/__tests__/audit-log.test.js
@@ -64,6 +64,40 @@ describe('GET /api/admin/audit', () => {
     expect(res.body.entries[0].actorUsername).toBe('adminuser')
   })
 
+  it('falls back to a captured actorUsername when the usernames doc is gone', async () => {
+    // A self-service account deletion writes its audit row and deletes the
+    // actor's usernames doc in the same cascade, so the live enrichment lookup
+    // misses. The handle captured on the row must still surface.
+    admin.__setClaims({ admin: true })
+    await seedUser(TEST_UID, 'adminuser') // the admin viewing the log
+    await seedAudit([
+      {
+        action: 'user.delete',
+        actorUid: 'gone-uid',
+        actorType: 'user',
+        actorUsername: 'goner',
+        targetType: 'user',
+        targetId: 'gone-uid',
+      },
+    ])
+
+    const res = await request(app).get('/api/admin/audit').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.entries[0].actorUsername).toBe('goner')
+    expect(res.body.entries[0].actorType).toBe('user')
+  })
+
+  it('prefers the live username lookup over a stale captured one', async () => {
+    admin.__setClaims({ admin: true })
+    await seedUser(TEST_UID, 'currentname')
+    await seedAudit([
+      { action: 'recipe.hide', actorUid: TEST_UID, actorUsername: 'oldname' },
+    ])
+
+    const res = await request(app).get('/api/admin/audit').set(AUTH_HEADER)
+    expect(res.body.entries[0].actorUsername).toBe('currentname')
+  })
+
   it('filters by action and by targetType', async () => {
     admin.__setClaims({ admin: true })
     await seedAudit([

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -642,6 +642,12 @@ describe('POST /deleteAccount', () => {
     expect(entry.actorUid).toBe(TEST_UID)
     expect(entry.targetType).toBe('user')
     expect(entry.targetLabel).toBe('@goner')
+    // Self-service, not an admin action: stamped 'user' so the audit feed reads
+    // "@goner deleted their account" rather than "An admin …".
+    expect(entry.actorType).toBe('user')
+    // The handle is captured on the row because the usernames doc was deleted in
+    // the same cascade — read-time enrichment can no longer resolve actorUid.
+    expect(entry.actorUsername).toBe('goner')
   })
 
   it('still deletes the Firebase account when the user has no other data', async () => {

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -26,14 +26,21 @@ function escapeRegex(str) {
 
 // Attach each audit entry's actor username in one batched lookup, so a page of
 // entries shows "@admin did X" without a per-row query. Shared by the audit
-// trail and the analytics "recent actions" feed.
+// trail and the analytics "recent actions" feed. The live `usernames` lookup
+// wins (an admin who renamed shows their current handle), but falls back to a
+// username captured on the row at action time — the only label left for a
+// self-service account deletion, which removes the actor's `usernames` doc in
+// the same cascade that writes the audit row.
 async function enrichActors(db, entries) {
   const actorUids = [...new Set(entries.map((e) => e.actorUid).filter(Boolean))]
   const actorDocs = actorUids.length
     ? await db.collection('usernames').find({ _id: { $in: actorUids } }).toArray()
     : []
   const actorByUid = Object.fromEntries(actorDocs.map((d) => [d._id, d.username]))
-  return entries.map((e) => ({ ...e, actorUsername: actorByUid[e.actorUid] || null }))
+  return entries.map((e) => ({
+    ...e,
+    actorUsername: actorByUid[e.actorUid] || e.actorUsername || null,
+  }))
 }
 
 // Build a complete, zero-filled daily time series for the last `days` days

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -461,10 +461,15 @@ router.post('/deleteAccount', verifyToken, asyncHandler(async (req, res) => {
   await deleteProfilePhoto(uid)
 
   // Leave a trail in the audit log (best-effort) so an admin can see that the
-  // account was self-deleted rather than removed by moderation.
+  // account was self-deleted rather than removed by moderation. actorType 'user'
+  // marks it as a self-service action (not an admin one), and actorUsername
+  // captures the handle here because the `usernames` doc was just deleted in the
+  // cascade above — read-time enrichment can no longer resolve it.
   await recordAudit(db, {
     action: 'user.delete',
     actorUid: uid,
+    actorType: 'user',
+    actorUsername: username,
     targetType: 'user',
     targetId: uid,
     targetLabel: username ? `@${username}` : null,

--- a/server/util/auditLog.js
+++ b/server/util/auditLog.js
@@ -62,7 +62,10 @@ const SYSTEM_ACTOR = { uid: 'system:automod', type: 'system' }
  * @param {object} entry
  * @param {string} entry.action       one of AUDIT_ACTIONS
  * @param {string} entry.actorUid     admin uid performing the action (or SYSTEM_ACTOR.uid)
- * @param {string} [entry.actorType]  'admin' (default) | 'system' — machine vs human
+ * @param {string} [entry.actorType]  'admin' (default) | 'system' | 'user' — machine vs human admin vs self-service
+ * @param {string} [entry.actorUsername] handle captured at action time; the only
+ *   way to label the actor when their `usernames` doc won't survive to read time
+ *   (e.g. self-service account deletion removes it in the same cascade)
  * @param {string} entry.targetType   one of AUDIT_TARGET_TYPES
  * @param {string} entry.targetId     recipeId / uid / reportId (or username+recipeId for reviews)
  * @param {string} [entry.targetLabel] human-readable label captured at action time (recipe title, @username)
@@ -77,6 +80,7 @@ async function recordAudit(db, entry) {
       action: entry.action,
       actorUid: entry.actorUid,
       actorType: entry.actorType || 'admin',
+      actorUsername: entry.actorUsername || null,
       targetType: entry.targetType,
       targetId: entry.targetId != null ? String(entry.targetId) : null,
       targetLabel: entry.targetLabel || null,
@@ -107,6 +111,7 @@ async function recordAuditMany(db, entries) {
         action: entry.action,
         actorUid: entry.actorUid,
         actorType: entry.actorType || 'admin',
+        actorUsername: entry.actorUsername || null,
         targetType: entry.targetType,
         targetId: entry.targetId != null ? String(entry.targetId) : null,
         targetLabel: entry.targetLabel || null,

--- a/src/pages/Admin/Analytics/Analytics.tsx
+++ b/src/pages/Admin/Analytics/Analytics.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react'
 import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { AuditEntryType, TimeBucket } from 'types'
 import AdminAPI from 'src/api/admin'
-import { ACTION_META, formatAuditActor } from 'src/pages/Admin/auditMeta'
+import { ACTION_META, formatAuditActor, isSelfAction } from 'src/pages/Admin/auditMeta'
 import './Analytics.scss'
 
 // Day windows offered by the toggle. Server clamps to 7–90 regardless.
@@ -150,8 +150,15 @@ const Analytics: FC = () => {
                           <strong className='actor'>
                             {formatAuditActor(entry)}
                           </strong>{' '}
-                          {meta?.label || entry.action}{' '}
-                          <span className='target'>{entry.targetLabel || entry.targetId}</span>
+                          {meta?.label || entry.action}
+                          {!isSelfAction(entry) && (
+                            <>
+                              {' '}
+                              <span className='target'>
+                                {entry.targetLabel || entry.targetId}
+                              </span>
+                            </>
+                          )}
                         </p>
                         <p className='action-time'>
                           {new Date(entry.createdAt).toLocaleString()}

--- a/src/pages/Admin/Audit/Audit.tsx
+++ b/src/pages/Admin/Audit/Audit.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { AuditAction, AuditEntryType, AuditTargetType } from 'types'
 import AdminAPI from 'src/api/admin'
-import { ACTION_META, formatAuditActor } from 'src/pages/Admin/auditMeta'
+import { ACTION_META, formatAuditActor, isSelfAction } from 'src/pages/Admin/auditMeta'
 import SavedFilterBar from 'src/Components/SavedFilters/SavedFilterBar'
 import './Audit.scss'
 
@@ -129,8 +129,15 @@ const Audit: FC = () => {
                       <strong className='actor'>
                         {formatAuditActor(entry)}
                       </strong>{' '}
-                      {meta?.label || entry.action}{' '}
-                      <span className='target'>{entry.targetLabel || entry.targetId}</span>
+                      {meta?.label || entry.action}
+                      {!isSelfAction(entry) && (
+                        <>
+                          {' '}
+                          <span className='target'>
+                            {entry.targetLabel || entry.targetId}
+                          </span>
+                        </>
+                      )}
                     </p>
                     {entry.reason && (
                       <p className='audit-reason'>“{entry.reason}”</p>

--- a/src/pages/Admin/auditMeta.ts
+++ b/src/pages/Admin/auditMeta.ts
@@ -19,10 +19,12 @@ export const formatAuditActor = (
 // A self-service row (the user acting on their own account, e.g. account
 // deletion) has the actor as its own target, so the trailing target label would
 // just repeat the actor's handle — "@user deleted their account @user". Callers
-// suppress the target span for these rows.
+// suppress the target span for these rows. Keyed off actor-is-target rather than
+// actorType so a future self-service action with a distinct target (e.g. a user
+// deleting their own recipe) still renders its target.
 export const isSelfAction = (
-  entry: Pick<AuditEntryType, 'actorType'>
-): boolean => entry.actorType === 'user'
+  entry: Pick<AuditEntryType, 'actorType' | 'actorUid' | 'targetId'>
+): boolean => entry.actorType === 'user' && entry.actorUid === entry.targetId
 
 // Short human phrasing + a colour tone per audit action, used for the row label
 // in both the Audit log and the Analytics "recent actions" feed. Kept here so

--- a/src/pages/Admin/auditMeta.ts
+++ b/src/pages/Admin/auditMeta.ts
@@ -5,12 +5,24 @@ import { AuditAction, AuditEntryType } from 'types'
 // (autohold, content.blocked) are credited to the synthetic system actor, whose
 // uid never resolves to a username — show "Automod" instead of the misleading
 // "An admin" fallback. Human admins show their @handle (or a generic fallback).
+// Self-service actions ('user') are the account owner acting on themselves, so
+// they must never read as "An admin"; fall back to "A user" if the captured
+// handle is missing.
 export const formatAuditActor = (
   entry: Pick<AuditEntryType, 'actorType' | 'actorUsername'>
 ): string => {
   if (entry.actorType === 'system') return 'Automod'
-  return entry.actorUsername ? `@${entry.actorUsername}` : 'An admin'
+  if (entry.actorUsername) return `@${entry.actorUsername}`
+  return entry.actorType === 'user' ? 'A user' : 'An admin'
 }
+
+// A self-service row (the user acting on their own account, e.g. account
+// deletion) has the actor as its own target, so the trailing target label would
+// just repeat the actor's handle — "@user deleted their account @user". Callers
+// suppress the target span for these rows.
+export const isSelfAction = (
+  entry: Pick<AuditEntryType, 'actorType'>
+): boolean => entry.actorType === 'user'
 
 // Short human phrasing + a colour tone per audit action, used for the row label
 // in both the Audit log and the Analytics "recent actions" feed. Kept here so

--- a/src/test/auditMeta.test.ts
+++ b/src/test/auditMeta.test.ts
@@ -38,14 +38,20 @@ describe('formatAuditActor', () => {
 })
 
 describe('isSelfAction', () => {
-  it('is true for a self-service (user) row', () => {
-    expect(isSelfAction({ actorType: 'user' })).toBe(true)
+  it('is true for a self-service row where the actor is its own target', () => {
+    expect(isSelfAction({ actorType: 'user', actorUid: 'u1', targetId: 'u1' })).toBe(true)
+  })
+
+  it('is false for a user-actor row whose target is something else', () => {
+    // Guards the latent case: a future self-service action with a distinct
+    // target must still render its target rather than be suppressed.
+    expect(isSelfAction({ actorType: 'user', actorUid: 'u1', targetId: 'r9' })).toBe(false)
   })
 
   it('is false for admin and system rows', () => {
-    expect(isSelfAction({ actorType: 'admin' })).toBe(false)
-    expect(isSelfAction({ actorType: 'system' })).toBe(false)
-    expect(isSelfAction({ actorType: undefined })).toBe(false)
+    expect(isSelfAction({ actorType: 'admin', actorUid: 'u1', targetId: 'u1' })).toBe(false)
+    expect(isSelfAction({ actorType: 'system', actorUid: 'u1', targetId: 'u1' })).toBe(false)
+    expect(isSelfAction({ actorType: undefined, actorUid: 'u1', targetId: 'u1' })).toBe(false)
   })
 })
 

--- a/src/test/auditMeta.test.ts
+++ b/src/test/auditMeta.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { formatAuditActor, ACTION_META } from 'src/pages/Admin/auditMeta'
+import { formatAuditActor, isSelfAction, ACTION_META } from 'src/pages/Admin/auditMeta'
 
 describe('formatAuditActor', () => {
   it('labels a system-actor row "Automod"', () => {
@@ -26,6 +26,37 @@ describe('formatAuditActor', () => {
 
   it('falls back to "An admin" for a human row with no resolved username', () => {
     expect(formatAuditActor({ actorType: 'admin', actorUsername: null })).toBe('An admin')
+  })
+
+  it('shows a self-service actor by their captured @handle', () => {
+    expect(formatAuditActor({ actorType: 'user', actorUsername: 'jess' })).toBe('@jess')
+  })
+
+  it('falls back to "A user" (never "An admin") for a self-service row with no handle', () => {
+    expect(formatAuditActor({ actorType: 'user', actorUsername: null })).toBe('A user')
+  })
+})
+
+describe('isSelfAction', () => {
+  it('is true for a self-service (user) row', () => {
+    expect(isSelfAction({ actorType: 'user' })).toBe(true)
+  })
+
+  it('is false for admin and system rows', () => {
+    expect(isSelfAction({ actorType: 'admin' })).toBe(false)
+    expect(isSelfAction({ actorType: 'system' })).toBe(false)
+    expect(isSelfAction({ actorType: undefined })).toBe(false)
+  })
+})
+
+describe('ACTION_META — user.delete', () => {
+  it('reads as a self-described action ("deleted their account")', () => {
+    // Rendered as "{actor} deleted their account" with the target suppressed,
+    // so the label must not need a trailing target to make sense.
+    expect(ACTION_META['user.delete']).toEqual({
+      label: 'deleted their account',
+      tone: 'danger',
+    })
   })
 })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -368,8 +368,9 @@ export interface AuditEntryType {
   action: AuditAction
   actorUid: string
   // 'system' marks an automated (non-human) action — autohold, content.blocked.
-  // 'admin' (or absent, for legacy rows) is a human admin.
-  actorType?: 'admin' | 'system'
+  // 'user' marks a self-service action (the user acting on their own account,
+  // e.g. account deletion). 'admin' (or absent, for legacy rows) is a human admin.
+  actorType?: 'admin' | 'system' | 'user'
   actorUsername: string | null
   targetType: AuditTargetType
   targetId: string | null


### PR DESCRIPTION
## Problem

A self-service account deletion (`user.delete`) renders in the admin Audit log and Analytics "recent actions" feed as:

> **An admin** deleted their account **@user**

Two root causes:
1. `auth.js` `deleteAccount` called `recordAudit` without `actorType`, so it defaulted to `'admin'`.
2. Read-time enrichment (`enrichActors`) resolves the actor's `@handle` from the `usernames` collection — but that doc is deleted in the *same cascade* that writes the audit row, so the lookup misses and `formatAuditActor` falls back to `'An admin'`. The visible `@user` is actually the `targetLabel` (captured at delete time).

## Fix

- **`auth.js`** — stamp `actorType: 'user'` and capture `actorUsername` on the delete row (the only surviving source of the handle after the cascade).
- **`auditLog.js`** — persist `actorUsername` on audit rows (`recordAudit` + `recordAuditMany`).
- **`admin.js` `enrichActors`** — prefer the live `usernames` lookup (so a renamed admin shows their current handle), fall back to the captured `actorUsername` (so deleted users still show a handle).
- **`auditMeta.ts`** — `formatAuditActor` returns the `@handle` / `'A user'` (never `'An admin'`) for self-service rows; new `isSelfAction()` helper.
- **Audit + Analytics feeds** — suppress the redundant trailing target for self-actions.

Result:

> **@user** deleted their account

## Tests
- FE `auditMeta.test.ts`: self-service actor labelling (`@handle` + `'A user'` fallback) and `isSelfAction`.
- Server `auth.test.js`: `actorType`/`actorUsername` stamping on the delete row.
- Server `audit-log.test.js`: enrichment fallback when the `usernames` doc is gone + live-lookup precedence over a stale captured handle.

tsc clean · FE 399 pass · server suite green (one pre-existing parallel-load flake in `admin-moderation.test.js`, passes 17/17 in isolation) · build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)