### PR TITLE
test(server): restore real timers per-test (Node 26 jest harness fix)

### DIFF
--- a/server/__tests__/setup.js
+++ b/server/__tests__/setup.js
@@ -1,5 +1,29 @@
+const timers = require('node:timers')
 const { MongoMemoryReplSet } = require('mongodb-memory-server')
 const { connectDB, closeDB } = require('../db')
+
+// Under Node 26's jest environment the global timer functions aren't stable
+// across a fake-timer test: once a test runs `jest.useFakeTimers()` and then
+// `jest.useRealTimers()`, the restored globals can come back undefined, so the
+// NEXT test's HTTP call throws `clearTimeout is not defined` from `superagent`
+// (via supertest) and times out. Re-install the canonical `node:timers`
+// implementations before every test so a prior fake-timer test can't leave the
+// globals broken. A test that opts into `jest.useFakeTimers()` still overrides
+// these afterwards, so fake-timer behaviour is unchanged.
+const installRealTimers = () => {
+  for (const name of [
+    'setTimeout',
+    'clearTimeout',
+    'setInterval',
+    'clearInterval',
+    'setImmediate',
+    'clearImmediate',
+  ]) {
+    globalThis[name] = timers[name]
+  }
+}
+installRealTimers()
+beforeEach(installRealTimers)
 
 let mongod
 


### PR DESCRIPTION
## Problem
On Node 26, the server Jest suite is **red on `development`**: `server/__tests__/email-notifications.test.js` fails **7/22** with `ReferenceError: clearTimeout is not defined`, thrown from `superagent` (via `supertest`) and cascading to 5000ms test timeouts.

## Root cause
The failing tests are the `moderation routes trigger the right sends` block. The block **above** them contains the `throttles repeat alerts` test, which does `jest.useFakeTimers()` … `jest.useRealTimers()`. Under Node 26's jest environment, that `useRealTimers()` restore leaves the **global timer functions undefined** — so every *subsequent* test that makes an HTTP call breaks when superagent calls the global `clearTimeout` to clear its response timer.

This is why it's load/order-dependent and why a one-time setup assignment doesn't help: the globals are fine at setup, then get clobbered mid-file by the fake-timer test.

## Fix
Re-install the canonical `node:timers` implementations **before every test** in the shared `setupFilesAfterEnv` (`server/__tests__/setup.js`), so a prior fake-timer test can't leave the globals broken. A test that opts into `jest.useFakeTimers()` still overrides them afterward, so fake-timer behaviour is unchanged.

It's the server-side counterpart to the client `localStorage` polyfill already shipped (same Node-26 family of test-harness gaps).

## Verification (this branch, Node 26)
- **Baseline reproduced:** `email-notifications.test.js` → 7 failed / 15 passed, 7× `clearTimeout is not defined`.
- **With fix:** `email-notifications.test.js` → **22/22 passed**, 0 `clearTimeout` errors.
- **Full server suite:** **28 suites / 632 tests passed**, 0 failures — including the fake-timer `throttles` test, confirming no regression from the timer reassignment.

## Scope
Test harness only — one file (`server/__tests__/setup.js`). No product code. Independent of the account-bugfix PR (#156); both target `development` and can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)