### PR TITLE
feat(single-recipe): polish — price prominence, report relocation, 404, a11y, JSON-LD

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -65,6 +65,10 @@ The triage date stamped on items is the date they were filed here, not when they
 - `[ ]` **Serving price not prominent enough** — surface it more clearly on the single-recipe page.
 - `[ ]` **Review UI needs work** — the "Your Review" UI is poor, and the rating dropdown (shown once
   you give a rating) isn't positioned where it should be.
+- `[ ]` **Show the recipe rating up top on the single-recipe page** — the top action-bar rating tile
+  was replaced by the per-serving price tile (2c). Re-surface the rating compactly near the title/hero
+  (e.g. "★ 4.5 · N ratings") rather than adding a 4th action-bar tile (which would crowd mobile). It
+  still shows in the Ratings & Reviews header. *(→ Track 3c)*
 - `[ ]` **Account nav sections UI** — improve the Saved / Ratings / etc. section navigation styling.
 - `[ ]` **`/u/:username` public profile visual polish** — minor visual updates.
 - `[ ]` **"Change Password" title is redundant/cluttered** — in Account & Security settings.
@@ -84,6 +88,12 @@ The triage date stamped on items is the date they were filed here, not when they
 - `[ ]` **Report a *user* from their profile page** *(admin)* — `ReportTargetType` is only
   `'recipe' | 'review'` (`src/types.ts:188`); add a user-report flow. *(verified missing)*
 - `[ ]` **Double-check report-recipe styling in the controls element** *(admin)*.
+- `[ ]` **Report controls should be visible when logged out** — `ReportControl` renders `null` for
+  logged-out users (both the single-recipe footer link and the per-review links), so they have no
+  signal that reporting exists. Keep the trigger visible and, on click while logged out, prompt to log
+  in (a toast or a login link is enough — no full modal). One change covers both recipe + review since
+  they share `ReportControl`. *(→ Track 3c; behavior change to a shared component, so out of the 2c
+  visual-polish scope)*
 - `[ ]` **Username validation: disallow certain characters** — tighten the allowed character set.
 
 ## Tech debt / process / infra

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -51,7 +51,7 @@ same commit.**
 | 1d | Serving-price bug | `[x]` | #152 ✅ |
 | 2a | Homepage redesign (design + For You row + "What should I cook?") | `[x]` | #153 + #154 ✅ |
 | 2b | Public Help/Contact page | `[ ]` | — |
-| 2c | Single-recipe polish | `[~]` | worktree-feat+single-recipe-page-polish |
+| 2c | Single-recipe polish | `[P]` | #160 |
 | 2d | Recipes browse polish | `[ ]` | — |
 | 2e | Account/profile polish | `[ ]` | — |
 | 3a | a11y (focus-visible, chevron) | `[ ]` | — |

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -51,7 +51,7 @@ same commit.**
 | 1d | Serving-price bug | `[x]` | #152 ✅ |
 | 2a | Homepage redesign (design + For You row + "What should I cook?") | `[x]` | #153 + #154 ✅ |
 | 2b | Public Help/Contact page | `[ ]` | — |
-| 2c | Single-recipe polish | `[ ]` | — |
+| 2c | Single-recipe polish | `[~]` | worktree-feat+single-recipe-page-polish |
 | 2d | Recipes browse polish | `[ ]` | — |
 | 2e | Account/profile polish | `[ ]` | — |
 | 3a | a11y (focus-visible, chevron) | `[ ]` | — |
@@ -125,7 +125,7 @@ All isolated files — safe to run together.
 |---|---|---|
 | **3a** a11y | `:focus-visible` only (no outline on mouse click); fix chevron animation shifting the focus outline | `src/Components/Navbar/*`, global styles |
 | **3b** Meta/SEO finish | favicon, OG image for link previews, per-page `<title>`s | `index.html`, per-page Helmet |
-| **3c** Features | username char-validation; report-a-user from profile *(admin; `ReportTargetType` currently only recipe/review)* | `server/routes/*`, `ReportControl`, `types.ts` |
+| **3c** Features | username char-validation; report-a-user from profile *(admin; `ReportTargetType` currently only recipe/review)*; show report controls to logged-out users with a login prompt (recipe + reviews); surface the recipe rating up top (near the title) | `server/routes/*`, `ReportControl`, `types.ts`, `src/pages/SingleRecipe/*` |
 | **3d** Add-recipe UX | optimistic ingredient add; ingredient-parser not-found timeout/exit; bottom bar overlapping footer | `src/pages/AddRecipe/*` |
 | **3e** create-username | revamp the page + add a logout/escape hatch so users can't get stuck | `src/pages/CreateUsername/*` |
 

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
@@ -128,16 +128,19 @@
       }
 
       .curr-user-review {
-        margin: 2rem 0;
-        border: 1px solid s.$primary;
-        padding: 1rem 1rem 0 1rem;
-        border-radius: s.$border-radius;
+        margin: 0 0 1.5rem;
         width: 100%;
 
+        // Eyebrow-style label, left-aligned to match the page's section labels
+        // (replaces the old centered orange heading in an orange box).
         .heading {
-          text-align: center;
-          font-weight: 600;
-          color: s.$primary;
+          text-align: left;
+          font-size: 0.78rem;
+          font-weight: 700;
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+          color: s.$secondary;
+          margin-bottom: 0.55rem;
         }
       }
 

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewsContainer.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewsContainer.tsx
@@ -75,7 +75,7 @@ const ReviewsContainer: FC<ReviewsContainerProps> = ({
             />
           ) : (
             <div className='curr-user-review'>
-              <h4 className='heading'>Your Review:</h4>
+              <h4 className='heading'>Your review</h4>
               <RecipeReview
                 review={currUserReview}
                 setCurrUserReview={setCurrUserReview}

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
@@ -120,11 +120,22 @@
         padding: 0.55rem 0.5rem;
       }
     }
+    // Equal-width stat strip with hairline dividers — replaces the old
+    // space-between layout, which scattered the three stats (and wrapped
+    // awkwardly on narrow phones) instead of reading as one tidy row.
     .owner-stats {
-      justify-content: space-between;
-      gap: 0.5rem 0.75rem;
+      flex-wrap: nowrap;
+      gap: 0;
       padding-top: 0.8rem;
-      .stat { font-size: 0.8rem; }
+      .stat {
+        flex: 1;
+        min-width: 0;
+        justify-content: center;
+        font-size: 0.8rem;
+        white-space: nowrap;
+        .icon { height: 15px; width: 15px; }
+        & + .stat { border-left: 1px solid rgba(s.$primary, 0.15); }
+      }
     }
   }
 }

--- a/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
+++ b/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
@@ -4,23 +4,99 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
   // Fills the flexbox app-main; the app shell positions the footer (Layout.scss).
   flex: 1 0 auto;
-  padding-top: s.$nav-height;
-  margin: 0 auto;
+  padding: calc(#{s.$nav-height} + 2rem) 1.25rem 3rem;
+  width: 100%;
+  box-sizing: border-box;
+
+  .rnf-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    width: 100%;
+    max-width: 560px;
+    padding: 2.75rem 2rem;
+    background: s.$white;
+    border: 1.5px solid s.$gray-200;
+    border-radius: 20px;
+    box-shadow: rgba(48, 56, 65, 0.06) 0px 10px 30px;
+  }
+
+  .rnf-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 76px;
+    height: 76px;
+    margin-bottom: 1.4rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, rgba(s.$secondary, 0.14), rgba(s.$primary, 0.12));
+    color: s.$primary;
+    svg { width: 38px; height: 38px; }
+  }
 
   h1 {
-    margin-top: 2rem;
+    font-size: 1.85rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.6rem;
+    color: s.$primary-text;
   }
+
   p.text {
-    text-align: center;
-    max-width: 700px;
+    max-width: 420px;
+    margin: 0 0 1.75rem;
     font-weight: 500;
+    line-height: 1.6;
     color: s.$secondary-text;
-    padding-bottom: 1rem;
+  }
+
+  .rnf-search {
+    width: 100%;
+    .rnf-search-label {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.4rem;
+      margin-bottom: 0.6rem;
+      font-size: 0.75rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: s.$tertiary-text;
+      svg { width: 16px; height: 16px; }
+    }
+  }
+
+  .rnf-actions {
+    margin-top: 1.5rem;
+    .rnf-browse {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.75rem 1.6rem;
+      border-radius: 10px;
+      background: s.$primary;
+      color: s.$white;
+      font-weight: 700;
+      font-size: 0.95rem;
+      text-decoration: none;
+      transition: background 0.12s ease;
+      &:hover { background: #e74e1d; }
+      &:focus { @include s.outline(); }
+    }
+  }
+
+  .rnf-help {
+    margin: 1.6rem 0 0;
+    font-size: 0.85rem;
+    color: s.$tertiary-text;
     .contact-link {
       color: s.$secondary;
+      font-weight: 600;
+      &:hover { text-decoration: underline; }
     }
   }
 }

--- a/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.tsx
+++ b/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.tsx
@@ -1,21 +1,45 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { TbChefHat } from 'react-icons/tb'
+import { BiSearchAlt } from 'react-icons/bi'
 import SearchRecipesInput from 'src/Components/SearchRecipesInput/SearchRecipesInput'
 import './RecipeNotFound.scss'
 
 const RecipeNotFound = () => {
   return (
     <div className='recipe-not-found'>
-      <h1>Recipe not found!</h1>
-      <p className='text'>
-        It doesn't look like the recipe you are looking for exists. If you think
-        this is an error, please{' '}
-        <Link to='/help' className='contact-link'>
-          contact our help team
-        </Link>
-        .
-      </p>
-      <SearchRecipesInput autoComplete={true} />
+      <div className='rnf-card'>
+        <span className='rnf-icon' aria-hidden='true'>
+          <TbChefHat />
+        </span>
+        <h1>Recipe not found</h1>
+        <p className='text'>
+          We couldn't find the recipe you're looking for — it may have been
+          removed, or the link might be incorrect.
+        </p>
+
+        <div className='rnf-search'>
+          <div className='rnf-search-label'>
+            <BiSearchAlt aria-hidden='true' />
+            <span>Search for something else</span>
+          </div>
+          <SearchRecipesInput autoComplete={true} />
+        </div>
+
+        <div className='rnf-actions'>
+          <Link to='/recipes' className='rnf-browse'>
+            Browse all recipes
+          </Link>
+        </div>
+
+        <p className='rnf-help'>
+          Think this is a mistake?{' '}
+          <Link to='/help' className='contact-link'>
+            Contact our help team
+          </Link>
+          .
+        </p>
+      </div>
     </div>
   )
 }

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -133,6 +133,9 @@ $danger: #d23f31;
     .m-top { display: inline-flex; align-items: baseline; gap: 0.45rem; }
     .m-ic { align-self: center; color: s.$primary; font-size: 1.1rem; }
     .m-v { font-weight: 800; font-size: 1.1rem; }
+    // cost tile: the per-serving price is a headline number, so color it brand
+    // primary to pull the eye — this is the "make pricing prominent" beat
+    .m-cost .m-v { color: s.$primary; }
     .m-l {
       font-size: 0.72rem;
       color: s.$tertiary-text;
@@ -268,6 +271,7 @@ $danger: #d23f31;
         cursor: pointer;
         font-size: 0.94rem;
         &:hover { background: s.$primary-background; }
+        &:focus-visible { @include s.outline(); }
         // qty + name flow as one inline text block, so a long name wraps
         // naturally under the quantity instead of in its own cramped column
         .ing-text { line-height: 1.45; }
@@ -578,6 +582,14 @@ $danger: #d23f31;
       // removed); owners still get their edit/delete row
       .review-options:empty { display: none; }
     }
+    // the signed-in user's own review — mark it as "yours" with a soft teal
+    // accent + tint so it reads as distinct from the public review list
+    .curr-user-review .recipe-review {
+      margin-bottom: 0;
+      border-color: rgba(s.$secondary, 0.45);
+      border-left: 3px solid s.$secondary;
+      background: rgba(s.$secondary, 0.04);
+    }
 
     // write-a-review — appears in-flow after a signed-in user taps a star
     .leave-review-input-container {
@@ -625,6 +637,22 @@ $danger: #d23f31;
         &:hover { background: #e74e1d; }
       }
     }
+  }
+
+  // ── report footer (quiet, de-emphasized — secondary action lives here, away
+  // from the primary Save/Rate/Print CTAs at the top) ─────────────────────────
+  .sr-report-foot {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid s.$gray-200;
+    font-size: 0.85rem;
+    color: s.$tertiary-text;
+    .report-control-trigger { font-size: 0.85rem; font-weight: 700; }
   }
 
   // ── responsive ──────────────────────────────────────────────────────────────

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -44,25 +44,27 @@ const skeletonColor = '#d6d6d6'
 const SingleRecipe: FC = () => {
   const { recipeId } = useParams<{ recipeId: string }>()
 
-  const { data: fetchedRecipe, isPending, isError, error } = useQuery({
+  const { data: fetchedRecipe, isPending, isError } = useQuery({
     queryKey: ['recipe', recipeId],
-    queryFn: () => RecipeAPI.getRecipe(recipeId!),
+    // Map a 404 to null instead of throwing: a missing recipe is a definitive
+    // "not found", not a transient failure, so it should render RecipeNotFound
+    // immediately rather than burning the query's retry budget (~7s) and then
+    // showing a generic error. Other failures still throw → normal retry path.
+    queryFn: async () => {
+      try {
+        return await RecipeAPI.getRecipe(recipeId!)
+      } catch (err) {
+        if (isAxiosError(err) && err.response?.status === 404) return null
+        throw err
+      }
+    },
     enabled: !!recipeId,
-    // A 404 is a definitive "no such recipe" — don't burn ~7s of retries on it;
-    // surface RecipeNotFound immediately. Other failures still retry.
-    retry: (failureCount, err) =>
-      isAxiosError(err) && err.response?.status === 404 ? false : failureCount < 3,
   })
 
   const loading = isPending
-  // Treat a 404 (or a 2xx with no recipe body) as "not found" → RecipeNotFound.
-  // Any other error is a transient failure → show the retry message.
-  const is404 =
-    (isError && isAxiosError(error) && error.response?.status === 404) ||
-    (!isPending && !isError && (!fetchedRecipe || !fetchedRecipe.title))
-  const recipe404 = is404
-  const recipeError =
-    isError && !is404 ? 'Failed to load recipe. Please try again.' : null
+  const recipe404 =
+    !isPending && !isError && (!fetchedRecipe || !fetchedRecipe.title)
+  const recipeError = isError ? 'Failed to load recipe. Please try again.' : null
   const currRecipe: RecipeType | null =
     !isPending && fetchedRecipe && fetchedRecipe.title ? fetchedRecipe : null
 

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState, useEffect, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useParams, Link } from 'react-router-dom'
+import { isAxiosError } from 'axios'
 import { Helmet } from 'react-helmet-async'
 import Skeleton from 'react-loading-skeleton'
 import 'react-loading-skeleton/dist/skeleton.css'
@@ -8,6 +9,7 @@ import { AiOutlineClockCircle, AiOutlineUsergroupAdd } from 'react-icons/ai'
 import { BsStar } from 'react-icons/bs'
 import { BiLeftArrowAlt, BiCheckCircle } from 'react-icons/bi'
 import { CiShoppingBasket } from 'react-icons/ci'
+import { TbCurrencyDollar } from 'react-icons/tb'
 
 import './SingleRecipe.scss'
 
@@ -33,6 +35,7 @@ import { closestFraction } from 'src/util/validateIngredientQuantityStr'
 import { IngredientsType, InstructionsType, RecipeType, ReviewType } from 'types'
 import RecipeAPI from 'src/api/recipes'
 import AuthAPI from 'src/api/auth'
+import { buildRecipeJsonLd } from 'src/pages/SingleRecipe/buildRecipeJsonLd'
 
 type LocalStorageRecipeType = { recipeId: string; numServings: number }
 
@@ -41,16 +44,25 @@ const skeletonColor = '#d6d6d6'
 const SingleRecipe: FC = () => {
   const { recipeId } = useParams<{ recipeId: string }>()
 
-  const { data: fetchedRecipe, isPending, isError } = useQuery({
+  const { data: fetchedRecipe, isPending, isError, error } = useQuery({
     queryKey: ['recipe', recipeId],
     queryFn: () => RecipeAPI.getRecipe(recipeId!),
     enabled: !!recipeId,
+    // A 404 is a definitive "no such recipe" — don't burn ~7s of retries on it;
+    // surface RecipeNotFound immediately. Other failures still retry.
+    retry: (failureCount, err) =>
+      isAxiosError(err) && err.response?.status === 404 ? false : failureCount < 3,
   })
 
   const loading = isPending
-  const recipe404 =
-    !isPending && !isError && (!fetchedRecipe || !fetchedRecipe.title)
-  const recipeError = isError ? 'Failed to load recipe. Please try again.' : null
+  // Treat a 404 (or a 2xx with no recipe body) as "not found" → RecipeNotFound.
+  // Any other error is a transient failure → show the retry message.
+  const is404 =
+    (isError && isAxiosError(error) && error.response?.status === 404) ||
+    (!isPending && !isError && (!fetchedRecipe || !fetchedRecipe.title))
+  const recipe404 = is404
+  const recipeError =
+    isError && !is404 ? 'Failed to load recipe. Please try again.' : null
   const currRecipe: RecipeType | null =
     !isPending && fetchedRecipe && fetchedRecipe.title ? fetchedRecipe : null
 
@@ -114,11 +126,17 @@ const SingleRecipe: FC = () => {
     ? [currRecipe.cuisine, currRecipe.mealTypes?.[0]].filter(Boolean).join(' · ')
     : ''
   const ratingCount = currRecipe?.rating?.rateCount ?? 0
+  const servPrice = currRecipe?.servingPrice ?? 0
+  const hasPrice = servPrice > 0
   const currUID = AuthAPI.getUID()
   const isOwner = !!currUID && !!currRecipe?.userId && currUID === currRecipe.userId
   const ingredients =
     modIngredients.length > 0 ? modIngredients : currRecipe?.ingredients ?? []
   const instructions = currRecipe?.instructions ?? []
+
+  const pageUrl =
+    typeof window !== 'undefined' ? window.location.href : ''
+  const recipeJsonLd = currRecipe ? buildRecipeJsonLd(currRecipe, pageUrl) : null
 
   const renderIngredient = (ingr: IngredientsType) => {
     if ('parsedIngredient' in ingr) {
@@ -129,7 +147,16 @@ const SingleRecipe: FC = () => {
         <li
           key={ingr.id}
           className={`ing ${isChecked ? 'checked' : ''}`}
+          role='checkbox'
+          aria-checked={isChecked}
+          tabIndex={0}
           onClick={() => toggleChecked(ingr.id)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              toggleChecked(ingr.id)
+            }
+          }}
         >
           <span className='box'>{isChecked ? <BiCheckCircle /> : null}</span>
           <span className='thumb'>
@@ -188,6 +215,19 @@ const SingleRecipe: FC = () => {
             : 'Recipe 404'}
         </title>
         <meta name='description' content={currRecipe?.description} />
+        {/*
+          Recipe structured data (schema.org/Recipe) → rich search results.
+          NOTE: per-page Open Graph / Twitter tags are intentionally NOT set here.
+          index.html ships static og:* defaults that react-helmet-async can't
+          dedupe (they aren't Helmet-managed), so adding page-level ones produces
+          duplicate tags and crawlers fall back to the generic site values.
+          Fixing that belongs to Track 3b (global meta / SEO component).
+        */}
+        {recipeJsonLd && (
+          <script type='application/ld+json'>
+            {JSON.stringify(recipeJsonLd)}
+          </script>
+        )}
       </Helmet>
 
       {recipeError ? (
@@ -274,17 +314,27 @@ const SingleRecipe: FC = () => {
                 </span>
                 <span className='m-l'>Servings</span>
               </div>
-              <div className='m-item'>
-                <span className='m-top'>
-                  <BsStar className='m-ic' />
-                  <span className='m-v'>
-                    {currRecipe && ratingCount > 0
-                      ? formatRating(currRecipe.rating?.rateValue, ratingCount)
-                      : '—'}
+              {hasPrice ? (
+                <div className='m-item m-cost'>
+                  <span className='m-top'>
+                    <TbCurrencyDollar className='m-ic' />
+                    <span className='m-v'>{formatPrice(servPrice)}</span>
                   </span>
-                </span>
-                <span className='m-l'>{ratingCount > 0 ? `(${ratingCount})` : 'No ratings'}</span>
-              </div>
+                  <span className='m-l'>Per serving</span>
+                </div>
+              ) : (
+                <div className='m-item'>
+                  <span className='m-top'>
+                    <BsStar className='m-ic' />
+                    <span className='m-v'>
+                      {currRecipe && ratingCount > 0
+                        ? formatRating(currRecipe.rating?.rateValue, ratingCount)
+                        : '—'}
+                    </span>
+                  </span>
+                  <span className='m-l'>{ratingCount > 0 ? `(${ratingCount})` : 'No ratings'}</span>
+                </div>
+              )}
             </div>
             <div className='sr-actions'>
               {currRecipe && (
@@ -298,12 +348,6 @@ const SingleRecipe: FC = () => {
                   />
                   <AddRatingBtn currUserReview={currUserReview} />
                   <PrintRecipeBtn printedRef={printedRef} />
-                  {!isOwner && (
-                    <ReportControl
-                      target={{ targetType: 'recipe', recipeId: currRecipe._id }}
-                      variant='button'
-                    />
-                  )}
                 </>
               )}
             </div>
@@ -418,6 +462,15 @@ const SingleRecipe: FC = () => {
               setCurrUserReview={setCurrUserReview}
               isOwner={isOwner}
             />
+          )}
+
+          {!loading && currRecipe && currUID && !isOwner && (
+            <div className='sr-report-foot'>
+              <span>See something wrong with this recipe?</span>
+              <ReportControl
+                target={{ targetType: 'recipe', recipeId: currRecipe._id }}
+              />
+            </div>
           )}
 
           {!loading && currRecipe && (

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -9,7 +9,7 @@ import { AiOutlineClockCircle, AiOutlineUsergroupAdd } from 'react-icons/ai'
 import { BsStar } from 'react-icons/bs'
 import { BiLeftArrowAlt, BiCheckCircle } from 'react-icons/bi'
 import { CiShoppingBasket } from 'react-icons/ci'
-import { TbCurrencyDollar } from 'react-icons/tb'
+import { TbTag } from 'react-icons/tb'
 
 import './SingleRecipe.scss'
 
@@ -317,7 +317,7 @@ const SingleRecipe: FC = () => {
               {hasPrice ? (
                 <div className='m-item m-cost'>
                   <span className='m-top'>
-                    <TbCurrencyDollar className='m-ic' />
+                    <TbTag className='m-ic' />
                     <span className='m-v'>{formatPrice(servPrice)}</span>
                   </span>
                   <span className='m-l'>Per serving</span>

--- a/src/pages/SingleRecipe/buildRecipeJsonLd.ts
+++ b/src/pages/SingleRecipe/buildRecipeJsonLd.ts
@@ -1,0 +1,82 @@
+import { IngredientsType, InstructionsType, RecipeType } from 'types'
+
+// Build a schema.org/Recipe JSON-LD object for a recipe so search engines can
+// render rich results (rating stars, cook time, ingredients). Every field is
+// emitted only when present, so a sparse recipe still produces valid markup.
+
+// Minutes → ISO-8601 duration (e.g. 40 → "PT40M"). Returns undefined for
+// missing/zero so the caller can omit the field entirely.
+const isoDuration = (mins: number | null | undefined): string | undefined =>
+  mins && mins > 0 ? `PT${Math.round(mins)}M` : undefined
+
+const ingredientToString = (ing: IngredientsType): string | null => {
+  if ('parsedIngredient' in ing) {
+    const { quantity, unit, ingredient, comment } = ing.parsedIngredient
+    return [quantity, unit, ingredient].filter(Boolean).join(' ').trim() +
+      (comment ? `, ${comment}` : '')
+  }
+  return null // group labels aren't ingredients
+}
+
+export const buildRecipeJsonLd = (
+  recipe: RecipeType,
+  pageUrl: string
+): Record<string, unknown> => {
+  const recipeIngredient = recipe.ingredients
+    .map(ingredientToString)
+    .filter((s): s is string => !!s && s.length > 0)
+
+  const recipeInstructions = recipe.instructions
+    .filter((i: InstructionsType): i is { content: string; index: number; id: string } =>
+      'content' in i && !!i.content
+    )
+    .map(step => ({ '@type': 'HowToStep', text: step.content }))
+
+  const jsonLd: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'Recipe',
+    name: recipe.title,
+    description: recipe.description,
+    mainEntityOfPage: pageUrl,
+  }
+
+  if (recipe.recipeImage) jsonLd.image = [recipe.recipeImage]
+  if (recipe.authorUsername) {
+    jsonLd.author = { '@type': 'Person', name: recipe.authorUsername }
+  }
+  if (recipe.createdAt) jsonLd.datePublished = recipe.createdAt
+
+  const prep = isoDuration(recipe.prepTime)
+  const cook = isoDuration(recipe.cookTime)
+  const total = isoDuration(recipe.totalTime)
+  if (prep) jsonLd.prepTime = prep
+  if (cook) jsonLd.cookTime = cook
+  if (total) jsonLd.totalTime = total
+
+  if (recipe.servings > 0) {
+    jsonLd.recipeYield = `${recipe.servings} ${recipe.servings === 1 ? 'serving' : 'servings'}`
+  }
+  if (recipeIngredient.length) jsonLd.recipeIngredient = recipeIngredient
+  if (recipeInstructions.length) jsonLd.recipeInstructions = recipeInstructions
+
+  if (recipe.rating && recipe.rating.rateCount > 0) {
+    jsonLd.aggregateRating = {
+      '@type': 'AggregateRating',
+      ratingValue: Number(recipe.rating.rateValue.toFixed(2)),
+      ratingCount: recipe.rating.rateCount,
+      bestRating: 5,
+      worstRating: 1,
+    }
+  }
+
+  // Per-serving calories (Edamam totals are for the whole recipe yield).
+  const nd = recipe.nutritionData
+  if (nd && nd.calories > 0 && nd.yield > 0) {
+    jsonLd.nutrition = {
+      '@type': 'NutritionInformation',
+      calories: `${Math.round(nd.calories / nd.yield)} calories`,
+    }
+  }
+
+  return jsonLd
+}

--- a/src/test/RatingsAndReviews.integration.test.tsx
+++ b/src/test/RatingsAndReviews.integration.test.tsx
@@ -161,7 +161,7 @@ describe('RatingsAndReviews integration', () => {
       mockGetUID.mockReturnValue('user-1')
       mockCheckIfReviewed.mockResolvedValue(baseReview)
       render(<IntegrationWrapper />)
-      await screen.findByText('Your Review:')
+      await screen.findByText('Your review')
       expect(screen.queryByText('Add Review')).toBeNull()
     })
   })
@@ -193,7 +193,7 @@ describe('RatingsAndReviews integration', () => {
       )
       // After a successful submit, setCurrUserReview(baseReview) causes ReviewsContainer
       // to switch from AddReview to the curr-user-review section containing RecipeReview.
-      await screen.findByText('Your Review:')
+      await screen.findByText('Your review')
       expect(screen.getByText('Really great recipe!')).toBeInTheDocument()
     })
   })
@@ -252,7 +252,7 @@ describe('RatingsAndReviews integration', () => {
       // setCurrUserReview(null) switches ReviewsContainer back to the write-review
       // box (the user still has their rating, so the textarea reappears in-flow)
       await screen.findByText(/Add a written review/i)
-      expect(screen.queryByText('Your Review:')).toBeNull()
+      expect(screen.queryByText('Your review')).toBeNull()
     })
   })
 

--- a/src/test/ReviewsContainer.test.tsx
+++ b/src/test/ReviewsContainer.test.tsx
@@ -149,7 +149,7 @@ describe('ReviewsContainer', () => {
 
   it('shows the user\'s existing review and hides AddReview when currUserReview is set', async () => {
     renderContainer({ currUserReview: baseReview })
-    expect(screen.getByText('Your Review:')).toBeInTheDocument()
+    expect(screen.getByText('Your review')).toBeInTheDocument()
     await screen.findByText('Really great recipe!')
     expect(screen.queryByText('Add Review')).toBeNull()
   })


### PR DESCRIPTION
**Track 2c — Single-recipe polish.** Scope: `src/pages/SingleRecipe/*` + a new Recipe JSON-LD util. No API/route changes.

## What changed
1. **Per-serving price prominence** — cost is now a brand-orange stat tile in the top action bar (replaces the rating tile). Rating still shows in the Ratings & Reviews header.
2. **Stats row cleanup** — clean 3-tile row (time / servings / price).
3. **Report relocated** — pulled out of the Save/Rate/Print CTA row into a quiet "See something wrong? Report" link at the bottom (logged-in non-owners only).
4. **Owner banner mobile** — the stats strip used `space-between` (scattered, and wrapped awkwardly at 320px) → now an equal-width strip with hairline dividers.
5. **RecipeNotFound** — redesigned empty-state card (icon + search + "Browse all recipes" CTA). **Also fixed 404 routing**: a missing recipe used to retry ~7s then show a generic error; 404s now skip retry and render `RecipeNotFound` instantly.
6. **"Your review" UI** — replaced the centered-orange-in-orange-box with an eyebrow label + a teal-accented, tinted card that reads as distinct from the public review list.
7. **Ingredient a11y** — rows are keyboard-operable (`role=checkbox`, `aria-checked`, Enter/Space toggle, `:focus-visible` ring).
8. **SEO** — added schema.org/Recipe JSON-LD for rich results.

## Notes / decisions
- **OG/Twitter tags deferred to Track 3b/3c.** `index.html` ships static `og:*` defaults that react-helmet-async can't dedupe, so per-page OG tags would duplicate and crawlers fall back to the generic site values. JSON-LD (the high-value part) is in and clean.
- The gameplan's "rating dropdown position" is moot — Track 1a already replaced it with the working "Remove rating" button.
- Two follow-ups filed under **Track 3c**: show report controls to logged-out users (login prompt); surface the rating up top near the title.

## Verification
- Live smoke test, logged in, real UI clicks: rate → write → submit → the redesigned **"Your review"** card renders with real data; Report link opens its modal; delete + remove-rating work; recipe restored to original state (rating `4.5 / 4`, no leftover review).
- Driven at the browser surface: price tile + 3-tile row, 404 → `RecipeNotFound` in ~380ms (incl. malformed-id probe), ingredient Space-key toggles `aria-checked`, JSON-LD present (Recipe, 8 ingredients, 9 steps, rating).
- Owner banner (#4) verified via local force-render (deterministic mobile CSS) at 320/390px.

## Pre-existing (not this PR)
- `SingleRecipe.test.tsx` is red on `development` too — `localStorage` undefined under Node 26 / vitest 4 / jsdom 29. Test-infra, out of scope here. Touched review tests pass (copy assertion updated "Your Review:" → "Your review").

🤖 Generated with [Claude Code](https://claude.com/claude-code)