### PR TITLE
fix(save): heal optimistic save/unsave clobbered by stale refetch

### DIFF
--- a/cypress/e2e/recipe.cy.ts
+++ b/cypress/e2e/recipe.cy.ts
@@ -27,10 +27,17 @@ describe('Single Recipe', () => {
 
   it('save/unsave button toggles correctly when logged in', () => {
     cy.intercept('GET', `${api()}/api/getTrendingRecipes*`, { fixture: 'trending-recipes.json' })
-    // The unified SaveControl resolves "is this saved" from getSavedRecipeIds;
-    // the `getSavedRecipe*` glob covers both that and the popover's per-recipe
-    // getSavedRecipe lookup. Stub empty so the recipe starts "not saved".
-    cy.intercept('GET', `${api()}/api/getSavedRecipe*`, { body: null }).as('getSavedRecipe')
+    // The unified SaveControl resolves "is this saved" from getSavedRecipeIds.
+    // Back it with a stateful list the save/unsave handlers below mutate, so the
+    // server "remembers" the write — useSaveRecipe reconciles its optimistic
+    // cache against this list after each toggle (a static stub would report the
+    // recipe un-saved again on that reconciliation refetch and revert the icon).
+    // The same `getSavedRecipe*` glob also catches the popover's per-recipe
+    // getSavedRecipe lookup, which has no "Ids" and gets the null body.
+    let savedIds: string[] = []
+    cy.intercept('GET', `${api()}/api/getSavedRecipe*`, (req) => {
+      req.reply(req.url.includes('getSavedRecipeIds') ? savedIds : { body: null })
+    }).as('getSavedRecipe')
     cy.intercept('GET', `${api()}/api/getUsername*`, { body: 'testinguser' })
     // Opening the collections popover loads the user's folders.
     cy.intercept('GET', `${api()}/api/collections*`, { body: [] }).as('getCollections')
@@ -47,8 +54,16 @@ describe('Single Recipe', () => {
     cy.wait('@getSavedRecipe')
     cy.get('button.save-recipe-btn', { timeout: 5000 }).should('be.visible').and('not.have.class', 'is-saved')
 
-    cy.intercept('POST', `${api()}/api/recipes/*/save`, { fixture: 'save-recipe.json' }).as('saveRecipe')
-    cy.intercept('DELETE', `${api()}/api/recipes/*/save`, { body: {} }).as('unsaveRecipe')
+    // Save/unsave mutate the stateful list above so the post-write reconciliation
+    // refetch sees the committed state.
+    cy.intercept('POST', `${api()}/api/recipes/*/save`, (req) => {
+      savedIds = [recipeId]
+      req.reply({ fixture: 'save-recipe.json' })
+    }).as('saveRecipe')
+    cy.intercept('DELETE', `${api()}/api/recipes/*/save`, (req) => {
+      savedIds = []
+      req.reply({ body: {} })
+    }).as('unsaveRecipe')
 
     // One tap saves to the master list (Spotify-style).
     cy.get('button.save-recipe-btn').click()

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -46,7 +46,7 @@ same commit.**
 | 0a | Repo/secrets hygiene | `[x]` | #151 ✅ |
 | 0c | Infra (Jesse, dashboards) | `[ ]` | n/a |
 | 1a | Ratings/reviews bug | `[x]` | #150 ✅ |
-| 1b | Save-recipe broken | `[P]` | worktree-feat+fix-save-recipe |
+| 1b | Save-recipe broken | `[P]` | #157 |
 | 1c | Account data (images, empty-flash) | `[ ]` | — |
 | 1d | Serving-price bug | `[x]` | #152 ✅ |
 | 2a | Homepage redesign (design + For You row + "What should I cook?") | `[x]` | #153 + #154 ✅ |
@@ -221,7 +221,7 @@ Append a one-liner when a track changes state (started / PR / merged). Keeps ses
 - _2026-06-18_ — **Wave 2 defined** (see "Suggested second wave"): **1b** save bug, **1c** account-data bug,
   **2b** Help/Contact (App.tsx route slot), **2c** single-recipe polish. Zero file overlap. Holds **2e**
   behind 1c (both `Account/*`) and **2d** behind 2b (shared Navbar).
-- _2026-06-18_ — **1b → PR open.** Root-caused the "save is broken" report to `useSaveRecipe`'s
+- _2026-06-18_ — **1b → PR open (#157).** Root-caused the "save is broken" report to `useSaveRecipe`'s
   hand-rolled optimistic write: the shared `['savedRecipeIds']` cache runs at the default staleTime (0),
   so a stale refetch (window-focus / sibling card / `invalidateSavedCaches`) resolving mid-write overwrote
   the optimistic value — and with no post-write reconciliation the bookmark stayed reverted even though the

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -46,7 +46,7 @@ same commit.**
 | 0a | Repo/secrets hygiene | `[x]` | #151 ✅ |
 | 0c | Infra (Jesse, dashboards) | `[ ]` | n/a |
 | 1a | Ratings/reviews bug | `[x]` | #150 ✅ |
-| 1b | Save-recipe broken | `[ ]` | — |
+| 1b | Save-recipe broken | `[P]` | worktree-feat+fix-save-recipe |
 | 1c | Account data (images, empty-flash) | `[ ]` | — |
 | 1d | Serving-price bug | `[x]` | #152 ✅ |
 | 2a | Homepage redesign (design + For You row + "What should I cook?") | `[x]` | #153 + #154 ✅ |
@@ -221,6 +221,15 @@ Append a one-liner when a track changes state (started / PR / merged). Keeps ses
 - _2026-06-18_ — **Wave 2 defined** (see "Suggested second wave"): **1b** save bug, **1c** account-data bug,
   **2b** Help/Contact (App.tsx route slot), **2c** single-recipe polish. Zero file overlap. Holds **2e**
   behind 1c (both `Account/*`) and **2d** behind 2b (shared Navbar).
+- _2026-06-18_ — **1b → PR open.** Root-caused the "save is broken" report to `useSaveRecipe`'s
+  hand-rolled optimistic write: the shared `['savedRecipeIds']` cache runs at the default staleTime (0),
+  so a stale refetch (window-focus / sibling card / `invalidateSavedCaches`) resolving mid-write overwrote
+  the optimistic value — and with no post-write reconciliation the bookmark stayed reverted even though the
+  server save had succeeded. Rewrote the toggle as a proper React Query optimistic mutation
+  (`onMutate` cancel+snapshot, `onError` rollback, `onSettled` reconcile). Client change confined to the
+  hook — `SaveControl`/`SingleRecipe`/`api` untouched (keeps clear of 2c). Tests: new Vitest suite for the
+  hook (optimistic, rollback, and a reconcile-after-clobber guard that fails on the old hook) + extended
+  server Jest with `GET /getSavedRecipeIds` shape + save/unsave round-trip. tsc + build clean.
 
 ---
 

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -620,6 +620,64 @@ describe('DELETE /recipes/:id/save', () => {
   })
 })
 
+// ─── GET /getSavedRecipeIds ────────────────────────────────────────────────────
+// This is the single read the client's useSaveRecipe hook resolves every card's
+// saved state from, so its shape (a flat array of recipeId strings) and its
+// save/unsave round-trip are part of the save subsystem's contract.
+
+describe('GET /getSavedRecipeIds', () => {
+  it('returns [] when the user has no saved-recipe data', async () => {
+    const res = await request(server)
+      .get('/api/getSavedRecipeIds')
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual([])
+  })
+
+  it('returns a flat array of saved recipe id strings', async () => {
+    const db = getDB()
+    await db.collection('userRecipeData').insertOne({
+      _id: TEST_UID,
+      savedRecipes: [
+        { recipeId: 'recipe-001', dateSaved: '1' },
+        { recipeId: 'recipe-002', dateSaved: '2' },
+      ],
+    })
+
+    const res = await request(server)
+      .get('/api/getSavedRecipeIds')
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(['recipe-001', 'recipe-002'])
+  })
+
+  it('round-trips: a saved id appears here, then disappears after unsave', async () => {
+    const db = getDB()
+    await db.collection('recipes').insertOne({ ...BASE_RECIPE, numTimesSaved: 0 })
+
+    // Initially not saved.
+    let ids = await request(server).get('/api/getSavedRecipeIds').set(AUTH_HEADER)
+    expect(ids.body).not.toContain(RECIPE_ID)
+
+    // Save → id is now present.
+    await request(server).post(`/api/recipes/${RECIPE_ID}/save`).set(AUTH_HEADER)
+    ids = await request(server).get('/api/getSavedRecipeIds').set(AUTH_HEADER)
+    expect(ids.body).toContain(RECIPE_ID)
+
+    // Unsave → id is gone again.
+    await request(server).delete(`/api/recipes/${RECIPE_ID}/save`).set(AUTH_HEADER)
+    ids = await request(server).get('/api/getSavedRecipeIds').set(AUTH_HEADER)
+    expect(ids.body).not.toContain(RECIPE_ID)
+  })
+
+  it('requires auth', async () => {
+    const res = await request(server).get('/api/getSavedRecipeIds')
+    expect(res.status).toBe(401)
+  })
+})
+
 // ─── GET /health ──────────────────────────────────────────────────────────────
 
 describe('GET /health', () => {

--- a/src/hooks/useSaveRecipe.ts
+++ b/src/hooks/useSaveRecipe.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import AuthAPI from 'src/api/auth'
 import RecipeAPI from 'src/api/recipes'
@@ -9,8 +9,22 @@ import RecipeAPI from 'src/api/recipes'
  *
  * Saved state for the whole session is resolved from ONE request — the user's
  * saved-id list cached under `['savedRecipeIds', uid]` — instead of one
- * `getSavedRecipe` request per rendered card. Toggling writes that cache
- * optimistically and rolls back if the request fails.
+ * `getSavedRecipe` request per rendered card.
+ *
+ * Toggling is a proper React Query optimistic mutation. The saved-id list is a
+ * SHARED cache that other surfaces refetch constantly (`invalidateSavedCaches`,
+ * window-focus, a newly mounted card) — and it runs at the app's default
+ * staleTime (0), so those refetches fire all the time. The old hook hand-rolled
+ * `setQueryData` with no protection, so a stale refetch resolving mid-write
+ * overwrote the optimistic value AND, with no post-write reconciliation, the
+ * bookmark stayed reverted even though the save had succeeded on the server —
+ * the "saving is broken" symptom. The mutation guards both ends:
+ *   - `onMutate` CANCELS in-flight refetches before the optimistic write, so a
+ *     refetch already running at click time can't clobber it (prevents a flicker).
+ *   - `onError` rolls back to the pre-write snapshot.
+ *   - `onSettled` re-fetches the committed truth, so any clobber from a refetch
+ *     that started AFTER onMutate (which cancel can't catch) self-heals instead
+ *     of leaving a stuck bookmark. This is what actually fixes the reported bug.
  */
 export const useSaveRecipe = (recipeId: string) => {
   const uid = AuthAPI.getUID()
@@ -25,6 +39,37 @@ export const useSaveRecipe = (recipeId: string) => {
 
   const isSaved = !!savedIds?.includes(recipeId)
 
+  const mutation = useMutation({
+    mutationFn: (nextSaved: boolean) =>
+      nextSaved
+        ? RecipeAPI.saveRecipe(recipeId)
+        : RecipeAPI.unsaveRecipe(recipeId),
+    onMutate: async (nextSaved: boolean) => {
+      // Cancel outgoing refetches so an in-flight (stale) saved-id list can't
+      // resolve after this write and clobber the optimistic value.
+      await queryClient.cancelQueries({ queryKey })
+      const previous = queryClient.getQueryData<string[]>(queryKey) ?? []
+      const next = nextSaved
+        ? [...previous, recipeId]
+        : previous.filter(id => id !== recipeId)
+      queryClient.setQueryData(queryKey, next)
+      return { previous }
+    },
+    onError: (_err, _nextSaved, context) => {
+      // Roll back to the snapshot taken before the optimistic write.
+      if (context) queryClient.setQueryData(queryKey, context.previous)
+    },
+    onSettled: () => {
+      // Reconcile with the committed server state once the write resolves. The
+      // saved-id list runs with the app's default staleTime (0), so a card
+      // mounting or a window-focus right AFTER onMutate can kick off a fresh
+      // refetch that cancelQueries (which only cancels what's in flight AT mutate
+      // time) can't catch. Re-fetching here means any such transient clobber
+      // self-heals to the truth instead of leaving a stuck bookmark.
+      queryClient.invalidateQueries({ queryKey })
+    },
+  })
+
   // Resolves true once the server write lands, false on failure (after rolling
   // back the optimistic cache). Never rejects, so fire-and-forget callers can't
   // leak an unhandled rejection; callers that need to refetch dependent caches
@@ -35,19 +80,10 @@ export const useSaveRecipe = (recipeId: string) => {
       toast('Please login to save recipes.', { duration: 6000 })
       return false
     }
-    const current = savedIds ?? []
-    const next = isSaved
-      ? current.filter(id => id !== recipeId)
-      : [...current, recipeId]
-    queryClient.setQueryData(queryKey, next) // optimistic
-    const request = isSaved
-      ? RecipeAPI.unsaveRecipe(recipeId)
-      : RecipeAPI.saveRecipe(recipeId)
     try {
-      await request
+      await mutation.mutateAsync(!isSaved)
       return true
     } catch {
-      queryClient.setQueryData(queryKey, current) // roll back on failure
       return false
     }
   }

--- a/src/test/useSaveRecipe.test.tsx
+++ b/src/test/useSaveRecipe.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * useSaveRecipe — the shared save/unsave hook behind every bookmark (browse
+ * cards + the single-recipe action row). Exercises the optimistic toggle over
+ * the shared ['savedRecipeIds', uid] cache, rollback on a failed write, and the
+ * race where a background refetch lands while a save is still in flight.
+ *
+ * RecipeAPI + AuthAPI are mocked; react-query is real (a fresh client per test).
+ */
+
+import React, { FC, ReactNode } from 'react'
+import { vi, Mock } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useSaveRecipe } from 'src/hooks/useSaveRecipe'
+import RecipeAPI from 'src/api/recipes'
+
+vi.mock('src/api/recipes', () => ({
+  __esModule: true,
+  default: {
+    getSavedRecipeIds: vi.fn(),
+    saveRecipe: vi.fn(),
+    unsaveRecipe: vi.fn(),
+  },
+}))
+vi.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }),
+}))
+
+// uid drives the query key + the logged-in gate. Overridable per test so the
+// logged-out path can be exercised too.
+let mockUid: string | null = 'test-uid'
+vi.mock('src/api/auth', () => ({
+  __esModule: true,
+  default: { getUID: () => mockUid },
+}))
+
+const mockedSavedIds = RecipeAPI.getSavedRecipeIds as unknown as Mock
+const mockedSave = RecipeAPI.saveRecipe as unknown as Mock
+const mockedUnsave = RecipeAPI.unsaveRecipe as unknown as Mock
+
+const makeWrapper = (client: QueryClient): FC<{ children: ReactNode }> => {
+  return ({ children }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+// staleTime: Infinity + no focus refetch removes INCIDENTAL refetches so each
+// test drives the exact getSavedRecipeIds call sequence it sets up (otherwise a
+// stray refetch consumes a mockResolvedValueOnce and makes the guard flaky). The
+// bug scenarios still trigger refetches explicitly, and onSettled's
+// invalidateQueries forces a refetch regardless of staleTime.
+const newClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, refetchOnWindowFocus: false },
+    },
+  })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUid = 'test-uid'
+  mockedSavedIds.mockResolvedValue([])
+  mockedSave.mockResolvedValue({ data: { saved: true } })
+  mockedUnsave.mockResolvedValue({ data: { unsaved: true } })
+})
+
+it('reflects server saved-ids: isSaved is true for an already-saved recipe', async () => {
+  mockedSavedIds.mockResolvedValue(['r1'])
+  const { result } = renderHook(() => useSaveRecipe('r1'), {
+    wrapper: makeWrapper(newClient()),
+  })
+  await waitFor(() => expect(result.current.isSaved).toBe(true))
+})
+
+it('optimistically flips to saved and POSTs the save', async () => {
+  // Server reflects the committed save on any subsequent (re)fetch — the shape
+  // the onSettled reconciliation reads back.
+  mockedSavedIds.mockResolvedValueOnce([]).mockResolvedValue(['r1'])
+  const client = newClient()
+  const { result } = renderHook(() => useSaveRecipe('r1'), {
+    wrapper: makeWrapper(client),
+  })
+  await waitFor(() => expect(result.current.isSaved).toBe(false))
+
+  await act(async () => {
+    await result.current.toggle()
+  })
+
+  expect(mockedSave).toHaveBeenCalledWith('r1')
+  expect(mockedUnsave).not.toHaveBeenCalled()
+  // Cache (and therefore isSaved) reflects the save, and stays saved once the
+  // post-write reconciliation (onSettled) settles.
+  expect(client.getQueryData(['savedRecipeIds', 'test-uid'])).toContain('r1')
+  await waitFor(() => expect(result.current.isSaved).toBe(true))
+})
+
+it('optimistically flips to unsaved and DELETEs the save', async () => {
+  // Initial load shows it saved; once unsaved, the server reflects [] on refetch.
+  mockedSavedIds.mockResolvedValueOnce(['r1']).mockResolvedValue([])
+  const client = newClient()
+  const { result } = renderHook(() => useSaveRecipe('r1'), {
+    wrapper: makeWrapper(client),
+  })
+  await waitFor(() => expect(result.current.isSaved).toBe(true))
+
+  await act(async () => {
+    await result.current.toggle()
+  })
+
+  expect(mockedUnsave).toHaveBeenCalledWith('r1')
+  // Cache drops it optimistically and the post-write reconciliation keeps it out.
+  expect(client.getQueryData(['savedRecipeIds', 'test-uid'])).not.toContain('r1')
+  await waitFor(() => expect(result.current.isSaved).toBe(false))
+})
+
+it('rolls back to unsaved when the save request fails', async () => {
+  mockedSave.mockRejectedValue(new Error('network'))
+  const client = newClient()
+  const { result } = renderHook(() => useSaveRecipe('r1'), {
+    wrapper: makeWrapper(client),
+  })
+  await waitFor(() => expect(result.current.isSaved).toBe(false))
+
+  let ok: boolean | undefined
+  await act(async () => {
+    ok = await result.current.toggle()
+  })
+
+  expect(ok).toBe(false)
+  await waitFor(() => expect(result.current.isSaved).toBe(false))
+  expect(client.getQueryData(['savedRecipeIds', 'test-uid'])).not.toContain('r1')
+})
+
+it('rolls back to saved when the unsave request fails', async () => {
+  mockedSavedIds.mockResolvedValue(['r1'])
+  mockedUnsave.mockRejectedValue(new Error('network'))
+  const client = newClient()
+  const { result } = renderHook(() => useSaveRecipe('r1'), {
+    wrapper: makeWrapper(client),
+  })
+  await waitFor(() => expect(result.current.isSaved).toBe(true))
+
+  let ok: boolean | undefined
+  await act(async () => {
+    ok = await result.current.toggle()
+  })
+
+  expect(ok).toBe(false)
+  await waitFor(() => expect(result.current.isSaved).toBe(true))
+})
+
+it('logged-out toggle no-ops without hitting the API', async () => {
+  mockUid = null
+  const client = newClient()
+  const { result } = renderHook(() => useSaveRecipe('r1'), {
+    wrapper: makeWrapper(client),
+  })
+  let ok: boolean | undefined
+  await act(async () => {
+    ok = await result.current.toggle()
+  })
+  expect(ok).toBe(false)
+  expect(mockedSave).not.toHaveBeenCalled()
+})
+
+// The reproduction (the actual "saving is broken" root cause). The saved-id
+// list is a SHARED cache that runs at the app's default staleTime (0), so a
+// refetch is triggered all the time — a window-focus, another card mounting, or
+// invalidateSavedCaches firing on a different surface. When such a refetch fires
+// AFTER the user toggles but BEFORE the server write commits, it resolves with
+// the stale pre-save list and overwrites the optimistic value. The original hook
+// had no post-write reconciliation, so the bookmark stayed reverted even once
+// the save had succeeded on the server — a stuck, "broken" bookmark.
+//
+// This models that exact ordering and asserts the bookmark ends up saved.
+// The fix's core guarantee: after the server write commits, the hook reconciles
+// the shared saved-id cache against the server. Without it (the old hook), a
+// stale refetch that overwrote the optimistic value mid-write left the bookmark
+// stuck in the wrong state even though the save succeeded — the "saving is
+// broken" symptom. Here the stale refetch is simulated deterministically by
+// clobbering the cache via setQueryData while the POST is in flight; the
+// post-write reconciliation must restore the committed truth.
+it('reconciles with the server after a write, healing a mid-write clobber', async () => {
+  const client = newClient()
+  // The server reflects the committed save on the reconciliation refetch.
+  mockedSavedIds.mockResolvedValueOnce([]).mockResolvedValue(['r1'])
+
+  let resolvePost: (v: unknown) => void = () => {}
+  mockedSave.mockReturnValue(
+    new Promise(res => {
+      resolvePost = res
+    })
+  )
+
+  const { result } = renderHook(() => useSaveRecipe('r1'), {
+    wrapper: makeWrapper(client),
+  })
+  await waitFor(() => expect(result.current.isSaved).toBe(false))
+
+  // User saves; POST is in flight, optimistic cache shows it saved.
+  let togglePromise!: Promise<boolean>
+  act(() => {
+    togglePromise = result.current.toggle()
+  })
+  await waitFor(() =>
+    expect(client.getQueryData(['savedRecipeIds', 'test-uid'])).toContain('r1')
+  )
+
+  // A stale refetch lands mid-write and overwrites the optimistic value (this is
+  // exactly what a window-focus / sibling-card refetch did in production).
+  act(() => {
+    client.setQueryData(['savedRecipeIds', 'test-uid'], [])
+  })
+  await waitFor(() => expect(result.current.isSaved).toBe(false))
+
+  const callsBeforeCommit = mockedSavedIds.mock.calls.length
+
+  // The write commits. onSettled must re-fetch the committed truth so the stuck
+  // clobber self-heals.
+  await act(async () => {
+    resolvePost({ data: { saved: true } })
+    await togglePromise
+  })
+
+  // A reconciliation refetch fired after the write...
+  expect(mockedSavedIds.mock.calls.length).toBeGreaterThan(callsBeforeCommit)
+  // ...and it restored the committed (saved) state.
+  await waitFor(() => expect(result.current.isSaved).toBe(true))
+})


### PR DESCRIPTION
## Track 1b — Save-recipe broken

### How the bug reproduces
`useSaveRecipe` hand-rolled an optimistic write directly over the **shared** React Query cache `['savedRecipeIds', uid]` — the one list every bookmark on the page reads from. That query runs at the app's **default `staleTime` (0)** (`new QueryClient()` in `src/index.tsx`), so the list is refetched constantly: on window-focus, whenever another card mounts, and whenever `invalidateSavedCaches` fires on a different surface.

When such a refetch resolves **mid-write** (after the optimistic toggle, before the server `POST/DELETE` commits) it returns the *pre-write* list and overwrites the optimistic value. The old toggle did **no post-write reconciliation**, so the bookmark stayed reverted **even though the save/unsave had already succeeded on the server** — a stuck bookmark that reads as "saving is broken."

I reproduced this deterministically in a hook test: against the old hook, after a save commits the cache is left `[]` and `isSaved` is stuck `false`; the new hook heals to the committed state.

> Note: the server routes (`POST/DELETE /recipes/:id/save`, `GET /getSavedRecipeIds`) and the request paths/methods were all verified correct and already had passing Jest coverage — the break was purely the client cache handling, not the API/server chain.

### What fixed it
Rewrote the toggle as a proper React Query optimistic mutation (`src/hooks/useSaveRecipe.ts`):
- **`onMutate`** cancels in-flight refetches, snapshots the cache, then writes optimistically (cancel prevents a clobber/flicker from a refetch already running at click time).
- **`onError`** rolls back to the snapshot.
- **`onSettled`** re-fetches the committed truth — so a clobber from a refetch that *started after* `onMutate` (which `cancelQueries` can't catch) self-heals instead of leaving a stuck bookmark. **This is the load-bearing fix for the report.**

Client change is **confined to the hook** — `SaveControl`, the SingleRecipe page, and `api/recipes.ts` are untouched (stays clear of track 2c).

### Tests
- **New `src/test/useSaveRecipe.test.tsx`** — optimistic save & unsave, rollback on save/unsave failure, logged-out no-op, and a **reconcile-after-clobber** guard that *fails on the old hook* and passes on the fixed one.
- **Extended `server/__tests__/recipes.test.js`** — `GET /getSavedRecipeIds` (empty, id-array shape, requires auth) + a `save → read → unsave → read` round-trip (the exact contract the hook consumes).

### Verification
- `npx vitest run src/test/useSaveRecipe.test.tsx` → 7 passed
- `cd server && npx jest recipes.test.js` → 101 passed
- `npx tsc --noEmit` → clean · `npm run build` → passes

⚠️ Pre-existing, unrelated to this change (confirmed identical with my changes stashed): in this sandbox jsdom does not provide `localStorage`, so `src/test/savedFilters.test.ts` and `src/test/SingleRecipe.test.tsx` fail; and `server/__tests__/email-notifications.test.js` fails (email-send mocks). None touch the save subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)