### PR TITLE
cleanup(moderation): email fallback for fresh-account blocks + shared ClassifierNote

### DIFF
--- a/server/__tests__/automod.test.js
+++ b/server/__tests__/automod.test.js
@@ -9,6 +9,7 @@
  * unmoderated. Assert the real keys make it into the blob.
  */
 
+const admin = require('firebase-admin') // auto-mocked (server/__mocks__/firebase-admin.js)
 const { gatherRecipeText, holdRecipeForReview, auditContentBlock, respondBlocked } = require('../util/automod')
 const { SYSTEM_ACTOR } = require('../util/auditLog')
 
@@ -155,6 +156,10 @@ describe('holdRecipeForReview — report-gated hold', () => {
 })
 
 describe('auditContentBlock — system-actor trail for a refused write', () => {
+  // The email fallback calls admin.auth().getUser; reset the mock's user
+  // registry between cases so a fresh-account lookup misses unless set.
+  afterEach(() => admin.__resetUsers())
+
   // Fake Db capturing the auditLog insert and serving a usernames lookup.
   const fakeDb = ({ username, findThrows, insertThrows } = {}) => {
     const inserts = []
@@ -212,11 +217,28 @@ describe('auditContentBlock — system-actor trail for a refused write', () => {
     expect(inserts[0].reason).toBeFalsy()
   })
 
-  it('falls back to a null targetLabel (→ bare uid at render) when the username lookup misses', async () => {
+  it('falls back to the Firebase email when there is no usernames doc yet (fresh account)', async () => {
+    // A brand-new account blocked on its first username/displayName write has no
+    // usernames doc; the email keeps the queue row identifiable instead of a uid.
+    admin.__setUsers([{ uid: 'uid-fresh', email: 'fresh@example.com' }])
     const { db, inserts } = fakeDb({ username: null })
-    await auditContentBlock(db, { uid: 'uid-2', surface: 'profile', verdict: VERDICT })
+    await auditContentBlock(db, { uid: 'uid-fresh', surface: 'username', verdict: VERDICT })
+    expect(inserts[0].targetLabel).toBe('fresh@example.com')
+    expect(inserts[0].targetId).toBe('uid-fresh')
+  })
+
+  it('prefers the @handle over the email when a usernames doc exists', async () => {
+    admin.__setUsers([{ uid: 'uid-both', email: 'both@example.com' }])
+    const { db, inserts } = fakeDb({ username: 'baduser' })
+    await auditContentBlock(db, { uid: 'uid-both', surface: 'username', verdict: VERDICT })
+    expect(inserts[0].targetLabel).toBe('@baduser')
+  })
+
+  it('falls back to a null targetLabel (→ bare uid at render) when both lookups miss', async () => {
+    const { db, inserts } = fakeDb({ username: null })
+    await auditContentBlock(db, { uid: 'uid-2-unknown', surface: 'profile', verdict: VERDICT })
     expect(inserts[0].targetLabel).toBeNull()
-    expect(inserts[0].targetId).toBe('uid-2')
+    expect(inserts[0].targetId).toBe('uid-2-unknown')
   })
 
   it('is best-effort: a username-lookup failure still records the row', async () => {

--- a/server/util/automod.js
+++ b/server/util/automod.js
@@ -4,6 +4,7 @@
 // state. Used by the recipe write routes; reviews/profile block inline and need
 // none of this.
 
+const admin = require('firebase-admin')
 const { ObjectId } = require('mongodb')
 const { recordAudit, SYSTEM_ACTOR } = require('./auditLog')
 const { recipeIdQuery } = require('./recipeIdQuery')
@@ -45,9 +46,17 @@ async function auditContentBlock(db, { uid, surface, verdict } = {}) {
         .collection('usernames')
         .findOne({ _id: uid }, { projection: { username: 1 } })
       if (doc?.username) targetLabel = `@${doc.username}`
+      // A brand-new account blocked on its very first username/displayName/profile
+      // write has no `usernames` doc yet, so the lookup above misses. Fall back to
+      // the account's Firebase email — still a human identifier an admin can act
+      // on (and already shown in the user-detail view), rather than a bare uid.
+      if (!targetLabel) {
+        const userRecord = await admin.auth().getUser(uid)
+        if (userRecord?.email) targetLabel = userRecord.email
+      }
     }
   } catch (_) {
-    // ignore — targetLabel stays null
+    // ignore — targetLabel stays null (renders as the bare uid)
   }
   await recordAudit(db, {
     action: 'content.blocked',

--- a/src/Components/AdminRecipeControls/AdminRecipeControls.scss
+++ b/src/Components/AdminRecipeControls/AdminRecipeControls.scss
@@ -49,14 +49,11 @@
     }
   }
 
-  // Auto-hold explanation; wraps to its own line under the strip.
+  // Auto-hold explanation; wraps to its own line under the strip. Shared visual
+  // treatment lives on .classifier-note (ClassifierNote.scss); only the
+  // full-width wrap is overridden here.
   .arc-automod-note {
     flex-basis: 100%;
-    margin: 0;
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: #4338ca;
-    text-transform: capitalize;
   }
 
   .arc-btn {

--- a/src/Components/AdminRecipeControls/AdminRecipeControls.tsx
+++ b/src/Components/AdminRecipeControls/AdminRecipeControls.tsx
@@ -5,6 +5,7 @@ import { RecipeType } from 'types'
 import { useAuth } from 'src/context/AuthContext'
 import AdminAPI from 'src/api/admin'
 import ReportAPI from 'src/api/reports'
+import ClassifierNote from 'src/Components/ClassifierNote/ClassifierNote'
 import { formatClassifier } from 'src/util/formatClassifier'
 import './AdminRecipeControls.scss'
 
@@ -98,10 +99,10 @@ const AdminRecipeControls: FC<AdminRecipeControlsProps> = ({ recipe }) => {
       {isFeatured && <span className='arc-pill featured'>Featured</span>}
 
       {isPendingReview && (
-        <p className='arc-automod-note'>
+        <ClassifierNote className='arc-automod-note'>
           Auto-held for moderation review
           {automodClassifier ? ` — ${formatClassifier(automodClassifier)}` : ''}.
-        </p>
+        </ClassifierNote>
       )}
 
       {isPendingReview && (

--- a/src/Components/ClassifierNote/ClassifierNote.scss
+++ b/src/Components/ClassifierNote/ClassifierNote.scss
@@ -1,0 +1,10 @@
+// Shared visual identity for an automod classifier note (see ClassifierNote.tsx).
+// Surface-specific layout (margins, flex-basis) lives in each caller's stylesheet
+// on its own override class, which wins on specificity when nested under a parent.
+.classifier-note {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #4338ca;
+  text-transform: capitalize;
+}

--- a/src/Components/ClassifierNote/ClassifierNote.tsx
+++ b/src/Components/ClassifierNote/ClassifierNote.tsx
@@ -1,0 +1,21 @@
+import React, { FC, ReactNode } from 'react'
+import './ClassifierNote.scss'
+
+// Shared automod "classifier note" — the small, bold, indigo, capitalized line
+// that explains an automated moderation decision. Two surfaces render it (the
+// Reports queue: "Auto-flagged: …", and the recipe-controls strip: "Auto-held
+// for moderation review — …"), so the wording and the layout differ per caller;
+// this component owns only the shared visual identity via the `classifier-note`
+// base class. Callers compose their own sentence (including the formatClassifier
+// detail) as children, and pass a surface class for any layout overrides.
+type ClassifierNoteProps = {
+  children: ReactNode
+  // Surface-specific layout overrides (e.g. margins, flex-basis). Optional.
+  className?: string
+}
+
+const ClassifierNote: FC<ClassifierNoteProps> = ({ children, className }) => (
+  <p className={['classifier-note', className].filter(Boolean).join(' ')}>{children}</p>
+)
+
+export default ClassifierNote

--- a/src/pages/Admin/Reports/Reports.scss
+++ b/src/pages/Admin/Reports/Reports.scss
@@ -198,13 +198,11 @@
       }
     }
 
-    // Why the system held this content (automod reports only).
+    // Why the system held this content (automod reports only). Shared visual
+    // treatment lives on .classifier-note (ClassifierNote.scss); only the
+    // queue-specific bottom margin is overridden here.
     .report-classifier {
       margin: 0 0 0.65rem;
-      font-size: 0.8rem;
-      font-weight: 600;
-      color: #4338ca;
-      text-transform: capitalize;
     }
 
     .preview {

--- a/src/pages/Admin/Reports/Reports.tsx
+++ b/src/pages/Admin/Reports/Reports.tsx
@@ -6,6 +6,7 @@ import { AdminReportType, ReportStatus } from 'types'
 import ReportAPI from 'src/api/reports'
 import AdminAPI from 'src/api/admin'
 import SavedFilterBar from 'src/Components/SavedFilters/SavedFilterBar'
+import ClassifierNote from 'src/Components/ClassifierNote/ClassifierNote'
 import { formatClassifier } from 'src/util/formatClassifier'
 import './Reports.scss'
 
@@ -321,9 +322,9 @@ const Reports: FC = () => {
                 </div>
 
                 {report.classifier && (
-                  <p className='report-classifier'>
+                  <ClassifierNote className='report-classifier'>
                     Auto-flagged: {formatClassifier(report.classifier)}
-                  </p>
+                  </ClassifierNote>
                 )}
 
                 {renderPreview(report)}


### PR DESCRIPTION
Two small, deferred moderation-polish items from the P3 follow-up backlog. No behavior change beyond the audit-label improvement.

## 1. Fresh-account content blocks now labeled by email, not a bare uid
A `content.blocked` audit row for a brand-new account blocked on its **first** `username` / `displayName` / `profile` write had no `usernames` doc yet, so `auditContentBlock` left `targetLabel` null and the moderation queue showed a bare 28-char uid. It now falls back to the account's Firebase **email** (best-effort, only after the `@handle` lookup misses) so the row stays identifiable. The `@handle` still wins when a usernames doc exists; both lookups missing still degrades cleanly to the uid.

## 2. Shared `ClassifierNote` component
The Reports queue (`Auto-flagged: …`) and the recipe-controls strip (`Auto-held for moderation review — …`) rendered the automod classifier note with the **same** visual treatment (small, bold, indigo, capitalized) duplicated across both stylesheets. Extracted a thin presentational `<ClassifierNote>` that owns the shared `.classifier-note` look; each surface keeps its own sentence (children) and a layout-only override class (bottom margin / full-width wrap). Purely cosmetic refactor.

## Verification
- tsc clean
- Frontend: 400 pass (2 skipped) — incl. updated `automod` server tests for the email fallback (`@handle` precedence + both-miss → null)
- Server: 561 pass (27 suites)
- Build OK

After this, the moderation P3 follow-up backlog is empty except the deliberately-separate CSAM/PhotoDNA track.
