### PR TITLE
fix(price): correct recipe serving-price calculation

### DIFF
--- a/server/scripts/backfillServingPrice.js
+++ b/server/scripts/backfillServingPrice.js
@@ -1,0 +1,163 @@
+/**
+ * Backfill — recompute and correct the stored `servingPrice` on existing recipes.
+ *
+ * Why: `servingPrice` is computed once at create/edit time (client-side, via
+ * src/util/calculateServingPrice.ts) and stored on the recipe doc. A bug in that
+ * util (fixed in PR #152) divided the total cost by `numServings` TWICE and then
+ * rounded up to the nearest whole dollar, so historical recipes carry wrong
+ * values — typically a flat $1.00/serving regardless of real cost. New/edited
+ * recipes already recompute with the corrected formula; this script fixes the
+ * docs that haven't been touched since.
+ *
+ * The recompute below MIRRORS src/util/calculateServingPrice.ts exactly:
+ *   servingPrice = round( sum(ingredient.ingredientData.totalPriceUSACents) / servings )
+ * counting only real ingredient rows (those with a `parsedIngredient`) and
+ * skipping NaN prices. Keep the two in sync if the util changes.
+ *
+ * SAFE BY DEFAULT: this is a DRY RUN unless you pass --apply. The dry run reads
+ * only — it counts what would change and prints a sample of before/after values
+ * so you can eyeball them against a prod snapshot first.
+ *
+ * Idempotent: only recipes whose recomputed price DIFFERS from the stored value
+ * are written, so a second --apply run is a no-op. Recipes with non-positive or
+ * missing `servings` are skipped (the util returns 0 for those — we don't clobber
+ * an existing value over a bad divisor) and listed as anomalies.
+ *
+ * Usage:
+ *   node server/scripts/backfillServingPrice.js            # dry run (default)
+ *   node server/scripts/backfillServingPrice.js --apply    # actually write
+ *
+ * Reads MONGO_URI from server/.env. Exit code 0 = success, 1 = error.
+ */
+const path = require('path')
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') })
+const { MongoClient } = require('mongodb')
+
+const APPLY = process.argv.includes('--apply')
+const SAMPLE_LIMIT = 25 // how many before/after rows to print
+
+// Mirror of src/util/calculateServingPrice.ts. Returns whole cents.
+function calculateServingPrice(ingredientsList, numServings) {
+  if (!Array.isArray(ingredientsList) || numServings <= 0) return 0
+  let totalRecipeCents = 0
+  for (const ingr of ingredientsList) {
+    if (ingr && 'parsedIngredient' in ingr && ingr.ingredientData) {
+      const ingrPrice = Number(ingr.ingredientData.totalPriceUSACents)
+      if (!Number.isNaN(ingrPrice)) totalRecipeCents += ingrPrice
+    }
+  }
+  return Math.round(totalRecipeCents / numServings)
+}
+
+const fmt = (cents) =>
+  cents == null || Number.isNaN(Number(cents))
+    ? String(cents)
+    : `$${(Number(cents) / 100).toFixed(2)}`
+
+async function main() {
+  const uri = process.env.MONGO_URI
+  if (!uri) {
+    console.error('MONGO_URI is not set (looked in server/.env).')
+    process.exit(1)
+  }
+
+  const client = new MongoClient(uri, {
+    tls: true,
+    serverSelectionTimeoutMS: 5000,
+    socketTimeoutMS: 45000,
+    maxPoolSize: 10,
+  })
+
+  try {
+    await client.connect()
+    const db = client.db('prepify')
+    console.log(
+      `Connected to MongoDB (prepify). Mode: ${APPLY ? 'APPLY (writing)' : 'DRY RUN (read-only)'}\n`
+    )
+
+    const col = db.collection('recipes')
+
+    let scanned = 0
+    let changed = 0 // recompute differs from stored → (would) update
+    let unchanged = 0 // already correct
+    let written = 0 // actually updated (APPLY only)
+    const anomalies = [] // { id, title, servings } — bad/missing servings, skipped
+    const samples = [] // { id, title, servings, before, after }
+
+    const cursor = col.find(
+      {},
+      { projection: { ingredients: 1, servings: 1, servingPrice: 1, title: 1 } }
+    )
+
+    for await (const doc of cursor) {
+      scanned++
+      const servings = Number(doc.servings)
+
+      if (!Number.isFinite(servings) || servings <= 0) {
+        anomalies.push({ id: String(doc._id), title: doc.title, servings: doc.servings })
+        continue
+      }
+
+      const before = doc.servingPrice
+      const after = calculateServingPrice(doc.ingredients, servings)
+
+      if (Number(before) === after) {
+        unchanged++
+        continue
+      }
+
+      changed++
+      if (samples.length < SAMPLE_LIMIT) {
+        samples.push({ id: String(doc._id), title: doc.title, servings, before, after })
+      }
+
+      if (APPLY) {
+        await col.updateOne({ _id: doc._id }, { $set: { servingPrice: after } })
+        written++
+      }
+    }
+
+    console.log('Sample of recipes that ' + (APPLY ? 'were' : 'would be') + ' corrected')
+    console.log('─'.repeat(60))
+    if (samples.length === 0) {
+      console.log('  (none — every recipe already has the correct servingPrice)')
+    } else {
+      for (const s of samples) {
+        console.log(
+          `  ${s.id}  "${s.title ?? '(untitled)'}"  servings=${s.servings}\n` +
+            `      ${fmt(s.before)}/serving  →  ${fmt(s.after)}/serving`
+        )
+      }
+      if (changed > samples.length) {
+        console.log(`  …and ${changed - samples.length} more not shown.`)
+      }
+    }
+
+    console.log('\nSummary')
+    console.log('───────')
+    console.log(`  scanned:    ${scanned} recipe(s)`)
+    console.log(`  ${APPLY ? 'updated' : 'would update'}: ${APPLY ? written : changed}`)
+    console.log(`  unchanged:  ${unchanged} (already correct)`)
+    console.log(`  skipped:    ${anomalies.length} (servings missing or <= 0 — left untouched)`)
+    if (anomalies.length) {
+      console.log('    Anomalies (need a manual look — divisor is invalid):')
+      for (const a of anomalies) {
+        console.log(`      - ${a.id} "${a.title ?? '(untitled)'}" servings=${JSON.stringify(a.servings)}`)
+      }
+    }
+
+    if (!APPLY) {
+      console.log('\nDRY RUN — nothing was written. Re-run with --apply to commit.')
+    } else {
+      console.log('\nDone. Backfill applied.')
+    }
+    process.exit(0)
+  } catch (err) {
+    console.error('\nBackfill failed:', err.message)
+    process.exit(1)
+  } finally {
+    await client.close().catch(() => {})
+  }
+}
+
+main()

--- a/src/test/calculateServingPrice.test.ts
+++ b/src/test/calculateServingPrice.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { calculateServingPrice } from 'src/util/calculateServingPrice'
+import { IngredientsType } from 'types'
+
+// Minimal ingredient factory: the util only reads `parsedIngredient` (presence)
+// and `ingredientData.totalPriceUSACents`, so we stub just enough to satisfy the
+// type guard. `totalPriceUSACents` is the cost of the full quantity used in the
+// recipe (in cents), per the @jclind/ingredient-parser contract.
+const ingr = (totalPriceUSACents: number | undefined): IngredientsType =>
+  ({
+    id: Math.random().toString(),
+    parsedIngredient: {} as never,
+    ingredientData: { totalPriceUSACents } as never,
+  } as IngredientsType)
+
+// A non-ingredient label row (section header). Has no `parsedIngredient`/data
+// and must be ignored by the sum.
+const label: IngredientsType = { id: 'lbl', label: 'For the sauce' }
+
+describe('calculateServingPrice', () => {
+  it('returns total grocery cost divided by servings, in cents', () => {
+    // 600 + 400 = 1000 cents total over 4 servings = 250 cents/serving.
+    const result = calculateServingPrice([ingr(600), ingr(400)], 4)
+    expect(result).toBe(250)
+  })
+
+  it('does NOT double-divide by servings (regression for the core bug)', () => {
+    // Total 1000 cents over 4 servings must be 250, not 1000/4/4 = 62.5.
+    expect(calculateServingPrice([ingr(1000)], 4)).toBe(250)
+  })
+
+  it('preserves sub-dollar precision instead of rounding up to whole dollars', () => {
+    // 150 cents over 1 serving = $1.50. The old impl snapped this up to $2.00
+    // (Math.ceil(x/100)*100). It should stay 150.
+    expect(calculateServingPrice([ingr(150)], 1)).toBe(150)
+  })
+
+  it('rounds to the nearest whole cent', () => {
+    // 100 cents over 3 servings = 33.33… → 33.
+    expect(calculateServingPrice([ingr(100)], 3)).toBe(33)
+    // 200 cents over 3 servings = 66.66… → 67.
+    expect(calculateServingPrice([ingr(200)], 3)).toBe(67)
+  })
+
+  it('returns 0 for zero or negative servings (no divide-by-zero)', () => {
+    expect(calculateServingPrice([ingr(500)], 0)).toBe(0)
+    expect(calculateServingPrice([ingr(500)], -2)).toBe(0)
+  })
+
+  it('returns 0 for an empty ingredient list', () => {
+    expect(calculateServingPrice([], 4)).toBe(0)
+  })
+
+  it('ignores label rows that carry no price data', () => {
+    const result = calculateServingPrice([label, ingr(800), label], 2)
+    expect(result).toBe(400)
+  })
+
+  it('skips ingredients whose price is missing or non-numeric', () => {
+    // undefined → NaN; must be treated as 0 rather than poisoning the sum.
+    const result = calculateServingPrice([ingr(600), ingr(undefined)], 2)
+    expect(result).toBe(300)
+  })
+
+  it('handles a single-serving recipe (total == per-serving price)', () => {
+    expect(calculateServingPrice([ingr(325), ingr(175)], 1)).toBe(500)
+  })
+
+  it('handles fractional input cents from the parser', () => {
+    // The parser can return fractional cents (e.g. 75.71). 75.71 + 24.29 = 100
+    // over 2 servings = 50.
+    expect(calculateServingPrice([ingr(75.71), ingr(24.29)], 2)).toBe(50)
+  })
+})

--- a/src/util/calculateServingPrice.ts
+++ b/src/util/calculateServingPrice.ts
@@ -1,19 +1,23 @@
 import { IngredientsType } from 'types'
 
+// Each ingredient's `totalPriceUSACents` is the cost (in cents) of the full
+// quantity used in the recipe, so summing them across all ingredients gives the
+// total grocery cost. The per-serving price is simply that total divided by the
+// number of servings. Result is returned in whole cents — callers render it as a
+// dollar string via `formatPrice` / `.toFixed(2)`.
 export const calculateServingPrice = (
   ingredientsList: IngredientsType[],
   numServings: number
 ) => {
   if (numServings <= 0) return 0
 
-  let priceForAllServings = 0
+  let totalRecipeCents = 0
   ingredientsList.forEach(ingr => {
     if ('parsedIngredient' in ingr && ingr.ingredientData) {
       const ingrPrice = Number(ingr.ingredientData.totalPriceUSACents)
-      const singleServingIngrPrice = ingrPrice / numServings
-      priceForAllServings += singleServingIngrPrice
+      if (!isNaN(ingrPrice)) totalRecipeCents += ingrPrice
     }
   })
-  const servingPrice = priceForAllServings / numServings
-  return Math.ceil(servingPrice / 100) * 100
+
+  return Math.round(totalRecipeCents / numServings)
 }


### PR DESCRIPTION
## What & why

`calculateServingPrice` produced wrong per-serving prices for every recipe. Two bugs compounded:

1. **Double division by `numServings`.** The loop accumulated `ingrPrice / numServings` into `priceForAllServings` — so after the loop that variable *already held* the per-serving total. The function then divided **again** (`priceForAllServings / numServings`), giving `total / numServings²`.
2. **Round-up to the nearest whole dollar.** `Math.ceil(servingPrice / 100) * 100` snapped the cents result up to a whole dollar, so every serving rendered as `$X.00` and the cents-precision display (`formatPrice` / `.toFixed(2)`) was meaningless.

Net effect: prices were understated by the double-divide, then bucketed into whole dollars — so most recipes showed `$1.00`.

## The fix

Sum each ingredient's `totalPriceUSACents` (the cost of the full quantity used in the recipe) into the total grocery cost, divide **once** by servings, and round to the nearest whole cent. Also skip `NaN` prices so a single missing price no longer poisons the whole sum.

## Before / after — real recipe

**"Egg Friend Rice"** — 4 servings, total grocery cost **$3.05** (sum of ingredient prices: rice 151.42¢, eggs 48¢, oil 11.83¢, mixed veg 46.14¢, garlic 13.34¢, soy sauce 20.11¢, sesame oil 5.93¢, green onions 7.92¢ = 304.69¢).

| | Per serving | Recipe total (price × servings) |
|---|---|---|
| **Before** (stored value: `100`) | `$1.00` | `$4.00` |
| **After** | `$0.76` | `$3.05` ✓ matches actual grocery cost |

The currently-stored `servingPrice` of `100` exactly reproduces the old buggy formula (`ceil((304.69/4/4)/100)*100`), confirming the bug is live in production data.

## Tests

New `src/test/calculateServingPrice.test.ts` (10 cases): the double-division regression, sub-dollar precision, nearest-cent rounding, label-row skipping, NaN/missing-price handling, zero/negative servings, single-serving, and fractional parser cents.

## Checks
- `npx vitest run` — 410 passed / 2 skipped (58 files), incl. the new suite
- `npx tsc --noEmit` — clean
- `npm run build` — passes (pre-existing chunk-size warning only)

## Scope / notes
- Scoped to `src/util/calculateServingPrice.ts` + its test. No single-recipe-page restyling (price *prominence* is a separate polish track).
- **Existing recipes keep their old stored `servingPrice`** — only newly created/edited recipes recompute. A one-time backfill to recompute stored prices is worth a follow-up (relates to the "post-refactor DB check" backlog item).


---

## Follow-up included: data backfill for existing recipes

`servingPrice` is stored at create/edit time, so recipes not touched since this fix keep the old buggy value. Added `server/scripts/backfillServingPrice.js` to recompute and correct them — mirrors the util's formula, **dry-run by default** (`--apply` to write), idempotent, skips recipes with invalid `servings`.

Validated against the live DB (dry run): **11/11** recipes would be corrected, 0 anomalies. Sample:

```
Egg Friend Rice (4 servings):        $1.00 → $0.76
Yogurt and Fruit Parfaits (4):       $3.00 → $10.85
Cheesy Sausage One Pot Pasta (6):    $1.00 → $1.97
Zesty Blueberry & Almond Muffins(12):$1.00 → $0.73
```

Every stored "before" is a flat whole-dollar value — the bug signature. **Run `node server/scripts/backfillServingPrice.js --apply` against prod after merge/deploy.**
