### PR TITLE
moderation: review follow-ups — tighter recipe limiter + strand-guard note

### DIFF
--- a/server/__tests__/writeLimiter.test.js
+++ b/server/__tests__/writeLimiter.test.js
@@ -119,8 +119,10 @@ describe('makeUserLimiter — per-user content-write cap', () => {
 describe('per-surface limiters are independent buckets', () => {
   // The whole point of #3: exhausting one surface must NOT throttle another, so a
   // legit cross-surface burst can't 429. Each exported limiter is its own
-  // instance with its own store, so a single uid gets a separate 30/min budget on
-  // recipes vs reviews vs profile.
+  // instance with its own store, so a single uid gets a separate budget on
+  // recipes vs reviews vs profile. The recipe surface is capped tighter (12) than
+  // review/profile (30) because a recipe write can trigger a paid image scan.
+  const RECIPE_LIMIT = 12
   it('exhausting the recipe surface leaves review + profile untouched for the same user', async () => {
     const server = start({
       '/recipe': recipeWriteLimiter,
@@ -130,7 +132,7 @@ describe('per-surface limiters are independent buckets', () => {
     const uid = 'cross-surface-user'
 
     // Burn the full recipe budget.
-    for (let i = 0; i < 30; i++) {
+    for (let i = 0; i < RECIPE_LIMIT; i++) {
       expect((await request(server).post('/recipe').set('x-test-uid', uid)).status).toBe(200)
     }
     expect((await request(server).post('/recipe').set('x-test-uid', uid)).status).toBe(429)

--- a/server/middleware/writeLimiter.js
+++ b/server/middleware/writeLimiter.js
@@ -52,9 +52,16 @@ function makeUserLimiter({
 // then tweak your profile — could 429 even though no single surface was abused.
 // Separate instances ⇒ separate buckets, so each surface is bounded on its own
 // and normal mixed activity never trips the limit; scripted spam of any one
-// surface still hits its cap at 30/min. A real user never approaches 30 writes
-// to a single surface in a minute, so only abuse is affected.
-const recipeWriteLimiter = makeUserLimiter()
+// surface still hits its own cap. A real user never approaches these in a
+// minute, so only abuse is affected.
+//
+// The recipe surface is capped TIGHTER than the others (12 vs 30/min): a recipe
+// write is the one content write that can trigger a paid Cloud Vision image scan,
+// so it's the expensive surface to spam. 12/min is still far above any human
+// add/edit cadence but bounds the paid-scan blast radius of a single rogue
+// account to ~40% of the 30/min exposure. Review/profile carry no per-write paid
+// cost beyond the (free) OpenAI moderation call, so they keep the 30/min default.
+const recipeWriteLimiter = makeUserLimiter({ limit: 12 })
 const reviewWriteLimiter = makeUserLimiter()
 const profileWriteLimiter = makeUserLimiter()
 

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -15,6 +15,19 @@ const { notifyInBackground, notifyReportResolved, notifyReportResolvedMany } = r
 // status filter inside that helper means a recipe an admin has separately taken
 // down ('hidden') is left down — only genuine strays (still 'pending_review') are
 // restored.
+//
+// IMPORTANT — resolve and dismiss are treated IDENTICALLY here: both close the
+// report, so both restore a still-held recipe to 'active'. "Resolve" does NOT take
+// the recipe down. Taking a held recipe down is a SEPARATE action (admin recipe
+// controls → Take down, or the /admin/recipes/:id/moderation route → 'hidden'),
+// after which this guard becomes a no-op. So the rule is: to keep a held recipe
+// down, hide it FIRST, then close its report. The admin UI enforces this by
+// offering a held report only Approve / Take down (never a bare Resolve/Dismiss,
+// which from the queue would silently publish the content) and by excluding held
+// reports from bulk selection. This server guard is the backstop for direct API
+// calls — it can't tell "resolve = publish" from "resolve = should've hidden", so
+// it always restores; the takedown-first ordering is the contract that keeps a
+// resolve from publishing content an admin meant to remove.
 const isAutomodRecipeReport = (r) => r && r.source === 'automod' && r.targetType === 'recipe'
 
 const router = Router()


### PR DESCRIPTION
Small follow-up PR from a high-effort code review + security pass over the recent moderation batch (PRs #142–#148). The review found **no correctness bugs**; these are the two changes worth shipping out of it.

## Changes

### 1. Tighten the recipe write limiter to 12/min (`995f53c`)
The per-surface limiter split (PR #145) gave recipe/review/profile each their own 30/min/user bucket. But a **recipe write is the only content write that can trigger a paid Cloud Vision image scan**, so it's the expensive surface to spam. This caps `recipeWriteLimiter` at **12/min/user** while keeping the 30/min default for review/profile (which carry no per-write paid cost beyond the free OpenAI moderation call).

- 12/min is far above any human add/edit cadence — only scripted abuse is affected.
- Bounds the paid-scan blast radius of a single rogue account to ~40% of the prior exposure.
- Independent-buckets test updated to the new cap.

### 2. Clarify strand-guard resolve/dismiss semantics (`047f451`, comment-only)
Documents that in `reports.js`, **resolve and dismiss are treated identically** — both close an automod report and restore a still-held recipe to `active`; resolve is **not** a takedown. The contract is hide-first-then-close; the admin UI enforces it (Approve/Take-down only on held reports, excluded from bulk), and this server guard is the backstop for direct API calls.

## Verification
- Server Jest: **561/561** green (incl. updated `writeLimiter` suite).
- Reviewed live earlier in the worktree: full FE 400 pass / 2 skip, tsc clean, build OK, and a 14/14 live authed smoke against real Firebase + Mongo (content.blocked email fallback, approve-endpoint guards 401/403/409, self-service delete audit label) with test data torn down.

## Notes / deferred (from the same review, not in this PR)
- **Altitude:** "clear an automod hold" (restore recipe + close its open automod report) is assembled by hand in 3 places — a single `clearAutomodHold` helper would prevent a future close-path from re-introducing the strand bug. Left for a dedicated change.
- **Reuse:** `approveMutation` is duplicated between `Reports.tsx` and `AdminRecipeControls.tsx` — extract a `useApproveRecipe` hook.
- **Privacy:** the #148 email fallback now persists a raw account email in `auditLog.targetLabel` (admin-only, intended) — noting in case audit export / lower-priv admin tiers land later.
- **Ops:** the limiter store is in-memory per-process; on a multi-replica deploy the effective cap is `limit × replicas`. Fine on a single replica.