### PR TITLE
fix(reviews): remove-rating path + ratings-doc orphan cleanup

### DIFF
--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -310,13 +310,21 @@ All endpoints hit the main server (`VITE_API_URL`). Auth is via the interceptor 
 - **Auth:** Bearer token via interceptor only — server must extract `userId` from token to authorize the edit.
 - **Error handling:** No catch. Call site uses `.then()` with no error branch.
 
-### PUT /deleteReview
+### DELETE /deleteReview
 - **Called from:** `src/api/recipes.ts` → `RecipeAPI.deleteReview(recipeId)`
 - **Used by:** `RecipeReview.tsx`, `ConfirmDeleteReviewModal.tsx`
-- **Request:** Query params `userId` (resolved via `AuthAPI.getUID()`) and `recipeId`. No body.
-- **Response:** Not destructured
-- **Auth:** Bearer token via interceptor AND `userId` in query param (redundant — see Flags).
-- **Error handling:** No catch. Call site uses `await` with no try/catch.
+- **Request:** Query param `recipeId`. No body. No `userId` (author resolved from the Bearer token).
+- **Response:** `{ deleted: true }`
+- **Behavior:** Removes the written review but **keeps** any star rating the user left. If the doc has no rating to keep, the whole doc is deleted (no orphan with neither text nor rating). The recipe aggregate is unaffected, so it is not recomputed.
+- **Auth:** Bearer token via interceptor only — server extracts `userId` from the token; only the author's own doc can match.
+
+### DELETE /removeRating
+- **Called from:** `src/api/recipes.ts` → `RecipeAPI.removeRating(recipeId)`
+- **Used by:** `src/pages/SingleRecipe/DataSections/RatingsAndReviews/Ratings/Ratings.tsx`
+- **Request:** Query param `recipeId`. No body. No `userId` (author resolved from the Bearer token).
+- **Response:** `{ removed: true }` (404 if the user has no rating doc for the recipe).
+- **Behavior:** Removes **only** the star rating. If a written review exists it is kept (doc reset to the review-only shape, `rating: null`); otherwise the whole doc is deleted. The recipe aggregate is recomputed so the removed star stops counting toward the average.
+- **Auth:** Bearer token via interceptor only; only the author's own doc can match. Requires an active (non-suspended) account.
 
 ### GET /getReviews
 - **Called from:** `src/api/recipes.ts` → `RecipeAPI.getReviews(recipeId, filter, page, reviewsPerPage)`

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -324,7 +324,7 @@ All endpoints hit the main server (`VITE_API_URL`). Auth is via the interceptor 
 - **Request:** Query param `recipeId`. No body. No `userId` (author resolved from the Bearer token).
 - **Response:** `{ removed: true }`. Returns 404 only when the user has **no doc at all** for the recipe; it's an idempotent 200 no-op on a review-only doc (one already without a star rating).
 - **Behavior:** Removes **only** the star rating. If a written review exists it is kept (doc reset to the review-only shape, `rating: null`); otherwise the whole doc is deleted. The recipe aggregate is recomputed so the removed star stops counting toward the average.
-- **Auth:** Bearer token via interceptor only; only the author's own doc can match. Requires an active (non-suspended) account.
+- **Auth:** Bearer token via interceptor only; only the author's own doc can match. Like `/deleteReview`, this is a self-service removal of the user's own content, so it stays allowed even for a suspended/banned account (no `requireActive`).
 
 ### GET /getReviews
 - **Called from:** `src/api/recipes.ts` → `RecipeAPI.getReviews(recipeId, filter, page, reviewsPerPage)`

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -322,7 +322,7 @@ All endpoints hit the main server (`VITE_API_URL`). Auth is via the interceptor 
 - **Called from:** `src/api/recipes.ts` → `RecipeAPI.removeRating(recipeId)`
 - **Used by:** `src/pages/SingleRecipe/DataSections/RatingsAndReviews/Ratings/Ratings.tsx`
 - **Request:** Query param `recipeId`. No body. No `userId` (author resolved from the Bearer token).
-- **Response:** `{ removed: true }` (404 if the user has no rating doc for the recipe).
+- **Response:** `{ removed: true }`. Returns 404 only when the user has **no doc at all** for the recipe; it's an idempotent 200 no-op on a review-only doc (one already without a star rating).
 - **Behavior:** Removes **only** the star rating. If a written review exists it is kept (doc reset to the review-only shape, `rating: null`); otherwise the whole doc is deleted. The recipe aggregate is recomputed so the removed star stops counting toward the average.
 - **Auth:** Bearer token via interceptor only; only the author's own doc can match. Requires an active (non-suspended) account.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -10,14 +10,20 @@ Legend: `[ ]` todo · `[~]` partial · `[x]` done · `[?]` needs a decision.
 
 ## Bugs
 
-- `[ ]` **Deleting a review leaves the star rating behind** — there's no way to remove just a star
-  rating; you can only delete the review text. `deleteReview` blanks `reviewText`/`reviewLastUpdated`
-  but leaves the `rating` field on the doc (`server/routes/reviews.js:163`). Add a "remove rating"
-  path and have review deletion optionally clear the rating too. *(verified)*
+- `[~]` **Deleting a review leaves the star rating behind** — **fix implemented in PR #150 (open, track
+  1a)**: added `DELETE /removeRating` (clears just the star; keeps any review; deletes the doc when
+  rating-only), and `deleteReview` now keeps the rating and deletes the doc when there's nothing left —
+  no orphan with neither text nor rating. A "Remove rating" control was added to the recipe rating card.
+  Flip to `[x]` when #150 merges. *(verified; live authed smoke-test passed 2026-06-17)*
 - `[ ]` **Save-recipe functionality is broken** — needs a fix and test coverage.
 - `[ ]` **Account "Ratings" list renders inaccurately** — recipe images aren't loading for rated recipes.
-- `[ ]` **Rating aggregate went *down* after a 5-star** — observed the average drop when adding a
-  5-star rating; investigate `recomputeRecipeRating`.
+- `[~]` **Rating aggregate went *down* after a 5-star** — **root cause found (PR #150, track 1a):** the
+  `recomputeRecipeRating` math is correct; the drop is a **stale STORED aggregate** being corrected on
+  the next recompute. A live smoke test found *Homemade Granola* stored `5/4.6` while only 4 rating docs
+  actually exist (true avg `4.5`). PR #150 makes every rating change recompute + the UI refresh, so a
+  recipe self-heals the moment anyone rates it, and the displayed average no longer lags. **REMAINING
+  (does not block #150):** recipes nobody re-rates stay drifted → needs the one-off reconciliation in
+  Tech debt below.
 - `[ ]` **Serving price looks wrong** — recipe serving pricing appears miscalculated; audit
   `src/util/calculateServingPrice.ts` against real data.
 - `[ ]` **"Your Recipes" flashes an empty state** — the account section shows "no recipes" briefly
@@ -67,6 +73,17 @@ Legend: `[ ]` todo · `[~]` partial · `[x]` done · `[?]` needs a decision.
 
 ## Tech debt / process / infra
 
+- `[ ]` **One-off rating-aggregate reconciliation** — stored `recipes.rating` aggregates can drift from
+  the actual `ratings` docs (confirmed live: *Homemade Granola* stored `5/4.6` vs true `4/4.5`). Likely
+  legacy/pre-recompute data or a past silent best-effort failure. Write a script (alongside
+  `server/scripts/`) that loops every recipe and runs `recomputeRecipeRating(db, recipeId)`
+  (`server/util/recipeRating.js`) to reconcile the whole catalog in one pass. *(surfaced by track 1a /
+  PR #150, which only self-heals a recipe when someone next rates it.)*
+- `[ ]` **Harden `deleteAccount`'s rating recompute** — the per-recipe recompute after an account delete
+  is best-effort/post-commit and only `console.error`s on failure (`server/routes/auth.js` ~L447-454),
+  so a silent failure can re-introduce aggregate drift. The set of recipes is correct
+  (`distinct('recipeId', { userId })` covers rating-only docs); only the failure mode is silent. Consider
+  a periodic reconciliation job (pairs with the item above) or alerting on recompute failure. *(low priority)*
 - `[ ]` **Migrate Sass `@import` → `@use`** — build emits Sass `@import` deprecation warnings
   (pre-existing; Sass 1.x warns `@import` is going away in 3.x). Cosmetic now, worth migrating.
 - `[ ]` **Point Railway at the production branch** — currently not deploying from production.

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -43,9 +43,9 @@ same commit.**
 
 | Track | Title | Status | Branch / PR |
 |---|---|---|---|
-| 0a | Repo/secrets hygiene | `[ ]` | — |
+| 0a | Repo/secrets hygiene | `[x]` | #151 (merged) |
 | 0c | Infra (Jesse, dashboards) | `[ ]` | n/a |
-| 1a | Ratings/reviews bug | `[ ]` | — |
+| 1a | Ratings/reviews bug | `[P]` | `worktree-feat+delete-review-star-rating-fix` / #150 |
 | 1b | Save-recipe broken | `[ ]` | — |
 | 1c | Account data (images, empty-flash) | `[ ]` | — |
 | 1d | Serving-price bug | `[ ]` | — |
@@ -174,6 +174,11 @@ Append a one-liner when a track changes state (started / PR / merged). Keeps ses
 
 - _2026-06-17_ — Gameplan created; Track Board added. First wave defined (0a / 1a / 1d / 2a). Nothing
   started yet.
+- _2026-06-17_ — **0a merged** (#151). **1a → PR open (#150):** delete-review now keeps the rating +
+  new `DELETE /removeRating` + orphan cleanup; recompute on every rating change + UI refresh. Bug 2
+  ("avg dropped on a 5-star") root-caused = stale stored aggregate corrected on recompute (math is
+  correct); confirmed by a live authed smoke test. Two follow-ups filed in `BACKLOG.md` → Tech debt:
+  one-off catalog-wide aggregate reconciliation + harden `deleteAccount`'s best-effort recompute.
 
 ---
 

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -406,6 +406,30 @@ describe('DELETE /removeRating', () => {
     expect(recipe.rating.rateCount).toBe(1)
     expect(recipe.rating.rateValue).toBe(4)
   })
+
+  // Removing your own rating is a self-service delete, so it stays allowed even
+  // for a suspended/banned account (mirrors /deleteReview — no requireActive).
+  it('is allowed for a suspended account (self-service delete)', async () => {
+    const db = getDB()
+    await db.collection('users').insertOne({ _id: TEST_UID, status: 'suspended' })
+    await seedRating({
+      userId: TEST_UID,
+      username: TEST_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 4,
+      reviewText: '',
+      ratingLastUpdated: new Date(),
+    })
+    try {
+      const res = await request(app)
+        .delete(`/api/removeRating?recipeId=${RECIPE_ID}`)
+        .set(AUTH_HEADER)
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ removed: true })
+    } finally {
+      await db.collection('users').deleteMany({})
+    }
+  })
 })
 
 // ─── POST /newReview ───────────────────────────────────────────────────────────

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -133,6 +133,31 @@ describe('POST /addRating', () => {
     expect(recipe.rating.rateValue).toBe(4)
     expect(Number.isNaN(recipe.rating.rateValue)).toBe(false)
   })
+
+  // Bug 2 regression: adding a 5-star can never LOWER a correctly-stored
+  // average. Seed an existing 4-star from another user, then add a 5 → the
+  // aggregate must rise to 4.5 (count 2), proving the recompute math is sound.
+  it('adding a 5-star raises (never lowers) the average', async () => {
+    const db = getDB()
+    await seedRating({
+      userId: OTHER_UID,
+      username: OTHER_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 4,
+      reviewText: '',
+      ratingLastUpdated: new Date(),
+    })
+
+    const res = await request(app)
+      .post(`/api/addRating?recipeId=${RECIPE_ID}&rating=5`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+
+    const recipe = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.rating.rateCount).toBe(2)
+    expect(recipe.rating.rateValue).toBe(4.5)
+    expect(recipe.rating.rateValue).toBeGreaterThanOrEqual(4)
+  })
 })
 
 // ─── POST /editReview ──────────────────────────────────────────────────────────
@@ -228,7 +253,7 @@ describe('DELETE /deleteReview', () => {
     expect(res.status).toBe(403)
   })
 
-  it('allows the author to delete their own review', async () => {
+  it('allows the author to delete their own review but KEEPS the star rating', async () => {
     const res = await request(app)
       .delete(`/api/deleteReview?recipeId=${RECIPE_ID}`)
       .set(AUTH_HEADER)
@@ -240,7 +265,146 @@ describe('DELETE /deleteReview', () => {
     const doc = await db
       .collection('ratings')
       .findOne({ username: TEST_USERNAME, recipeId: RECIPE_ID })
+    // Review text gone, but the 3-star rating is retained on the doc.
     expect(doc.reviewText).toBe('')
+    expect(doc.rating).toBe(3)
+  })
+
+  // Orphan cleanup: deleting a review on a doc that has NO star rating must
+  // remove the whole doc, not leave one with neither text nor rating.
+  it('deletes the whole doc when the review had no rating to keep', async () => {
+    const db = getDB()
+    // Replace the rated fixture with a review-only doc (rating: null).
+    await db.collection('ratings').deleteMany({})
+    await seedRating({
+      userId: TEST_UID,
+      username: TEST_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: null,
+      reviewText: 'Review with no star rating',
+      reviewCreatedAt: '1000',
+      reviewLastUpdated: '1000',
+      ratingLastUpdated: '',
+    })
+
+    const res = await request(app)
+      .delete(`/api/deleteReview?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+
+    const doc = await db
+      .collection('ratings')
+      .findOne({ userId: TEST_UID, recipeId: RECIPE_ID })
+    expect(doc).toBeNull()
+  })
+})
+
+// ─── DELETE /removeRating ────────────────────────────────────────────────────
+// Bug 1: a user can remove just their star rating. The review (if any) is kept;
+// a rating-only doc is deleted outright so no orphan lingers; and the recipe
+// aggregate is recomputed so the removed star stops counting.
+
+describe('DELETE /removeRating', () => {
+  it('rejects request with no auth token (401)', async () => {
+    const res = await request(app).delete(`/api/removeRating?recipeId=${RECIPE_ID}`)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 if recipeId is missing', async () => {
+    const res = await request(app).delete('/api/removeRating').set(AUTH_HEADER)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when the user has no rating doc for the recipe', async () => {
+    const res = await request(app)
+      .delete(`/api/removeRating?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(404)
+  })
+
+  it('removes the star rating but KEEPS the review, and recomputes the average', async () => {
+    const db = getDB()
+    await seedRating({
+      userId: TEST_UID,
+      username: TEST_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 5,
+      reviewText: 'Loved it',
+      reviewCreatedAt: '1000',
+      reviewLastUpdated: '1000',
+      ratingLastUpdated: new Date(),
+    })
+
+    const res = await request(app)
+      .delete(`/api/removeRating?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ removed: true })
+
+    const doc = await db
+      .collection('ratings')
+      .findOne({ userId: TEST_UID, recipeId: RECIPE_ID })
+    // Review survives; the rating is cleared back to the review-only shape.
+    expect(doc).not.toBeNull()
+    expect(doc.reviewText).toBe('Loved it')
+    expect(doc.rating).toBeNull()
+
+    // The recipe aggregate drops the removed star — no ratings now → 0/0.
+    const recipe = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.rating.rateCount).toBe(0)
+    expect(recipe.rating.rateValue).toBe(0)
+  })
+
+  it('deletes the whole doc when removing a rating-only entry (no review)', async () => {
+    const db = getDB()
+    await seedRating({
+      userId: TEST_UID,
+      username: TEST_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 4,
+      reviewText: '',
+      ratingLastUpdated: new Date(),
+    })
+
+    const res = await request(app)
+      .delete(`/api/removeRating?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+
+    const doc = await db
+      .collection('ratings')
+      .findOne({ userId: TEST_UID, recipeId: RECIPE_ID })
+    expect(doc).toBeNull()
+  })
+
+  it('recomputes the average from the remaining ratings after one is removed', async () => {
+    const db = getDB()
+    // TEST_UID rated 2, OTHER_UID rated 4 → avg 3. Remove TEST_UID's → avg 4.
+    await seedRating({
+      userId: TEST_UID,
+      username: TEST_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 2,
+      reviewText: '',
+      ratingLastUpdated: new Date(),
+    })
+    await seedRating({
+      userId: OTHER_UID,
+      username: OTHER_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 4,
+      reviewText: '',
+      ratingLastUpdated: new Date(),
+    })
+
+    const res = await request(app)
+      .delete(`/api/removeRating?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+
+    const recipe = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.rating.rateCount).toBe(1)
+    expect(recipe.rating.rateValue).toBe(4)
   })
 })
 

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -7,7 +7,7 @@ const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { REVIEW_VISIBLE, RECIPE_VISIBLE } = require('../util/moderation')
 const { DESCRIPTION_MAX_LENGTH } = require('../util/recipeLimits')
 const { recordAudit } = require('../util/auditLog')
-const { recomputeRecipeRating } = require('../util/recipeRating')
+const { recomputeRecipeRating, hasNumericRating } = require('../util/recipeRating')
 const { upsertWithDupRetry } = require('../util/upsertWithDupRetry')
 const { notifyInBackground, notifyReviewTakenDown } = require('../util/email')
 const { moderateText } = require('../util/textModeration')
@@ -168,7 +168,7 @@ router.delete('/deleteReview', verifyToken, asyncHandler(async (req, res) => {
     return res.status(403).json({ error: 'Review not found or not authorized' })
   }
 
-  if (Number.isFinite(parseFloat(doc.rating))) {
+  if (hasNumericRating(doc.rating)) {
     // A real star rating remains — keep it, just clear the review text.
     await db.collection('ratings').updateOne(
       { userId, recipeId },
@@ -187,7 +187,10 @@ router.delete('/deleteReview', verifyToken, asyncHandler(async (req, res) => {
 // review intact. If there's no review either, the whole doc is deleted so we
 // never leave an orphan with neither a rating nor text. Either way the recipe
 // aggregate is recomputed so the removed star stops counting toward the average.
-router.delete('/removeRating', verifyToken, requireActive, asyncHandler(async (req, res) => {
+// No requireActive: like /deleteReview this is a self-service removal of the
+// user's own content, which stays allowed even for a suspended/banned account
+// (see user-status-enforcement: "deletes remain allowed when suspended").
+router.delete('/removeRating', verifyToken, asyncHandler(async (req, res) => {
   const db = getDB()
   const { recipeId } = req.query
   const userId = req.uid

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -150,7 +150,10 @@ router.post('/editReview', verifyToken, requireActive, reviewWriteLimiter, async
   res.json({ edited: true })
 }))
 
-// DELETE /deleteReview
+// DELETE /deleteReview — removes the written review but KEEPS any star rating
+// the user left (the rating is removed separately via /removeRating). If the
+// doc has no rating to keep, blanking the text would leave an orphan with
+// neither text nor rating, so the whole doc is deleted instead.
 router.delete('/deleteReview', verifyToken, asyncHandler(async (req, res) => {
   const db = getDB()
   const { recipeId } = req.query
@@ -160,14 +163,59 @@ router.delete('/deleteReview', verifyToken, asyncHandler(async (req, res) => {
   }
 
   // Keyed by the stable uid (D1) — only the author's own doc can match.
-  const deleteResult = await db.collection('ratings').updateOne(
-    { userId, recipeId },
-    { $set: { reviewText: '', reviewLastUpdated: '' } }
-  )
-  if (deleteResult.matchedCount === 0) {
+  const doc = await db.collection('ratings').findOne({ userId, recipeId })
+  if (!doc) {
     return res.status(403).json({ error: 'Review not found or not authorized' })
   }
+
+  if (Number.isFinite(parseFloat(doc.rating))) {
+    // A real star rating remains — keep it, just clear the review text.
+    await db.collection('ratings').updateOne(
+      { userId, recipeId },
+      { $set: { reviewText: '', reviewLastUpdated: '' } }
+    )
+  } else {
+    // No rating to keep — drop the doc so we never leave an empty orphan.
+    await db.collection('ratings').deleteOne({ userId, recipeId })
+  }
+  // The recipe aggregate is unaffected either way (the rating, if any, is kept;
+  // a rating-less orphan never counted), so no recompute is needed.
   res.json({ deleted: true })
+}))
+
+// DELETE /removeRating — removes JUST the star rating, keeping any written
+// review intact. If there's no review either, the whole doc is deleted so we
+// never leave an orphan with neither a rating nor text. Either way the recipe
+// aggregate is recomputed so the removed star stops counting toward the average.
+router.delete('/removeRating', verifyToken, requireActive, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { recipeId } = req.query
+  const userId = req.uid
+  if (!recipeId) {
+    return res.status(400).json({ error: 'recipeId is required' })
+  }
+
+  // Keyed by the stable uid (D1) — only the author's own doc can match.
+  const doc = await db.collection('ratings').findOne({ userId, recipeId })
+  if (!doc) {
+    return res.status(404).json({ error: 'Rating not found' })
+  }
+
+  const hasReview = typeof doc.reviewText === 'string' && doc.reviewText !== ''
+  if (hasReview) {
+    // Keep the review; reset to the review-only shape (rating: null).
+    await db.collection('ratings').updateOne(
+      { userId, recipeId },
+      { $set: { rating: null, ratingLastUpdated: '' } }
+    )
+  } else {
+    // Nothing left without the rating — drop the doc entirely.
+    await db.collection('ratings').deleteOne({ userId, recipeId })
+  }
+
+  // The removed star must no longer influence the recipe's score.
+  await recomputeRecipeRating(db, recipeId)
+  res.json({ removed: true })
 }))
 
 // GET /getReviews — anonymous-friendly. `optionalAuth` sets req.uid only when a

--- a/server/util/recipeRating.js
+++ b/server/util/recipeRating.js
@@ -1,6 +1,15 @@
 const { recipeIdQuery } = require('./recipeIdQuery')
 const { REVIEW_VISIBLE } = require('./moderation')
 
+// A ratings doc can be review-only (rating null/absent) or carry a real star
+// rating, which legacy data may store as a string ("5") or a number (5). This
+// is the single source of truth for "does this doc have a real numeric rating"
+// — parseFloat handles both shapes, and Number.isFinite rejects null/NaN so a
+// review-only doc never poisons an average or gets mistaken for a rating.
+function hasNumericRating(rating) {
+  return Number.isFinite(parseFloat(rating))
+}
+
 // Recompute and persist a recipe's aggregate rating from its ratings docs,
 // EXCLUDING any that have been taken down by moderation (REVIEW_VISIBLE). Called
 // whenever ratings change (new rating) or a review is hidden/restored, so a
@@ -14,7 +23,7 @@ async function recomputeRecipeRating(db, recipeId) {
   // A ratings doc can be review-only (posted before any star rating), so its
   // `rating` is null/absent. Count and average ONLY docs with a real numeric
   // rating — otherwise parseFloat(null) → NaN poisons the whole aggregate.
-  const ratings = docs.filter((r) => Number.isFinite(parseFloat(r.rating)))
+  const ratings = docs.filter((r) => hasNumericRating(r.rating))
   const rateCount = ratings.length
   const rateValue = rateCount
     ? ratings.reduce((sum, r) => sum + parseFloat(r.rating), 0) / rateCount
@@ -25,4 +34,4 @@ async function recomputeRecipeRating(db, recipeId) {
   return { rateCount, rateValue }
 }
 
-module.exports = { recomputeRecipeRating }
+module.exports = { recomputeRecipeRating, hasNumericRating }

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -436,6 +436,11 @@ class RecipeAPIClass {
     if (!AuthAPI.getUID()) return null
     return await http.delete(`api/deleteReview?recipeId=${recipeId}`)
   }
+  // Removes only the user's star rating (keeps any written review).
+  async removeRating(recipeId: string): Promise<AxiosResponse | null> {
+    if (!AuthAPI.getUID()) return null
+    return await http.delete(`api/removeRating?recipeId=${recipeId}`)
+  }
   async getReviews(
     recipeId: string,
     filter = 'new',

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Ratings/Ratings.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Ratings/Ratings.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import { BsStar } from 'react-icons/bs'
 import { Link } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 import StarRating from 'src/Components/StarRating/StarRating'
 import AuthAPI from 'src/api/auth'
 import RecipeAPI from 'src/api/recipes'
@@ -21,12 +22,28 @@ const Ratings: FC<RatingsProps> = ({
   ratingCount,
   recipeId,
 }) => {
-  const changeRating = (e: number) => {
-    RecipeAPI.addRating(recipeId, e)
-    setRating(e)
+  const queryClient = useQueryClient()
+  const uid = AuthAPI.getUID()
+
+  // After a rating change, refresh the recipe aggregate (the displayed
+  // "Average Rating") and the user's own rating so both reflect the server
+  // recompute rather than the stale page-load value.
+  const refreshRatingViews = () => {
+    queryClient.invalidateQueries({ queryKey: ['recipe', recipeId] })
+    queryClient.invalidateQueries({ queryKey: ['check-made', recipeId] })
   }
 
-  const uid = AuthAPI.getUID()
+  const changeRating = async (e: number) => {
+    setRating(e)
+    await RecipeAPI.addRating(recipeId, e)
+    refreshRatingViews()
+  }
+
+  const handleRemoveRating = async () => {
+    setRating(0)
+    await RecipeAPI.removeRating(recipeId)
+    refreshRatingViews()
+  }
 
   return (
     <div className='overview'>
@@ -55,6 +72,15 @@ const Ratings: FC<RatingsProps> = ({
                 onChange={changeRating}
               />
               <span className='rate-hint'>{rating > 0 ? `${rating} / 5` : 'Tap a star'}</span>
+              {rating > 0 && (
+                <button
+                  type='button'
+                  className='remove-rating'
+                  onClick={handleRemoveRating}
+                >
+                  Remove rating
+                </button>
+              )}
             </div>
           ) : (
             <Link to='/login' className='signin-rate'>

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Ratings/Ratings.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Ratings/Ratings.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react'
 import { BsStar } from 'react-icons/bs'
 import { Link } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
 import StarRating from 'src/Components/StarRating/StarRating'
 import AuthAPI from 'src/api/auth'
 import RecipeAPI from 'src/api/recipes'
@@ -34,14 +35,31 @@ const Ratings: FC<RatingsProps> = ({
   }
 
   const changeRating = async (e: number) => {
+    // Optimistic: show the new star immediately, but revert if the server
+    // rejects (e.g. a suspended account hitting requireActive, or a network
+    // failure) so the UI never shows a rating that wasn't actually saved.
+    const prev = rating
     setRating(e)
-    await RecipeAPI.addRating(recipeId, e)
+    try {
+      await RecipeAPI.addRating(recipeId, e)
+    } catch (err) {
+      setRating(prev)
+      toast.error('Could not save your rating. Please try again.')
+      return
+    }
     refreshRatingViews()
   }
 
   const handleRemoveRating = async () => {
+    const prev = rating
     setRating(0)
-    await RecipeAPI.removeRating(recipeId)
+    try {
+      await RecipeAPI.removeRating(recipeId)
+    } catch (err) {
+      setRating(prev)
+      toast.error('Could not remove your rating. Please try again.')
+      return
+    }
     refreshRatingViews()
   }
 

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
@@ -80,6 +80,22 @@
             @include s.outline();
           }
         }
+        .remove-rating {
+          background: none;
+          border: none;
+          padding: 0;
+          margin-left: 0.5rem;
+          font-size: 0.8125rem;
+          color: s.$secondary-text;
+          text-decoration: underline;
+          cursor: pointer;
+          &:hover {
+            color: s.$primary-text;
+          }
+          &:focus {
+            @include s.outline();
+          }
+        }
       }
 
       @media screen and (max-width: 450px) {

--- a/src/test/RatingsAndReviews.test.tsx
+++ b/src/test/RatingsAndReviews.test.tsx
@@ -97,6 +97,7 @@ describe('Ratings', () => {
     mockAddRating.mockReset()
     mockRemoveRating.mockReset()
     mockGetUID.mockReturnValue(null)
+    mockToast.error.mockClear()
   })
 
   it('shows "Sign In To Rate" with non-interactive display stars when no uid is available', async () => {
@@ -150,6 +151,30 @@ describe('Ratings', () => {
     await user.click(screen.getByText('Remove rating'))
     expect(setRating).toHaveBeenCalledWith(0)
     await waitFor(() => expect(mockRemoveRating).toHaveBeenCalledWith('recipe-1'))
+  })
+
+  it('reverts the optimistic star and shows a toast when addRating fails', async () => {
+    const user = userEvent.setup()
+    const setRating = vi.fn()
+    mockAddRating.mockRejectedValue(new Error('network'))
+    renderRatings('user-1', 0, 0, 0, setRating)
+    await user.click(screen.getByTestId('star-ratings-rating'))
+    // optimistic to 4, then reverted back to the prior value (0)
+    expect(setRating).toHaveBeenCalledWith(4)
+    await waitFor(() => expect(setRating).toHaveBeenLastCalledWith(0))
+    expect(mockToast.error).toHaveBeenCalled()
+  })
+
+  it('reverts the cleared star and shows a toast when removeRating fails', async () => {
+    const user = userEvent.setup()
+    const setRating = vi.fn()
+    mockRemoveRating.mockRejectedValue(new Error('network'))
+    renderRatings('user-1', 4, 1, 4, setRating)
+    await user.click(screen.getByText('Remove rating'))
+    // optimistic to 0, then reverted back to the prior rating (4)
+    expect(setRating).toHaveBeenCalledWith(0)
+    await waitFor(() => expect(setRating).toHaveBeenLastCalledWith(4))
+    expect(mockToast.error).toHaveBeenCalled()
   })
 })
 

--- a/src/test/RatingsAndReviews.test.tsx
+++ b/src/test/RatingsAndReviews.test.tsx
@@ -17,6 +17,7 @@ const createTestQueryClient = () =>
 vi.mock('src/api/recipes', () => ({
   default: {
     addRating: vi.fn(),
+    removeRating: vi.fn(),
     getReviews: vi.fn().mockResolvedValue({ reviews: [], totalCount: 0 }),
     newReview: vi.fn(),
     editReview: vi.fn(),
@@ -48,6 +49,7 @@ const mockToast = vi.hoisted(() => Object.assign(vi.fn(), { success: vi.fn(), er
 vi.mock('react-hot-toast', () => ({ default: mockToast }))
 
 const mockAddRating = RecipeAPI.addRating as ReturnType<typeof vi.fn>
+const mockRemoveRating = RecipeAPI.removeRating as ReturnType<typeof vi.fn>
 const mockNewReview = RecipeAPI.newReview as ReturnType<typeof vi.fn>
 const mockEditReview = RecipeAPI.editReview as ReturnType<typeof vi.fn>
 const mockDeleteReview = RecipeAPI.deleteReview as ReturnType<typeof vi.fn>
@@ -68,23 +70,32 @@ const baseReview = {
 // ─── Ratings ─────────────────────────────────────────────────────────────────
 
 describe('Ratings', () => {
-  const renderRatings = (uid: string | null = null, ratingVal = 0, ratingCount = 0) => {
+  const renderRatings = (
+    uid: string | null = null,
+    ratingVal = 0,
+    ratingCount = 0,
+    rating = 0,
+    setRating = vi.fn()
+  ) => {
     mockGetUID.mockReturnValue(uid)
     return render(
-      <MemoryRouter>
-        <Ratings
-          rating={0}
-          setRating={vi.fn()}
-          ratingVal={ratingVal}
-          ratingCount={ratingCount}
-          recipeId='recipe-1'
-        />
-      </MemoryRouter>
+      <QueryClientProvider client={createTestQueryClient()}>
+        <MemoryRouter>
+          <Ratings
+            rating={rating}
+            setRating={setRating}
+            ratingVal={ratingVal}
+            ratingCount={ratingCount}
+            recipeId='recipe-1'
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
     )
   }
 
   beforeEach(() => {
     mockAddRating.mockReset()
+    mockRemoveRating.mockReset()
     mockGetUID.mockReturnValue(null)
   })
 
@@ -119,6 +130,26 @@ describe('Ratings', () => {
     renderRatings(null, 4, 10)
     expect(screen.getByText(/4\.0/)).toBeInTheDocument()
     expect(screen.getByText('(10)')).toBeInTheDocument()
+  })
+
+  it('does NOT show "Remove rating" when the user has no rating', () => {
+    renderRatings('user-1', 0, 0, 0)
+    expect(screen.queryByText('Remove rating')).toBeNull()
+  })
+
+  it('shows "Remove rating" once the user has a rating', () => {
+    renderRatings('user-1', 4, 1, 4)
+    expect(screen.getByText('Remove rating')).toBeInTheDocument()
+  })
+
+  it('clicking "Remove rating" calls RecipeAPI.removeRating and clears the local rating', async () => {
+    const user = userEvent.setup()
+    const setRating = vi.fn()
+    mockRemoveRating.mockResolvedValue(undefined)
+    renderRatings('user-1', 4, 1, 4, setRating)
+    await user.click(screen.getByText('Remove rating'))
+    expect(setRating).toHaveBeenCalledWith(0)
+    await waitFor(() => expect(mockRemoveRating).toHaveBeenCalledWith('recipe-1'))
   })
 })
 


### PR DESCRIPTION
## Summary
Two related ratings bugs in the reviews subsystem.

### Bug 1 (fixed): deleting a review left the star rating behind
- `DELETE /deleteReview` previously only blanked `reviewText`, leaving the `rating` field intact, and there was no way to remove a rating on its own.
- **UX chosen:** deleting a review *keeps* the rating; a separate **"Remove rating"** control on the recipe rating card removes just the star.
- New **`DELETE /removeRating`**: clears the star rating, keeps any written review (`rating: null`), or deletes the whole doc when it was rating-only. Recomputes the recipe aggregate (`recomputeRecipeRating`).
- `deleteReview` now keeps the rating, and deletes the whole doc when there's no rating to keep — so we never leave an **orphan** doc with neither text nor rating.

### Bug 2 (investigated): "average dropped after adding a 5-star"
- Traced `recomputeRecipeRating` + the `addRating` upsert. The math is **correct**: it averages only visible docs with a finite numeric rating (review-only `null`s excluded). Adding a 5-star can never lower a correctly-stored average.
- Root cause of the *observed* drop was **frontend staleness**: the rating card fired `addRating` without refreshing the page-load aggregate, so a later reload surfaced the (correct) recomputed value, which could look like a drop versus a stale higher value.
- **Fix:** invalidate the `['recipe', id]` + `['check-made', id]` queries after add/remove so the displayed average reflects the server recompute live.
- Added a regression test asserting adding a 5-star raises (never lowers) the average.

## Tests
- Server (Jest): **569 green** — new `removeRating` suite, `deleteReview` orphan-cleanup, and 5-star regression.
- Frontend (Vitest): **403 green** — "Remove rating" control behavior.
- `tsc --noEmit` clean, production build passing.

## Scope
Stayed within the reviews/ratings subsystem (`server/routes/reviews.js`, `util/recipeRating`, `RatingsAndReviews/*`, `api/recipes.ts`). No review-UI redesign. API contract doc updated.