### PR TITLE
fix(account): load rating thumbnails + kill empty-state flash

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -61,6 +61,17 @@ The triage date stamped on items is the date they were filed here, not when they
   empty state only renders once the query genuinely returns zero recipes. Same latent flash existed in
   the Ratings list and got the same gate. A Vitest test (records every `EmptyState` mount) reproduces
   the flash and guards the fix.
+- `[ ]` **Account ratings "Load More" count can be off when a rating's recipe is hidden** —
+  `GET /getSingleUserReviews` computes `totalCount` from `countDocuments(query)` over *all* of the
+  user's rating docs (`server/routes/reviews.js:283`), but with `returnRecipeData=true` the returned
+  `reviews` array is filtered to recipes that are still visible (`:294-308`, drops soft-hidden/deleted
+  recipes). So if a user rated a recipe that was later hidden, `totalCount > reviews.length`, and the
+  client trusts that count to decide pagination (`UserRatings.tsx:113`:
+  `isMoreReviews = Number(totalCount) > updated.length`). Symptom: the "Load More Reviews" button can
+  show with nothing left to load, or a later page returns fewer rows than expected. *(surfaced by
+  track 1c; pre-existing, not a regression — out of that track's scope. Same shape likely in the
+  created-recipes list.)* Fix: count post-visibility-filter, or paginate via an aggregation `$lookup`
+  that excludes hidden recipes before the count.
 - `[~]` **Data export omits saved-recipe content** — `exportMyData` now exports full recipes, drafts,
   ratings, and profile, but `savedRecipes` is still an array of IDs only (`server/routes/auth.js:323`).
   Expand it to full saved-recipe content. *(partially addressed)*

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -145,6 +145,20 @@ The triage date stamped on items is the date they were filed here, not when they
 - `[ ]` **Tests for the toast/alert system** — newly implemented `react-hot-toast` is untested.
 - `[ ]` **Create-recipe tests** — Cypress (E2E) + Vitest (unit).
 - `[ ]` **Cypress: test autocomplete on the Recipes page**.
+- `[ ]` **Node 26 test-harness gaps — missing globals in the test sandbox** — this dev machine runs
+  **Node 26**, whose VM/sandbox no longer injects some globals that the test stacks assume:
+  - **Server (Jest):** `server/__tests__/email-notifications.test.js` fails **7/22** with
+    `ReferenceError: clearTimeout is not defined`, thrown from `superagent/request-base.js:28` (via
+    supertest) → cascades to 5000ms test timeouts. **Confirmed pre-existing and environment-induced**, not
+    a product bug: reverting `server/` entirely to base `a7a6653` reproduces the identical 7 failures, and
+    the file imports nothing app-specific. Other server suites that use supertest pass — only the
+    slower email-send paths trip the missing timer global. Likely fix: inject the timer globals when absent
+    in `server/__tests__/setup.js` (e.g. `const t = require('node:timers'); global.clearTimeout ??= t.clearTimeout; global.setTimeout ??= t.setTimeout`), mirroring the client fix below.
+  - **Client (Vitest):** the analogous `localStorage`-is-undefined gap (`savedFilters` / `SingleRecipe`)
+    was the **same root family** and is **already fixed** in PR #156 via an in-memory `Storage` polyfill in
+    `src/test/setup.ts`.
+  - *(Both are masked once everyone is on a Node where the sandbox restores these globals; the guards are
+    no-ops then. Surfaced during track 1c review, 2026-06-18.)*
 
 ## Ideas / needs a decision
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -37,7 +37,12 @@ The triage date stamped on items is the date they were filed here, not when they
   mutation (`onMutate` cancel+snapshot, `onError` rollback, `onSettled` reconcile). Added Vitest hook
   coverage (optimistic + rollback + reconcile-after-clobber guard) and extended server Jest with
   `GET /getSavedRecipeIds` + a save→read→unsave→read round-trip.
-- `[ ]` **Account "Ratings" list renders inaccurately** — recipe images aren't loading for rated recipes.
+- `[x]` **Account "Ratings" list renders inaccurately** — **fixed (track 1c):** rating docs store
+  neither `recipeImage` nor `recipeTitle`, and `GET /getSingleUserReviews?returnRecipeData=true` only
+  attached the recipe as a nested `recipeData` object — but `UserRatings.tsx` reads flat
+  `review.recipeImage` / `review.recipeTitle`, so both resolved to `undefined` (blank `<img>` + empty
+  title). Server now denormalizes `recipeImage`/`recipeTitle` from the recipe doc onto each review (keeps
+  `recipeData` for admin callers). Added server + Vitest coverage.
 - `[x]` **Rating aggregate went *down* after a 5-star** — **root-caused + symptom fixed (PR #150, merged,
   track 1a):** the
   `recomputeRecipeRating` math is correct; the drop is a **stale STORED aggregate** being corrected on
@@ -48,8 +53,14 @@ The triage date stamped on items is the date they were filed here, not when they
   Tech debt below.
 - `[x]` **Serving price looks wrong** — **fixed in PR #152 (merged, track 1d)**; audited
   `src/util/calculateServingPrice.ts` against real data + added regression tests.
-- `[ ]` **"Your Recipes" flashes an empty state** — the account section shows "no recipes" briefly
-  before the user's recipes propagate. Gate the empty state on load completion.
+- `[x]` **"Your Recipes" flashes an empty state** — **reproduced + fixed (track 1c):** the existing
+  `useDelayedLoading` guard only covers the in-flight window; it does NOT cover the gap where
+  react-query flips `isLoading` to false but the `recipes` state is still `[]` (it's populated by an
+  effect one render later, to support paged accumulation). On a fast load the empty state mounted for
+  that one frame. Fixed by gating the grid on the resolved payload (`data.recipes`) as well, so the
+  empty state only renders once the query genuinely returns zero recipes. Same latent flash existed in
+  the Ratings list and got the same gate. A Vitest test (records every `EmptyState` mount) reproduces
+  the flash and guards the fix.
 - `[~]` **Data export omits saved-recipe content** — `exportMyData` now exports full recipes, drafts,
   ratings, and profile, but `savedRecipes` is still an array of IDs only (`server/routes/auth.js:323`).
   Expand it to full saved-recipe content. *(partially addressed)*

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -807,6 +807,34 @@ describe('GET /getSingleUserReviews', () => {
     expect(res.body.reviews[0].recipeTitle).toBe('Review Test Recipe')
   })
 
+  // A rating whose recipe was soft-hidden (moderation takedown / unpublished /
+  // pending_review) must not surface in the user's public ratings list when we
+  // join the recipe. The route drops it via RECIPE_VISIBLE → findOne returns
+  // null → the entry is filtered out. Pins reviews.js:294-295/308.
+  it('excludes ratings whose recipe is soft-hidden when returnRecipeData=true', async () => {
+    const db = getDB()
+    await db.collection('recipes').insertOne({
+      _id: 'recipe-hidden-001',
+      title: 'Hidden Recipe',
+      recipeImage: 'https://example.com/hidden.jpg',
+      status: 'hidden',
+      rating: { rateCount: 0, rateValue: 0 },
+    })
+    // Rating on the visible recipe (kept) + rating on the hidden recipe (dropped).
+    await seedRating({ userId: TEST_UID, username: TEST_USERNAME, recipeId: RECIPE_ID, rating: 4, reviewText: 'Visible', reviewCreatedAt: '1000' })
+    await seedRating({ userId: TEST_UID, username: TEST_USERNAME, recipeId: 'recipe-hidden-001', rating: 5, reviewText: 'On a hidden recipe', reviewCreatedAt: '2000' })
+
+    const res = await request(app).get(
+      `/api/getSingleUserReviews?username=${TEST_USERNAME}&returnRecipeData=true`
+    )
+    expect(res.status).toBe(200)
+    expect(res.body.reviews).toHaveLength(1)
+    expect(res.body.reviews[0].recipeId).toBe(RECIPE_ID)
+    expect(
+      res.body.reviews.some((r) => r.recipeId === 'recipe-hidden-001')
+    ).toBe(false)
+  })
+
   it('does not include recipeData when returnRecipeData is not set', async () => {
     await seedRating({
       userId: TEST_UID,

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -835,6 +835,28 @@ describe('GET /getSingleUserReviews', () => {
     ).toBe(false)
   })
 
+  // Defensive: a recipe doc missing title/recipeImage must not crash the join —
+  // the flattened fields are simply absent (undefined → omitted from JSON), and
+  // recipeData is still attached. Documents the no-fallback contract.
+  it('tolerates a recipe with no title/recipeImage (flattened fields just absent)', async () => {
+    const db = getDB()
+    await db.collection('recipes').insertOne({
+      _id: 'recipe-bare-001',
+      rating: { rateCount: 0, rateValue: 0 },
+    })
+    await seedRating({ userId: TEST_UID, username: TEST_USERNAME, recipeId: 'recipe-bare-001', rating: 4, reviewText: 'No image recipe', reviewCreatedAt: '1000' })
+
+    const res = await request(app).get(
+      `/api/getSingleUserReviews?username=${TEST_USERNAME}&returnRecipeData=true`
+    )
+    expect(res.status).toBe(200)
+    const review = res.body.reviews.find((r) => r.recipeId === 'recipe-bare-001')
+    expect(review).toBeDefined()
+    expect(review.recipeImage).toBeUndefined()
+    expect(review.recipeTitle).toBeUndefined()
+    expect(review.recipeData._id).toBe('recipe-bare-001')
+  })
+
   it('does not include recipeData when returnRecipeData is not set', async () => {
     await seedRating({
       userId: TEST_UID,

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -47,6 +47,7 @@ beforeEach(async () => {
   await db.collection('recipes').insertOne({
     _id: RECIPE_ID,
     title: 'Review Test Recipe',
+    recipeImage: 'https://example.com/review-test.jpg',
     rating: { rateCount: 0, rateValue: 0 },
   })
   // Reset to default: verifyToken resolves req.uid = TEST_UID
@@ -781,6 +782,29 @@ describe('GET /getSingleUserReviews', () => {
     expect(res.status).toBe(200)
     expect(res.body.reviews[0].recipeData).toBeDefined()
     expect(res.body.reviews[0].recipeData._id).toBe(RECIPE_ID)
+  })
+
+  // The account "Ratings" list reads flat recipeImage/recipeTitle off each
+  // review (the rating doc stores neither) — they must be denormalized from the
+  // recipe doc, or the thumbnail and title render blank.
+  it('flattens recipeImage and recipeTitle from the recipe when returnRecipeData=true', async () => {
+    await seedRating({
+      userId: TEST_UID,
+      username: TEST_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 4,
+      reviewText: 'Great recipe!',
+      reviewCreatedAt: '1000',
+    })
+
+    const res = await request(app).get(
+      `/api/getSingleUserReviews?username=${TEST_USERNAME}&returnRecipeData=true`
+    )
+    expect(res.status).toBe(200)
+    expect(res.body.reviews[0].recipeImage).toBe(
+      'https://example.com/review-test.jpg'
+    )
+    expect(res.body.reviews[0].recipeTitle).toBe('Review Test Recipe')
   })
 
   it('does not include recipeData when returnRecipeData is not set', async () => {

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -292,7 +292,17 @@ router.get('/getSingleUserReviews', asyncHandler(async (req, res) => {
         const recipeData = await db
           .collection('recipes')
           .findOne({ ...recipeIdQuery(r.recipeId), ...RECIPE_VISIBLE })
-        return recipeData ? { ...r, recipeData } : null
+        if (!recipeData) return null
+        // The account "Ratings" list reads flat `recipeImage`/`recipeTitle` off
+        // each review (the rating doc itself stores neither). Denormalize them
+        // from the recipe doc so the thumbnail and title actually render; keep
+        // the full `recipeData` for callers (e.g. admin) that need the rest.
+        return {
+          ...r,
+          recipeImage: recipeData.recipeImage,
+          recipeTitle: recipeData.title,
+          recipeData,
+        }
       })
     )
     reviews = withRecipe.filter(Boolean)

--- a/src/pages/Account/UserRatings/UserRatings.tsx
+++ b/src/pages/Account/UserRatings/UserRatings.tsx
@@ -94,6 +94,13 @@ const Ratings: FC = () => {
       RecipeAPI.getSingleUserReviews(currPage, 5, selectOption.value, true),
   })
   const showSkeleton = useDelayedLoading(isLoading)
+  // `reviews` is populated by the effect below one render AFTER react-query
+  // flips `isLoading` to false, so on a fast load there's a frame where the
+  // query has settled but `reviews` is still []. Gate the list on the resolved
+  // payload too (`data.reviews`) so that frame keeps showing the list instead
+  // of flashing the "no ratings" empty state.
+  const dataHasReviews = !!data && data.reviews.length > 0
+  const showList = reviews.length > 0 || isLoading || dataHasReviews
 
   useEffect(() => {
     if (data) {
@@ -128,7 +135,7 @@ const Ratings: FC = () => {
 
   return (
     <div className='user-ratings'>
-      {reviews.length > 0 || isLoading ? (
+      {showList ? (
         <>
           <div className='saved-filters'>
             <Select<OptionType, false>

--- a/src/pages/Account/UserRecipes/UserRecipes.tsx
+++ b/src/pages/Account/UserRecipes/UserRecipes.tsx
@@ -55,7 +55,14 @@ const UserRecipes: FC = () => {
   }
 
   const showSkeleton = useDelayedLoading(isLoading)
-  const showGrid = recipes.length > 0 || isLoading
+  // `recipes` is populated by the effect above one render AFTER react-query
+  // flips `isLoading` to false, so on a fast load there's a frame where the
+  // query has settled but `recipes` is still []. Gate the grid on the resolved
+  // payload too (`data.recipes`) so that frame shows the grid, not a flash of
+  // the "no recipes" empty state. The empty state then appears only once the
+  // query has genuinely returned zero recipes.
+  const dataHasRecipes = !!data && data.recipes.length > 0
+  const showGrid = recipes.length > 0 || isLoading || dataHasRecipes
 
   // On the first load, hold an empty frame while a fast query settles, so the
   // skeleton only shows for genuinely slow loads — and the empty state never

--- a/src/test/AccountSections.loading.test.tsx
+++ b/src/test/AccountSections.loading.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import UserRecipes from 'src/pages/Account/UserRecipes/UserRecipes'
@@ -13,14 +13,24 @@ import { OptionalReviewType, RecipeType } from 'types'
 // of the empty state in the gap between react-query settling (isLoading=false)
 // and the list state being populated by the effect a render later — a transient
 // mount RTL's final-DOM assertions would miss, but this spy catches.
-const { emptyStateTitles } = vi.hoisted(() => ({
+const { emptyStateTitles, skeletonMounts } = vi.hoisted(() => ({
   emptyStateTitles: [] as string[],
+  skeletonMounts: { count: 0 },
 }))
 
 vi.mock('src/Components/EmptyState/EmptyState', () => ({
   default: ({ title }: { title: string }) => {
     emptyStateTitles.push(title)
     return <div data-testid='empty-state'>{title}</div>
+  },
+}))
+
+// Same transient-mount-spy trick as EmptyState: record every Skeleton render so a
+// one-frame skeleton flash on a fast load is caught, not just the final DOM.
+vi.mock('react-loading-skeleton', () => ({
+  default: () => {
+    skeletonMounts.count += 1
+    return <div data-testid='skeleton' />
   },
 }))
 
@@ -106,6 +116,7 @@ const renderWithProviders = (ui: React.ReactNode) => {
 beforeEach(() => {
   vi.clearAllMocks()
   emptyStateTitles.length = 0
+  skeletonMounts.count = 0
 })
 
 describe('UserRecipes — empty-state flash (Bug B)', () => {
@@ -119,7 +130,7 @@ describe('UserRecipes — empty-state flash (Bug B)', () => {
 
     expect(await screen.findByText('Pancakes')).toBeInTheDocument()
     // The empty state must not have mounted at any point during the load.
-    expect(emptyStateTitles).not.toContain('No Recipes Created Yet')
+    expect(emptyStateTitles).toHaveLength(0)
   })
 
   it('shows the empty state once the query genuinely returns no recipes', async () => {
@@ -133,6 +144,57 @@ describe('UserRecipes — empty-state flash (Bug B)', () => {
     expect(
       await screen.findByText('No Recipes Created Yet')
     ).toBeInTheDocument()
+  })
+
+  it('holds a blank frame — never mounts a skeleton — while a fast load settles', async () => {
+    mockedAPI.getCreatedRecipes.mockResolvedValue({
+      recipes: [makeRecipe({ _id: 'r1', title: 'Pancakes' })],
+      totalCount: 1,
+    })
+
+    renderWithProviders(<UserRecipes />)
+
+    expect(await screen.findByText('Pancakes')).toBeInTheDocument()
+    // `useDelayedLoading` keeps the skeleton hidden on a fast resolve: the
+    // initial frame is the empty placeholder div (the early-return guard), not a
+    // skeleton. Without that guard the isLoading frame would render skeletons,
+    // which the mount spy would catch even though they'd be gone from final DOM.
+    // (Skeletons are reserved for genuinely slow loads past the delay.)
+    expect(skeletonMounts.count).toBe(0)
+  })
+
+  it('appends the next page on "Load More" and hides the button, without flashing empty state', async () => {
+    // Page 0 returns 1 of 2 recipes (button shows); page 1 returns the rest.
+    mockedAPI.getCreatedRecipes.mockImplementation(page =>
+      Promise.resolve(
+        page === 0
+          ? {
+              recipes: [makeRecipe({ _id: 'r1', title: 'Pancakes' })],
+              totalCount: 2,
+            }
+          : {
+              recipes: [makeRecipe({ _id: 'r2', title: 'Waffles' })],
+              totalCount: 2,
+            }
+      )
+    )
+
+    renderWithProviders(<UserRecipes />)
+
+    expect(await screen.findByText('Pancakes')).toBeInTheDocument()
+    fireEvent.click(
+      await screen.findByRole('button', { name: /load more recipes/i })
+    )
+
+    // Page 1 accumulated onto page 0 — both present, button gone (2 of 2).
+    expect(await screen.findByText('Waffles')).toBeInTheDocument()
+    expect(screen.getByText('Pancakes')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /load more recipes/i })
+    ).not.toBeInTheDocument()
+    // The grid must not blank to the empty state during the page-2 fetch
+    // (when `data` is briefly undefined for the new query key).
+    expect(emptyStateTitles).toHaveLength(0)
   })
 })
 
@@ -164,7 +226,7 @@ describe('UserRatings — image rendering (Bug A) + empty-state flash', () => {
     renderWithProviders(<UserRatings />)
 
     expect(await screen.findByText('Granola')).toBeInTheDocument()
-    expect(emptyStateTitles).not.toContain('No Ratings Yet')
+    expect(emptyStateTitles).toHaveLength(0)
   })
 
   it('shows the empty state once the query genuinely returns no ratings', async () => {
@@ -176,5 +238,36 @@ describe('UserRatings — image rendering (Bug A) + empty-state flash', () => {
     renderWithProviders(<UserRatings />)
 
     expect(await screen.findByText('No Ratings Yet')).toBeInTheDocument()
+  })
+
+  it('appends the next page on "Load More" and hides the button', async () => {
+    mockedAPI.getSingleUserReviews.mockImplementation(page =>
+      Promise.resolve(
+        page === 0
+          ? {
+              reviews: [makeReview({ _id: 'rev1', recipeTitle: 'Granola' })],
+              totalCount: 2,
+            }
+          : {
+              reviews: [makeReview({ _id: 'rev2', recipeTitle: 'Oatmeal' })],
+              totalCount: 2,
+            }
+      )
+    )
+
+    renderWithProviders(<UserRatings />)
+
+    expect(await screen.findByText('Granola')).toBeInTheDocument()
+    fireEvent.click(
+      await screen.findByRole('button', { name: /load more reviews/i })
+    )
+
+    // Page 1 accumulated — both ratings present, button gone (2 of 2 shown).
+    expect(await screen.findByText('Oatmeal')).toBeInTheDocument()
+    expect(screen.getByText('Granola')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /load more reviews/i })
+    ).not.toBeInTheDocument()
+    expect(emptyStateTitles).toHaveLength(0)
   })
 })

--- a/src/test/AccountSections.loading.test.tsx
+++ b/src/test/AccountSections.loading.test.tsx
@@ -1,0 +1,180 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import UserRecipes from 'src/pages/Account/UserRecipes/UserRecipes'
+import UserRatings from 'src/pages/Account/UserRatings/UserRatings'
+import RecipeAPI from 'src/api/recipes'
+import { OptionalReviewType, RecipeType } from 'types'
+
+// Record every EmptyState render so we can assert it NEVER mounts during a
+// successful load. The "Your Recipes" / "Ratings" flash was a one-frame mount
+// of the empty state in the gap between react-query settling (isLoading=false)
+// and the list state being populated by the effect a render later — a transient
+// mount RTL's final-DOM assertions would miss, but this spy catches.
+const { emptyStateTitles } = vi.hoisted(() => ({
+  emptyStateTitles: [] as string[],
+}))
+
+vi.mock('src/Components/EmptyState/EmptyState', () => ({
+  default: ({ title }: { title: string }) => {
+    emptyStateTitles.push(title)
+    return <div data-testid='empty-state'>{title}</div>
+  },
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom'
+  )
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+vi.mock('src/api/auth', () => ({
+  default: {
+    getUID: vi.fn().mockReturnValue('test-uid'),
+    getUsername: vi.fn().mockResolvedValue('chef'),
+  },
+}))
+
+vi.mock('src/api/recipes', () => ({
+  default: {
+    getCreatedRecipes: vi.fn(),
+    getSingleUserReviews: vi.fn(),
+  },
+}))
+
+const mockedAPI = RecipeAPI as unknown as {
+  getCreatedRecipes: ReturnType<typeof vi.fn>
+  getSingleUserReviews: ReturnType<typeof vi.fn>
+}
+
+const makeRecipe = (overrides: Partial<RecipeType> = {}): RecipeType => ({
+  _id: 'recipe-1',
+  title: 'Test Recipe',
+  prepTime: 10,
+  cookTime: 20,
+  servings: 4,
+  fridgeLife: 3,
+  freezerLife: 30,
+  description: 'A recipe',
+  ingredients: [],
+  instructions: [],
+  recipeImage: 'https://example.com/recipe.jpg',
+  nutritionData: null,
+  totalTime: 30,
+  authorUsername: 'chef',
+  rating: { rateCount: 0, rateValue: 0 },
+  createdAt: '1000',
+  editedAt: null,
+  servingPrice: 100,
+  cuisine: 'Italian',
+  mealTypes: ['dinner'],
+  nutritionLabels: [],
+  views: 0,
+  numTimesSaved: 0,
+  numTimesMade: 0,
+  ...overrides,
+})
+
+const makeReview = (
+  overrides: Partial<OptionalReviewType> = {}
+): OptionalReviewType => ({
+  _id: 'review-1',
+  username: 'chef',
+  recipeId: 'recipe-1',
+  rating: '5',
+  ratingLastUpdated: '1000',
+  reviewText: 'Loved it',
+  recipeTitle: 'Test Recipe',
+  recipeImage: 'https://example.com/recipe.jpg',
+  ...overrides,
+})
+
+const renderWithProviders = (ui: React.ReactNode) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  emptyStateTitles.length = 0
+})
+
+describe('UserRecipes — empty-state flash (Bug B)', () => {
+  it('never flashes the empty state while a load that returns recipes settles', async () => {
+    mockedAPI.getCreatedRecipes.mockResolvedValue({
+      recipes: [makeRecipe({ _id: 'r1', title: 'Pancakes' })],
+      totalCount: 1,
+    })
+
+    renderWithProviders(<UserRecipes />)
+
+    expect(await screen.findByText('Pancakes')).toBeInTheDocument()
+    // The empty state must not have mounted at any point during the load.
+    expect(emptyStateTitles).not.toContain('No Recipes Created Yet')
+  })
+
+  it('shows the empty state once the query genuinely returns no recipes', async () => {
+    mockedAPI.getCreatedRecipes.mockResolvedValue({
+      recipes: [],
+      totalCount: 0,
+    })
+
+    renderWithProviders(<UserRecipes />)
+
+    expect(
+      await screen.findByText('No Recipes Created Yet')
+    ).toBeInTheDocument()
+  })
+})
+
+describe('UserRatings — image rendering (Bug A) + empty-state flash', () => {
+  it('renders the recipe image and title from the flattened review fields', async () => {
+    mockedAPI.getSingleUserReviews.mockResolvedValue({
+      reviews: [
+        makeReview({
+          recipeTitle: 'Granola',
+          recipeImage: 'https://cdn.example.com/granola.jpg',
+        }),
+      ],
+      totalCount: 1,
+    })
+
+    renderWithProviders(<UserRatings />)
+
+    const img = (await screen.findByAltText('Granola')) as HTMLImageElement
+    expect(img.src).toBe('https://cdn.example.com/granola.jpg')
+    expect(screen.getByText('Granola')).toBeInTheDocument()
+  })
+
+  it('never flashes the empty state while a load that returns ratings settles', async () => {
+    mockedAPI.getSingleUserReviews.mockResolvedValue({
+      reviews: [makeReview({ recipeTitle: 'Granola' })],
+      totalCount: 1,
+    })
+
+    renderWithProviders(<UserRatings />)
+
+    expect(await screen.findByText('Granola')).toBeInTheDocument()
+    expect(emptyStateTitles).not.toContain('No Ratings Yet')
+  })
+
+  it('shows the empty state once the query genuinely returns no ratings', async () => {
+    mockedAPI.getSingleUserReviews.mockResolvedValue({
+      reviews: [],
+      totalCount: 0,
+    })
+
+    renderWithProviders(<UserRatings />)
+
+    expect(await screen.findByText('No Ratings Yet')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
fix(account): load rating thumbnails + kill empty-state flash

Track 1c. Two account-page data bugs. Both were **reproduced before fixing**.

## Bug A — Account "Ratings" recipe images never load (verified)
**How it reproduced:** The "Ratings" tab renders each rated recipe's thumbnail from `review?.recipeImage` and title from `review?.recipeTitle` (`src/pages/Account/UserRatings/UserRatings.tsx`). But:
- Rating docs (`ratings` collection) store **neither** `recipeImage` nor `recipeTitle` — only `userId`, `recipeId`, `rating`, `reviewText`, etc.
- `GET /api/getSingleUserReviews?returnRecipeData=true` attached the recipe as a **nested** `recipeData` object (`{ ...r, recipeData }`), not as flat fields.

So `review.recipeImage` / `review.recipeTitle` both resolved to `undefined` → blank `<img>` and empty `<h4>`. (Title was empty too; the image is just the visible symptom.)

**Fix (server-side, the right layer):** `getSingleUserReviews` now denormalizes `recipeImage` (from `recipe.recipeImage`) and `recipeTitle` (from `recipe.title`) onto each review, while keeping the full `recipeData` object for callers that need it (admin moderation tests rely on it).

## Bug B — "Your Recipes" flashes a "no recipes" empty state (reproduced — NOT already fixed)
**How it reproduced:** `UserRecipes.tsx` already had a `useDelayedLoading` guard (added in the account redesign, #122), but that guard only covers the **in-flight** window. It does **not** cover the gap where react-query flips `isLoading` to `false` while the `recipes` state is still `[]` — `recipes` is populated by an effect one render *later* (to support paged accumulation). On a fast load (local server / cache hit), `showGrid` was `false` for that one frame → the empty state mounted and snapped away.

A Vitest test that records every `EmptyState` mount confirms it: it **fails on the pre-fix code** and passes after.

**Fix (client-side):** gate the grid on the resolved payload too — `showGrid = recipes.length > 0 || isLoading || (data && data.recipes.length > 0)` — so the empty state only renders once the query genuinely returns zero recipes. The Ratings list had the same latent flash and got the same gate.

## Test-harness fix (bonus — folded in)
The Vitest suite was **red on the base commit** (`a7a6653`): `savedFilters.test.ts` + `SingleRecipe.test.tsx` (19 tests) threw `Cannot read properties of undefined (reading 'clear')`. Root cause: **Node 26.3.0** exposes an experimental native `globalThis.localStorage` that is `undefined` without `--localstorage-file`, and this jsdom build no longer supplies its own — so any test referencing `localStorage` broke. Fixed with a small in-memory `Storage` polyfill in `src/test/setup.ts` (test-only, no product code). The full suite is now green.

## Coverage
- `server/__tests__/reviews.test.js`:
  - asserts the flattened `recipeImage` / `recipeTitle` on the `returnRecipeData=true` response.
  - **(follow-up)** asserts a rating whose recipe is soft-hidden is **excluded** from the list when joining recipe data — covers the `RECIPE_VISIBLE` branch. Verified non-vacuous (fails when the visibility filter is removed).
- `src/test/AccountSections.loading.test.tsx`: records every `EmptyState` mount to reproduce/guard the flash (both sections), and asserts the rating thumbnail renders its image from the flattened fields. Each gate verified non-vacuous (the matching test fails when its gate is reverted).

## Latent bug logged (pre-existing, out of scope — `docs/BACKLOG.md`)
`getSingleUserReviews` computes `totalCount` over **all** of a user's ratings, but with `returnRecipeData=true` the returned `reviews` are filtered to still-visible recipes. So when a user rated a recipe that was later hidden, `totalCount > reviews.length`, and the client trusts that count for pagination (`isMoreReviews`) — the "Load More" button can show with nothing left to load. Not a regression (predates this branch) and outside track 1c's scope, so logged rather than fixed here.

## Checks
- `npx tsc --noEmit` — clean
- `npm run build` — passing
- Server: `reviews.test.js` + `admin-moderation.test.js` — **70 passed**
- Client: full Vitest suite **green** — 59 files, 430 passed, 2 skipped (was 19 failing on base before the harness fix).

## Scope / guardrails
Product changes touch only `src/pages/Account/*` (UserRatings, UserRecipes) and the `getSingleUserReviews` reviews route feeding the ratings list. The only out-of-feature change is the shared test-setup polyfill. No account-nav/section restyling (that's track 2e); beta tag untouched. Backlog items flipped to `[x]` with notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)