### PR TITLE
feat(home): "What should I cook?" button (taste-aware random pick)

### DIFF
--- a/docs/FEATURE_IDEAS.md
+++ b/docs/FEATURE_IDEAS.md
@@ -20,6 +20,8 @@ The previous list's biggest holes are now done and live:
 - **Servings scaling** — `SingleRecipe.tsx` has +/− steppers that rescale ingredient quantities and persist the chosen serving size.
 - **Empty states (partial)** — `HomeTrending` and `SavedRecipes` now render real "nothing here" copy instead of perpetual skeletons.
 - **Gamification (partial)** — XP/levels + achievements engine (`server/util/gamification.js`: `first_save`, `collector`, `first_recipe`, `prolific`, `first_review`, `critic`) with an unlock toast and an Account rewards gallery.
+- **Personalized "For You" row on Home** — content-based row inferred from the user's saves/makes/ratings (`HomeForYou` + `GET /api/getForYouRecipes` + `server/util/forYou.js`), hidden until personalized, capped at 4 to match Trending. Shipped via PR #153.
+- **"What should I cook?" button** — taste-aware random pick in `HomeHero` (reuses the For You profile via `server/util/tasteContext.js`; uniform `$sample` fallback) revealed in a spotlight modal with a "Try another" re-roll (`HomeCookSuggestion` + `GET /api/recipes/random`). Shipped via PR #154.
 
 Adjacent systems that also landed and reshape the roadmap: **drafts**, **admin moderation + audit log + analytics**, **report content**, **bug reporting**, a URL-routed **Settings** area (Profile / Account & Security / Privacy / Danger), and transactional **email** (currently moderation outcomes only).
 
@@ -48,10 +50,8 @@ Adjacent systems that also landed and reshape the roadmap: **drafts**, **admin m
 
 - **Recipe collections / folders for saved recipes** — `SavedRecipes.tsx` is still one flat list sortable only by date. Letting users group saves into "Weeknight dinners," "Thanksgiving," etc. turns the saved page into an actual cookbook. `[needs API]` (collection CRUD; saves get `collectionIds`)
 - **Search-history dropdown** — `SearchRecipesInput` still shows nothing on focus until you type. Surfacing the last ~5 searches from localStorage on focus is essentially one component change.
-- **Personalized "For You" row on Home** — Home is Hero → Trending → Browse-by-meal. A "more like your saves/makes" row (derived from the cuisines/meal-types the user already engages with) is the obvious next section. `[needs API or a client-side similarity pass over /recipes]`
 - **Substitute-ingredient suggestions** — on hover/tap of an ingredient, show 1–3 common swaps ("no buttermilk → milk + lemon"). Could lean on Spoonacular via the existing `/api/ingredients/parse` infra.
 - **Time-based cooking streaks** — gamification today is count-based achievements. Adding "cooked 4 recipes this week" / "3 new cuisines this month" streaks (from the `datesMade` data the server already keeps) gives a recurring reason to come back, distinct from the one-shot badges.
-- **"What should I cook?" button** — one button on `HomeHero` that picks a random recipe matching the user's diet/cuisine preferences. Decision-fatigue killer. `[reuses getAllRecipes random sort, or GET /recipes/random]`
 
 ---
 

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -49,7 +49,7 @@ same commit.**
 | 1b | Save-recipe broken | `[ ]` | — |
 | 1c | Account data (images, empty-flash) | `[ ]` | — |
 | 1d | Serving-price bug | `[ ]` | — |
-| 2a | Homepage redesign (design shipped; For You row in progress) | `[~]` | feat/homepage-redesign |
+| 2a | Homepage redesign (design + For You row + "What should I cook?") | `[x]` | #153 + #154 ✅ |
 | 2b | Public Help/Contact page | `[ ]` | — |
 | 2c | Single-recipe polish | `[ ]` | — |
 | 2d | Recipes browse polish | `[ ]` | — |
@@ -110,7 +110,7 @@ All isolated files — safe to run together.
 
 | Track | Work | Domain |
 |---|---|---|
-| **2a** Homepage redesign *(design shipped; feature work in progress)* | redesign live (`HomeHero → Trending → Browse by meal`). Remaining = features: **For You** personalized row (in progress), **"What should I cook?"** button (next) | `src/pages/Home/*`, `server/routes/recipes.js`, `server/util/forYou.js` |
+| **2a** Homepage redesign *(complete)* | redesign live (`HomeHero → Trending → Browse by meal`) + both feature items shipped: **For You** personalized row (#153) and **"What should I cook?"** spotlight-modal button (#154) | `src/pages/Home/*`, `server/routes/recipes.js`, `server/util/forYou.js`, `server/util/tasteContext.js` |
 | **2b** Public Help/Contact *(blocker)* | move route out of `PrivateRoute`, add a public link (footer/nav), refresh layout | `src/pages/Help/*`, **`App.tsx`**, Navbar link |
 | **2c** Single-recipe polish | serving-price prominence, "You created this" mobile styling, stats row styling, `RecipeNotFound` visual, "Your Review" UI + rating-dropdown position | `src/pages/SingleRecipe/*` |
 | **2d** Recipes browse polish | better no-results indicator, autocomplete redesign + autocorrect, drop search from the top-most navbar on /recipes | `src/pages/Recipes/*`, `SearchRecipesInput`, Navbar |
@@ -184,6 +184,14 @@ Append a one-liner when a track changes state (started / PR / merged). Keeps ses
   ("avg dropped on a 5-star") root-caused = stale stored aggregate corrected on recompute (math is
   correct); confirmed by a live authed smoke test. Two follow-ups filed in `BACKLOG.md` → Tech debt:
   one-off catalog-wide aggregate reconciliation + harden `deleteAccount`'s best-effort recompute.
+- _2026-06-17_ — **2a For You row → merged** (PR #153). Content-based personalized Home row inferred from
+  saves/makes/ratings (`HomeForYou` + `GET /api/getForYouRecipes` + `server/util/forYou.js`);
+  hide-until-personalized, capped at 4 to match Trending.
+- _2026-06-17_ — **2a "What should I cook?" button → merged** (PR #154) — **Track 2a complete.** Taste-aware
+  random pick (reuses the For You profile via the extracted `server/util/tasteContext.js`; uniform `$sample`
+  fallback) revealed in a spotlight modal with a "Try another" re-roll (`HomeCookSuggestion` +
+  `GET /api/recipes/random`). Fallback prefers unseen recipes, only resurfacing seen ones once the whole
+  catalog is exhausted.
 
 ---
 

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -232,12 +232,15 @@ Chunky design efforts that are bigger than a single checkbox. Tag each as **(blo
   - **Shipped:** the redesign landed earlier (`e1539c3`) — Home is now `HomeHero → Trending → Browse by
     meal → View all recipes`, fully responsive with empty/loading states. The "sparse Home" wording here
     was pre-redesign and is now stale.
-  - **Remaining Home work** is feature, not design — tracked from `docs/FEATURE_IDEAS.md`:
-    - `[~]` **Personalized "For You" row** — content-based row inferred from saves/makes/ratings
-      (`HomeForYou` + `GET /api/getForYouRecipes`). In progress on `feat/homepage-redesign`.
-    - `[ ]` **"What should I cook?" button** — random on-taste pick from `HomeHero`. Next up.
-  - **Touches:** `src/pages/Home/*` (`Home.tsx`, `HomeForYou.tsx`, `HomeRecipeCard.tsx`),
-    `src/api/recipes.ts`, `server/routes/recipes.js`, `server/util/forYou.js`.
+  - **Remaining Home work** was feature, not design — tracked from `docs/FEATURE_IDEAS.md`, now all shipped:
+    - `[x]` **Personalized "For You" row** — content-based row inferred from saves/makes/ratings
+      (`HomeForYou` + `GET /api/getForYouRecipes`). Merged via **PR #153**.
+    - `[x]` **"What should I cook?" button** — taste-aware random pick from `HomeHero`, revealed in a
+      spotlight modal with "Try another" (`HomeCookSuggestion` + `GET /api/recipes/random`). Merged via
+      **PR #154**.
+  - **Touches:** `src/pages/Home/*` (`Home.tsx`, `HomeForYou.tsx`, `HomeRecipeCard.tsx`,
+    `HomeCookSuggestion.tsx`), `src/api/recipes.ts`, `server/routes/recipes.js`,
+    `server/util/forYou.js`, `server/util/tasteContext.js`.
 
 - `[ ]` **Help / Contact Support page** — **(blocker)**
   - **Now:** the page already exists — `src/pages/Help/Help.tsx` (routed `/help`) is a Formspree form

--- a/server/__tests__/forYou.test.js
+++ b/server/__tests__/forYou.test.js
@@ -7,6 +7,7 @@ const {
   scoreRecipe,
   selectForYou,
   shuffle,
+  weightedSample,
 } = require('../util/forYou')
 
 // Hand-build a profile (the same shape buildTasteProfile returns) so scoring
@@ -322,5 +323,58 @@ describe('shuffle', () => {
 describe('MIN_SIGNAL', () => {
   it('is exported as a positive threshold', () => {
     expect(MIN_SIGNAL).toBeGreaterThan(0)
+  })
+})
+
+describe('weightedSample', () => {
+  const items = [
+    { recipe: 'a', weight: 1 },
+    { recipe: 'b', weight: 3 }, // 60% of total weight
+    { recipe: 'c', weight: 1 },
+  ]
+
+  it('returns undefined for an empty list', () => {
+    expect(weightedSample([])).toBeUndefined()
+  })
+
+  it('returns the only item when there is one', () => {
+    expect(weightedSample([{ recipe: 'solo', weight: 5 }]).recipe).toBe('solo')
+  })
+
+  it('selects by cumulative weight (rng maps into each band)', () => {
+    // total weight = 5, bands: a=[0,1), b=[1,4), c=[4,5).
+    expect(weightedSample(items, () => 0).recipe).toBe('a') // r=0 → a
+    expect(weightedSample(items, () => 0.5).recipe).toBe('b') // r=2.5 → b
+    expect(weightedSample(items, () => 0.99).recipe).toBe('c') // r≈4.95 → c
+  })
+
+  it('never picks a zero-weight item when positive-weight items exist', () => {
+    const mixed = [
+      { recipe: 'zero', weight: 0 },
+      { recipe: 'pos', weight: 2 },
+    ]
+    for (const r of [0, 0.25, 0.5, 0.75, 0.999]) {
+      expect(weightedSample(mixed, () => r).recipe).toBe('pos')
+    }
+  })
+
+  it('falls back to a uniform pick when all weights are zero', () => {
+    const zeros = [
+      { recipe: 'x', weight: 0 },
+      { recipe: 'y', weight: 0 },
+    ]
+    expect(weightedSample(zeros, () => 0).recipe).toBe('x')
+    expect(weightedSample(zeros, () => 0.99).recipe).toBe('y')
+  })
+
+  it('treats negative/missing weights as zero', () => {
+    const items2 = [
+      { recipe: 'neg', weight: -5 },
+      { recipe: 'none' },
+      { recipe: 'real', weight: 4 },
+    ]
+    for (const r of [0, 0.5, 0.99]) {
+      expect(weightedSample(items2, () => r).recipe).toBe('real')
+    }
   })
 })

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -1254,6 +1254,108 @@ describe('GET /getForYouRecipes', () => {
   })
 })
 
+describe('GET /recipes/random', () => {
+  it('returns a visible recipe for an anonymous user, never a hidden one', async () => {
+    await seedRecipes([
+      { ...BASE_RECIPE, _id: 'rnd-vis', title: 'Visible' },
+      { ...BASE_RECIPE, _id: 'rnd-hidden', title: 'Hidden', status: 'hidden' },
+    ])
+    // Only one visible candidate, so the (random) pick is deterministic here.
+    for (let i = 0; i < 4; i++) {
+      const res = await request(server).get('/api/recipes/random')
+      expect(res.status).toBe(200)
+      expect(res.body._id).toBe('rnd-vis')
+    }
+  })
+
+  it('returns 404 when there are no recipes', async () => {
+    const res = await request(server).get('/api/recipes/random')
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when the only recipes are hidden (fallback excludes them)', async () => {
+    await seedRecipes([
+      { ...BASE_RECIPE, _id: 'rnd-h1', status: 'hidden' },
+      { ...BASE_RECIPE, _id: 'rnd-h2', status: 'unpublished' },
+    ])
+    const res = await request(server).get('/api/recipes/random')
+    expect(res.status).toBe(404)
+  })
+
+  it('honors the exclude param (never returns the excluded recipe)', async () => {
+    await seedRecipes([
+      { ...BASE_RECIPE, _id: 'rnd-a', title: 'A' },
+      { ...BASE_RECIPE, _id: 'rnd-b', title: 'B' },
+    ])
+    for (let i = 0; i < 6; i++) {
+      const res = await request(server).get('/api/recipes/random?exclude=rnd-a')
+      expect(res.status).toBe(200)
+      expect(res.body._id).toBe('rnd-b')
+    }
+  })
+
+  it('gives a signal user a weighted on-taste pick, excluding seen and own', async () => {
+    await seedRecipes([
+      // 3 saved Italian dinners → Italian-dinner taste profile.
+      { ...BASE_RECIPE, _id: 'rnd-s1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'rnd-s2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'rnd-s3', cuisine: 'Italian', mealTypes: ['dinner'] },
+      // The ONLY unseen, non-own, on-taste candidate → must always be the pick.
+      { ...BASE_RECIPE, _id: 'rnd-on', cuisine: 'Italian', mealTypes: ['dinner'] },
+      // Own (excluded) + off-taste (taste 0 → filtered out) decoys.
+      { ...BASE_RECIPE, _id: 'rnd-own', cuisine: 'Italian', mealTypes: ['dinner'], userId: TEST_UID },
+      { ...BASE_RECIPE, _id: 'rnd-off', cuisine: 'Mexican', mealTypes: ['breakfast'], nutritionLabels: [] },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'rnd-s1', dateSaved: '1' },
+        { recipeId: 'rnd-s2', dateSaved: '2' },
+        { recipeId: 'rnd-s3', dateSaved: '3' },
+      ],
+    })
+
+    for (let i = 0; i < 5; i++) {
+      const res = await request(server).get('/api/recipes/random').set(AUTH_HEADER)
+      expect(res.status).toBe(200)
+      expect(res.body._id).toBe('rnd-on')
+    }
+  })
+
+  it('falls back to a random visible recipe when a signal user has no on-taste candidate', async () => {
+    await seedRecipes([
+      { ...BASE_RECIPE, _id: 'rnd-s1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'rnd-s2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'rnd-s3', cuisine: 'Italian', mealTypes: ['dinner'] },
+      // Only unseen candidate is off-taste → taste path finds nothing, so the
+      // route falls through to a uniform random pick rather than 404.
+      { ...BASE_RECIPE, _id: 'rnd-offonly', cuisine: 'Thai', mealTypes: ['breakfast'], nutritionLabels: [] },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'rnd-s1', dateSaved: '1' },
+        { recipeId: 'rnd-s2', dateSaved: '2' },
+        { recipeId: 'rnd-s3', dateSaved: '3' },
+      ],
+    })
+
+    const res = await request(server).get('/api/recipes/random').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body._id).toBe('rnd-offonly')
+  })
+
+  it('still returns a recipe for an authed user below the signal threshold (fallback)', async () => {
+    await seedRecipes([{ ...BASE_RECIPE, _id: 'rnd-only', title: 'Solo' }])
+    // 1 save → below MIN_SIGNAL, so the taste path is skipped and the fallback
+    // random pick runs. (Fallback excludes own + excluded, not merely-seen.)
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [{ recipeId: 'rnd-only', dateSaved: '1' }],
+    })
+    const res = await request(server).get('/api/recipes/random').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body._id).toBe('rnd-only')
+  })
+})
+
 // ─── Phase 5-D _id coercion regression tests ─────────────────────────────────
 
 describe('Phase 5-D — recipeIdQuery coercion', () => {

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -1346,13 +1346,44 @@ describe('GET /recipes/random', () => {
   it('still returns a recipe for an authed user below the signal threshold (fallback)', async () => {
     await seedRecipes([{ ...BASE_RECIPE, _id: 'rnd-only', title: 'Solo' }])
     // 1 save → below MIN_SIGNAL, so the taste path is skipped and the fallback
-    // random pick runs. (Fallback excludes own + excluded, not merely-seen.)
+    // runs. The only recipe is one they've seen, so the "prefer unseen" pool is
+    // empty and the fallback relaxes to return the seen recipe anyway (rather
+    // than a dead end).
     await seedUserRecipeData(TEST_UID, {
       savedRecipes: [{ recipeId: 'rnd-only', dateSaved: '1' }],
     })
     const res = await request(server).get('/api/recipes/random').set(AUTH_HEADER)
     expect(res.status).toBe(200)
     expect(res.body._id).toBe('rnd-only')
+  })
+
+  it('fallback prefers an unseen recipe over seen ones for a signal user', async () => {
+    await seedRecipes([
+      // 3 saved Italian dinners → signal, but all SEEN.
+      { ...BASE_RECIPE, _id: 'rnd-s1', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'rnd-s2', cuisine: 'Italian', mealTypes: ['dinner'] },
+      { ...BASE_RECIPE, _id: 'rnd-s3', cuisine: 'Italian', mealTypes: ['dinner'] },
+      // A SEEN off-taste recipe (saved) — a valid fallback candidate by status,
+      // but the user has already seen it, so it must NOT be preferred.
+      { ...BASE_RECIPE, _id: 'rnd-seen-off', cuisine: 'Mexican', mealTypes: ['breakfast'], nutritionLabels: [] },
+      // The only UNSEEN recipe is off-taste, so the taste path finds nothing and
+      // the fallback runs — it must always pick this unseen one, never the seen.
+      { ...BASE_RECIPE, _id: 'rnd-unseen-off', cuisine: 'Thai', mealTypes: ['breakfast'], nutritionLabels: [] },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'rnd-s1', dateSaved: '1' },
+        { recipeId: 'rnd-s2', dateSaved: '2' },
+        { recipeId: 'rnd-s3', dateSaved: '3' },
+        { recipeId: 'rnd-seen-off', dateSaved: '4' },
+      ],
+    })
+
+    for (let i = 0; i < 8; i++) {
+      const res = await request(server).get('/api/recipes/random').set(AUTH_HEADER)
+      expect(res.status).toBe(200)
+      expect(res.body._id).toBe('rnd-unseen-off')
+    }
   })
 })
 

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -5,7 +5,8 @@ const { getDB, getClient } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeWriteLimiter } = require('../middleware/writeLimiter')
 const { recipeIdQuery, recipeIdInQuery } = require('../util/recipeIdQuery')
-const { MIN_SIGNAL, buildTasteProfile, interactionWeight, selectForYou } = require('../util/forYou')
+const { MIN_SIGNAL, selectForYou, tasteScore, weightedSample } = require('../util/forYou')
+const { loadInteractions, buildSeenProfile } = require('../util/tasteContext')
 const { RECIPE_VISIBLE, RECIPE_OWNER_VISIBLE } = require('../util/moderation')
 const { recordAudit } = require('../util/auditLog')
 const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
@@ -22,6 +23,20 @@ const router = Router()
 // Hard ceiling on client-requested page sizes so a single request can never
 // dump a whole collection (audit §4.5). Shared by every paginated route here.
 const MAX_PER_PAGE = 50
+
+// Fields the home recipe cards (For You row + "What should I cook?" pick) need
+// to render. Shared so the personalized routes project an identical shape.
+const RECIPE_CARD_PROJECTION = {
+  title: 1,
+  recipeImage: 1,
+  cuisine: 1,
+  totalTime: 1,
+  servingPrice: 1,
+  rating: 1,
+  mealTypes: 1,
+  nutritionLabels: 1,
+  numTimesSaved: 1,
+}
 
 function escapeRegex(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -208,61 +223,16 @@ router.get('/getForYouRecipes', verifyToken, asyncHandler(async (req, res) => {
   const uid = req.uid
   const limit = Math.max(1, Math.min(parseInt(req.query.limit, 10) || 8, 20))
 
-  // 1. Gather the user's interactions.
-  const [userData, ratingDocs] = await Promise.all([
-    db.collection('userRecipeData').findOne(
-      { _id: uid },
-      { projection: { savedRecipes: 1, madeRecipes: 1 } }
-    ),
-    db.collection('ratings')
-      .find({ userId: uid }, { projection: { recipeId: 1, rating: 1 } })
-      .toArray(),
-  ])
-
-  const savedIds = new Set((userData?.savedRecipes ?? []).map((e) => e.recipeId))
-  const madeIds = new Set((userData?.madeRecipes ?? []).map((e) => e.recipeId))
-  const ratingById = new Map(
-    ratingDocs
-      .filter((r) => r.rating != null)
-      .map((r) => [r.recipeId, r.rating])
-  )
-
-  // Recipes that carry actual taste signal: saved, made, or given a real
-  // (non-null) rating. This drives both the threshold and the profile below.
-  const signalIds = new Set([...savedIds, ...madeIds, ...ratingById.keys()])
-  if (signalIds.size < MIN_SIGNAL) {
+  // 1. Gather the user's interactions (cheap, indexed reads). Below the signal
+  // threshold the row is hidden, so bail before the costlier profile lookup.
+  const interactions = await loadInteractions(db, uid)
+  if (interactions.signalIds.size < MIN_SIGNAL) {
     return res.json([])
   }
+  const seenIds = interactions.seenIds
 
-  // Everything the user has engaged with — signal plus review-only rating docs
-  // (rating: null, e.g. a written review without a star rating) — is excluded
-  // from recommendations so we never suggest a recipe back to them. Review-only
-  // docs add no profile signal (ratingById already drops them), but they
-  // shouldn't reappear in the row either.
-  const seenIds = new Set([...signalIds, ...ratingDocs.map((r) => r.recipeId)])
-
-  // 2. Look up the feature tags of the seen recipes (some may be deleted —
-  // those just drop out).
-  const seenFeatureDocs = await db
-    .collection('recipes')
-    .find(recipeIdInQuery([...seenIds]), {
-      projection: { cuisine: 1, mealTypes: 1, nutritionLabels: 1 },
-    })
-    .toArray()
-
-  // 3. Build the taste profile, combining each recipe's signals into one weight.
-  const interactions = seenFeatureDocs.map((recipe) => {
-    const id = String(recipe._id)
-    return {
-      recipe,
-      weight: interactionWeight({
-        made: madeIds.has(id),
-        saved: savedIds.has(id),
-        rating: ratingById.get(id) ?? null,
-      }),
-    }
-  })
-  const profile = buildTasteProfile(interactions)
+  // 2-3. Build the taste profile from the seen recipes' feature tags.
+  const profile = await buildSeenProfile(db, interactions)
 
   // 4. Candidate pool: every visible recipe except ones the user has already
   // seen or authored. Project only what scoring + the card need.
@@ -271,19 +241,7 @@ router.get('/getForYouRecipes', verifyToken, asyncHandler(async (req, res) => {
     .collection('recipes')
     .find(
       { ...RECIPE_VISIBLE, userId: { $ne: uid }, _id: { $nin: excludeVariants } },
-      {
-        projection: {
-          title: 1,
-          recipeImage: 1,
-          cuisine: 1,
-          totalTime: 1,
-          servingPrice: 1,
-          rating: 1,
-          mealTypes: 1,
-          nutritionLabels: 1,
-          numTimesSaved: 1,
-        },
-      }
+      { projection: RECIPE_CARD_PROJECTION }
     )
     .toArray()
 
@@ -294,6 +252,64 @@ router.get('/getForYouRecipes', verifyToken, asyncHandler(async (req, res) => {
   )
   const recipes = selectForYou(candidates, profile, { limit, numTimesSavedMax })
   res.json(recipes)
+}))
+
+// GET /recipes/random — one recipe for the "What should I cook?" button.
+// optionalAuth so it works logged-out. A signed-in user with >= MIN_SIGNAL
+// interactions gets a weighted-random ON-TASTE pick (reusing the For You taste
+// profile); everyone else (anonymous, below threshold, or no on-taste match)
+// gets a uniform random visible recipe via $sample. `exclude` lets the client
+// re-roll ("Try another") without immediately repeating the current pick.
+router.get('/recipes/random', optionalAuth, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const uid = req.uid || null
+  const exclude = typeof req.query.exclude === 'string' ? req.query.exclude : null
+  const excludeVariants = exclude ? recipeIdInQuery([exclude])._id.$in : []
+
+  // 1. Taste-aware path: signed-in user with enough signal to personalize.
+  if (uid) {
+    const interactions = await loadInteractions(db, uid)
+    if (interactions.signalIds.size >= MIN_SIGNAL) {
+      const profile = await buildSeenProfile(db, interactions)
+      const seenVariants = recipeIdInQuery([...interactions.seenIds])._id.$in
+      const candidates = await db
+        .collection('recipes')
+        .find(
+          {
+            ...RECIPE_VISIBLE,
+            userId: { $ne: uid },
+            _id: { $nin: [...seenVariants, ...excludeVariants] },
+          },
+          { projection: RECIPE_CARD_PROJECTION }
+        )
+        .toArray()
+
+      // Keep only recipes the user has positive affinity for, then pick one
+      // weighted by that affinity (stronger match = likelier, but still varied).
+      const scored = candidates
+        .map((recipe) => ({ recipe, weight: tasteScore(recipe, profile) }))
+        .filter((s) => s.weight > 0)
+      const pick = weightedSample(scored)
+      if (pick) return res.json(pick.recipe)
+      // No on-taste candidate (rare) → fall through to a uniform random pick.
+    }
+  }
+
+  // 2. Fallback: uniform random over visible recipes (minus own + excluded).
+  const match = { ...RECIPE_VISIBLE }
+  if (uid) match.userId = { $ne: uid }
+  if (excludeVariants.length) match._id = { $nin: excludeVariants }
+  const [random] = await db
+    .collection('recipes')
+    .aggregate([
+      { $match: match },
+      { $sample: { size: 1 } },
+      { $project: RECIPE_CARD_PROJECTION },
+    ])
+    .toArray()
+
+  if (!random) return res.status(404).json({ error: 'No recipes available' })
+  res.json(random)
 }))
 
 // GET /getRecipe — fetch single recipe and increment view count.

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -38,6 +38,14 @@ const RECIPE_CARD_PROJECTION = {
   numTimesSaved: 1,
 }
 
+// The id-shape variants (string + ObjectId) for a list of recipe ids, ready to
+// drop into an `_id: { $nin: [...] }` clause. Thin wrapper over recipeIdInQuery
+// so callers don't reach into its `{ _id: { $in } }` return shape. Skips falsy
+// ids (e.g. a missing `exclude` query param).
+function idVariants(ids) {
+  return recipeIdInQuery(ids.filter(Boolean))._id.$in
+}
+
 function escapeRegex(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
@@ -236,7 +244,7 @@ router.get('/getForYouRecipes', verifyToken, asyncHandler(async (req, res) => {
 
   // 4. Candidate pool: every visible recipe except ones the user has already
   // seen or authored. Project only what scoring + the card need.
-  const excludeVariants = recipeIdInQuery([...seenIds])._id.$in
+  const excludeVariants = idVariants([...seenIds])
   const candidates = await db
     .collection('recipes')
     .find(
@@ -264,14 +272,19 @@ router.get('/recipes/random', optionalAuth, asyncHandler(async (req, res) => {
   const db = getDB()
   const uid = req.uid || null
   const exclude = typeof req.query.exclude === 'string' ? req.query.exclude : null
-  const excludeVariants = exclude ? recipeIdInQuery([exclude])._id.$in : []
+  const excludeVariants = idVariants([exclude])
+
+  // Recipes the user has already engaged with — preferred OUT of suggestions so
+  // we surface something fresh. Loaded once (cheap, indexed) and reused by both
+  // the taste path and the fallback below. Empty for anonymous users.
+  let seenVariants = []
 
   // 1. Taste-aware path: signed-in user with enough signal to personalize.
   if (uid) {
     const interactions = await loadInteractions(db, uid)
+    seenVariants = idVariants([...interactions.seenIds])
     if (interactions.signalIds.size >= MIN_SIGNAL) {
       const profile = await buildSeenProfile(db, interactions)
-      const seenVariants = recipeIdInQuery([...interactions.seenIds])._id.$in
       const candidates = await db
         .collection('recipes')
         .find(
@@ -295,18 +308,26 @@ router.get('/recipes/random', optionalAuth, asyncHandler(async (req, res) => {
     }
   }
 
-  // 2. Fallback: uniform random over visible recipes (minus own + excluded).
-  const match = { ...RECIPE_VISIBLE }
-  if (uid) match.userId = { $ne: uid }
-  if (excludeVariants.length) match._id = { $nin: excludeVariants }
-  const [random] = await db
-    .collection('recipes')
-    .aggregate([
-      { $match: match },
-      { $sample: { size: 1 } },
-      { $project: RECIPE_CARD_PROJECTION },
-    ])
-    .toArray()
+  // 2. Fallback: uniform random over visible recipes (never own). Prefer one the
+  // user hasn't seen yet (and isn't the just-shown pick); only if excluding seen
+  // leaves nothing — e.g. they've already seen the whole catalog — do we relax
+  // that so the button still returns a recipe instead of a dead end.
+  const baseMatch = { ...RECIPE_VISIBLE }
+  if (uid) baseMatch.userId = { $ne: uid }
+
+  const sampleOne = async (notIds) => {
+    const match = notIds.length ? { ...baseMatch, _id: { $nin: notIds } } : baseMatch
+    const [doc] = await db
+      .collection('recipes')
+      .aggregate([{ $match: match }, { $sample: { size: 1 } }, { $project: RECIPE_CARD_PROJECTION }])
+      .toArray()
+    return doc
+  }
+
+  let random = await sampleOne([...seenVariants, ...excludeVariants])
+  // Nothing unseen left → relax the "unseen" constraint (still skip the just-shown
+  // pick when possible) so an active user keeps getting suggestions.
+  if (!random && seenVariants.length) random = await sampleOne(excludeVariants)
 
   if (!random) return res.status(404).json({ error: 'No recipes available' })
   res.json(random)

--- a/server/util/forYou.js
+++ b/server/util/forYou.js
@@ -148,6 +148,25 @@ function shuffle(arr, rng = Math.random) {
   return a
 }
 
+// Pick ONE element from a list of { recipe, weight } by weight (weights must be
+// >= 0). Used by the "What should I cook?" button to choose a single on-taste
+// recipe: a stronger taste match is likelier, but every positive-weight recipe
+// can come up, so repeated presses feel varied instead of always the top match.
+// Injectable RNG for deterministic tests. Returns undefined for an empty list;
+// if all weights are 0 it falls back to a uniform pick so we still return one.
+function weightedSample(scored, rng = Math.random) {
+  if (!scored.length) return undefined
+  const w = (x) => Math.max(0, x.weight || 0)
+  const total = scored.reduce((s, x) => s + w(x), 0)
+  if (total <= 0) return scored[Math.floor(rng() * scored.length)]
+  let r = rng() * total
+  for (const x of scored) {
+    r -= w(x)
+    if (r < 0) return x
+  }
+  return scored[scored.length - 1] // float-rounding guard
+}
+
 // Rank candidates, enforce per-cuisine diversity, then shuffle the top tier for
 // "fresh each visit" variety. Returns up to `limit` recipes.
 //
@@ -199,4 +218,5 @@ module.exports = {
   scoreRecipe,
   selectForYou,
   shuffle,
+  weightedSample,
 }

--- a/server/util/tasteContext.js
+++ b/server/util/tasteContext.js
@@ -1,0 +1,74 @@
+// Shared loader for a user's content-based taste context, used by both the
+// "For You" home row (GET /getForYouRecipes) and the "What should I cook?"
+// button (GET /recipes/random). Keeping this in one place means the signal/seen
+// split and the profile are defined exactly once.
+//
+// Split into two steps on purpose: loadInteractions() is cheap (two indexed
+// reads, no recipe scan) so a caller can check the MIN_SIGNAL threshold and bail
+// BEFORE paying for the feature-doc lookup that buildSeenProfile() needs.
+
+const { recipeIdInQuery } = require('./recipeIdQuery')
+const { buildTasteProfile, interactionWeight } = require('./forYou')
+
+// Read the user's saves / makes / ratings and derive the two id sets the
+// recommendation routes care about:
+//  - signalIds: recipes carrying REAL taste signal (saved | made | non-null
+//    rating). Drives the MIN_SIGNAL threshold AND the taste profile.
+//  - seenIds: everything engaged with — signal PLUS review-only (rating: null)
+//    docs. Used only to EXCLUDE recipes from suggestions; a null rating is never
+//    taste signal and never counts toward the threshold.
+// Also returns the raw maps so buildSeenProfile can weight each recipe's signals.
+async function loadInteractions(db, uid) {
+  const [userData, ratingDocs] = await Promise.all([
+    db.collection('userRecipeData').findOne(
+      { _id: uid },
+      { projection: { savedRecipes: 1, madeRecipes: 1 } }
+    ),
+    db.collection('ratings')
+      .find({ userId: uid }, { projection: { recipeId: 1, rating: 1 } })
+      .toArray(),
+  ])
+
+  const savedIds = new Set((userData?.savedRecipes ?? []).map((e) => e.recipeId))
+  const madeIds = new Set((userData?.madeRecipes ?? []).map((e) => e.recipeId))
+  const ratingById = new Map(
+    ratingDocs
+      .filter((r) => r.rating != null)
+      .map((r) => [r.recipeId, r.rating])
+  )
+
+  const signalIds = new Set([...savedIds, ...madeIds, ...ratingById.keys()])
+  const seenIds = new Set([...signalIds, ...ratingDocs.map((r) => r.recipeId)])
+
+  return { savedIds, madeIds, ratingById, signalIds, seenIds }
+}
+
+// Build the taste profile for a user from the feature tags of their seen
+// recipes. Looks up cuisine/mealTypes/nutritionLabels for the seenIds (deleted
+// recipes just drop out), combines each recipe's signals into one weight via
+// interactionWeight (review-only docs weigh 0 → ignored), and folds them into a
+// buildTasteProfile() result. Call only after the threshold check.
+async function buildSeenProfile(db, { savedIds, madeIds, ratingById, seenIds }) {
+  const seenFeatureDocs = await db
+    .collection('recipes')
+    .find(recipeIdInQuery([...seenIds]), {
+      projection: { cuisine: 1, mealTypes: 1, nutritionLabels: 1 },
+    })
+    .toArray()
+
+  const interactions = seenFeatureDocs.map((recipe) => {
+    const id = String(recipe._id)
+    return {
+      recipe,
+      weight: interactionWeight({
+        made: madeIds.has(id),
+        saved: savedIds.has(id),
+        rating: ratingById.get(id) ?? null,
+      }),
+    }
+  })
+
+  return buildTasteProfile(interactions)
+}
+
+module.exports = { loadInteractions, buildSeenProfile }

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -104,6 +104,20 @@ class RecipeAPIClass {
     const result = await http.get(`api/getForYouRecipes?limit=${limit}`)
     return result.data
   }
+  // One random recipe for the "What should I cook?" button. Taste-aware when
+  // signed in (token attached by the interceptor); a uniform random pick
+  // otherwise. `excludeId` re-rolls without repeating the current pick. Resolves
+  // null when the catalog is empty (404) so the caller can show a soft message.
+  async getRandomRecipe(excludeId?: string): Promise<RecipeType | null> {
+    const params = excludeId ? `?exclude=${encodeURIComponent(excludeId)}` : ''
+    try {
+      const result = await http.get(`api/recipes/random${params}`)
+      return result.data
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response?.status === 404) return null
+      throw err
+    }
+  }
   async getRecipe(id: string): Promise<RecipeType> {
     const result = await http.get(`api/getRecipe?id=${id}`)
     return result.data

--- a/src/pages/Home/HomeCookSuggestion.scss
+++ b/src/pages/Home/HomeCookSuggestion.scss
@@ -1,0 +1,168 @@
+@use '../../helpers.scss' as s;
+
+// Spotlight modal card for "What should I cook?". The price chip + thumb match
+// the standard home recipe thumbnails (see Home.scss .home-recipe-card .thumb).
+.cook-modal-card {
+  position: relative;
+  width: min(360px, 90vw);
+  background: #fff;
+  border-radius: 16px;
+  overflow: hidden;
+  text-align: left;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  animation: cook-modal-pop 0.18s ease;
+
+  .cook-modal-close {
+    position: absolute;
+    top: 0.55rem;
+    right: 0.55rem;
+    z-index: 2;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(255, 255, 255, 0.92);
+    color: s.$primary-text;
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    font-size: 1.1rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    &:hover { background: #fff; }
+  }
+
+  .thumb {
+    position: relative;
+    // The container reserves the height (4:3) so it's constant even before the
+    // next image loads — picks never change the image box size.
+    aspect-ratio: 4 / 3;
+    overflow: hidden;
+    background: #eceef0;
+    img {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    // Same chip as the standard recipe thumbnails.
+    .price-chip {
+      position: absolute;
+      bottom: 0.6rem;
+      right: 0.6rem;
+      background: rgba(255, 255, 255, 0.95);
+      color: s.$primary;
+      font-weight: 800;
+      font-size: 0.78rem;
+      padding: 0.28rem 0.6rem;
+      border-radius: 999px;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+    }
+    .reroll-veil {
+      position: absolute;
+      inset: 0;
+      background: rgba(255, 255, 255, 0.55);
+      display: grid;
+      place-items: center;
+      .spinner {
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+        border: 3px solid rgba(0, 0, 0, 0.15);
+        border-top-color: s.$primary;
+        animation: cook-spin 0.7s linear infinite;
+      }
+    }
+  }
+
+  .body { padding: 0.9rem 1rem 1rem; }
+  h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    line-height: 1.3;
+    text-transform: capitalize;
+    margin: 0 0 0.5rem;
+    color: s.$primary-text;
+    // Always reserve two lines and clamp longer titles, so a 1-line and a
+    // 2-line title occupy the same height (no vertical jump between picks).
+    min-height: 2.6em;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .meta {
+    display: flex;
+    flex-wrap: nowrap; // keep meta on one line so its height is constant
+    align-items: center;
+    gap: 0.7rem;
+    color: #6b7480;
+    font-size: 0.85rem;
+    margin-bottom: 0.95rem;
+    overflow: hidden;
+    span { display: inline-flex; align-items: center; gap: 0.25rem; white-space: nowrap; }
+    .cuisine { color: s.$primary; font-weight: 600; overflow: hidden; text-overflow: ellipsis; }
+  }
+  .actions { display: flex; gap: 0.6rem; }
+  // skeleton stand-ins for the two action buttons
+  .actions .sk-btn { flex: 1; line-height: 1; }
+  .primary,
+  .ghost {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    flex: 1;
+    border: none;
+    border-radius: 999px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 0.6rem 1rem;
+    cursor: pointer;
+    text-decoration: none;
+    transition: filter 0.12s ease, background 0.12s ease;
+    svg { font-size: 1.1rem; }
+  }
+  .primary { background: s.$primary; color: #fff; &:hover { filter: brightness(1.06); } }
+  .ghost {
+    background: #f0f1f3;
+    color: s.$primary-text;
+    font-weight: 500;
+    &:hover { background: #e4e6e9; }
+    &:disabled { opacity: 0.7; cursor: default; }
+  }
+}
+
+// Loading / empty / error states reuse the card frame.
+.cook-modal-state {
+  width: min(360px, 90vw);
+  background: #fff;
+  border-radius: 16px;
+  overflow: hidden;
+  .body { padding: 0.9rem 1rem 1rem; }
+  &.cook-modal-msg {
+    padding: 1.6rem 1.4rem;
+    text-align: center;
+    color: s.$primary-text;
+    p { margin: 0 0 0.9rem; }
+    .ghost {
+      background: #f0f1f3;
+      border: none;
+      border-radius: 999px;
+      padding: 0.5rem 1.1rem;
+      font-weight: 600;
+      cursor: pointer;
+      &:hover { background: #e4e6e9; }
+    }
+  }
+}
+
+@keyframes cook-modal-pop {
+  from { opacity: 0; transform: scale(0.95) translateY(6px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+@keyframes cook-spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/pages/Home/HomeCookSuggestion.tsx
+++ b/src/pages/Home/HomeCookSuggestion.tsx
@@ -1,69 +1,147 @@
-import React, { FC } from 'react'
+import React, { FC, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
-import { IoDiceOutline } from 'react-icons/io5'
+import Modal from 'react-modal'
+import { Link } from 'react-router-dom'
+import { CgTimer } from 'react-icons/cg'
+import { AiOutlineStar } from 'react-icons/ai'
+import { IoDiceOutline, IoClose } from 'react-icons/io5'
+import Skeleton from 'react-loading-skeleton'
 import RecipeAPI from 'src/api/recipes'
 import { RecipeType } from 'types'
-import { HomeRecipeCard } from './HomeRecipeCard'
+import { fmtPrice, ratingLabel, skeletonColor } from './homeFormat'
+import './HomeCookSuggestion.scss'
 
-// "What should I cook?" — a one-tap decision-fatigue killer in the hero. Asks
-// the server for a single recipe (taste-aware when signed in, a uniform random
-// pick otherwise — the server decides based on the attached token) and reveals
-// it as a card the user can open or re-roll with "Try another". Available to
-// everyone; no auth gate here. Silent-ish: a rare empty catalog (404 → null)
-// shows a soft note, a transient error lets them retry.
+// react-modal positions the overlay; the visible card is styled via
+// .cook-modal-card so the content frame itself stays transparent (same approach
+// as AchievementsModal).
+const modalStyles = {
+  content: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    right: 'auto',
+    bottom: 'auto',
+    marginRight: '-50%',
+    transform: 'translate(-50%, -50%)',
+    padding: 0,
+    border: 'none',
+    background: 'transparent',
+    overflow: 'visible',
+  },
+  overlay: { zIndex: '1000', background: 'rgba(0, 0, 0, 0.6)' },
+}
+
+// Card-shaped skeleton, matching the real card's layout so the modal doesn't
+// resize between the loading and loaded states.
+const CardSkeleton: FC = () => (
+  <>
+    <div className='thumb'>
+      <Skeleton baseColor={skeletonColor} height='100%' style={{ aspectRatio: '4 / 3', display: 'block' }} />
+    </div>
+    <div className='body'>
+      <h3><Skeleton baseColor={skeletonColor} width='75%' /></h3>
+      <div className='meta'><Skeleton baseColor={skeletonColor} width={170} /></div>
+      <div className='actions'>
+        <span className='sk-btn'><Skeleton baseColor={skeletonColor} height={38} borderRadius={999} /></span>
+        <span className='sk-btn'><Skeleton baseColor={skeletonColor} height={38} borderRadius={999} /></span>
+      </div>
+    </div>
+  </>
+)
+
+// "What should I cook?" — a one-tap decision-fatigue killer in the hero. The
+// button never moves; clicking opens a spotlight modal with a single recipe the
+// user can open or re-roll with "Try another". Taste-aware when signed in, a
+// random pick otherwise (the server decides via the attached token). Available
+// to everyone — no auth gate here.
 const HomeCookSuggestion: FC = () => {
-  const { mutate, data, isPending, isError } = useMutation<
-    RecipeType | null,
-    unknown,
-    string | undefined
-  >({
+  const [isOpen, setIsOpen] = useState(false)
+  // The currently displayed pick is held in state (not read off the mutation)
+  // so a re-roll keeps the previous card on screen — stable size, no squish —
+  // until the next pick arrives. undefined = nothing fetched yet, null = 404.
+  const [pick, setPick] = useState<RecipeType | null | undefined>(undefined)
+
+  const { mutate, isPending, isError, reset } = useMutation<RecipeType | null, unknown, string | undefined>({
     mutationFn: (excludeId) => RecipeAPI.getRandomRecipe(excludeId),
+    onSuccess: (r) => setPick(r),
   })
 
-  const pick = data ?? null
-  // data === null only after a resolved 404 (empty catalog); undefined before
-  // the first run or after an error.
-  const mode: 'idle' | 'revealed' | 'empty' = pick
-    ? 'revealed'
-    : data === null
-      ? 'empty'
-      : 'idle'
+  const open = () => {
+    setIsOpen(true)
+    setPick(undefined)
+    mutate(undefined)
+  }
+  const tryAnother = () => mutate(pick?._id)
+  const close = () => {
+    setIsOpen(false)
+    setPick(undefined)
+    reset()
+  }
 
   return (
     <div className='home-cook-suggestion'>
-      {mode === 'idle' && (
-        <button
-          type='button'
-          className='cook-suggestion-btn'
-          onClick={() => mutate(undefined)}
-          disabled={isPending}
-        >
-          <IoDiceOutline />
-          {isPending ? 'Finding a recipe…' : 'What should I cook?'}
-        </button>
-      )}
+      <button className='cook-suggestion-btn' type='button' onClick={open}>
+        <IoDiceOutline /> What should I cook?
+      </button>
 
-      {mode === 'revealed' && pick && (
-        <div className='cook-suggestion-reveal'>
-          <HomeRecipeCard recipe={pick} />
-          <button
-            type='button'
-            className='try-another-btn'
-            onClick={() => mutate(pick._id)}
-            disabled={isPending}
-          >
-            <IoDiceOutline />
-            {isPending ? 'Finding…' : 'Try another'}
+      <Modal
+        isOpen={isOpen}
+        onRequestClose={close}
+        style={modalStyles}
+        className='cook-modal'
+        contentLabel='Recipe suggestion'
+      >
+        <div className='cook-modal-card'>
+          <button className='cook-modal-close' onClick={close} aria-label='Close' type='button'>
+            <IoClose />
           </button>
-        </div>
-      )}
 
-      {mode === 'empty' && (
-        <p className='cook-suggestion-msg'>No recipes to suggest yet — check back soon.</p>
-      )}
-      {isError && (
-        <p className='cook-suggestion-msg'>Couldn’t pick a recipe. Give it another try.</p>
-      )}
+          {pick ? (
+            <>
+              <div className='thumb'>
+                <img src={pick.recipeImage} alt={pick.title} />
+                {pick.servingPrice != null && (
+                  <span className='price-chip'>{fmtPrice(pick.servingPrice)}/serv</span>
+                )}
+                {isPending && (
+                  <div className='reroll-veil' aria-hidden>
+                    <span className='spinner' />
+                  </div>
+                )}
+              </div>
+              <div className='body'>
+                <h3>{pick.title}</h3>
+                <div className='meta'>
+                  <span><CgTimer /> {pick.totalTime}m</span>
+                  <span><AiOutlineStar /> {ratingLabel(pick.rating)}</span>
+                  {pick.cuisine && <span className='cuisine'>{pick.cuisine}</span>}
+                </div>
+                <div className='actions'>
+                  <Link to={`/recipes/${pick._id}`} className='primary' onClick={close}>
+                    View recipe
+                  </Link>
+                  <button className='ghost' onClick={tryAnother} disabled={isPending} type='button'>
+                    <IoDiceOutline /> {isPending ? 'Finding…' : 'Try another'}
+                  </button>
+                </div>
+              </div>
+            </>
+          ) : isPending ? (
+            <CardSkeleton />
+          ) : isError ? (
+            <div className='cook-modal-state cook-modal-msg'>
+              <p>Couldn’t pick a recipe.</p>
+              <button className='ghost' onClick={() => mutate(undefined)} type='button'>
+                Try again
+              </button>
+            </div>
+          ) : (
+            <div className='cook-modal-state cook-modal-msg'>
+              <p>No recipes to suggest yet — check back soon.</p>
+            </div>
+          )}
+        </div>
+      </Modal>
     </div>
   )
 }

--- a/src/pages/Home/HomeCookSuggestion.tsx
+++ b/src/pages/Home/HomeCookSuggestion.tsx
@@ -1,0 +1,71 @@
+import React, { FC } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { IoDiceOutline } from 'react-icons/io5'
+import RecipeAPI from 'src/api/recipes'
+import { RecipeType } from 'types'
+import { HomeRecipeCard } from './HomeRecipeCard'
+
+// "What should I cook?" — a one-tap decision-fatigue killer in the hero. Asks
+// the server for a single recipe (taste-aware when signed in, a uniform random
+// pick otherwise — the server decides based on the attached token) and reveals
+// it as a card the user can open or re-roll with "Try another". Available to
+// everyone; no auth gate here. Silent-ish: a rare empty catalog (404 → null)
+// shows a soft note, a transient error lets them retry.
+const HomeCookSuggestion: FC = () => {
+  const { mutate, data, isPending, isError } = useMutation<
+    RecipeType | null,
+    unknown,
+    string | undefined
+  >({
+    mutationFn: (excludeId) => RecipeAPI.getRandomRecipe(excludeId),
+  })
+
+  const pick = data ?? null
+  // data === null only after a resolved 404 (empty catalog); undefined before
+  // the first run or after an error.
+  const mode: 'idle' | 'revealed' | 'empty' = pick
+    ? 'revealed'
+    : data === null
+      ? 'empty'
+      : 'idle'
+
+  return (
+    <div className='home-cook-suggestion'>
+      {mode === 'idle' && (
+        <button
+          type='button'
+          className='cook-suggestion-btn'
+          onClick={() => mutate(undefined)}
+          disabled={isPending}
+        >
+          <IoDiceOutline />
+          {isPending ? 'Finding a recipe…' : 'What should I cook?'}
+        </button>
+      )}
+
+      {mode === 'revealed' && pick && (
+        <div className='cook-suggestion-reveal'>
+          <HomeRecipeCard recipe={pick} />
+          <button
+            type='button'
+            className='try-another-btn'
+            onClick={() => mutate(pick._id)}
+            disabled={isPending}
+          >
+            <IoDiceOutline />
+            {isPending ? 'Finding…' : 'Try another'}
+          </button>
+        </div>
+      )}
+
+      {mode === 'empty' && (
+        <p className='cook-suggestion-msg'>No recipes to suggest yet — check back soon.</p>
+      )}
+      {isError && (
+        <p className='cook-suggestion-msg'>Couldn’t pick a recipe. Give it another try.</p>
+      )}
+    </div>
+  )
+}
+
+export default HomeCookSuggestion

--- a/src/pages/Home/HomeHero/HomeHero.scss
+++ b/src/pages/Home/HomeHero/HomeHero.scss
@@ -46,16 +46,13 @@
   }
 }
 
-// "What should I cook?" button + its reveal card, living in the hero overlay
-// under the search input.
+// "What should I cook?" trigger button, living in the hero overlay under the
+// search input. Clicking opens a spotlight modal (HomeCookSuggestion.scss); the
+// button itself never moves, so nothing on the page shifts.
 .home-cook-suggestion {
   margin-top: 1.25rem;
-  width: 90%;
-  max-width: 520px;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.85rem;
+  justify-content: center;
 
   .cook-suggestion-btn {
     display: inline-flex;
@@ -70,70 +67,14 @@
     font-weight: 600;
     cursor: pointer;
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
-    transition: transform 0.12s ease, filter 0.12s ease, opacity 0.12s ease;
+    transition: transform 0.12s ease, filter 0.12s ease;
 
     svg {
       font-size: 1.25rem;
     }
-    &:hover:not(:disabled) {
+    &:hover {
       transform: translateY(-1px);
       filter: brightness(1.06);
     }
-    &:disabled {
-      opacity: 0.75;
-      cursor: default;
-    }
-  }
-
-  .cook-suggestion-reveal {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.75rem;
-
-    // The shared home card is sized for a grid cell; constrain + lift it here so
-    // the single reveal reads as a floating card on the hero rather than a row.
-    .home-recipe-card {
-      width: 100%;
-      max-width: 320px;
-      background: s.$white;
-      border-radius: 12px;
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
-    }
-
-    .try-another-btn {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      padding: 0.5rem 1.1rem;
-      border: 1px solid rgba(255, 255, 255, 0.55);
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.14);
-      color: s.$white;
-      font-size: 0.9rem;
-      font-weight: 500;
-      cursor: pointer;
-      transition: background 0.12s ease;
-
-      svg {
-        font-size: 1.05rem;
-      }
-      &:hover:not(:disabled) {
-        background: rgba(255, 255, 255, 0.24);
-      }
-      &:disabled {
-        opacity: 0.7;
-        cursor: default;
-      }
-    }
-  }
-
-  .cook-suggestion-msg {
-    margin: 0;
-    color: s.$white;
-    font-size: 0.9rem;
-    text-align: center;
-    opacity: 0.9;
   }
 }

--- a/src/pages/Home/HomeHero/HomeHero.scss
+++ b/src/pages/Home/HomeHero/HomeHero.scss
@@ -45,3 +45,95 @@
     font-weight: 500;
   }
 }
+
+// "What should I cook?" button + its reveal card, living in the hero overlay
+// under the search input.
+.home-cook-suggestion {
+  margin-top: 1.25rem;
+  width: 90%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.85rem;
+
+  .cook-suggestion-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.7rem 1.4rem;
+    border: none;
+    border-radius: 999px;
+    background: s.$primary;
+    color: s.$white;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+    transition: transform 0.12s ease, filter 0.12s ease, opacity 0.12s ease;
+
+    svg {
+      font-size: 1.25rem;
+    }
+    &:hover:not(:disabled) {
+      transform: translateY(-1px);
+      filter: brightness(1.06);
+    }
+    &:disabled {
+      opacity: 0.75;
+      cursor: default;
+    }
+  }
+
+  .cook-suggestion-reveal {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+
+    // The shared home card is sized for a grid cell; constrain + lift it here so
+    // the single reveal reads as a floating card on the hero rather than a row.
+    .home-recipe-card {
+      width: 100%;
+      max-width: 320px;
+      background: s.$white;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+    }
+
+    .try-another-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.5rem 1.1rem;
+      border: 1px solid rgba(255, 255, 255, 0.55);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.14);
+      color: s.$white;
+      font-size: 0.9rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.12s ease;
+
+      svg {
+        font-size: 1.05rem;
+      }
+      &:hover:not(:disabled) {
+        background: rgba(255, 255, 255, 0.24);
+      }
+      &:disabled {
+        opacity: 0.7;
+        cursor: default;
+      }
+    }
+  }
+
+  .cook-suggestion-msg {
+    margin: 0;
+    color: s.$white;
+    font-size: 0.9rem;
+    text-align: center;
+    opacity: 0.9;
+  }
+}

--- a/src/pages/Home/HomeHero/HomeHero.tsx
+++ b/src/pages/Home/HomeHero/HomeHero.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import './HomeHero.scss'
 import SearchRecipesInput from 'src/Components/SearchRecipesInput/SearchRecipesInput'
+import HomeCookSuggestion from '../HomeCookSuggestion'
 
 const HomeHero: FC = () => {
   return (
@@ -17,6 +18,7 @@ const HomeHero: FC = () => {
       <div className='hero-overlay'>
         <h1 className='text'>Save money. Reduce stress. Be healthy.</h1>
         <SearchRecipesInput autoComplete={true} />
+        <HomeCookSuggestion />
       </div>
     </div>
   )

--- a/src/test/Home.test.tsx
+++ b/src/test/Home.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -13,6 +13,7 @@ vi.mock('src/api/recipes', () => ({
     getTrendingRecipes: vi.fn(),
     getAllRecipes: vi.fn(),
     getForYouRecipes: vi.fn(),
+    getRandomRecipe: vi.fn(),
   },
 }))
 
@@ -29,6 +30,7 @@ vi.mock('src/context/AuthContext', () => ({
 const mockGetTrendingRecipes = RecipeAPI.getTrendingRecipes as ReturnType<typeof vi.fn>
 const mockGetAllRecipes = RecipeAPI.getAllRecipes as ReturnType<typeof vi.fn>
 const mockGetForYouRecipes = RecipeAPI.getForYouRecipes as ReturnType<typeof vi.fn>
+const mockGetRandomRecipe = RecipeAPI.getRandomRecipe as ReturnType<typeof vi.fn>
 const mockUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>
 
 const makeRecipe = (id: string) => ({
@@ -82,6 +84,7 @@ describe('Home page', () => {
     mockGetTrendingRecipes.mockReset()
     mockGetAllRecipes.mockReset()
     mockGetForYouRecipes.mockReset()
+    mockGetRandomRecipe.mockReset()
     mockUseAuth.mockReset()
     // Neutral defaults; individual tests override the section they exercise.
     mockGetTrendingRecipes.mockReturnValue(new Promise(() => {}))
@@ -172,6 +175,50 @@ describe('Home page', () => {
       const section = screen.getByText('For you').closest('.home-section')
       expect(section).not.toBeNull()
       expect(section!.querySelectorAll('.home-recipe-card')).toHaveLength(4)
+    })
+  })
+
+  describe('What should I cook?', () => {
+    const cookButton = () => screen.getByRole('button', { name: /what should i cook/i })
+
+    it('shows the button for a logged-out visitor and does not fetch until clicked', () => {
+      renderHome() // user = null by default
+      expect(cookButton()).toBeInTheDocument()
+      expect(mockGetRandomRecipe).not.toHaveBeenCalled()
+    })
+
+    it('shows the button for a logged-in user too (not auth-gated)', () => {
+      mockUseAuth.mockReturnValue({ user: { uid: 'u1' } })
+      renderHome()
+      expect(cookButton()).toBeInTheDocument()
+    })
+
+    it('reveals a recipe card when clicked', async () => {
+      mockGetRandomRecipe.mockResolvedValue(makeRecipe('rnd1'))
+      renderHome()
+      fireEvent.click(cookButton())
+      expect(await screen.findByText('Recipe rnd1')).toBeInTheDocument()
+      expect(mockGetRandomRecipe).toHaveBeenCalledWith(undefined)
+    })
+
+    it('"Try another" re-rolls, excluding the current pick', async () => {
+      mockGetRandomRecipe
+        .mockResolvedValueOnce(makeRecipe('rnd1'))
+        .mockResolvedValueOnce(makeRecipe('rnd2'))
+      renderHome()
+      fireEvent.click(cookButton())
+      expect(await screen.findByText('Recipe rnd1')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: /try another/i }))
+      expect(await screen.findByText('Recipe rnd2')).toBeInTheDocument()
+      expect(mockGetRandomRecipe).toHaveBeenLastCalledWith('rnd1')
+    })
+
+    it('shows a soft message when there are no recipes (404 → null)', async () => {
+      mockGetRandomRecipe.mockResolvedValue(null)
+      renderHome()
+      fireEvent.click(cookButton())
+      expect(await screen.findByText(/no recipes to suggest yet/i)).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## What

A one-tap **"What should I cook?"** decision-fatigue killer in the hero (`FEATURE_IDEAS.md`). Clicking reveals a single recipe as a card the user can open or **re-roll with "Try another"**.

Builds on the just-merged For You row (#153): the spec's "matching the user's diet/cuisine preferences" reuses the **behavior-inferred taste profile** rather than a (deferred) preferences store.

## Behavior (locked with @jclind)

- **Reveal + reroll** — button → reveal card → "Try another" (re-rolls without repeating the current pick), click the card to open the recipe.
- **Available to everyone, taste-aware** — signed-in users with ≥ `MIN_SIGNAL` (3) interactions get a weighted-random **on-taste** pick; logged-out / low-signal users get a uniform random visible recipe. The server decides based on the attached token; the button is always shown.

## Backend

- **`GET /recipes/random`** (`optionalAuth`, `?exclude=` for re-roll variety, `404` on empty catalog). Taste path scores `RECIPE_VISIBLE` candidates (excluding seen/own/excluded) with `tasteScore` and picks one via `weightedSample`; falls back to `$sample` when anonymous, below threshold, or no on-taste match.
- **`weightedSample(scored, rng)`** — pure helper in `forYou.js` (injectable RNG; stronger taste match = likelier, but varied).
- **Refactor (DRY):** extracted `loadInteractions()` / `buildSeenProfile()` into **`server/util/tasteContext.js`** so the For You row and this route share one signal/seen split + profile; `getForYouRecipes` refactored to use it (behavior-preserving). Shared `RECIPE_CARD_PROJECTION`.

## Frontend

- **`getRandomRecipe(excludeId?)`** API client (`404 → null`).
- **`HomeCookSuggestion`** in the hero overlay: button → loading → reveal card (reuses `HomeRecipeCard`) + "Try another"; soft message on empty/error. No auth gate.

## Tests

- `weightedSample` unit (weight bands, zero/negative weights, empty, uniform fallback).
- `GET /recipes/random` integration: anon → visible (never hidden); on-taste pick excluding seen/own; `exclude` respected; below-signal + no-on-taste → fallback; empty → 404.
- `Home.test`: button renders logged-in/out, click reveals card, "Try another" re-rolls with `exclude`, 404 → soft message.

## Verification

- **Server 627 / FE 425 green**, `tsc --noEmit` + `npm run build` clean. (The existing For You suite stays green after the `tasteContext` refactor.)
- **Live authed smoke 8/8** against the running stack (minted-token throwaway users): anonymous random varies; signal user → every pick verified **on-taste against the route's own gate**, never a saved recipe; `exclude` never returns the excluded id; below-signal authed → fallback returns a recipe. All catalog mutations reversed (save-count multiplicity handled); zero residue verified.

## Notes / deferred

- A real Cooking-Preferences store stays deferred — taste remains behavior-inferred.
- "Surprise me" filter chips (cuisine/time) on the reveal — possible v2.
- Hero layout with the reveal card open is worth an eyeball on a narrow viewport (the hero is a fixed 500px); happy to tweak placement.