### PR TITLE
fix(a11y): site-wide :focus-visible-only outline + decouple navbar chevron

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -106,15 +106,23 @@ The triage date stamped on items is the date they were filed here, not when they
 - `[ ]` **Account nav sections UI** — improve the Saved / Ratings / etc. section navigation styling.
 - `[ ]` **`/u/:username` public profile visual polish** — minor visual updates.
 - `[ ]` **"Change Password" title is redundant/cluttered** — in Account & Security settings.
-- `[ ]` **create-username page revamp** — re-evaluate the page, and add a logout (or escape hatch) so a
-  user can't get stuck on it. Page lives at `src/pages/CreateUsername/`.
+- `[x]` **create-username page revamp** — **done (track 3e):** the page was redesigned into the shared
+  soft-glass auth vocabulary alongside login/signup/forgot in **PR #131**, and the escape hatch (a
+  "Cancel and log out" control wired to the auth signout, plus a guard that bounces users who already
+  have a username) landed in **PR #98**. Reconciled + escape-hatch regression test added in **PR #162**.
+  Page lives at `src/pages/CreateUsername/`. Username validation tightening is tracked separately under 3c.
 
 ## Accessibility
 
-- `[ ]` **Stop focus outline on mouse button clicks** — keep it for keyboard nav only
-  (`:focus-visible`).
-- `[ ]` **Desktop navbar account chevron animation shifts the focus outline** — the chevron animation
-  moves the focus outline; decouple them.
+- `[P]` **Stop focus outline on mouse button clicks** — **done in PR #163 (track 3a, open — not yet
+  merged):** the global `button`/`a` outline rule (`src/index.scss`) and every component-local
+  `@include s.outline()` ring were switched from `:focus` to `:focus-visible`, so the ring shows for
+  keyboard nav only. Input/textarea focus affordances (border/box-shadow/background) were deliberately
+  left on `:focus` — clicking into a field should still highlight it.
+- `[P]` **Desktop navbar account chevron animation shifts the focus outline** — **done in PR #163
+  (track 3a, open):** the caret was wrapped in a fixed-size `overflow:hidden` clip box with an inner
+  rotating `<svg>` (`DesktopAccountMenu.tsx` + `DesktopNav.scss`), so the `outline:auto` ring no longer
+  tracks the rotating icon's bounding box.
 - `[ ]` **Account Ratings list nests a `<button>` inside a `<button>`** — each rating row is a clickable
   `<button className="single-review">` (`src/pages/Account/UserRatings/.../SingleReview`) that renders a
   `StarRating`, which itself emits a `<button>` per star (even when non-interactive). React logs

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -54,11 +54,11 @@ same commit.**
 | 2c | Single-recipe polish | `[x]` | #160 ✅ |
 | 2d | Recipes browse polish | `[ ]` | — |
 | 2e | Account/profile polish | `[ ]` | — |
-| 3a | a11y (focus-visible, chevron) | `[ ]` | — |
+| 3a | a11y (focus-visible, chevron) | `[P]` | #163 |
 | 3b | Meta/SEO finish (favicon/OG/titles) | `[ ]` | — |
 | 3c | Username validation + report-user | `[ ]` | — |
 | 3d | Add-recipe UX | `[ ]` | — |
-| 3e | create-username revamp | `[ ]` | — |
+| 3e | create-username revamp | `[x]` | #131 + #98 (+ #162 reconcile/test) ✅ |
 | 4-sass | Sass `@import`→`@use` (LONER) | `[ ]` | — |
 | 4-about | About rewrite (Jesse) | `[ ]` | — |
 | 4-qa | Empty/error sweep + links + copy + mobile + Lighthouse | `[ ]` | — |
@@ -123,7 +123,7 @@ All isolated files — safe to run together.
 
 | Track | Work | Domain |
 |---|---|---|
-| **3a** a11y | `:focus-visible` only (no outline on mouse click); fix chevron animation shifting the focus outline | `src/Components/Navbar/*`, global styles |
+| **3a** a11y | `:focus-visible` only (no outline on mouse click); fix chevron animation shifting the focus outline *(PR #163, open — global rule + every component-local `s.outline()` ring swept site-wide; input/textarea focus affordances left on `:focus`)* | `src/index.scss` + component SCSS site-wide, `src/Components/Navbar/*` |
 | **3b** Meta/SEO finish | favicon, OG image for link previews, per-page `<title>`s | `index.html`, per-page Helmet |
 | **3c** Features | username char-validation; report-a-user from profile *(admin; `ReportTargetType` currently only recipe/review)*; show report controls to logged-out users with a login prompt (recipe + reviews); surface the recipe rating up top (near the title) | `server/routes/*`, `ReportControl`, `types.ts`, `src/pages/SingleRecipe/*` |
 | **3d** Add-recipe UX | optimistic ingredient add; ingredient-parser not-found timeout/exit; bottom bar overlapping footer | `src/pages/AddRecipe/*` |
@@ -202,10 +202,12 @@ Part 2's prompts once Part 1 merges (the board will have moved).
 - **2e** Account/profile polish — `src/pages/Account/*` (in-page `SegmentedNav`) + `src/pages/PublicProfile/*`.
   *Unblocked: 1c merged.* Owns **PublicProfile** this part.
 - **3a** a11y — global `:focus-visible` (`src/index.scss`) + `src/Components/Navbar/*` (chevron/focus).
-  Owns **Navbar** this part.
+  Owns **Navbar** this part. **PR #163 open** — global rule + component-local `s.outline()` rings swept
+  site-wide; chevron decoupled from the ring via a clip box. Awaiting merge; 2d rebases on the Navbar after.
 - **3d** Add-recipe UX — `src/pages/AddRecipe/*` (optimistic ingredient add, parser not-found timeout,
   sticky bar overlapping footer). Fully isolated.
-- **3e** create-username revamp — `src/pages/CreateUsername/*` (+ logout/escape hatch). Fully isolated.
+- ~~**3e** create-username revamp — `src/pages/CreateUsername/*` (+ logout/escape hatch). Fully isolated.~~
+  **Already merged** (PR #131 redesign + PR #98 escape hatch) — predates this board; nothing to start.
 
 No App.tsx route additions in Part 1 (3e's route already exists). The two "account navs" are different
 components: 2e owns the in-page `Account/components/SegmentedNav`; 3a owns the Navbar account dropdown.
@@ -521,6 +523,10 @@ Guardrails: scope STRICTLY to src/pages/AddRecipe/*. Don't touch the beta tag, N
 ```
 
 #### Track 3e · create-username revamp
+
+> **⚠️ SUPERSEDED — do not run.** This work already shipped before the board existed: the soft-glass
+> redesign in **PR #131** and the logout/escape hatch + page guard in **PR #98** (both merged to
+> `development`). The board (track 3e) and `BACKLOG.md` are reconciled to `[x]`. Prompt kept for history.
 
 ```
 /worktree-create revamp create-username page + escape hatch

--- a/src/Components/Navbar/Navbar.scss
+++ b/src/Components/Navbar/Navbar.scss
@@ -159,7 +159,7 @@
     -webkit-animation: breathing 5s ease-out infinite normal;
     animation: breathing 5s ease-out infinite normal;
     cursor: pointer;
-    &:focus {
+    &:focus-visible {
       @include s.outline();
     }
   }

--- a/src/Components/Navbar/Navbar.scss
+++ b/src/Components/Navbar/Navbar.scss
@@ -142,7 +142,7 @@
     text-decoration: none;
     padding: 0.25rem 0.35rem;
     margin: -0.25rem -0.35rem;
-    &:focus {
+    &:focus-visible {
       @include s.outline();
     }
   }

--- a/src/Components/Navbar/desktop/DesktopAccountMenu.tsx
+++ b/src/Components/Navbar/desktop/DesktopAccountMenu.tsx
@@ -88,7 +88,11 @@ const DesktopAccountMenu: FC<DesktopAccountMenuProps> = ({
         onClick={() => setOpen(o => !o)}
       >
         {renderAvatar('dnav-account__avatar')}
-        <MdKeyboardArrowDown className='dnav-account__caret' />
+        {/* Fixed-size clip box; the inner icon (not this box) rotates, so the
+            rotation never enlarges the button's `outline: auto` focus ring. */}
+        <span className='dnav-account__caret'>
+          <MdKeyboardArrowDown className='dnav-account__caret-icon' />
+        </span>
       </button>
 
       <div className='dnav-account__menu' id={panelId}>

--- a/src/Components/Navbar/desktop/DesktopNav.scss
+++ b/src/Components/Navbar/desktop/DesktopNav.scss
@@ -280,12 +280,20 @@
     border: 1px solid #{rgba(s.$white, 0.6)};
   }
   &__caret {
+    display: flex;
     height: 20px;
     width: 20px;
     color: var(--dnav-text);
+    // Clip box: keeps the rotating icon's growing bounding box from leaking into
+    // the button's `outline: auto` focus ring, so the ring stays put as it spins.
+    overflow: hidden;
+  }
+  &__caret-icon {
+    height: 20px;
+    width: 20px;
     transition: transform 0.15s ease;
   }
-  &.is-open &__caret {
+  &.is-open &__caret-icon {
     transform: rotate(180deg);
   }
 

--- a/src/Components/RecipeThumbnail/RecipeThumbnail.scss
+++ b/src/Components/RecipeThumbnail/RecipeThumbnail.scss
@@ -11,7 +11,7 @@
   max-width: 300px;
   text-align: center;
   cursor: pointer;
-  &:focus {
+  &:focus-visible {
     @include s.outline();
   }
 

--- a/src/Components/ReleaseNotes/ReleaseNotes.scss
+++ b/src/Components/ReleaseNotes/ReleaseNotes.scss
@@ -16,7 +16,7 @@
       height: 30px;
       width: 30px;
     }
-    &:focus {
+    &:focus-visible {
       @include s.outline();
     }
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -49,13 +49,17 @@ input {
     color: s.$tertiary-text;
   }
 }
+// Show the focus ring for keyboard navigation only (`:focus-visible`), not for
+// mouse/touch clicks. Keyboard users still get a clear indicator on Tab; a plain
+// pointer click no longer leaves an outline behind. Modern browsers already drive
+// their default ring off the same heuristic, so no `:focus` fallback is needed.
 button {
-  &:focus {
+  &:focus-visible {
     @include s.outline();
   }
 }
 a {
-  &:focus {
+  &:focus-visible {
     @include s.outline();
   }
 }

--- a/src/pages/Account/UserRecipes/UserRecipeThumbnail.scss
+++ b/src/pages/Account/UserRecipes/UserRecipeThumbnail.scss
@@ -15,7 +15,7 @@
   background: s.$white;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 
-  &:focus {
+  &:focus-visible {
     @include s.outline();
   }
   &:hover {

--- a/src/pages/AddRecipe/AddLabel/AddLabel.scss
+++ b/src/pages/AddRecipe/AddLabel/AddLabel.scss
@@ -28,7 +28,7 @@
     &:hover {
       color: s.$primary;
     }
-    &:focus {
+    &:focus-visible {
       @include s.outline();
     }
   }

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.scss
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.scss
@@ -75,7 +75,7 @@
       color: s.$primary-text;
       border-color: s.$tertiary-text;
     }
-    &:focus {
+    &:focus-visible {
       @include s.outline();
     }
     &:disabled {
@@ -98,7 +98,7 @@
     outline: none;
     transition: all 0.1s linear;
 
-    &:focus {
+    &:focus-visible {
       @include s.outline();
     }
   }

--- a/src/pages/AddRecipe/Ingredients/IngredientList/IngredientList.scss
+++ b/src/pages/AddRecipe/Ingredients/IngredientList/IngredientList.scss
@@ -135,7 +135,7 @@
         color: s.$primary;
         background: s.$white;
       }
-      &:focus {
+      &:focus-visible {
         @include s.outline();
       }
     }

--- a/src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem.scss
+++ b/src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem.scss
@@ -116,7 +116,7 @@
       color: s.$primary;
       background: s.$white;
     }
-    &:focus {
+    &:focus-visible {
       @include s.outline();
     }
   }

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
@@ -64,9 +64,8 @@
         .star,
         svg,
         path {
-          &:focus {
+          &:focus-visible {
             @include s.outline();
-            background: red;
           }
         }
       }
@@ -76,7 +75,7 @@
           font-size: 1.125rem;
           font-weight: 600;
           color: s.$primary-text;
-          &:focus {
+          &:focus-visible {
             @include s.outline();
           }
         }
@@ -92,7 +91,7 @@
           &:hover {
             color: s.$primary-text;
           }
-          &:focus {
+          &:focus-visible {
             @include s.outline();
           }
         }
@@ -181,7 +180,7 @@
           color: s.$primary-background;
           padding: 0.5rem 1rem;
           border-radius: s.$border-radius;
-          &:focus {
+          &:focus-visible {
             @include s.outline();
           }
         }

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
@@ -98,7 +98,7 @@
           &:hover {
             color: s.$primary-text;
           }
-          &:focus {
+          &:focus-visible {
             @include s.outline();
           }
         }
@@ -106,7 +106,7 @@
           &:hover {
             color: s.$error-red;
           }
-          &:focus {
+          &:focus-visible {
             @include s.outline();
           }
         }
@@ -126,7 +126,7 @@
       }
       button.like-review-btn,
       button.dislike-review-btn {
-        &:focus {
+        &:focus-visible {
           @include s.outline();
         }
       }

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
@@ -72,7 +72,7 @@
       height: 17px;
       width: 17px;
     }
-    &:focus {
+    &:focus-visible {
       @include s.outline();
     }
   }

--- a/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
+++ b/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
@@ -85,7 +85,7 @@
       text-decoration: none;
       transition: background 0.12s ease;
       &:hover { background: #e74e1d; }
-      &:focus { @include s.outline(); }
+      &:focus-visible { @include s.outline(); }
     }
   }
 

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -31,7 +31,7 @@ $danger: #d23f31;
       text-decoration: none;
       svg { font-size: 1.2rem; }
       &:hover { color: s.$primary; }
-      &:focus { @include s.outline(); }
+      &:focus-visible { @include s.outline(); }
     }
   }
   > .recipe-controls-container { margin-bottom: 1.5rem; }
@@ -167,7 +167,7 @@ $danger: #d23f31;
       transition: all 0.12s ease;
       .icon { height: 18px; width: 18px; }
       &:hover { border-color: s.$primary-text; }
-      &:focus { @include s.outline(); }
+      &:focus-visible { @include s.outline(); }
     }
     .save-recipe-btn {
       background: s.$primary;
@@ -376,7 +376,7 @@ $danger: #d23f31;
       font-weight: 600;
       text-decoration: none;
       &:hover { background: rgba(s.$secondary, 0.2); }
-      &:focus { @include s.outline(); }
+      &:focus-visible { @include s.outline(); }
     }
   }
 


### PR DESCRIPTION
Closes the two focus-outline items in **release track 3a** (`docs/RELEASE_GAMEPLAN.md`) and the **Accessibility** section of `docs/BACKLOG.md`, then extends the fix site-wide.

## 1. Focus ring on mouse clicks → keyboard-only
Interactive elements showed the keyboard focus ring even on a plain mouse/touch click (the user noticed it on "most if not every button"). Switched the focus *ring* rules from `:focus` to **`:focus-visible`** so the outline shows for keyboard nav only. Keyboard focus indication is fully preserved.

- **Global** (`src/index.scss`): the shared `button` / `a` outline rule — covers the majority of buttons site-wide in one place.
- **Component sweep** (per the user's follow-up: "change all of those as well"): every component-local focus *ring* (`@include s.outline()`) — navbar logo + beta tag, recipe thumbnails, release notes, and the AddRecipe / SingleRecipe / ratings-&-reviews controls.

**Deliberately left as `:focus`** (these are *desired* on click, not the bug): input/textarea/select affordances that change `border-color` / `box-shadow` / `background` (clicking into a field should highlight it), and the `:not(:focus)` placeholder logic in `RecipeFormInput.scss`. Each remaining `:focus` was audited to confirm it's an affordance, not a missed ring.

Also removed a stray `background: red;` debug leftover on the star-rating focus state in `RatingsAndReviews.scss`.

## 2. Chevron animation no longer drags the focus ring
The desktop account menu's caret rotates 180° on open. The ring uses `outline-style: auto`, which in Blink **expands to wrap the ink overflow of transformed descendants** — rotating the 20×20 caret swells its bounding box to ~28×28 mid-spin, visibly shifting the button's outline.

Fix (the "animate an inner element" approach): wrap the caret in a fixed-size `overflow: hidden` **clip box** and rotate an inner `<svg>` instead. The clip box never changes size, so the rotation can't reach the outlined button. The chevron stays fully visible (its ink stays well within the 20×20 box at every angle).

## Verification
`tsc --noEmit` clean · **451 tests pass** (2 skipped) · `npm run build` green.

Behavioral check via headless Chromium (playwright-core) against the running dev build:

| Action | element | `:focus-visible` | computed outline |
|---|---|---|---|
| **Mouse click** | `a.nav-logo` | `false` | `none` |
| **Mouse click** | `a.dnav__cta--signup` (focused: `isActive:true`) | `false` | `none` |
| **Keyboard Tab** | `button.beta-tag` (converted) | `true` | `auto` (5px) |
| **Keyboard Tab** | `a.dnav__link`, `a.dnav__cta--login` | `true` | `auto` (5px) |

→ a mouse click focuses the element but shows **no** ring; Tab shows the ring.

Chevron clip box (real compiled CSS, measured open vs closed): wrapper `overflow: hidden`, bounding box **20×20 closed === 20×20 open** (stable), inner icon transform rotates → the ring can no longer be moved by the animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)