### PR TITLE
feat(home): personalized "For You" row (content-based recs)

### DIFF
--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -49,7 +49,7 @@ same commit.**
 | 1b | Save-recipe broken | `[ ]` | — |
 | 1c | Account data (images, empty-flash) | `[ ]` | — |
 | 1d | Serving-price bug | `[ ]` | — |
-| 2a | Homepage redesign | `[ ]` | — |
+| 2a | Homepage redesign (design shipped; For You row in progress) | `[~]` | feat/homepage-redesign |
 | 2b | Public Help/Contact page | `[ ]` | — |
 | 2c | Single-recipe polish | `[ ]` | — |
 | 2d | Recipes browse polish | `[ ]` | — |
@@ -110,7 +110,7 @@ All isolated files — safe to run together.
 
 | Track | Work | Domain |
 |---|---|---|
-| **2a** Homepage redesign *(blocker)* | richer landing page (value prop, featured/seasonal, data blocks) | `src/pages/Home/*` |
+| **2a** Homepage redesign *(design shipped; feature work in progress)* | redesign live (`HomeHero → Trending → Browse by meal`). Remaining = features: **For You** personalized row (in progress), **"What should I cook?"** button (next) | `src/pages/Home/*`, `server/routes/recipes.js`, `server/util/forYou.js` |
 | **2b** Public Help/Contact *(blocker)* | move route out of `PrivateRoute`, add a public link (footer/nav), refresh layout | `src/pages/Help/*`, **`App.tsx`**, Navbar link |
 | **2c** Single-recipe polish | serving-price prominence, "You created this" mobile styling, stats row styling, `RecipeNotFound` visual, "Your Review" UI + rating-dropdown position | `src/pages/SingleRecipe/*` |
 | **2d** Recipes browse polish | better no-results indicator, autocomplete redesign + autocorrect, drop search from the top-most navbar on /recipes | `src/pages/Recipes/*`, `SearchRecipesInput`, Navbar |
@@ -229,14 +229,18 @@ Do: audit src/util/calculateServingPrice.ts against real recipe data — trace h
 Guardrails: scope to src/util/calculateServingPrice.ts and its direct callers/tests. Don't restyle the single-recipe page (price *prominence* is a separate polish track). Keep frontend tests green, tsc clean, build passing. Open a PR into development when green, and in the PR description show a before/after for a concrete recipe so the fix is reviewable.
 ```
 
-### Track 2a · Homepage redesign
+### Track 2a · Homepage features (redesign already shipped)
 
-```
-/worktree-create homepage redesign
+The visual redesign shipped earlier (`e1539c3`): Home is `HomeHero → Trending → Browse by meal → View
+all`. Remaining 2a work is **feature**, not design, sourced from `docs/FEATURE_IDEAS.md`:
 
-Read docs/RELEASE_GAMEPLAN.md (track 2a) and docs/RELEASE_PLAN.md (Section D "Homepage redesign", blocker). The current src/pages/Home/Home.tsx is sparse — only <HomeHero /> and <TrendingRecipes />. Goal: a richer, more polished landing page worthy of a 1.0.
+1. **Personalized "For You" row** *(in progress, `feat/homepage-redesign`)* — a content-based row inferred
+   from the user's saves/makes/ratings. Server: `GET /api/getForYouRecipes` (`verifyToken`) + pure scoring
+   helper `server/util/forYou.js`. Client: `HomeForYou` (gated on auth, hides until personalized) reusing the
+   extracted `HomeRecipeCard`. Decisions: hide-until-personalized, fresh each visit (shuffle top tier),
+   balanced cuisine/meal/diet scoring with community quality as tie-breaker.
+2. **"What should I cook?" button** *(next)* — one `HomeHero` button that picks a random on-taste recipe.
 
-This is a DESIGN task — before building, propose 1–2 layout directions (value-prop section, featured/seasonal/trending content, how-it-works, social proof, CTA to browse/create) and a section order, then implement the chosen direction. Use the existing design language (palette, spacing, components) — reuse RecipeCard/TrendingRecipes rather than reinventing. Must be fully responsive (test at 390px) with sensible empty/loading states for any data it fetches.
-
-Guardrails: stay within src/pages/Home/* (Home.tsx, HomeHero/*, and src/Components/TrendingRecipes/* if needed). Do NOT touch src/App.tsx routes, the Navbar, or global SCSS partials (avoids colliding with other worktrees). Don't touch the beta tag. Drive the running app to screenshot the result before/after. Keep tests green, tsc clean, build passing. Open a PR into development when green, with screenshots.
-```
+Guardrails for these: stay within `src/pages/Home/*` + `src/api/recipes.ts` + `server/routes/recipes.js` +
+`server/util/forYou.js`. Don't touch the beta tag. Keep tests green, tsc clean, build passing. PR into
+development when green.

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -228,13 +228,16 @@ Chunky design efforts that are bigger than a single checkbox. Tag each as **(blo
     usages (Home hero, `src/Components/Navbar/menu/`).
   - Gates nothing for 1.0 — tracked here so it isn't lost.
 
-- `[ ]` **Homepage redesign** — **(blocker)**
-  - **Now:** `src/pages/Home/Home.tsx` is sparse — it renders only `<HomeHero />` and
-    `<TrendingRecipes />`. No value-prop sections, feature highlights, or rich link/data blocks.
-  - **Goal:** _(fill in)_ — a richer landing page with more sections, links, and website data
-    (value prop, featured/seasonal content, etc.).
-  - **Touches:** `src/pages/Home/Home.tsx`, `src/pages/Home/HomeHero/HomeHero.tsx` (+ `.scss`), and
-    likely `src/Components/TrendingRecipes/`.
+- `[x]` **Homepage redesign** — **(design shipped)**
+  - **Shipped:** the redesign landed earlier (`e1539c3`) — Home is now `HomeHero → Trending → Browse by
+    meal → View all recipes`, fully responsive with empty/loading states. The "sparse Home" wording here
+    was pre-redesign and is now stale.
+  - **Remaining Home work** is feature, not design — tracked from `docs/FEATURE_IDEAS.md`:
+    - `[~]` **Personalized "For You" row** — content-based row inferred from saves/makes/ratings
+      (`HomeForYou` + `GET /api/getForYouRecipes`). In progress on `feat/homepage-redesign`.
+    - `[ ]` **"What should I cook?" button** — random on-taste pick from `HomeHero`. Next up.
+  - **Touches:** `src/pages/Home/*` (`Home.tsx`, `HomeForYou.tsx`, `HomeRecipeCard.tsx`),
+    `src/api/recipes.ts`, `server/routes/recipes.js`, `server/util/forYou.js`.
 
 - `[ ]` **Help / Contact Support page** — **(blocker)**
   - **Now:** the page already exists — `src/pages/Help/Help.tsx` (routed `/help`) is a Formspree form

--- a/server/__tests__/forYou.test.js
+++ b/server/__tests__/forYou.test.js
@@ -1,0 +1,326 @@
+const {
+  MIN_SIGNAL,
+  buildTasteProfile,
+  interactionWeight,
+  tasteScore,
+  qualityScore,
+  scoreRecipe,
+  selectForYou,
+  shuffle,
+} = require('../util/forYou')
+
+// Hand-build a profile (the same shape buildTasteProfile returns) so scoring
+// tests control affinities exactly.
+const profileOf = ({ cuisine = {}, meal = {}, diet = {} }) => {
+  const toMap = (o) => new Map(Object.entries(o))
+  const maxPos = (o) => Object.values(o).reduce((m, v) => (v > m ? v : m), 0)
+  return {
+    cuisine: toMap(cuisine),
+    meal: toMap(meal),
+    diet: toMap(diet),
+    max: { cuisine: maxPos(cuisine), meal: maxPos(meal), diet: maxPos(diet) },
+  }
+}
+
+describe('interactionWeight', () => {
+  it('sums made + saved + rating signals for one recipe', () => {
+    // made(3) + saved(2) + rated-5(3) = 8
+    expect(interactionWeight({ made: true, saved: true, rating: 5 })).toBe(8)
+  })
+
+  it('weights made above saved', () => {
+    expect(interactionWeight({ made: true })).toBeGreaterThan(
+      interactionWeight({ saved: true })
+    )
+  })
+
+  it('is negative for a low rating (avoid signal)', () => {
+    expect(interactionWeight({ rating: 1 })).toBeLessThan(0)
+    expect(interactionWeight({ rating: 2 })).toBeLessThan(0)
+  })
+
+  it('is neutral (0) for a 3-star rating', () => {
+    expect(interactionWeight({ rating: 3 })).toBe(0)
+  })
+
+  it('ignores a null/absent rating', () => {
+    expect(interactionWeight({ saved: true, rating: null })).toBe(2)
+  })
+})
+
+describe('buildTasteProfile', () => {
+  it('accumulates weighted affinity per feature dimension', () => {
+    const profile = buildTasteProfile([
+      { recipe: { cuisine: 'Italian', mealTypes: ['dinner'], nutritionLabels: ['vegan'] }, weight: 3 },
+      { recipe: { cuisine: 'Italian', mealTypes: ['lunch'], nutritionLabels: [] }, weight: 2 },
+      { recipe: { cuisine: 'Thai', mealTypes: ['dinner'], nutritionLabels: [] }, weight: -2 },
+    ])
+    expect(profile.cuisine.get('Italian')).toBe(5)
+    expect(profile.cuisine.get('Thai')).toBe(-2)
+    expect(profile.meal.get('dinner')).toBe(1) // 3 + (-2)
+    expect(profile.meal.get('lunch')).toBe(2)
+    expect(profile.diet.get('vegan')).toBe(3)
+    // max tracks the largest positive affinity per dimension (for normalization)
+    expect(profile.max.cuisine).toBe(5)
+    expect(profile.max.meal).toBe(2)
+  })
+
+  it('skips empty feature values', () => {
+    const profile = buildTasteProfile([
+      { recipe: { cuisine: '', mealTypes: [], nutritionLabels: [] }, weight: 3 },
+    ])
+    expect(profile.cuisine.size).toBe(0)
+  })
+
+  it('skips zero-weight interactions (e.g. a lone 3-star rating)', () => {
+    // weight 0 contributes nothing — a recipe whose only signal is a neutral
+    // 3-star rating must not register any affinity.
+    const profile = buildTasteProfile([
+      { recipe: { cuisine: 'Italian', mealTypes: ['dinner'], nutritionLabels: [] }, weight: 0 },
+    ])
+    expect(profile.cuisine.size).toBe(0)
+    expect(profile.meal.size).toBe(0)
+  })
+
+  it('tolerates a missing/null recipe in an interaction', () => {
+    const profile = buildTasteProfile([
+      { recipe: null, weight: 3 },
+      { recipe: { cuisine: 'Italian', mealTypes: [], nutritionLabels: [] }, weight: 2 },
+    ])
+    expect(profile.cuisine.get('Italian')).toBe(2)
+  })
+
+  it('returns empty maps and zero maxes for no interactions', () => {
+    const profile = buildTasteProfile([])
+    expect(profile.cuisine.size).toBe(0)
+    expect(profile.max).toEqual({ cuisine: 0, meal: 0, diet: 0 })
+  })
+})
+
+describe('tasteScore', () => {
+  const profile = profileOf({
+    cuisine: { Italian: 4, Thai: -2 },
+    meal: { dinner: 2 },
+    diet: { vegan: 2 },
+  })
+
+  it('is positive for a recipe matching a liked feature', () => {
+    // signed(4,4) === 1
+    expect(tasteScore({ cuisine: 'Italian', mealTypes: [], nutritionLabels: [] }, profile)).toBe(1)
+  })
+
+  it('is negative for a disliked feature', () => {
+    // signed(-2,4) === -0.5
+    expect(tasteScore({ cuisine: 'Thai', mealTypes: [], nutritionLabels: [] }, profile)).toBe(-0.5)
+  })
+
+  it('is exactly 0 for an unknown recipe (no affinity in any dimension)', () => {
+    expect(tasteScore({ cuisine: 'French', mealTypes: [], nutritionLabels: [] }, profile)).toBe(0)
+  })
+
+  it('sums the three dimensions equally (balanced)', () => {
+    // cuisine 1 + meal 1 + diet 1 === 3
+    expect(
+      tasteScore({ cuisine: 'Italian', mealTypes: ['dinner'], nutritionLabels: ['vegan'] }, profile)
+    ).toBe(3)
+  })
+
+  it('averages affinity across a multi-valued dimension', () => {
+    // mealTypes [dinner(2), lunch(0)] → mean 1 → signed(1,2) === 0.5
+    expect(
+      tasteScore({ cuisine: 'French', mealTypes: ['dinner', 'lunch'], nutritionLabels: [] }, profile)
+    ).toBe(0.5)
+  })
+
+  it('ignores a dimension the profile has no positive signal in', () => {
+    // profile has no meal/diet signal → only cuisine contributes
+    const cuisineOnly = profileOf({ cuisine: { Italian: 3 } })
+    expect(
+      tasteScore({ cuisine: 'Italian', mealTypes: ['dinner'], nutritionLabels: ['vegan'] }, cuisineOnly)
+    ).toBe(1)
+  })
+})
+
+describe('qualityScore', () => {
+  it('is 0 with no rating and no saves', () => {
+    expect(qualityScore({}, 10)).toBe(0)
+  })
+
+  it('scales with average star rating (half the weight)', () => {
+    // 0.5 * (5/5) + 0.5 * 0 === 0.5
+    expect(qualityScore({ rating: { rateValue: 5 } }, 0)).toBe(0.5)
+  })
+
+  it('normalizes save popularity against the catalog max (half the weight)', () => {
+    // 0.5 * 0 + 0.5 * (10/10) === 0.5
+    expect(qualityScore({ numTimesSaved: 10 }, 10)).toBe(0.5)
+  })
+
+  it('guards against a zero catalog max (no division by zero)', () => {
+    // numTimesSavedMax 0 → savePop contributes 0 regardless of numTimesSaved
+    expect(qualityScore({ numTimesSaved: 99 }, 0)).toBe(0)
+  })
+
+  it('blends rating and save popularity', () => {
+    // 0.5 * (4/5) + 0.5 * (5/10) === 0.4 + 0.25 === 0.65
+    expect(qualityScore({ rating: { rateValue: 4 }, numTimesSaved: 5 }, 10)).toBeCloseTo(0.65)
+  })
+})
+
+describe('scoreRecipe', () => {
+  const profile = profileOf({ cuisine: { Italian: 4, Thai: -2 }, meal: { dinner: 2 } })
+
+  it('scores a matching recipe positively', () => {
+    const score = scoreRecipe({ cuisine: 'Italian', mealTypes: ['dinner'] }, profile)
+    expect(score).toBeGreaterThan(0)
+  })
+
+  it('drives a disliked cuisine below zero', () => {
+    const score = scoreRecipe({ cuisine: 'Thai', mealTypes: [] }, profile)
+    expect(score).toBeLessThan(0)
+  })
+
+  it('gives an unknown recipe ~zero taste (only quality nudge)', () => {
+    const score = scoreRecipe(
+      { cuisine: 'French', mealTypes: [], nutritionLabels: [] },
+      profile
+    )
+    expect(score).toBe(0)
+  })
+
+  it('adds a small quality tie-breaker from rating + save popularity', () => {
+    const plain = scoreRecipe({ cuisine: 'Italian', mealTypes: ['dinner'] }, profile)
+    const loved = scoreRecipe(
+      { cuisine: 'Italian', mealTypes: ['dinner'], rating: { rateValue: 5 }, numTimesSaved: 10 },
+      profile,
+      10
+    )
+    expect(loved).toBeGreaterThan(plain)
+  })
+})
+
+describe('selectForYou', () => {
+  const profile = profileOf({ cuisine: { Italian: 3, Mexican: 3, Thai: -3 } })
+  const r = (id, cuisine) => ({ _id: id, cuisine, mealTypes: [], nutritionLabels: [] })
+
+  it('drops candidates with no positive taste match', () => {
+    const out = selectForYou(
+      [r('a', 'Italian'), r('b', 'Thai'), r('c', 'French')],
+      profile,
+      { rng: () => 0 }
+    )
+    const ids = out.map((x) => x._id)
+    expect(ids).toContain('a')
+    expect(ids).not.toContain('b') // disliked
+    expect(ids).not.toContain('c') // unknown → score 0
+  })
+
+  it('excludes a popular off-taste recipe despite its positive blended score', () => {
+    // The crux of the taste-vs-quality gate: a French recipe the user has no
+    // affinity for (taste 0) still has score = QUALITY_WEIGHT * quality > 0 once
+    // it carries a community rating + saves. It must NOT surface — quality is a
+    // tie-breaker among on-taste recipes, never an entry ticket on its own.
+    const lovedButOffTaste = {
+      _id: 'french-hit',
+      cuisine: 'French',
+      mealTypes: [],
+      nutritionLabels: [],
+      rating: { rateValue: 5 },
+      numTimesSaved: 100,
+    }
+    const onTastePlain = r('it', 'Italian')
+    const out = selectForYou([lovedButOffTaste, onTastePlain], profile, {
+      numTimesSavedMax: 100,
+      rng: () => 0,
+    })
+    const ids = out.map((x) => x._id)
+    expect(ids).toEqual(['it'])
+    expect(ids).not.toContain('french-hit')
+  })
+
+  it('excludes a disliked-cuisine recipe even when it is community-loved', () => {
+    const dislikedButLoved = {
+      _id: 'thai-hit',
+      cuisine: 'Thai', // profile affinity -3
+      mealTypes: [],
+      nutritionLabels: [],
+      rating: { rateValue: 5 },
+      numTimesSaved: 100,
+    }
+    const out = selectForYou([dislikedButLoved, r('it', 'Italian')], profile, {
+      numTimesSavedMax: 100,
+      rng: () => 0,
+    })
+    expect(out.map((x) => x._id)).toEqual(['it'])
+  })
+
+  it('uses quality to break ties among equally on-taste recipes', () => {
+    // Three equally on-taste recipes (taste identical); quality orders them. With
+    // limit 1 the relevant tier is the top 2 by blended score, so the lowest-
+    // quality one falls outside it and can never surface — whatever the shuffle
+    // draws. (The final slot is shuffled "fresh each visit", so we assert the
+    // exclusion, not which of the top two wins.)
+    const q = (id, rateValue, saves) => ({
+      _id: id,
+      cuisine: 'Mexican', // affinity +3, distinct from the Italian seeds below
+      mealTypes: [],
+      nutritionLabels: [],
+      rating: { rateValue },
+      numTimesSaved: saves,
+    })
+    const loved = q('loved', 5, 50)
+    const mid = q('mid', 4, 20)
+    const weak = q('weak', 1, 0)
+    for (const rng of [() => 0, () => 0.4, () => 0.99]) {
+      const out = selectForYou([weak, mid, loved], profile, {
+        limit: 1,
+        numTimesSavedMax: 50,
+        rng,
+      })
+      expect(out).toHaveLength(1)
+      expect(out[0]._id).not.toBe('weak')
+    }
+  })
+
+  it('caps at 2 recipes per cuisine for diversity', () => {
+    const candidates = [
+      r('i1', 'Italian'), r('i2', 'Italian'), r('i3', 'Italian'), r('i4', 'Italian'),
+      r('m1', 'Mexican'),
+    ]
+    const out = selectForYou(candidates, profile, { limit: 10, rng: () => 0 })
+    const italian = out.filter((x) => x.cuisine === 'Italian')
+    expect(italian).toHaveLength(2)
+    expect(out.filter((x) => x.cuisine === 'Mexican')).toHaveLength(1)
+  })
+
+  it('respects the limit', () => {
+    const candidates = [
+      r('i1', 'Italian'), r('i2', 'Italian'),
+      r('m1', 'Mexican'), r('m2', 'Mexican'),
+    ]
+    const out = selectForYou(candidates, profile, { limit: 2, rng: () => 0 })
+    expect(out).toHaveLength(2)
+  })
+
+  it('is deterministic given a fixed rng', () => {
+    const candidates = [r('i1', 'Italian'), r('i2', 'Italian'), r('m1', 'Mexican')]
+    const a = selectForYou(candidates, profile, { rng: () => 0 }).map((x) => x._id)
+    const b = selectForYou(candidates, profile, { rng: () => 0 }).map((x) => x._id)
+    expect(a).toEqual(b)
+  })
+})
+
+describe('shuffle', () => {
+  it('returns a permutation without mutating the input', () => {
+    const input = [1, 2, 3, 4, 5]
+    const out = shuffle(input, () => 0)
+    expect(out.sort()).toEqual([1, 2, 3, 4, 5])
+    expect(input).toEqual([1, 2, 3, 4, 5]) // original untouched
+  })
+})
+
+describe('MIN_SIGNAL', () => {
+  it('is exported as a positive threshold', () => {
+    expect(MIN_SIGNAL).toBeGreaterThan(0)
+  })
+})

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -1021,6 +1021,239 @@ describe('GET /getTrendingRecipes', () => {
   })
 })
 
+// ─── GET /getForYouRecipes ────────────────────────────────────────────────────
+
+describe('GET /getForYouRecipes', () => {
+  it('rejects request with no auth token (401)', async () => {
+    const res = await request(server).get('/api/getForYouRecipes')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns [] when the user has too little signal (< MIN_SIGNAL)', async () => {
+    // Only 2 interacted recipes — below the threshold to personalize.
+    await seedRecipes([
+      { ...BASE_RECIPE, _id: 'fy-a', cuisine: 'Italian' },
+      { ...BASE_RECIPE, _id: 'fy-b', cuisine: 'Italian' },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'fy-a', dateSaved: '1' },
+        { recipeId: 'fy-b', dateSaved: '2' },
+      ],
+    })
+    const res = await request(server).get('/api/getForYouRecipes').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual([])
+  })
+
+  it('recommends unseen recipes matching the user\'s taste, excluding seen and own', async () => {
+    await seedRecipes([
+      // Three saved Italian dinners → builds an Italian-dinner taste profile.
+      { ...BASE_RECIPE, _id: 'fy-s1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-s2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-s3', cuisine: 'Italian', mealTypes: ['dinner'] },
+      // Unseen Italian dinners → should be recommended.
+      { ...BASE_RECIPE, _id: 'fy-c1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-c2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      // Unseen Mexican breakfast sharing no feature with the profile → excluded.
+      // (nutritionLabels cleared so it doesn't match the inherited 'low-carb' diet.)
+      { ...BASE_RECIPE, _id: 'fy-mex', cuisine: 'Mexican', mealTypes: ['breakfast'], nutritionLabels: [] },
+      // Unseen Italian dinner but authored by the user → excluded as own.
+      { ...BASE_RECIPE, _id: 'fy-own', cuisine: 'Italian', mealTypes: ['dinner'], userId: TEST_UID },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'fy-s1', dateSaved: '1' },
+        { recipeId: 'fy-s2', dateSaved: '2' },
+        { recipeId: 'fy-s3', dateSaved: '3' },
+      ],
+    })
+
+    const res = await request(server).get('/api/getForYouRecipes').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body)).toBe(true)
+
+    const ids = res.body.map((r) => r._id)
+    // Only the unseen, on-taste Italian dinners qualify.
+    expect(ids.sort()).toEqual(['fy-c1', 'fy-c2'])
+    // Never recommend something already saved, the user's own, or off-taste.
+    expect(ids).not.toContain('fy-s1')
+    expect(ids).not.toContain('fy-own')
+    expect(ids).not.toContain('fy-mex')
+  })
+
+  it('excludes hidden recipes from recommendations', async () => {
+    await seedRecipes([
+      { ...BASE_RECIPE, _id: 'fy-s1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-s2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-s3', cuisine: 'Italian', mealTypes: ['dinner'] },
+      // On-taste but moderation-hidden → must not surface.
+      { ...BASE_RECIPE, _id: 'fy-hidden', cuisine: 'Italian', mealTypes: ['dinner'], status: 'hidden' },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'fy-s1', dateSaved: '1' },
+        { recipeId: 'fy-s2', dateSaved: '2' },
+        { recipeId: 'fy-s3', dateSaved: '3' },
+      ],
+    })
+
+    const res = await request(server).get('/api/getForYouRecipes').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.map((r) => r._id)).not.toContain('fy-hidden')
+  })
+
+  it('reaches the signal threshold via ratings and recommends on-taste recipes', async () => {
+    await seedRecipes([
+      // Three highly-rated Italian dinners → Italian-dinner taste profile, built
+      // entirely from ratings (no saves/makes), exercising that signal path.
+      { ...BASE_RECIPE, _id: 'fy-r1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-r2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-r3', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-rec', cuisine: 'Italian', mealTypes: ['dinner'] },
+    ])
+    await seedRating({ userId: TEST_UID, recipeId: 'fy-r1', rating: 5 })
+    await seedRating({ userId: TEST_UID, recipeId: 'fy-r2', rating: 5 })
+    await seedRating({ userId: TEST_UID, recipeId: 'fy-r3', rating: 4 })
+
+    const res = await request(server).get('/api/getForYouRecipes').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    const ids = res.body.map((r) => r._id)
+    expect(ids).toContain('fy-rec')
+    // Rated recipes are "seen" → never recommended back.
+    expect(ids).not.toContain('fy-r1')
+  })
+
+  it('reaches the signal threshold via made recipes', async () => {
+    await seedRecipes([
+      { ...BASE_RECIPE, _id: 'fy-m1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-m2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-m3', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-mrec', cuisine: 'Italian', mealTypes: ['dinner'] },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      madeRecipes: [{ recipeId: 'fy-m1' }, { recipeId: 'fy-m2' }, { recipeId: 'fy-m3' }],
+    })
+
+    const res = await request(server).get('/api/getForYouRecipes').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    const ids = res.body.map((r) => r._id)
+    expect(ids).toContain('fy-mrec')
+    expect(ids).not.toContain('fy-m1')
+  })
+
+  it('does not surface a community-popular recipe the user has no taste affinity for', async () => {
+    // Regression for the taste-vs-quality gate: an off-taste recipe with a strong
+    // community rating + many saves has a positive *blended* score but zero taste,
+    // and must NOT appear. (Seeds elsewhere carry no rating/saves, so only this
+    // case proves the quality nudge can't pull an off-taste recipe in.)
+    await seedRecipes([
+      { ...BASE_RECIPE, _id: 'fy-s1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-s2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-s3', cuisine: 'Italian', mealTypes: ['dinner'] },
+      // On-taste, unrated → should surface.
+      { ...BASE_RECIPE, _id: 'fy-italian', cuisine: 'Italian', mealTypes: ['dinner'] },
+      // Off-taste but community-loved → must stay out despite blended score > 0.
+      {
+        ...BASE_RECIPE,
+        _id: 'fy-popular',
+        cuisine: 'French',
+        mealTypes: ['breakfast'],
+        nutritionLabels: [],
+        rating: { rateCount: 200, rateValue: 5 },
+        numTimesSaved: 500,
+      },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'fy-s1', dateSaved: '1' },
+        { recipeId: 'fy-s2', dateSaved: '2' },
+        { recipeId: 'fy-s3', dateSaved: '3' },
+      ],
+    })
+
+    const res = await request(server).get('/api/getForYouRecipes').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    const ids = res.body.map((r) => r._id)
+    expect(ids).toContain('fy-italian')
+    expect(ids).not.toContain('fy-popular')
+  })
+
+  it('honors the limit query param (and the per-cuisine cap)', async () => {
+    await seedRecipes([
+      // Saves across two on-taste cuisines so several candidates qualify.
+      { ...BASE_RECIPE, _id: 'fy-i1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-i2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-x1', cuisine: 'Mexican', mealTypes: ['dinner'], nutritionLabels: ['low-carb'] },
+      // Unseen candidates: 2 Italian + 2 Mexican (4 pass the 2-per-cuisine cap).
+      { ...BASE_RECIPE, _id: 'fy-i3', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-i4', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-x2', cuisine: 'Mexican', mealTypes: ['dinner'], nutritionLabels: ['low-carb'] },
+      { ...BASE_RECIPE, _id: 'fy-x3', cuisine: 'Mexican', mealTypes: ['dinner'], nutritionLabels: ['low-carb'] },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'fy-i1', dateSaved: '1' },
+        { recipeId: 'fy-i2', dateSaved: '2' },
+        { recipeId: 'fy-x1', dateSaved: '3' },
+      ],
+    })
+
+    const res = await request(server).get('/api/getForYouRecipes?limit=2').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.length).toBeLessThanOrEqual(2)
+    expect(res.body.length).toBeGreaterThan(0)
+  })
+
+  it('excludes a review-only (rating: null) recipe from recommendations', async () => {
+    await seedRecipes([
+      { ...BASE_RECIPE, _id: 'fy-s1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-s2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-s3', cuisine: 'Italian', mealTypes: ['dinner'] },
+      // On-taste, but the user wrote a review with no star rating → engaged with
+      // it, so it must not be recommended back.
+      { ...BASE_RECIPE, _id: 'fy-reviewed', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-fresh', cuisine: 'Italian', mealTypes: ['dinner'] },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'fy-s1', dateSaved: '1' },
+        { recipeId: 'fy-s2', dateSaved: '2' },
+        { recipeId: 'fy-s3', dateSaved: '3' },
+      ],
+    })
+    await seedRating({ userId: TEST_UID, recipeId: 'fy-reviewed', rating: null })
+
+    const res = await request(server).get('/api/getForYouRecipes').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    const ids = res.body.map((r) => r._id)
+    expect(ids).not.toContain('fy-reviewed')
+    expect(ids).toContain('fy-fresh')
+  })
+
+  it('does not count review-only (rating: null) docs toward the signal threshold', async () => {
+    await seedRecipes([
+      { ...BASE_RECIPE, _id: 'fy-s1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-s2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-rev', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'fy-cand', cuisine: 'Italian', mealTypes: ['dinner'] },
+    ])
+    // 2 real signals (saves) + 1 review-only doc → still below MIN_SIGNAL (3),
+    // so the row stays hidden. A null rating must never act as taste signal.
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'fy-s1', dateSaved: '1' },
+        { recipeId: 'fy-s2', dateSaved: '2' },
+      ],
+    })
+    await seedRating({ userId: TEST_UID, recipeId: 'fy-rev', rating: null })
+
+    const res = await request(server).get('/api/getForYouRecipes').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual([])
+  })
+})
+
 // ─── Phase 5-D _id coercion regression tests ─────────────────────────────────
 
 describe('Phase 5-D — recipeIdQuery coercion', () => {

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -4,7 +4,8 @@ const { ObjectId } = require('mongodb')
 const { getDB, getClient } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeWriteLimiter } = require('../middleware/writeLimiter')
-const { recipeIdQuery } = require('../util/recipeIdQuery')
+const { recipeIdQuery, recipeIdInQuery } = require('../util/recipeIdQuery')
+const { MIN_SIGNAL, buildTasteProfile, interactionWeight, selectForYou } = require('../util/forYou')
 const { RECIPE_VISIBLE, RECIPE_OWNER_VISIBLE } = require('../util/moderation')
 const { recordAudit } = require('../util/auditLog')
 const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
@@ -193,6 +194,105 @@ router.get('/getTrendingRecipes', asyncHandler(async (req, res) => {
     .sort({ featured: -1, views: -1 })
     .limit(limit)
     .toArray()
+  res.json(recipes)
+}))
+
+// GET /getForYouRecipes — personalized home row, logged-in only.
+// Content-based: infer a taste profile from the user's saves/makes/ratings, then
+// score unseen visible recipes by feature overlap (see util/forYou.js). Returns
+// [] (frontend hides the row) when the user has too little signal. verifyToken,
+// not optionalAuth: the client only calls this when authed, so 401-on-anonymous
+// is the correct, simpler contract.
+router.get('/getForYouRecipes', verifyToken, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const uid = req.uid
+  const limit = Math.max(1, Math.min(parseInt(req.query.limit, 10) || 8, 20))
+
+  // 1. Gather the user's interactions.
+  const [userData, ratingDocs] = await Promise.all([
+    db.collection('userRecipeData').findOne(
+      { _id: uid },
+      { projection: { savedRecipes: 1, madeRecipes: 1 } }
+    ),
+    db.collection('ratings')
+      .find({ userId: uid }, { projection: { recipeId: 1, rating: 1 } })
+      .toArray(),
+  ])
+
+  const savedIds = new Set((userData?.savedRecipes ?? []).map((e) => e.recipeId))
+  const madeIds = new Set((userData?.madeRecipes ?? []).map((e) => e.recipeId))
+  const ratingById = new Map(
+    ratingDocs
+      .filter((r) => r.rating != null)
+      .map((r) => [r.recipeId, r.rating])
+  )
+
+  // Recipes that carry actual taste signal: saved, made, or given a real
+  // (non-null) rating. This drives both the threshold and the profile below.
+  const signalIds = new Set([...savedIds, ...madeIds, ...ratingById.keys()])
+  if (signalIds.size < MIN_SIGNAL) {
+    return res.json([])
+  }
+
+  // Everything the user has engaged with — signal plus review-only rating docs
+  // (rating: null, e.g. a written review without a star rating) — is excluded
+  // from recommendations so we never suggest a recipe back to them. Review-only
+  // docs add no profile signal (ratingById already drops them), but they
+  // shouldn't reappear in the row either.
+  const seenIds = new Set([...signalIds, ...ratingDocs.map((r) => r.recipeId)])
+
+  // 2. Look up the feature tags of the seen recipes (some may be deleted —
+  // those just drop out).
+  const seenFeatureDocs = await db
+    .collection('recipes')
+    .find(recipeIdInQuery([...seenIds]), {
+      projection: { cuisine: 1, mealTypes: 1, nutritionLabels: 1 },
+    })
+    .toArray()
+
+  // 3. Build the taste profile, combining each recipe's signals into one weight.
+  const interactions = seenFeatureDocs.map((recipe) => {
+    const id = String(recipe._id)
+    return {
+      recipe,
+      weight: interactionWeight({
+        made: madeIds.has(id),
+        saved: savedIds.has(id),
+        rating: ratingById.get(id) ?? null,
+      }),
+    }
+  })
+  const profile = buildTasteProfile(interactions)
+
+  // 4. Candidate pool: every visible recipe except ones the user has already
+  // seen or authored. Project only what scoring + the card need.
+  const excludeVariants = recipeIdInQuery([...seenIds])._id.$in
+  const candidates = await db
+    .collection('recipes')
+    .find(
+      { ...RECIPE_VISIBLE, userId: { $ne: uid }, _id: { $nin: excludeVariants } },
+      {
+        projection: {
+          title: 1,
+          recipeImage: 1,
+          cuisine: 1,
+          totalTime: 1,
+          servingPrice: 1,
+          rating: 1,
+          mealTypes: 1,
+          nutritionLabels: 1,
+          numTimesSaved: 1,
+        },
+      }
+    )
+    .toArray()
+
+  // 5. Score, diversify, shuffle the top tier (fresh each visit), slice.
+  const numTimesSavedMax = candidates.reduce(
+    (max, r) => Math.max(max, r.numTimesSaved || 0),
+    0
+  )
+  const recipes = selectForYou(candidates, profile, { limit, numTimesSavedMax })
   res.json(recipes)
 }))
 

--- a/server/util/forYou.js
+++ b/server/util/forYou.js
@@ -1,0 +1,202 @@
+// Pure scoring helpers for the personalized "For You" home row.
+//
+// The home row is content-based: there are no stored diet/cuisine preferences
+// (Settings "Cooking Preferences" is deferred), and the user base is too small
+// for collaborative filtering to be reliable. So we infer a taste profile from
+// the user's own behavior (saves / makes / ratings), then score unseen recipes
+// by how well their categorical features (cuisine / mealTypes / nutritionLabels)
+// overlap that profile, with community quality as a tie-breaker.
+//
+// Everything here is pure (no DB, no I/O) so it can be unit-tested directly and
+// the route stays thin. The route is responsible for loading interactions and
+// the candidate pool and passing them in.
+
+// A user needs at least this many distinct interacted recipes before the row is
+// shown at all (the "hide until personalized" decision). Below this the route
+// returns [] and the frontend renders nothing.
+const MIN_SIGNAL = 3
+
+// How strongly each kind of interaction pushes a feature value. A single recipe
+// can contribute via several signals (e.g. saved AND made AND rated) — those sum.
+const WEIGHTS = {
+  made: 3,
+  saved: 2,
+  rating: { 5: 3, 4: 2, 3: 0, 2: -2, 1: -2 },
+}
+
+// Final-score blend. Cuisine / meal / diet affinities are each normalized to
+// 0..1 (see scoreRecipe) and summed equally ("balanced"); quality is a small
+// additive tie-breaker so a well-loved recipe edges out an obscure one of equal
+// taste-match, without overriding the personalization.
+const QUALITY_WEIGHT = 0.25
+
+// Diversity: at most this many recipes of any single cuisine in the final row.
+const MAX_PER_CUISINE = 2
+
+const ratingWeight = (rating) =>
+  Object.prototype.hasOwnProperty.call(WEIGHTS.rating, rating)
+    ? WEIGHTS.rating[rating]
+    : 0
+
+// Add `weight` to map[key], skipping empty keys.
+function bump(map, key, weight) {
+  if (key == null || key === '') return
+  map.set(key, (map.get(key) || 0) + weight)
+}
+
+// Build a taste profile from the user's interactions.
+//
+// `interactions` is an array of { recipe, weight } where `recipe` is a feature
+// doc ({ cuisine, mealTypes, nutritionLabels }) and `weight` is the combined
+// signal weight for that recipe (made + saved + rating, already summed by the
+// caller via interactionWeight()). Returns three Maps of value -> affinity plus
+// the max positive affinity per dimension (used to normalize at score time).
+function buildTasteProfile(interactions) {
+  const cuisine = new Map()
+  const meal = new Map()
+  const diet = new Map()
+
+  for (const { recipe, weight } of interactions) {
+    if (!recipe || !weight) continue
+    bump(cuisine, recipe.cuisine, weight)
+    for (const m of recipe.mealTypes || []) bump(meal, m, weight)
+    for (const d of recipe.nutritionLabels || []) bump(diet, d, weight)
+  }
+
+  const maxPos = (map) => {
+    let max = 0
+    for (const v of map.values()) if (v > max) max = v
+    return max
+  }
+
+  return {
+    cuisine,
+    meal,
+    diet,
+    max: { cuisine: maxPos(cuisine), meal: maxPos(meal), diet: maxPos(diet) },
+  }
+}
+
+// Combine a recipe's interaction signals into one weight for the profile.
+// `signals` = { made: bool, saved: bool, rating: number|null }.
+function interactionWeight({ made, saved, rating } = {}) {
+  let w = 0
+  if (made) w += WEIGHTS.made
+  if (saved) w += WEIGHTS.saved
+  if (rating != null) w += ratingWeight(rating)
+  return w
+}
+
+// Signed normalization against the dimension's max positive affinity, so the
+// three dimensions are comparable regardless of how many recipes the user has
+// touched. Negatives are kept (not clamped): a value the user rated 1-star has
+// a negative affinity and drags the score down, which is what we want.
+const signed = (value, max) => (max > 0 ? value / max : 0)
+
+// Mean affinity across a recipe's values in one (multi-valued) dimension.
+const meanAffinity = (values, map) =>
+  values.length ? values.reduce((s, v) => s + (map.get(v) || 0), 0) / values.length : 0
+
+// Pure taste affinity: equal-weighted, signed, normalized affinity across the
+// three dimensions ("balanced"). This is what decides whether a recipe belongs
+// in the row at all — a value the user has positive affinity for pushes it up, a
+// disliked one pushes it negative. A recipe the user has no signal on scores 0.
+//
+// Kept separate from quality so the row can gate strictly on taste: a popular
+// recipe the user has no affinity for must NOT surface just because it's loved
+// by the community (see selectForYou's filter).
+function tasteScore(recipe, profile) {
+  const cuisineRaw = profile.cuisine.get(recipe.cuisine) || 0
+  const mealRaw = meanAffinity(recipe.mealTypes || [], profile.meal)
+  const dietRaw = meanAffinity(recipe.nutritionLabels || [], profile.diet)
+
+  return (
+    signed(cuisineRaw, profile.max.cuisine) +
+    signed(mealRaw, profile.max.meal) +
+    signed(dietRaw, profile.max.diet)
+  )
+}
+
+// Community-quality term, normalized to 0..1: half from the average star rating,
+// half from save popularity relative to the catalog-wide max (passed by the
+// caller). Used only as a tie-breaker between recipes that are already on-taste.
+function qualityScore(recipe, numTimesSavedMax = 0) {
+  const rateValue = recipe.rating?.rateValue || 0
+  const savePop = numTimesSavedMax > 0 ? (recipe.numTimesSaved || 0) / numTimesSavedMax : 0
+  return 0.5 * (rateValue / 5) + 0.5 * savePop
+}
+
+// Blended score used to RANK on-taste candidates: taste plus a small additive
+// quality nudge, so a well-loved recipe edges out an obscure one of equal taste
+// match without overriding the personalization. Note this is intentionally NOT
+// the inclusion gate — a recipe with zero taste but good quality has a positive
+// blended score yet must not appear (selectForYou filters on tasteScore).
+//
+// numTimesSavedMax is the catalog-wide max (passed by the caller) so the quality
+// term is normalized rather than unbounded.
+function scoreRecipe(recipe, profile, numTimesSavedMax = 0) {
+  return tasteScore(recipe, profile) + QUALITY_WEIGHT * qualityScore(recipe, numTimesSavedMax)
+}
+
+// Fisher-Yates shuffle with an injectable RNG (so tests are deterministic).
+function shuffle(arr, rng = Math.random) {
+  const a = arr.slice()
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
+}
+
+// Rank candidates, enforce per-cuisine diversity, then shuffle the top tier for
+// "fresh each visit" variety. Returns up to `limit` recipes.
+//
+// - candidates: visible recipes already excluding seen/own (caller's job)
+// - profile: from buildTasteProfile
+// - limit: row size (default 8)
+// - rng: injectable for tests
+function selectForYou(candidates, profile, { limit = 8, numTimesSavedMax = 0, rng = Math.random } = {}) {
+  const scored = candidates
+    .map((recipe) => ({
+      recipe,
+      taste: tasteScore(recipe, profile),
+      score: scoreRecipe(recipe, profile, numTimesSavedMax),
+    }))
+    // Gate on TASTE, not the blended score — better an empty/short row than
+    // padding it with irrelevant recipes. A popular recipe the user has no
+    // affinity for has taste === 0 (blended score > 0 from the quality nudge),
+    // and is dropped here so quality only ever ranks on-taste recipes.
+    .filter((s) => s.taste > 0)
+    .sort((a, b) => b.score - a.score)
+
+  // Diversity cap: at most MAX_PER_CUISINE of any cuisine, walking best-first.
+  const perCuisine = new Map()
+  const diverse = []
+  for (const s of scored) {
+    const c = s.recipe.cuisine || ''
+    const n = perCuisine.get(c) || 0
+    if (n >= MAX_PER_CUISINE) continue
+    perCuisine.set(c, n + 1)
+    diverse.push(s)
+  }
+
+  // Freshness: keep a top tier of 2x the row size, shuffle, then slice. This
+  // varies membership/order between visits while staying in the relevant set.
+  const tier = diverse.slice(0, limit * 2)
+  return shuffle(tier, rng)
+    .slice(0, limit)
+    .map((s) => s.recipe)
+}
+
+module.exports = {
+  MIN_SIGNAL,
+  WEIGHTS,
+  MAX_PER_CUISINE,
+  buildTasteProfile,
+  interactionWeight,
+  tasteScore,
+  qualityScore,
+  scoreRecipe,
+  selectForYou,
+  shuffle,
+}

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -98,6 +98,12 @@ class RecipeAPIClass {
     const result = await http.get(`api/getTrendingRecipes?limit=${limit}`)
     return result.data
   }
+  // Personalized home row. Requires auth (token attached by the http
+  // interceptor); returns [] when the user has too little signal to personalize.
+  async getForYouRecipes(limit = 8): Promise<RecipeType[]> {
+    const result = await http.get(`api/getForYouRecipes?limit=${limit}`)
+    return result.data
+  }
   async getRecipe(id: string): Promise<RecipeType> {
     const result = await http.get(`api/getRecipe?id=${id}`)
     return result.data

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet-async'
 import { Link } from 'react-router-dom'
 import { BiChevronRight } from 'react-icons/bi'
 import HomeHero from 'src/pages/Home/HomeHero/HomeHero'
+import HomeForYou from 'src/pages/Home/HomeForYou'
 import HomeTrending from 'src/pages/Home/HomeTrending'
 import HomeBrowseByMeal from 'src/pages/Home/HomeBrowseByMeal'
 import './Home.scss'
@@ -17,6 +18,8 @@ const Home: FC = () => {
       </Helmet>
       <div className='page home-page'>
         <HomeHero />
+
+        <HomeForYou />
 
         <section className='home-section'>
           <div className='home-section-header'>

--- a/src/pages/Home/HomeForYou.tsx
+++ b/src/pages/Home/HomeForYou.tsx
@@ -15,7 +15,8 @@ const HomeForYou: FC = () => {
 
   const { data, isLoading, isError } = useQuery<RecipeType[]>({
     queryKey: ['for-you-recipes', user?.uid],
-    queryFn: () => RecipeAPI.getForYouRecipes(8),
+    // Match the Trending row's count (4) so the desktop grid stays even.
+    queryFn: () => RecipeAPI.getForYouRecipes(4),
     enabled: !!user,
     staleTime: 5 * 60 * 1000,
   })

--- a/src/pages/Home/HomeForYou.tsx
+++ b/src/pages/Home/HomeForYou.tsx
@@ -1,0 +1,57 @@
+import React, { FC } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import RecipeAPI from 'src/api/recipes'
+import { useAuth } from 'src/context/AuthContext'
+import { RecipeType } from 'types'
+import { HomeRecipeCard, HomeRecipeCardSkeleton } from './HomeRecipeCard'
+
+// Personalized "For You" row. "Hide until personalized": only renders for a
+// logged-in user, and only once the server returns picks (it returns [] until
+// the user has enough saves/makes/ratings to infer taste). The component owns
+// its whole <section> — header included — so an empty/anonymous state collapses
+// cleanly with no orphaned heading. Silent on error: it's a bonus row, not core.
+const HomeForYou: FC = () => {
+  const user = useAuth()?.user ?? null
+
+  const { data, isLoading, isError } = useQuery<RecipeType[]>({
+    queryKey: ['for-you-recipes', user?.uid],
+    queryFn: () => RecipeAPI.getForYouRecipes(8),
+    enabled: !!user,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Logged out → the row doesn't exist.
+  if (!user) return null
+
+  if (isLoading) {
+    return (
+      <section className='home-section'>
+        <div className='home-section-header'>
+          <h2>For you</h2>
+          <p>Picked from recipes you’ve saved and cooked</p>
+        </div>
+        <div className='home-trending-grid'>
+          {Array.from({ length: 4 }).map((_, i) => <HomeRecipeCardSkeleton key={i} />)}
+        </div>
+      </section>
+    )
+  }
+
+  const recipes = data ?? []
+  // Not enough signal, or a failed fetch → hide the whole row.
+  if (isError || recipes.length === 0) return null
+
+  return (
+    <section className='home-section'>
+      <div className='home-section-header'>
+        <h2>For you</h2>
+        <p>Picked from recipes you’ve saved and cooked</p>
+      </div>
+      <div className='home-trending-grid'>
+        {recipes.map(r => <HomeRecipeCard recipe={r} key={r._id} />)}
+      </div>
+    </section>
+  )
+}
+
+export default HomeForYou

--- a/src/pages/Home/HomeRecipeCard.tsx
+++ b/src/pages/Home/HomeRecipeCard.tsx
@@ -1,0 +1,42 @@
+import React, { FC } from 'react'
+import { Link } from 'react-router-dom'
+import { AiOutlineStar } from 'react-icons/ai'
+import { CgTimer } from 'react-icons/cg'
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
+import { RecipeType } from 'types'
+import { skeletonColor, fmtPrice, ratingLabel } from './homeFormat'
+
+// Shared recipe card for the Home rows (Trending, For You). A lightweight
+// thumbnail+meta link — intentionally simpler than the full RecipeCard (no save
+// control) to keep the rows fast and uncluttered.
+export const HomeRecipeCard: FC<{ recipe: RecipeType }> = ({ recipe }) => (
+  <Link to={`/recipes/${recipe._id}`} className='home-recipe-card'>
+    <div className='thumb'>
+      <img src={recipe.recipeImage} alt={recipe.title} />
+      {recipe.servingPrice != null && (
+        <span className='price-chip'>{fmtPrice(recipe.servingPrice)}/serv</span>
+      )}
+    </div>
+    <div className='body'>
+      <h3>{recipe.title}</h3>
+      <div className='meta'>
+        <span><CgTimer /> {recipe.totalTime}m</span>
+        <span><AiOutlineStar /> {ratingLabel(recipe.rating)}</span>
+        {recipe.cuisine && <span className='cuisine'>{recipe.cuisine}</span>}
+      </div>
+    </div>
+  </Link>
+)
+
+export const HomeRecipeCardSkeleton: FC = () => (
+  <div className='home-recipe-card'>
+    <div className='thumb'>
+      <Skeleton baseColor={skeletonColor} height='100%' style={{ aspectRatio: '4 / 3', display: 'block' }} />
+    </div>
+    <div className='body'>
+      <h3><Skeleton baseColor={skeletonColor} count={2} /></h3>
+      <div className='meta'><Skeleton baseColor={skeletonColor} width={140} /></div>
+    </div>
+  </div>
+)

--- a/src/pages/Home/HomeTrending.tsx
+++ b/src/pages/Home/HomeTrending.tsx
@@ -1,44 +1,8 @@
 import React, { FC } from 'react'
-import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { AiOutlineStar } from 'react-icons/ai'
-import { CgTimer } from 'react-icons/cg'
-import Skeleton from 'react-loading-skeleton'
-import 'react-loading-skeleton/dist/skeleton.css'
 import RecipeAPI from 'src/api/recipes'
 import { RecipeType } from 'types'
-import { skeletonColor, fmtPrice, ratingLabel } from './homeFormat'
-
-const TrendingCard: FC<{ recipe: RecipeType }> = ({ recipe }) => (
-  <Link to={`/recipes/${recipe._id}`} className='home-recipe-card'>
-    <div className='thumb'>
-      <img src={recipe.recipeImage} alt={recipe.title} />
-      {recipe.servingPrice != null && (
-        <span className='price-chip'>{fmtPrice(recipe.servingPrice)}/serv</span>
-      )}
-    </div>
-    <div className='body'>
-      <h3>{recipe.title}</h3>
-      <div className='meta'>
-        <span><CgTimer /> {recipe.totalTime}m</span>
-        <span><AiOutlineStar /> {ratingLabel(recipe.rating)}</span>
-        {recipe.cuisine && <span className='cuisine'>{recipe.cuisine}</span>}
-      </div>
-    </div>
-  </Link>
-)
-
-const TrendingCardSkeleton: FC = () => (
-  <div className='home-recipe-card'>
-    <div className='thumb'>
-      <Skeleton baseColor={skeletonColor} height='100%' style={{ aspectRatio: '4 / 3', display: 'block' }} />
-    </div>
-    <div className='body'>
-      <h3><Skeleton baseColor={skeletonColor} count={2} /></h3>
-      <div className='meta'><Skeleton baseColor={skeletonColor} width={140} /></div>
-    </div>
-  </div>
-)
+import { HomeRecipeCard, HomeRecipeCardSkeleton } from './HomeRecipeCard'
 
 const HomeTrending: FC = () => {
   const { data, isLoading, isError } = useQuery<RecipeType[]>({
@@ -51,7 +15,7 @@ const HomeTrending: FC = () => {
   if (isLoading) {
     return (
       <div className='home-trending-grid'>
-        {Array.from({ length: 4 }).map((_, i) => <TrendingCardSkeleton key={i} />)}
+        {Array.from({ length: 4 }).map((_, i) => <HomeRecipeCardSkeleton key={i} />)}
       </div>
     )
   }
@@ -68,7 +32,7 @@ const HomeTrending: FC = () => {
 
   return (
     <div className='home-trending-grid'>
-      {recipes.map(r => <TrendingCard recipe={r} key={r._id} />)}
+      {recipes.map(r => <HomeRecipeCard recipe={r} key={r._id} />)}
     </div>
   )
 }

--- a/src/test/Home.test.tsx
+++ b/src/test/Home.test.tsx
@@ -6,11 +6,13 @@ import { HelmetProvider } from 'react-helmet-async'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import Home from 'src/pages/Home/Home'
 import RecipeAPI from 'src/api/recipes'
+import { useAuth } from 'src/context/AuthContext'
 
 vi.mock('src/api/recipes', () => ({
   default: {
     getTrendingRecipes: vi.fn(),
     getAllRecipes: vi.fn(),
+    getForYouRecipes: vi.fn(),
   },
 }))
 
@@ -19,8 +21,15 @@ vi.mock('src/Components/SearchRecipesInput/SearchRecipesInput', () => ({
   default: () => null,
 }))
 
+// For You is gated on auth — control the current user per test.
+vi.mock('src/context/AuthContext', () => ({
+  useAuth: vi.fn(),
+}))
+
 const mockGetTrendingRecipes = RecipeAPI.getTrendingRecipes as ReturnType<typeof vi.fn>
 const mockGetAllRecipes = RecipeAPI.getAllRecipes as ReturnType<typeof vi.fn>
+const mockGetForYouRecipes = RecipeAPI.getForYouRecipes as ReturnType<typeof vi.fn>
+const mockUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>
 
 const makeRecipe = (id: string) => ({
   _id: id,
@@ -72,9 +81,14 @@ describe('Home page', () => {
   beforeEach(() => {
     mockGetTrendingRecipes.mockReset()
     mockGetAllRecipes.mockReset()
+    mockGetForYouRecipes.mockReset()
+    mockUseAuth.mockReset()
     // Neutral defaults; individual tests override the section they exercise.
     mockGetTrendingRecipes.mockReturnValue(new Promise(() => {}))
     mockGetAllRecipes.mockResolvedValue(mealResult([]))
+    mockGetForYouRecipes.mockResolvedValue([])
+    // Logged out by default → the For You row is absent and doesn't interfere.
+    mockUseAuth.mockReturnValue({ user: null })
   })
 
   it('renders without crashing', () => {
@@ -113,6 +127,51 @@ describe('Home page', () => {
       mockGetTrendingRecipes.mockRejectedValue(new Error('boom'))
       renderHome()
       expect(await screen.findByText(/couldn.t load trending recipes/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('For you', () => {
+    const loggedIn = () => mockUseAuth.mockReturnValue({ user: { uid: 'u1' } })
+
+    it('is absent for a logged-out visitor', () => {
+      // default beforeEach: user = null
+      renderHome()
+      expect(screen.queryByText('For you')).not.toBeInTheDocument()
+      expect(mockGetForYouRecipes).not.toHaveBeenCalled()
+    })
+
+    it('renders recipe cards when the API returns personalized picks', async () => {
+      loggedIn()
+      mockGetForYouRecipes.mockResolvedValue([makeRecipe('fy1'), makeRecipe('fy2')])
+      renderHome()
+      expect(await screen.findByText('For you')).toBeInTheDocument()
+      expect(await screen.findByText('Recipe fy1')).toBeInTheDocument()
+      expect(screen.getByText('Recipe fy2')).toBeInTheDocument()
+    })
+
+    it('hides the whole row when the API returns no picks (too little signal)', async () => {
+      loggedIn()
+      mockGetForYouRecipes.mockResolvedValue([])
+      renderHome()
+      await waitFor(() => expect(mockGetForYouRecipes).toHaveBeenCalled())
+      await waitFor(() => expect(screen.queryByText('For you')).not.toBeInTheDocument())
+    })
+
+    it('hides the row on fetch error (silent, non-core)', async () => {
+      loggedIn()
+      mockGetForYouRecipes.mockRejectedValue(new Error('boom'))
+      renderHome()
+      await waitFor(() => expect(mockGetForYouRecipes).toHaveBeenCalled())
+      await waitFor(() => expect(screen.queryByText('For you')).not.toBeInTheDocument())
+    })
+
+    it('shows skeletons while the personalized fetch is pending', () => {
+      loggedIn()
+      mockGetForYouRecipes.mockReturnValue(new Promise(() => {}))
+      renderHome()
+      const section = screen.getByText('For you').closest('.home-section')
+      expect(section).not.toBeNull()
+      expect(section!.querySelectorAll('.home-recipe-card')).toHaveLength(4)
     })
   })
 


### PR DESCRIPTION
## What

Adds a personalized **"For You"** row to the homepage — a content-based recommendation row inferred from the signed-in user's own behavior (saves / makes / ratings). Placed first under the hero; **hidden entirely** until a user has enough signal to personalize.

Continues track-2a Home work (the homepage redesign itself shipped earlier in `e1539c3`). Remaining Home idea after this: the "What should I cook?" button.

## Why content-based (not collaborative)

There are no stored diet/cuisine preferences (Settings "Cooking Preferences" is deferred), and the user base is too small for collaborative filtering to be reliable. So we **infer a taste profile from behavior** and score unseen recipes by categorical-feature overlap (cuisine / mealTypes / nutritionLabels), with community quality as a tie-breaker only.

## Locked product decisions

- **Hide until personalized** — logged-in **and** ≥ `MIN_SIGNAL` (3) interacted recipes, else `[]` → the row renders nothing (no layout shift).
- **Fresh each visit** — shuffle the top-scoring tier (`2×limit`) before slicing.
- **Balanced** — cuisine + meal + diet affinities weighted equally; quality is a small ranking nudge, never an inclusion gate.

## Algorithm (`server/util/forYou.js`, pure + unit-tested)

- Per-interaction weights: made **+3**, rated5 **+3** / rated4 **+2** / rated3 **0** / rated1–2 **−2**, saved **+2** (a recipe sums its own signals).
- Build affinity maps over cuisine / mealTypes / nutritionLabels; `tasteScore` = signed-normalized equal-weighted sum across the three dims.
- `qualityScore` (avg rating + save-popularity, 0..1) blends in at `0.25×` **for ranking only**.
- **Selection gates on `tasteScore > 0`**, ranks on the blended score → a popular recipe the user has no affinity for never surfaces despite a positive blended score.
- Cap **2 per cuisine**, shuffle the top `2×limit`, slice (default 8). Injectable RNG → deterministic tests.

## Backend

- `GET /api/getForYouRecipes` (`verifyToken`, logged-in only). Reads `userRecipeData.{savedRecipes,madeRecipes}` + `ratings.find({userId})`, builds the profile, scans `RECIPE_VISIBLE` candidates excluding seen ids + the user's own, returns a `RecipeType[]` (same shape as `getTrendingRecipes`). `limit` clamped to 1..20. No new index (scan parity with browse).
- **"Seen" vs "signal" split:** saved ∪ made ∪ *non-null* ratings drive both the `MIN_SIGNAL` threshold and the taste profile; **all** rating docs (incl. review-only `rating: null`) are added to the *exclusion* set only — so a reviewed-but-unrated recipe is kept out of recs but never feeds the profile and never counts toward the threshold.

## Frontend

- `src/api/recipes.ts`: `getForYouRecipes(limit = 8)`.
- Extracted shared `HomeRecipeCard.tsx` (+ skeleton) out of `HomeTrending.tsx`; reused by both rows.
- New `HomeForYou.tsx`: gated on `useAuth()?.user` (`enabled: !!user`), owns its whole `<section>`, returns `null` when logged-out / empty / error (silent — it's a bonus row). Rendered first after `<HomeHero/>` in `Home.tsx`.

## Tests

- `server/__tests__/forYou.test.js` (new unit suite): profile weighting, `tasteScore`/`qualityScore` blocks, off-taste-popular & disliked-popular exclusion, quality tie-break, cap-per-cuisine, deterministic shuffle.
- `server/__tests__/recipes.test.js`: 401 no-auth; below-threshold → `[]`; ratings-signal + made-signal threshold paths; recommends on-taste excluding seen/own/off-taste; excludes hidden; popular-off-taste exclusion; `limit` param; review-only (`rating: null`) excluded from recs and not counted toward threshold.
- `src/test/Home.test.tsx`: hidden logged-out, hidden on `[]`, renders cards, skeletons while pending.

## Docs

- Corrected stale "Home is sparse" wording in `RELEASE_GAMEPLAN.md` (track 2a) / `RELEASE_PLAN.md` §D and reframed remaining Home work as the two feature ideas.

## Verification

- Server Jest **605 green**, frontend Home suite **15 green**, `tsc --noEmit` clean, build OK.
- Clean merge into `development` (no conflicts).
- **Live authed smoke passed** (throwaway minted-token user): cold start → `[]`; 3 saves → 200 with picks excluding the saved recipes; self-cleanup.

## Notes / deferred

- Recency-decay on saves (`dateSaved`) deferred to v2; `madeRecipes` is binary (no per-make timestamps).