### PR TITLE
feat(help): make the contact page publicly reachable + redesign

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -129,6 +129,10 @@ The triage date stamped on items is the date they were filed here, not when they
 
 ## Resolved / verified done (recorded, not active)
 
+- `[x]` **Local test suite fails on Node ≥24 (Web Storage shim)** — Node's experimental built-in
+  `localStorage` shadowed jsdom's and crashed the `savedFilters`/`SingleRecipe` tests on any Node newer
+  than CI's (pinned to 24). `src/test/setup.ts` now installs an in-memory Storage when the real one is
+  unusable. PR #159.
 - `[x]` **Sign-up button copy** — already reads "Create account" (`src/pages/Signup/Signup.tsx:110`).
 - `[x]` **Bug reporting & viewing system** — shipped: `BugReportModal` + `/admin/bug-reports` queue +
   `bugReports` collection/route.

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -50,7 +50,7 @@ same commit.**
 | 1c | Account data (images, empty-flash) | `[ ]` | — |
 | 1d | Serving-price bug | `[x]` | #152 ✅ |
 | 2a | Homepage redesign (design + For You row + "What should I cook?") | `[x]` | #153 + #154 ✅ |
-| 2b | Public Help/Contact page | `[ ]` | — |
+| 2b | Public Help/Contact page | `[P]` | #158 |
 | 2c | Single-recipe polish | `[ ]` | — |
 | 2d | Recipes browse polish | `[ ]` | — |
 | 2e | Account/profile polish | `[ ]` | — |

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -50,7 +50,7 @@ same commit.**
 | 1c | Account data (images, empty-flash) | `[ ]` | — |
 | 1d | Serving-price bug | `[x]` | #152 ✅ |
 | 2a | Homepage redesign (design + For You row + "What should I cook?") | `[x]` | #153 + #154 ✅ |
-| 2b | Public Help/Contact page | `[P]` | #158 |
+| 2b | Public Help/Contact page | `[x]` | #158 ✅ |
 | 2c | Single-recipe polish | `[ ]` | — |
 | 2d | Recipes browse polish | `[ ]` | — |
 | 2e | Account/profile polish | `[ ]` | — |

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -242,7 +242,7 @@ Chunky design efforts that are bigger than a single checkbox. Tag each as **(blo
     `HomeCookSuggestion.tsx`), `src/api/recipes.ts`, `server/routes/recipes.js`,
     `server/util/forYou.js`, `server/util/tasteContext.js`.
 
-- `[~]` **Help / Contact Support page** — **(blocker → PR #158 open)**
+- `[x]` **Help / Contact Support page** — **(blocker → done, PR #158)**
   - **Was:** `/help` (`src/pages/Help/Help.tsx`, a Formspree form) was already public (the route had
     been moved out of `PrivateRoute`), but **every link to it was hidden from logged-out users** — the
     footer link was tagged `auth: 'in'`, so a locked-out visitor had no way to reach support.

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -57,8 +57,8 @@ a feature flag. Do these together:
   by loading with the API down. **(nice-to-have, but high-impact)**
 - `[~]` **Broken-link & dead-route check** — click every nav item, footer link, and CTA; confirm no
   404s or dead `href="#"`. **Fixed 2026-06-09:** the 404 page's "contact our support team" link now
-  points to `/help` instead of `/` (`src/pages/404/404.tsx`) — note `/help` is still login-gated, so
-  this fully lands once the Help page goes public (Section D). Still to verify: the "View All Release
+  points to `/help` instead of `/` (`src/pages/404/404.tsx`) — the Help page is now public + redesigned
+  (Section D, PR #158 open), so that dependency is addressed. Still to verify: the "View All Release
   Notes" link in `ReleaseNotes.tsx:145` (`github.com/jclind/prepify/releases`). **(blocker)**
 - `[x]` **404 / not-found page** — a real designed 404 exists (`src/pages/404/404.tsx` — food-plate
   graphic, Return Home button) and renders correctly on an unknown route. *Copy nit:* the heading
@@ -242,16 +242,16 @@ Chunky design efforts that are bigger than a single checkbox. Tag each as **(blo
     `HomeCookSuggestion.tsx`), `src/api/recipes.ts`, `server/routes/recipes.js`,
     `server/util/forYou.js`, `server/util/tasteContext.js`.
 
-- `[ ]` **Help / Contact Support page** — **(blocker)**
-  - **Now:** the page already exists — `src/pages/Help/Help.tsx` (routed `/help`) is a Formspree form
-    (category / title / description). **But it's gated:** the route sits inside the `PrivateRoute`
-    block (`src/App.tsx:130`), so it requires login, and it's only linked from the logged-in account
-    dropdown (`src/Components/Navbar/Navbar.tsx:127`). A logged-out visitor can't reach support at all.
-  - **Goal:** _(fill in)_ — redesign as a proper *public* contact/support page: make it reachable when
-    logged out (move the route out of `PrivateRoute`, add a public link — e.g. from the new footer) and
-    refresh the layout.
-  - **Touches:** `src/pages/Help/Help.tsx` (+ `Help.scss`), the route in `src/App.tsx:130`, and the
-    nav link in `src/Components/Navbar/Navbar.tsx:127`.
+- `[~]` **Help / Contact Support page** — **(blocker → PR #158 open)**
+  - **Was:** `/help` (`src/pages/Help/Help.tsx`, a Formspree form) was already public (the route had
+    been moved out of `PrivateRoute`), but **every link to it was hidden from logged-out users** — the
+    footer link was tagged `auth: 'in'`, so a locked-out visitor had no way to reach support.
+  - **Done (PR #158):** un-gated the footer Help link; redesigned the page for a public audience —
+    soft-glass card matching the auth pages, progressive disclosure (topic chips → compact email +
+    message form, optional subject), email fallback, improved success state, a11y (aria-live / pressed).
+    Verified logged-out + signed-in (email pre-fill), runtime-verified, and high-effort reviewed.
+  - **Touches:** `src/pages/Help/Help.tsx` (+ `Help.scss`), `src/Components/Footer/footerData.ts`
+    (link un-gate). `App.tsx` not touched — route was already public.
 
 - `[ ]` **Data-integrity pass** — **(post-1.0)**
   - **Now:** several collections reference each other by mutable/denormalized fields rather than the

--- a/src/Components/Footer/footerData.ts
+++ b/src/Components/Footer/footerData.ts
@@ -26,10 +26,12 @@ export const footerColumns: FooterColumn[] = [
     links: [
       { label: 'Home', to: '/' },
       { label: 'All recipes', to: '/recipes' },
-      // Both require auth (PrivateRoute) — only show them to signed-in users so
+      // Add a recipe is behind PrivateRoute — only show it to signed-in users so
       // logged-out visitors aren't bounced to the login wall from the footer.
       { label: 'Add a recipe', to: '/add-recipe', auth: 'in' },
-      { label: 'Help', to: '/help', auth: 'in' },
+      // Help/support is public (route lives outside PrivateRoute) so locked-out
+      // users — forgot password, broken signup — can always reach the form.
+      { label: 'Help', to: '/help' },
     ],
   },
   {

--- a/src/pages/Help/Help.scss
+++ b/src/pages/Help/Help.scss
@@ -16,11 +16,11 @@
   min-height: 0;
   overflow-y: visible;
   padding: calc(#{s.$nav-height} + 1.5rem) 1rem 3rem;
-  // The global footer carries a 4rem top margin to separate itself from page
-  // content; on this gradient page that margin exposes a strip of body
+  // The global footer carries a $footer-margin top margin to separate itself
+  // from page content; on this gradient page that margin exposes a strip of body
   // background between the panel and the footer. Pull the panel down across it
-  // so the gradient meets the footer flush. (Kept in sync with .site-footer.)
-  margin-bottom: -4rem;
+  // (same token .site-footer uses) so the gradient meets the footer flush.
+  margin-bottom: -#{s.$footer-margin};
 
   .form-container {
     // A touch wider than the auth card to fit the 2-up topic grid comfortably.
@@ -90,15 +90,15 @@
       &.selected {
         border-color: s.$secondary;
         color: s.$secondary;
-        background: rgba(0, 173, 181, 0.07);
-        box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.12);
+        background: rgba(s.$secondary, 0.07);
+        box-shadow: 0 0 0 3px rgba(s.$secondary, 0.12);
         .chip-icon {
           color: s.$secondary;
         }
       }
       &:focus-visible {
         outline: none;
-        box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.25);
+        box-shadow: 0 0 0 3px rgba(s.$secondary, 0.25);
       }
     }
   }
@@ -129,7 +129,7 @@
 
         &:focus {
           border-color: s.$secondary;
-          box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.15);
+          box-shadow: 0 0 0 3px rgba(s.$secondary, 0.15);
         }
         &::placeholder {
           color: s.$tertiary-text;

--- a/src/pages/Help/Help.scss
+++ b/src/pages/Help/Help.scss
@@ -7,26 +7,28 @@
 // re-tuned here to fill the app-main flex slot instead of owning a 100vh,
 // self-scrolling screen.
 .help-page.form-format {
-  // Fill the flexbox app-main and let the document flow scroll past the footer,
-  // rather than forcing a viewport-height panel with its own inner scrollbar.
   flex: 1 0 auto;
   overflow-y: visible;
-  // Anchor near the top so the card top is always reachable when the form grows
-  // taller than the available height (the chips + open form can exceed it).
-  align-items: flex-start;
-  // The navbar is fixed/absolute (out of flow, $nav-height tall) and the footer
-  // flows right after app-main. Fill a full viewport height so the gradient
-  // always reaches the footer with no bare-background gap (the footer simply sits
-  // just below the fold, like the auth pages), and pad the top by the navbar
-  // height so the card clears it — the gradient still bleeds full-width behind
-  // the transparent navbar.
+  // Fill a full viewport height so the gradient spans navbar→footer (the footer
+  // just sits below the fold, like the auth pages). The navbar is fixed/absolute
+  // (out of flow, $nav-height tall) so the gradient bleeds full-width behind it;
+  // the top padding keeps the card clear of it.
   min-height: 100vh;
   min-height: 100dvh;
-  padding: calc(#{s.$nav-height} + 2rem) 1rem 3rem;
+  padding: calc(#{s.$nav-height} + 1.5rem) 1rem 3rem;
+  // The global footer carries a 4rem top margin to separate itself from page
+  // content; on this gradient page that margin exposes a strip of body
+  // background between the panel and the footer. Pull the panel down across it
+  // so the gradient meets the footer flush. (Kept in sync with .site-footer.)
+  margin-bottom: -4rem;
 
   .form-container {
     // A touch wider than the auth card to fit the 2-up topic grid comfortably.
     max-width: 460px;
+    // Auto block margins center the card vertically when there's room, but
+    // collapse to 0 (top-aligned) when the open form is taller than the
+    // viewport — so it never overflows upward behind the fixed navbar.
+    margin: auto;
   }
 
   // Heading + supporting line sit above the form (the chips live between them),

--- a/src/pages/Help/Help.scss
+++ b/src/pages/Help/Help.scss
@@ -9,12 +9,20 @@
 .help-page.form-format {
   // Fill the flexbox app-main and let the document flow scroll past the footer,
   // rather than forcing a viewport-height panel with its own inner scrollbar.
-  min-height: 0;
   flex: 1 0 auto;
   overflow-y: visible;
   // Anchor near the top so the card top is always reachable when the form grows
   // taller than the available height (the chips + open form can exceed it).
   align-items: flex-start;
+  // The navbar is fixed/absolute (out of flow, $nav-height tall) and the footer
+  // flows right after app-main. Fill a full viewport height so the gradient
+  // always reaches the footer with no bare-background gap (the footer simply sits
+  // just below the fold, like the auth pages), and pad the top by the navbar
+  // height so the card clears it — the gradient still bleeds full-width behind
+  // the transparent navbar.
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: calc(#{s.$nav-height} + 2rem) 1rem 3rem;
 
   .form-container {
     // A touch wider than the auth card to fit the 2-up topic grid comfortably.

--- a/src/pages/Help/Help.scss
+++ b/src/pages/Help/Help.scss
@@ -7,14 +7,14 @@
 // re-tuned here to fill the app-main flex slot instead of owning a 100vh,
 // self-scrolling screen.
 .help-page.form-format {
+  // Grow to fill app-main (which flex-grows to fill the shell minus the footer),
+  // so the gradient spans from the navbar down to the footer with the footer
+  // resting at the bottom of the viewport — not pushed below the fold by a forced
+  // 100vh. The navbar is fixed/absolute (out of flow, $nav-height tall) so the
+  // gradient bleeds full-width behind it; the top padding keeps the card clear.
   flex: 1 0 auto;
+  min-height: 0;
   overflow-y: visible;
-  // Fill a full viewport height so the gradient spans navbar→footer (the footer
-  // just sits below the fold, like the auth pages). The navbar is fixed/absolute
-  // (out of flow, $nav-height tall) so the gradient bleeds full-width behind it;
-  // the top padding keeps the card clear of it.
-  min-height: 100vh;
-  min-height: 100dvh;
   padding: calc(#{s.$nav-height} + 1.5rem) 1rem 3rem;
   // The global footer carries a 4rem top margin to separate itself from page
   // content; on this gradient page that margin exposes a strip of body

--- a/src/pages/Help/Help.scss
+++ b/src/pages/Help/Help.scss
@@ -1,126 +1,181 @@
 @use '../../helpers.scss' as s;
 
-.help-page {
-  display: flex;
-  justify-content: center;
-  // Fills the flexbox app-main; the app shell positions the footer (Layout.scss).
+// The Help/contact page reuses the auth pages' soft-glass form vocabulary
+// (`.form-format` → frosted `.form-container`, `.brand-mark`, `.input-fields`,
+// `.form-action-btn`, `.error`/`.success`) from Form/FormStyles.scss. Unlike the
+// auth routes, Help renders INSIDE <Layout> (navbar + footer), so the wrapper is
+// re-tuned here to fill the app-main flex slot instead of owning a 100vh,
+// self-scrolling screen.
+.help-page.form-format {
+  // Fill the flexbox app-main and let the document flow scroll past the footer,
+  // rather than forcing a viewport-height panel with its own inner scrollbar.
+  min-height: 0;
   flex: 1 0 auto;
+  overflow-y: visible;
+  // Anchor near the top so the card top is always reachable when the form grows
+  // taller than the available height (the chips + open form can exceed it).
+  align-items: flex-start;
+
   .form-container {
-    max-width: 400px;
-    width: 90%;
-    background: s.$white;
-    padding: 2rem;
-    height: fit-content;
-    border-radius: s.$border-radius;
+    // A touch wider than the auth card to fit the 2-up topic grid comfortably.
+    max-width: 460px;
+  }
 
-    .form-success {
+  // Heading + supporting line sit above the form (the chips live between them),
+  // so they're outside `.form` and styled here rather than inheriting the
+  // FormStyles `.form .title` / `.prompt` rules.
+  .title {
+    font-size: 1.55rem;
+    font-weight: 800;
+    color: s.$primary-text;
+    margin-bottom: 0.4rem;
+  }
+  .prompt {
+    margin: 0 auto 1.5rem;
+    max-width: 34ch;
+    font-weight: 500;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: s.$secondary-text;
+  }
+
+  // Topic chooser — the light entry point. Two-up grid of soft cards; picking
+  // one reveals the form below with that topic preselected.
+  .topic-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.6rem;
+
+    .topic-chip {
       display: flex;
-      justify-content: center;
-      align-items: center;
       flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.4rem;
+      padding: 0.9rem 0.5rem;
+      border: 1.5px solid s.$gray-300;
+      border-radius: 14px;
+      background: s.$white;
+      color: s.$secondary-text;
+      font-weight: 600;
+      font-size: 0.85rem;
+      cursor: pointer;
+      transition: border-color 0.15s ease, color 0.15s ease,
+        background 0.15s ease, box-shadow 0.15s ease;
 
-      .image-container {
-        margin: 1rem 0;
-        width: 180px;
-        height: 180px;
-        img {
-          object-fit: contain;
-          width: 180px;
-          height: 180px;
+      .chip-icon {
+        display: flex;
+        font-size: 1.45rem;
+        color: s.$tertiary-text;
+        transition: color 0.15s ease;
+      }
+
+      &:hover {
+        border-color: s.$secondary;
+        color: s.$primary-text;
+        .chip-icon {
+          color: s.$secondary;
         }
       }
-      button.submit-another-form-btn {
-        font-size: 1rem;
-        font-weight: 500;
+      &.selected {
+        border-color: s.$secondary;
         color: s.$secondary;
-        text-decoration: underline;
+        background: rgba(0, 173, 181, 0.07);
+        box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.12);
+        .chip-icon {
+          color: s.$secondary;
+        }
+      }
+      &:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.25);
+      }
+    }
+  }
+
+  // The form is revealed once a topic is chosen.
+  .help-form {
+    margin-top: 1.5rem;
+
+    // Message box — mirrors the FormInput field styling (FormInput.scss) for a
+    // consistent look, but as a multi-line textarea.
+    .message-field {
+      .message-textarea {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 0.7rem 0.85rem;
+        font-family: inherit;
+        font-size: 0.95rem;
+        font-weight: 500;
+        line-height: 1.5;
+        color: s.$primary-text;
+        border: 1.5px solid s.$gray-300;
+        border-radius: s.$border-radius;
+        background: s.$white;
+        outline: none;
+        resize: vertical;
+        min-height: 110px;
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+        &:focus {
+          border-color: s.$secondary;
+          box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.15);
+        }
+        &::placeholder {
+          color: s.$tertiary-text;
+          font-weight: 400;
+        }
       }
     }
 
-    // background: red;
-    .report-form {
-      display: flex;
-      flex-direction: column;
-      gap: 1.5rem;
+    // Optional "Add a subject" disclosure — a quiet text button so the baseline
+    // form stays to email + message.
+    .add-subject-btn {
+      align-self: flex-start;
+      padding: 0.15rem 0;
+      border: none;
+      background: transparent;
+      color: s.$secondary;
+      font-weight: 600;
+      font-size: 0.82rem;
+      cursor: pointer;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
 
-      .title {
-        text-align: center;
-        font-weight: 600;
-        font-size: 1.375rem;
+  // "Prefer email?" fallback for people who'd rather not use the form.
+  .email-fallback {
+    margin-top: 1.5rem;
+    font-size: 0.82rem;
+    color: s.$tertiary-text;
+    // The address is one unbreakable token — let it wrap rather than force the
+    // card wider than a narrow viewport.
+    overflow-wrap: anywhere;
+    a {
+      color: s.$secondary;
+      font-weight: 600;
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
       }
-      .error {
-        margin-bottom: 0;
-      }
-      .select-container {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        .text {
-          width: 5ch;
-          font-size: 0.875rem;
-          font-weight: 600;
-          color: s.$secondary;
-          padding-bottom: 0.25rem;
-        }
-        .select {
-          width: 100%;
-        }
-      }
-      label.email-input-label,
-      label.title-input-label {
-        width: 100%;
+    }
+  }
 
-        input.email-input,
-        input.title-input {
-          width: 100%;
-          height: 40px;
-          box-sizing: border-box;
-          padding: 0.5rem;
-        }
-      }
-      label.description-input-label {
-        width: 100%;
+  // Post-submit confirmation.
+  .help-success {
+    display: flex;
+    flex-direction: column;
 
-        textarea.description-textarea {
-          width: 100%;
-          box-sizing: border-box;
-          resize: vertical;
-          padding: 0.5rem;
-        }
-      }
-
-      label {
-        .text {
-          font-size: 0.875rem;
-          font-weight: 600;
-          padding-bottom: 0.25rem;
-          color: s.$secondary;
-        }
-      }
-      input,
-      textarea {
-        outline: none;
-        border: none;
-        border: 1px solid s.$gray-400;
-        border-radius: s.$border-radius;
-        font-size: 1rem;
-        font-weight: 500;
-
-        &::placeholder {
-          color: s.$gray-500;
-        }
-        &:focus {
-          border-color: s.$secondary;
-        }
-      }
-
-      button.submit-help-btn {
-        padding: 0.75rem;
-        font-size: 1.25rem;
-        font-weight: 600;
-        border-radius: s.$border-radius;
-        color: s.$white;
-        background: s.$secondary;
+    .title {
+      margin-bottom: 0.6rem;
+    }
+    .prompt {
+      margin-bottom: 1.75rem;
+      strong {
+        color: s.$primary-text;
+        font-weight: 700;
       }
     }
   }

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -63,7 +63,7 @@ const Help: FC = () => {
   const [showSubject, setShowSubject] = useState(false)
   const [description, setDescription] = useState('')
 
-  const [formState, submitFormspree] = useForm('xknyboeq')
+  const [formState, submitFormspree, resetFormspree] = useForm('xknyboeq')
 
   // Auth resolves async, so user is null on first render. Pre-fill the email
   // once it loads, but don't clobber anything the visitor has already typed.
@@ -74,6 +74,14 @@ const Help: FC = () => {
   }, [user])
 
   const activeTopic = TOPICS.find(t => t.value === topic) ?? null
+
+  const handleTopicSelect = (value: string) => {
+    setTopic(value)
+    // Clear a stale "couldn't send" banner from a previous attempt so it doesn't
+    // linger under a freshly-chosen topic (the error is Formspree hook state,
+    // independent of `topic`).
+    if (formState.errors) resetFormspree()
+  }
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -129,7 +137,7 @@ const Help: FC = () => {
                     type='button'
                     className={`topic-chip${topic === t.value ? ' selected' : ''}`}
                     aria-pressed={topic === t.value}
-                    onClick={() => setTopic(t.value)}
+                    onClick={() => handleTopicSelect(t.value)}
                   >
                     <span className='chip-icon'>{t.icon}</span>
                     <span className='chip-label'>{t.label}</span>

--- a/src/pages/Help/Help.tsx
+++ b/src/pages/Help/Help.tsx
@@ -1,72 +1,67 @@
-import React, { FC, useEffect, useState } from 'react'
-import Select, { SingleValue, StylesConfig } from 'react-select'
+import React, { FC, ReactElement, useEffect, useState } from 'react'
 import { useForm } from '@formspree/react'
-import './Help.scss'
 import { Helmet } from 'react-helmet-async'
+import { TailSpin } from 'react-loader-spinner'
+import {
+  MdOutlineEmail,
+  MdOutlineBugReport,
+  MdOutlineLightbulb,
+  MdOutlineHelpOutline,
+  MdOutlineChatBubbleOutline,
+  MdOutlineSubject,
+} from 'react-icons/md'
 import { useAuth } from 'src/context/AuthContext'
+import { contactEmail } from 'src/Components/Footer/footerData'
+import FormInput from 'src/Components/Form/FormInput'
+import '../../Components/Form/FormStyles.scss'
+import './Help.scss'
 
-type OptionType = { value: string; label: string }
-
-const options: OptionType[] = [
-  { value: 'bug', label: 'Reporting A Bug' },
-  { value: 'feature', label: 'Requesting A Feature' },
-  { value: 'question', label: 'Asking A Question' },
-  { value: 'other', label: 'Other' },
-]
-const customStyles: StylesConfig<OptionType> = {
-  control: (provided: any, state: any) => ({
-    ...provided,
-    background: 'white',
-    minHeight: '40px',
-    height: '40px',
-    minWidth: '100%',
-    boxShadow: state.isFocused ? null : null,
-    outline: 'none',
-    border: state.isFocused ? '1px solid #00adb5' : '1px solid #d6d6d6',
-    ':hover': {
-      border: '1px solid #00adb5',
-    },
-  }),
-  singleValue: (provided: any) => ({
-    ...provided,
-    color: 'hsl(0, 0%, 0%)',
-    fontWeight: '500',
-    paddingBottom: '3px',
-  }),
-
-  valueContainer: (provided: any) => ({
-    ...provided,
-    height: '40px',
-    padding: '0 6px',
-  }),
-
-  input: (provided: any) => ({
-    ...provided,
-    margin: '0px',
-  }),
-  indicatorSeparator: () => ({
-    display: 'none',
-  }),
-  indicatorsContainer: (provided: any) => ({
-    ...provided,
-    height: '40px',
-  }),
-  placeholder: (provided: any) => ({
-    ...provided,
-    fontWeight: '500',
-    color: '#bebebe',
-  }),
+type Topic = {
+  value: string
+  label: string
+  icon: ReactElement
+  /** Placeholder copy tailored to the topic, to nudge a useful first message. */
+  placeholder: string
 }
+
+// The four entry points. Picking one is all that's needed to open the form, so
+// the landing stays light — a logged-out visitor reporting a quick bug never
+// faces more than a topic, their email, and a message box.
+const TOPICS: Topic[] = [
+  {
+    value: 'bug',
+    label: 'Report a bug',
+    icon: <MdOutlineBugReport />,
+    placeholder: 'What went wrong, and what were you doing when it happened?',
+  },
+  {
+    value: 'feature',
+    label: 'Suggest an idea',
+    icon: <MdOutlineLightbulb />,
+    placeholder: 'What would you like to see in Prepify?',
+  },
+  {
+    value: 'question',
+    label: 'Ask a question',
+    icon: <MdOutlineHelpOutline />,
+    placeholder: 'What can we help you figure out?',
+  },
+  {
+    value: 'other',
+    label: 'Something else',
+    icon: <MdOutlineChatBubbleOutline />,
+    placeholder: 'How can we help?',
+  },
+]
 
 const Help: FC = () => {
   const user = useAuth()?.user
 
-  const [selectOption, setSelectOption] = useState<OptionType | null>(null)
+  const [topic, setTopic] = useState<string | null>(null)
   const [email, setEmail] = useState(user?.email ?? '')
   const [title, setTitle] = useState('')
+  const [showSubject, setShowSubject] = useState(false)
   const [description, setDescription] = useState('')
-
-  const [error, setError] = useState('')
 
   const [formState, submitFormspree] = useForm('xknyboeq')
 
@@ -78,107 +73,156 @@ const Help: FC = () => {
     }
   }, [user])
 
-  const handleSelectChange = (e: SingleValue<OptionType>) => {
-    setSelectOption(e)
-  }
-  const clearForm = () => {
-    setSelectOption(null)
-    setEmail(user?.email ?? '')
-    setTitle('')
-    setDescription('')
-  }
+  const activeTopic = TOPICS.find(t => t.value === topic) ?? null
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (!selectOption) return setError('Please Enter Category')
-
     submitFormspree(e)
-    clearForm()
   }
 
   return (
     <>
       <Helmet>
         <meta charSet='utf-8' />
-        <title>Prepify | Help</title>
+        <title>Prepify | Help &amp; Support</title>
         <meta
           name='description'
-          content='Contact Prepify support for help with meal planning or questions about Prepify. Our friendly team is dedicated to assisting you with your queries and health goals.'
+          content='Get help with Prepify — report a bug, suggest an idea, or ask a question. A real person reads every message and replies by email.'
         />
         <link rel='canonical' href='https://www.prepifymeals.com/help' />
       </Helmet>
-      <div className='help-page page'>
+      <div className='help-page form-format'>
         <div className='form-container'>
+          <div className='brand-mark'>P</div>
+
           {formState.succeeded ? (
-            <div className='form-success'>
-              <h1>Form Submitted!</h1>
-              <div className='image-container'>
-                <img src='/images/form-submitted.svg' alt='letter submitted' />
-              </div>
+            <div className='help-success'>
+              <h1 className='title'>Message sent — thank you!</h1>
+              <p className='prompt'>
+                We&rsquo;ll reply to <strong>{email || 'your email'}</strong> as
+                soon as we can, usually within a couple of days.
+              </p>
               <button
-                className='submit-another-form-btn btn'
+                type='button'
+                className='form-action-btn btn'
                 onClick={() => window.location.reload()}
               >
-                Submit Another Form
+                Send another message
               </button>
             </div>
           ) : (
-            <form className='report-form' onSubmit={handleSubmit}>
-              <h1 className='title'>Help Form</h1>
-              {error && <div className='error'>{error}</div>}
-              <div className='select-container'>
-                <div className='text'>Category</div>
-                <Select<OptionType, false>
-                  options={options}
-                  styles={customStyles}
-                  isSearchable={false}
-                  isClearable={false}
-                  className='select'
-                  value={selectOption}
-                  onChange={handleSelectChange}
-                  placeholder={'Select an option...'}
-                  name='category'
-                />
+            <>
+              <h1 className='title'>How can we help?</h1>
+              <p className='prompt'>
+                Pick a topic and send us a note — a real person reads every
+                message.
+              </p>
+
+              <div
+                className='topic-grid'
+                role='group'
+                aria-label='What do you need help with?'
+              >
+                {TOPICS.map(t => (
+                  <button
+                    key={t.value}
+                    type='button'
+                    className={`topic-chip${topic === t.value ? ' selected' : ''}`}
+                    aria-pressed={topic === t.value}
+                    onClick={() => setTopic(t.value)}
+                  >
+                    <span className='chip-icon'>{t.icon}</span>
+                    <span className='chip-label'>{t.label}</span>
+                  </button>
+                ))}
               </div>
-              <label htmlFor='' className='email-input-label'>
-                <div className='text'>Email</div>
-                <input
-                  type='email'
-                  name='email'
-                  className='email-input'
-                  value={email}
-                  onChange={e => setEmail(e.target.value)}
-                  placeholder='Enter your email'
-                  required={true}
-                />
-              </label>
-              <label htmlFor='' className='title-input-label'>
-                <div className='text'>Title</div>
-                <input
-                  type='text'
-                  name='title'
-                  className='title-input'
-                  value={title}
-                  onChange={e => setTitle(e.target.value)}
-                  placeholder='Enter a title'
-                  required={true}
-                />
-              </label>
-              <label htmlFor='' className='description-input-label'>
-                <div className='text'>Description</div>
-                <textarea
-                  className='description-textarea'
-                  value={description}
-                  name='description'
-                  onChange={e => setDescription(e.target.value)}
-                  placeholder='Enter a description'
-                  rows={5}
-                  required={true}
-                ></textarea>
-              </label>
-              <button type='submit' className='submit-help-btn btn'>
-                Submit
-              </button>
-            </form>
+
+              {activeTopic && (
+                <form className='form help-form' onSubmit={handleSubmit}>
+                  {/* Topic drives the form's appearance via the chips above; send
+                      its human label so it reads cleanly in the support inbox. */}
+                  <input type='hidden' name='category' value={activeTopic.label} />
+
+                  <div aria-live='polite'>
+                    {formState.errors ? (
+                      <div className='error'>
+                        Something went wrong sending your message. Please try
+                        again, or email us directly.
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <div className='input-fields'>
+                    <FormInput
+                      icon={<MdOutlineEmail className='icon' />}
+                      type='email'
+                      name='email'
+                      label='Your email'
+                      autoComplete='email'
+                      val={email}
+                      setVal={setEmail}
+                      placeholder='name@example.com'
+                    />
+
+                    <label className='form-input message-field'>
+                      <span className='label-title'>Message</span>
+                      <textarea
+                        name='description'
+                        className='message-textarea'
+                        value={description}
+                        onChange={e => setDescription(e.target.value)}
+                        placeholder={activeTopic.placeholder}
+                        rows={5}
+                        required
+                      />
+                    </label>
+
+                    {showSubject ? (
+                      <FormInput
+                        icon={<MdOutlineSubject className='icon' />}
+                        type='text'
+                        name='title'
+                        label='Subject'
+                        val={title}
+                        setVal={setTitle}
+                        placeholder='A short summary (optional)'
+                        required={false}
+                      />
+                    ) : (
+                      <button
+                        type='button'
+                        className='add-subject-btn'
+                        onClick={() => setShowSubject(true)}
+                      >
+                        + Add a subject
+                      </button>
+                    )}
+                  </div>
+
+                  <button
+                    type='submit'
+                    className='form-action-btn btn'
+                    disabled={formState.submitting}
+                  >
+                    {formState.submitting ? (
+                      <TailSpin
+                        height='28'
+                        width='28'
+                        color='white'
+                        ariaLabel='Sending'
+                      />
+                    ) : (
+                      'Send message'
+                    )}
+                  </button>
+                </form>
+              )}
+
+              <p className='email-fallback'>
+                Prefer email? Reach us at{' '}
+                <a href={`mailto:${contactEmail}`}>{contactEmail}</a>
+              </p>
+            </>
           )}
         </div>
       </div>

--- a/src/test/Footer.test.tsx
+++ b/src/test/Footer.test.tsx
@@ -93,13 +93,35 @@ describe('Footer', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('reveals the auth-gated Discover links when signed in', () => {
-      // Hidden when signed out so logged-out users aren't sent to the login wall.
+    it('hides the auth-gated Add a recipe link when signed out', () => {
+      // Behind PrivateRoute, so logged-out users aren't sent to the login wall.
+      authState.user = null
+      renderFooter()
+      expect(
+        screen.queryByRole('link', { name: 'Add a recipe' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('reveals the auth-gated Add a recipe link when signed in', () => {
       authState.user = { uid: 'abc123' }
       renderFooter()
       expect(
         screen.getByRole('link', { name: 'Add a recipe' })
       ).toHaveAttribute('href', '/add-recipe')
+    })
+
+    it('always shows the public Help link, signed in or out', () => {
+      // Help lives outside PrivateRoute so locked-out users can reach support.
+      authState.user = null
+      const { unmount } = renderFooter()
+      expect(screen.getByRole('link', { name: 'Help' })).toHaveAttribute(
+        'href',
+        '/help'
+      )
+      unmount()
+
+      authState.user = { uid: 'abc123' }
+      renderFooter()
       expect(screen.getByRole('link', { name: 'Help' })).toHaveAttribute(
         'href',
         '/help'

--- a/src/test/Help.test.tsx
+++ b/src/test/Help.test.tsx
@@ -15,9 +15,13 @@ vi.mock('@formspree/react', () => ({
   useForm: () => [formspree.state, formspree.submit],
 }))
 
-// Logged-out visitor by default — the whole point of the page being public.
+// Logged-out visitor by default — the whole point of the page being public —
+// but mutable so a test can sign in and check the email pre-fill.
+const authState = vi.hoisted(() => ({
+  user: null as null | { email?: string | null },
+}))
 vi.mock('src/context/AuthContext', () => ({
-  useAuth: () => ({ user: null }),
+  useAuth: () => ({ user: authState.user }),
 }))
 
 const renderHelp = () =>
@@ -32,6 +36,7 @@ const renderHelp = () =>
 beforeEach(() => {
   formspree.state = { succeeded: false, submitting: false, errors: null }
   formspree.submit.mockReset()
+  authState.user = null
 })
 
 describe('Help', () => {
@@ -92,6 +97,20 @@ describe('Help', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: /send message/i }))
     expect(formspree.submit).toHaveBeenCalled()
+  })
+
+  it('pre-fills the email for a signed-in user, but stays empty when logged out', () => {
+    // Logged out (default): the revealed email field is blank.
+    renderHelp()
+    fireEvent.click(screen.getByRole('button', { name: /report a bug/i }))
+    expect(screen.getByLabelText('Your email')).toHaveValue('')
+  })
+
+  it('pre-fills the email from the signed-in user', () => {
+    authState.user = { email: 'chef@example.com' }
+    renderHelp()
+    fireEvent.click(screen.getByRole('button', { name: /report a bug/i }))
+    expect(screen.getByLabelText('Your email')).toHaveValue('chef@example.com')
   })
 
   it('shows a confirmation once the message is sent', () => {

--- a/src/test/Help.test.tsx
+++ b/src/test/Help.test.tsx
@@ -10,9 +10,10 @@ import Help from 'src/pages/Help/Help'
 const formspree = vi.hoisted(() => ({
   state: { succeeded: false, submitting: false, errors: null as unknown },
   submit: vi.fn(),
+  reset: vi.fn(),
 }))
 vi.mock('@formspree/react', () => ({
-  useForm: () => [formspree.state, formspree.submit],
+  useForm: () => [formspree.state, formspree.submit, formspree.reset],
 }))
 
 // Logged-out visitor by default — the whole point of the page being public —
@@ -36,6 +37,7 @@ const renderHelp = () =>
 beforeEach(() => {
   formspree.state = { succeeded: false, submitting: false, errors: null }
   formspree.submit.mockReset()
+  formspree.reset.mockReset()
   authState.user = null
 })
 
@@ -111,6 +113,16 @@ describe('Help', () => {
     renderHelp()
     fireEvent.click(screen.getByRole('button', { name: /report a bug/i }))
     expect(screen.getByLabelText('Your email')).toHaveValue('chef@example.com')
+  })
+
+  it('clears a stale submit error when the visitor switches topic', () => {
+    formspree.state = { succeeded: false, submitting: false, errors: {} }
+    renderHelp()
+    fireEvent.click(screen.getByRole('button', { name: /report a bug/i }))
+    // Switching topic resets the Formspree state so the error banner doesn't
+    // linger under a freshly-chosen topic.
+    fireEvent.click(screen.getByRole('button', { name: /ask a question/i }))
+    expect(formspree.reset).toHaveBeenCalled()
   })
 
   it('shows a confirmation once the message is sent', () => {

--- a/src/test/Help.test.tsx
+++ b/src/test/Help.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import Help from 'src/pages/Help/Help'
+
+// Drive Formspree's hook state per-test (submit succeeded / pending) without
+// hitting the network, and capture the submit handler the form calls.
+const formspree = vi.hoisted(() => ({
+  state: { succeeded: false, submitting: false, errors: null as unknown },
+  submit: vi.fn(),
+}))
+vi.mock('@formspree/react', () => ({
+  useForm: () => [formspree.state, formspree.submit],
+}))
+
+// Logged-out visitor by default — the whole point of the page being public.
+vi.mock('src/context/AuthContext', () => ({
+  useAuth: () => ({ user: null }),
+}))
+
+const renderHelp = () =>
+  render(
+    <HelmetProvider>
+      <MemoryRouter>
+        <Help />
+      </MemoryRouter>
+    </HelmetProvider>
+  )
+
+beforeEach(() => {
+  formspree.state = { succeeded: false, submitting: false, errors: null }
+  formspree.submit.mockReset()
+})
+
+describe('Help', () => {
+  it('opens on a light topic chooser with the form hidden', () => {
+    renderHelp()
+    expect(
+      screen.getByRole('heading', { name: /how can we help/i })
+    ).toBeInTheDocument()
+    // All four entry points present...
+    expect(screen.getByRole('button', { name: /report a bug/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /suggest an idea/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /ask a question/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /something else/i })).toBeInTheDocument()
+    // ...but no form fields until a topic is chosen.
+    expect(screen.queryByLabelText('Message')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /send message/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('always offers the email fallback, even before picking a topic', () => {
+    renderHelp()
+    expect(
+      screen.getByRole('link', { name: /jesselindcs@gmail\.com/i })
+    ).toHaveAttribute('href', 'mailto:JesseLindCS@gmail.com')
+  })
+
+  it('reveals the compact form once a topic is selected', () => {
+    renderHelp()
+    fireEvent.click(screen.getByRole('button', { name: /report a bug/i }))
+    expect(screen.getByLabelText('Your email')).toBeInTheDocument()
+    expect(screen.getByLabelText('Message')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /send message/i })
+    ).toBeInTheDocument()
+    // The chosen chip is marked pressed for assistive tech.
+    expect(
+      screen.getByRole('button', { name: /report a bug/i })
+    ).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('keeps the subject field behind an optional disclosure', () => {
+    renderHelp()
+    fireEvent.click(screen.getByRole('button', { name: /ask a question/i }))
+    expect(screen.queryByLabelText('Subject')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /add a subject/i }))
+    expect(screen.getByLabelText('Subject')).toBeInTheDocument()
+  })
+
+  it('submits the message through the Formspree handler', () => {
+    renderHelp()
+    fireEvent.click(screen.getByRole('button', { name: /suggest an idea/i }))
+    fireEvent.change(screen.getByLabelText('Your email'), {
+      target: { value: 'visitor@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Message'), {
+      target: { value: 'It would be great if…' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }))
+    expect(formspree.submit).toHaveBeenCalled()
+  })
+
+  it('shows a confirmation once the message is sent', () => {
+    formspree.state = { succeeded: true, submitting: false, errors: null }
+    renderHelp()
+    expect(
+      screen.getByRole('heading', { name: /message sent/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /send another message/i })
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Track 2b — Public Help/Contact page *(1.0 blocker)*

The `/help` route was already public (outside `PrivateRoute`), but every link to it was hidden from logged-out users — the footer link was tagged `auth: 'in'` on a stale assumption that Help still required login. So a locked-out visitor (forgot password, broken signup) had **no way to reach support**. This makes it both reachable *and* discoverable, and refreshes the page for a public audience.

### Changes
- **Footer** (`footerData.ts`) — un-gate the Help link (drop `auth: 'in'`); fix the stale "requires auth" comment so it only covers *Add a recipe*.
- **Help page** (`Help.tsx` + `Help.scss`) — redesign to match the login/signup soft-glass form vocabulary (peach→teal gradient wash, frosted card, "P" brand mark, `FormInput` fields), kept **inside `<Layout>`** so the site nav/footer stay. Progressive disclosure so people aren't met with a wall of fields:
  - Opens on a light **topic chooser** (Report a bug / Suggest an idea / Ask a question / Something else).
  - Picking one reveals a **compact email + message form**; **subject** sits behind an optional toggle.
  - Adds a **"prefer email?"** fallback, an improved **success** state ("we'll reply to <email>…"), `aria-live` errors and `aria-pressed` chips.
- **Tests** — `Footer.test.tsx` now asserts Help is public (visible signed-in *and* signed-out) while *Add a recipe* stays gated; new `Help.test.tsx` covers the progressive-disclosure flow (chips → form, optional subject, submit handler, success state).

`App.tsx` was **not** touched — the route was already public.

### Signed-out verification
- Headless render of `/help` **logged out** shows the page renders directly (no redirect) and the footer now contains `<a href="/help">Help</a>` (and correctly still hides `/add-recipe`).
- Desktop screenshot confirms the redesign (gradient, frosted card, topic chips, email fallback) with the logged-out navbar (Log in / Sign up).

### Test status
- ✅ New + changed tests green: **Help (6) + Footer (9)** = 15 passing
- ✅ `tsc --noEmit` clean · ✅ production build passes
- ℹ️ Locally, 19 unrelated tests (`savedFilters`, `SingleRecipe`) fail **only under Node ≥ 24/26**, whose experimental built-in `localStorage` shadows jsdom's. CI pins **Node 24** and `development` is green; these predate this branch and touch none of these files. A separate PR hardens `src/test/setup.ts` against this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)