### PR TITLE
test(setup): shim Web Storage so the suite passes on Node >= 24

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -30,3 +30,68 @@ if (typeof window.matchMedia !== 'function') {
       dispatchEvent: () => false,
     } as unknown as MediaQueryList)
 }
+
+// Web Storage shim. Node >= 24 ships an experimental built-in `localStorage`
+// global that, without `--localstorage-file`, is unusable (throws / reads as
+// undefined and emits an ExperimentalWarning) AND shadows jsdom's own
+// implementation. So on any Node newer than CI's, tests that touch Web Storage
+// crash with "Cannot read properties of undefined (reading 'clear')". Install a
+// minimal in-memory Storage only when a working one is absent — when jsdom's
+// real implementation is usable (e.g. CI's Node) this leaves it untouched.
+const createMemoryStorage = (): Storage => {
+  let store: Record<string, string> = {}
+  return {
+    get length() {
+      return Object.keys(store).length
+    },
+    clear() {
+      store = {}
+    },
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null
+    },
+    key(index: number) {
+      return Object.keys(store)[index] ?? null
+    },
+    removeItem(key: string) {
+      delete store[key]
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value)
+    },
+  } as Storage
+}
+
+const ensureStorage = (name: 'localStorage' | 'sessionStorage') => {
+  let usable = false
+  try {
+    const existing = (globalThis as Record<string, unknown>)[name] as
+      | Storage
+      | undefined
+    if (existing) {
+      existing.setItem('__storage_probe__', '1')
+      existing.removeItem('__storage_probe__')
+      usable = true
+    }
+  } catch {
+    usable = false
+  }
+  if (usable) return
+
+  const memory = createMemoryStorage()
+  const define = (target: object) => {
+    try {
+      Object.defineProperty(target, name, {
+        configurable: true,
+        value: memory,
+      })
+    } catch {
+      /* non-configurable on this target — fall through to the other */
+    }
+  }
+  define(globalThis)
+  if (typeof window !== 'undefined') define(window)
+}
+
+ensureStorage('localStorage')
+ensureStorage('sessionStorage')


### PR DESCRIPTION
## Problem

On any Node newer than CI's pinned **Node 24**, `npm test` fails locally with 19 errors across `savedFilters.test.ts` and `SingleRecipe.test.tsx`:

```
TypeError: Cannot read properties of undefined (reading 'clear')
(node:…) ExperimentalWarning: localStorage is not available because --localstorage-file was not provided
```

**Root cause:** Node ≥ 24 ships an experimental built-in `localStorage` global. Without `--localstorage-file` it's unusable (reads as `undefined`, emits the warning above) **and shadows jsdom's own `localStorage`** inside the vitest worker. Any test that touches Web Storage then crashes. CI (Node 24) is unaffected and `development` is green there — so this was invisible in CI but blocked local development on newer Node (e.g. Node 26).

## Fix

`src/test/setup.ts` now installs a minimal in-memory `Storage` for `localStorage`/`sessionStorage` **only when a working one is absent** — it probes the existing global with `setItem`/`removeItem` and leaves jsdom's real implementation untouched where it works (so CI behavior is unchanged). Same "stub the jsdom/runtime gap" pattern as the existing `matchMedia` shim in that file.

## Verification (local, Node v26.3.0)

- Previously-failing files: **`savedFilters` + `SingleRecipe` → 19 passed**
- Full suite: **58 files, 425 passed, 2 skipped, 0 failed**
- No production code touched — test setup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)