### PR TITLE
Add-recipe UX: optimistic ingredient add, enrichment timeout, sticky-bar/footer fix (track 3d)

### DIFF
--- a/cypress/e2e/addRecipe.cy.ts
+++ b/cypress/e2e/addRecipe.cy.ts
@@ -147,6 +147,27 @@ const loginAndVisitAddRecipe = () => {
   cy.visit('/add-recipe')
 }
 
+// Reorder a list item with the keyboard, the way @hello-pangea/dnd supports
+// natively (and the only DnD path that's reliable to automate — a synthesised
+// mouse drag is timing-sensitive and flaky). Focus the drag handle, press Space
+// to lift, an arrow key per position to move, then Space to drop. Subsequent
+// keystrokes go through cy.focused() because the library keeps focus on the
+// lifted handle as the item moves. keyCodes: 32 = Space, 38 = ArrowUp, 40 = ArrowDown.
+const keyboardReorder = (
+  focusHandle: () => Cypress.Chainable,
+  arrowKeyCode: 38 | 40,
+  steps: number
+) => {
+  focusHandle().focus().trigger('keydown', { keyCode: 32, force: true })
+  cy.wait(300) // let the lift register + announce
+  for (let i = 0; i < steps; i++) {
+    cy.focused().trigger('keydown', { keyCode: arrowKeyCode, force: true })
+    cy.wait(300) // each move animates; give the placeholder time to settle
+  }
+  cy.focused().trigger('keydown', { keyCode: 32, force: true })
+  cy.wait(500) // drop + reorder commit
+}
+
 describe('Add Recipe', () => {
   beforeEach(() => {
     cy.intercept('GET', `${api()}/api/getTrendingRecipes*`, { body: [] })
@@ -233,18 +254,19 @@ describe('Add Recipe', () => {
     cy.contains('flour', { timeout: 5000 }).should('be.visible')
   })
 
-  it('ingredient parse failure shows inline warning but still adds the ingredient (soft-fail)', () => {
+  it('ingredient enrichment failure keeps the row and flags it with a retry (soft-fail)', () => {
     cy.intercept('POST', PARSE_URL, { statusCode: 500 }).as('parseIngredient')
 
     loginAndVisitAddRecipe()
     cy.get('input[placeholder="Add ingredients to your recipe."]').type('2 cups flour{enter}')
     cy.wait('@parseIngredient')
 
-    // Warning surfaces via the IngredientsInput .error role=status banner
-    cy.contains(/couldn't fetch nutrition\/image data/i, { timeout: 5000 }).should('be.visible')
-    // The ingredient row is still added (parsedIngredient parsed locally; enrichment soft-failed)
-    cy.get('.ingredients-container .item, .ingredients-container .ingredients-container.item')
-      .should('have.length.at.least', 1)
+    // Optimistic add parses locally, so the row is present immediately and stays
+    // even though enrichment failed; the row is flagged errored with a one-tap
+    // retry (no inline warning / no blocking — the ingredient is still usable).
+    cy.get('.ingredient-row', { timeout: 8000 }).should('have.length.at.least', 1)
+    cy.contains('.ingredient-row', 'flour').should('be.visible')
+    cy.get('[aria-label="Retry ingredient lookup"]', { timeout: 8000 }).should('be.visible')
   })
 
   it('removing the middle instruction re-indexes survivors sequentially (High #3 regression)', () => {
@@ -294,12 +316,73 @@ describe('Add Recipe', () => {
     cy.url({ timeout: 10000 }).should('include', '/recipes/cy-recipe-1')
   })
 
-  // Reordering via drag-and-drop in @hello-pangea/dnd requires simulating a specific
-  // pointer-event sequence (mousedown on the handle → mousemove → mouseup) and the
-  // library's sensor detection is timing-sensitive. The user explicitly authorised
-  // skipping this with a documenting comment if the implementation would be flaky.
-  // Intent: add three steps "Step A", "Step B", "Step C", drag "Step C" to the top,
-  // assert the DOM order is C / A / B and that the index spans are re-numbered
-  // 1 / 2 / 3 on the new positions.
-  it.skip('drag-and-drop reorder updates the instruction order and re-indexes', () => {})
+  it('keyboard drag-and-drop reorders the ingredient list', () => {
+    // Echo the typed string back as the parsed name so the three rows are
+    // distinguishable (the shared fixture would otherwise label them all "flour").
+    cy.intercept('POST', PARSE_URL, req => {
+      const name = String(req.body.ingredientString || '').trim()
+      req.reply({
+        parsedIngredient: {
+          quantity: null,
+          unit: null,
+          ingredient: name,
+          originalIngredientString: name,
+          comment: '',
+        },
+        ingredientData: {
+          _id: `srv-${name}`,
+          name,
+          amount: 1,
+          imagePath: 'https://img.spoonacular.com/ingredients_100x100/flour.png',
+          totalPriceUSACents: 42,
+        },
+        id: `srv-${name}`,
+      })
+    }).as('parseIngredient')
+
+    loginAndVisitAddRecipe()
+    const ingSel = 'input[placeholder="Add ingredients to your recipe."]'
+    ;['apple', 'banana', 'carrot'].forEach(name => {
+      cy.get(ingSel).type(`${name}{enter}`)
+      cy.wait('@parseIngredient')
+    })
+
+    const names = () =>
+      cy.get('.ingredient-row .ingredient-item-text').then($els =>
+        [...$els].map(e => (e.textContent || '').trim())
+      )
+
+    names().should('deep.equal', ['apple', 'banana', 'carrot'])
+
+    // Drag the first row ("apple") down two positions → it should land last.
+    keyboardReorder(() => cy.get('.ingredient-row .drag-handle').first(), 40, 2)
+
+    names().should('deep.equal', ['banana', 'carrot', 'apple'])
+  })
+
+  it('keyboard drag-and-drop reorders the instruction list and re-indexes', () => {
+    loginAndVisitAddRecipe()
+    const inputSel = 'input[placeholder="Add instruction for your recipe."]'
+    cy.get(inputSel).type('Step A{enter}')
+    cy.get(inputSel).type('Step B{enter}')
+    cy.get(inputSel).type('Step C{enter}')
+
+    cy.get('.instructions .item .index').then($i =>
+      expect([...$i].map(e => e.textContent?.trim())).to.deep.equal(['1', '2', '3'])
+    )
+
+    // Drag the last step ("Step C") up two positions → to the top.
+    keyboardReorder(() => cy.get('.instructions .item .drag-handle').last(), 38, 2)
+
+    // Order is now C / A / B, and the index spans are renumbered to their new spots.
+    cy.get('.instructions .item').then($items => {
+      const text = [...$items].map(el => el.textContent || '')
+      expect(text[0]).to.contain('Step C')
+      expect(text[1]).to.contain('Step A')
+      expect(text[2]).to.contain('Step B')
+    })
+    cy.get('.instructions .item .index').then($i =>
+      expect([...$i].map(e => e.textContent?.trim())).to.deep.equal(['1', '2', '3'])
+    )
+  })
 })

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -79,16 +79,24 @@ The triage date stamped on items is the date they were filed here, not when they
 ## UX / visual polish
 
 - `[ ]` **Better "no results found" on the Recipes page** — current indicator is weak.
-- `[ ]` **Optimistic ingredient add** — when adding an ingredient, show it in the list immediately
-  instead of waiting for the parse/nutrition request to return.
+- `[x]` **Optimistic ingredient add** — *done in PR #164 (track 3d; PR open).* Adding an ingredient now
+  parses locally and shows the row immediately, reconciling price/image when enrichment returns; a failure
+  keeps the row and flags it with a one-tap retry instead of waiting on the request.
 - `[ ]` **Search autocomplete "autocorrect" is weak** — fuzzy matching on recipe search autocomplete
   needs improvement.
 - `[x]` **"You created this recipe" — mobile styling** — *fixed in PR #160 (track 2c)*; owner-stats
   strip now an equal-width row with dividers instead of scattering via `space-between`.
 - `[x]` **Recipe stats styling** — *fixed in PR #160 (track 2c)*; rating dropped from the action-bar
   row, replaced by a per-serving price tile (time / servings / price).
-- `[ ]` **Add-recipe bottom bar overlaps the footer** — scrolling to the bottom of the add-recipe page,
-  the sticky bottom bar hides the footer. *(minor)*
+- `[x]` **Add-recipe bottom bar overlaps the footer** — *done in PR #164 (track 3d; PR open).* The summary
+  bar is now `position: sticky` (+ `margin-top: auto`) so it releases at the page end above the footer
+  instead of a fixed overlay; the footer's global top margin is also cancelled on this page (`:has`) so the
+  bar sits flush above it, and the cuisine/course dropdowns were lifted above the bar (menu z-index 50→60).
+- `[ ]` **Add-recipe group labels render underwhelming** — the section labels you can insert between
+  ingredients / instructions (the "Add Label" control) don't display the way they should on the create-recipe
+  page. Refine their styling/placement, and check how they carry through to the recipe view. *(noted
+  2026-06-18 after the track-3d smoke test; visual polish — fold into a future add-recipe pass, e.g. the
+  Phase-4 QA sweep or the "Refactor the create-recipe page" tech-debt item.)*
 - `[x]` **Single-recipe "no recipe found" looks bad** — *fixed in PR #160 (track 2c)*; redesigned
   empty-state card (icon + search + "Browse all recipes" CTA), and fixed 404 routing so a missing
   recipe renders instantly instead of retrying ~7s then showing a generic error.
@@ -159,13 +167,20 @@ The triage date stamped on items is the date they were filed here, not when they
   code stays consistent (likely an addition to `CLAUDE.md` or a new `CONVENTIONS.md`).
 - `[ ]` **Refactor the create-recipe page**.
 - `[ ]` **Refactor the account page**.
-- `[ ]` **Ingredient parser: handle "not found"** — on a parser miss, add an exit/timeout instead of
-  hanging.
+- `[x]` **Ingredient parser: handle "not found"** — *done in PR #164 (track 3d; PR open).* A client-side
+  `withTimeout` (12s) races the enrichment request so a hung/"not found" lookup no longer sticks the UI; on
+  timeout the row is kept, flagged errored with a retry, and a toast surfaces. Applied to both add and
+  inline-edit paths.
 
 ## Testing
 
 - `[ ]` **Tests for the toast/alert system** — newly implemented `react-hot-toast` is untested.
-- `[ ]` **Create-recipe tests** — Cypress (E2E) + Vitest (unit).
+- `[~]` **Create-recipe tests** — Cypress (E2E) + Vitest (unit). *Substantial sweep added in PR #164 (track
+  3d):* Vitest for the enrichment-timeout util, optimistic add / reconcile / soft-fail / retry / timeout,
+  inline-edit re-enrich + timeout, drag-reorder + id-keyed status survival, summary-bar rollup + submit
+  states, and servings/time validation; Cypress gained keyboard drag-reorder specs (ingredient + instruction)
+  and the soft-fail spec was updated to the new retry UX. Remaining: cuisine/meal-type selector units
+  (currently E2E-only) and broader E2E happy-path variants.
 - `[ ]` **Cypress: test autocomplete on the Recipes page**.
 - `[x]` **Node 26 test-harness gaps — missing globals in the test sandbox** — **both fixed.** This dev
   machine runs **Node 26**, whose VM/sandbox no longer keeps some globals the test stacks assume:

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -57,7 +57,7 @@ same commit.**
 | 3a | a11y (focus-visible, chevron) | `[ ]` | — |
 | 3b | Meta/SEO finish (favicon/OG/titles) | `[ ]` | — |
 | 3c | Username validation + report-user | `[ ]` | — |
-| 3d | Add-recipe UX | `[ ]` | — |
+| 3d | Add-recipe UX | `[P]` | #164 |
 | 3e | create-username revamp | `[ ]` | — |
 | 4-sass | Sass `@import`→`@use` (LONER) | `[ ]` | — |
 | 4-about | About rewrite (Jesse) | `[ ]` | — |
@@ -137,8 +137,9 @@ All isolated files — safe to run together.
   a stable app, so do near the end.
 - **Mobile hand-pass** (Add Recipe + Account/Settings flows) and **Lighthouse / perf**.
 - **Code & architecture standard for Claude** (new conventions doc) + **post-refactor DB-migration check**.
-- **Toast/alert tests**, **create-recipe Cypress+Vitest**, **Cypress autocomplete test** — fold into the
-  relevant domain track when that track is touched, or batch here.
+- **Toast/alert tests**, **create-recipe Cypress+Vitest** *(largely done in 3d / PR #164 — see Backlog →
+  Testing)*, **Cypress autocomplete test** — fold into the relevant domain track when that track is touched,
+  or batch here.
 
 ## Phase 5 — Cutover
 
@@ -322,6 +323,23 @@ Append a one-liner when a track changes state (started / PR / merged). Keeps ses
   create-username. **Part 2** (after Part 1 merges): **2d** recipes browse (rebases on 3a's Navbar), **3c**
   username-validation + report-user (rebases on 2e's PublicProfile; also carries the two 2c deferrals).
   **3b** meta/SEO held as a finishing pass. Part-1 kickoff prompts added to the appendix below.
+- _2026-06-18_ — **3d Add-recipe UX → PR open** (PR #164, into `development`). Delivered all three brief
+  items under `src/pages/AddRecipe/*`: (1) **optimistic ingredient add** — parse locally + show the row
+  instantly, reconcile price/image on response, keep + flag errored rows with a retry; (2) **enrichment
+  timeout** — a client-side `withTimeout` (12s) races the parse so a hung/"not found" lookup can't stick the
+  UI (toast + errored row + retry), applied to both add and inline-edit; (3) **sticky bar / footer** — bar
+  switched from `position: fixed` to `sticky` (+`margin-top: auto`) so it releases at page end above the
+  footer; per-row enrichment status is keyed by id, so it survives reorders. Two follow-up polish fixes also
+  landed in the PR after a live smoke test: the footer's global top-margin showing as a gap below the
+  released bar (cancelled on this page via `:has`), and the cuisine/course dropdowns opening behind the bar
+  (menu z-index 50→60). Plus a comprehensive **test sweep** (Backlog → Testing): Vitest for the timeout util /
+  optimistic-add / inline-edit / drag-reorder + id-keyed-status / summary-bar / servings+time validation, and
+  **Cypress keyboard drag-reorder** specs (the only reliable automated DnD path — mouse-drag stays manual;
+  gesture pre-verified in a real browser). Verified end-to-end via a live authed smoke test (create→publish,
+  all inputs incl. validation edge cases + an XSS-escape check) with full cleanup of the test account/recipes.
+  **Filed one follow-up → Backlog (UX/visual polish):** add-recipe group-label rendering needs a refinement —
+  a candidate for the Phase-4 QA pass or the create-recipe refactor. Board 3d `[ ]`→`[P]`; backlog
+  add-recipe items + create-recipe-tests flipped.
 
 ---
 

--- a/src/pages/AddRecipe/AddRecipe.scss
+++ b/src/pages/AddRecipe/AddRecipe.scss
@@ -13,8 +13,9 @@
   // distinct surface. Keep the global .page's top padding so the h1 sits at
   // the same height as headers on other pages (e.g. Recipes).
   background: s.$primary-background;
-  // Clear the fixed summary bar at the bottom of the page.
-  padding-bottom: 130px;
+  // The summary bar is now a sticky in-flow child (see AddRecipeSummaryBar.scss),
+  // so it reserves its own space at the end of the page — no bottom padding hack
+  // needed to clear a fixed overlay, and the footer below it stays reachable.
 
   .add-recipe-heading {
     display: flex;

--- a/src/pages/AddRecipe/AddRecipe.scss
+++ b/src/pages/AddRecipe/AddRecipe.scss
@@ -1,5 +1,14 @@
 @use '../../helpers.scss' as s;
 
+// The footer carries a global top margin ($footer-margin) for breathing room
+// after page content. On the create/edit-recipe page the sticky summary bar now
+// sits flush at the bottom of the form, so that margin renders as an empty gap
+// between the bar and the footer. Cancel it for this page only (the bar provides
+// the visual separation) — scoped via :has so no global footer style is touched.
+.app-shell:has(.add-recipe-page) .site-footer {
+  margin-top: 0;
+}
+
 .add-recipe-page {
   display: flex;
   flex-direction: column;

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.scss
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.scss
@@ -1,10 +1,19 @@
 @use '../../helpers.scss' as s;
 
 .add-recipe-summary-bar {
-  position: fixed;
-  left: 0;
-  right: 0;
+  // Sticky (not fixed) so the bar pins to the bottom of the viewport while the
+  // form scrolls, then releases at the end of the page — letting the footer,
+  // which lives just below this bar's containing block, become reachable
+  // instead of being permanently covered. Full width because, as a flex child
+  // of the centered page column, it would otherwise shrink to its content.
+  position: sticky;
   bottom: 0;
+  width: 100%;
+  // Push to the bottom of the page column so the bar still rests at the bottom
+  // of the viewport when the form is shorter than the screen (the auto margin
+  // absorbs the free space ahead of the page's `justify-content`); a no-op when
+  // the form overflows, where the sticky positioning takes over.
+  margin-top: auto;
   z-index: 50;
   background: s.$white;
   border-top: 1px solid s.$gray-400;

--- a/src/pages/AddRecipe/CuisineSelector/CuisineSelector.tsx
+++ b/src/pages/AddRecipe/CuisineSelector/CuisineSelector.tsx
@@ -13,6 +13,10 @@ const cuisineOptions: OptionType[] = cuisinesList.map(c => ({
   label: c,
 }))
 const customStyles: StylesConfig<OptionType> = {
+  // Lift the open menu above the sticky summary bar (z-index 50). Without this
+  // the Course/Cuisine dropdowns — which sit just above the bar — open partially
+  // hidden behind it.
+  menu: (provided: any) => ({ ...provided, zIndex: 60 }),
   control: (provided: any, state: any) => ({
     ...provided,
     borderColor: state.isFocused ? styles.primary : provided.borderColor,

--- a/src/pages/AddRecipe/Ingredients/IngredientItem.tsx
+++ b/src/pages/AddRecipe/Ingredients/IngredientItem.tsx
@@ -1,13 +1,19 @@
-import React, { Dispatch, SetStateAction, FC, useState, useRef } from 'react'
+import React, { FC, useState, useRef } from 'react'
 import { DraggableProvided, DraggableStateSnapshot } from '@hello-pangea/dnd'
 import { CiShoppingBasket } from 'react-icons/ci'
 import { MdDragIndicator } from 'react-icons/md'
 import { AiOutlineClose } from 'react-icons/ai'
+import { FiAlertCircle, FiRotateCw } from 'react-icons/fi'
 import Skeleton from 'react-loading-skeleton'
+import { toast } from 'react-hot-toast'
 import RecipeAPI from 'src/api/recipes'
-import { getIndexById } from 'src/util/getIndexById'
 import { IngredientsType } from 'types'
 import RecipeFormInput from 'src/pages/AddRecipe/RecipeFormInput'
+import {
+  IngredientEnrichTimeoutError,
+  withTimeout,
+} from 'src/pages/AddRecipe/Ingredients/ingredientEnrichment'
+import { IngredientStatus } from 'src/pages/AddRecipe/Ingredients/IngredientsContainer/IngredientsContainer'
 import '../ListComponents/Item.scss'
 import { TailSpin } from 'react-loader-spinner'
 import styles from 'src/_exports.module.scss'
@@ -18,17 +24,15 @@ const skeletonColor = '#d6d6d6'
 type IngredientItemProps = {
   ingredients: IngredientsType[]
   ingredient?: IngredientsType
-  setLoading: Dispatch<
-    SetStateAction<{
-      isLoading: boolean
-      index: number
-    }>
-  >
+  // Sets this row's enrichment status by id (see IngredientsContainer).
+  setItemStatus: (id: string, status: IngredientStatus | null) => void
   loading?: boolean
+  errored?: boolean
   provided?: DraggableProvided
   snapshot?: DraggableStateSnapshot
   removeIngredient: (id: string) => void
-  setIngredients: Dispatch<SetStateAction<IngredientsType[]>>
+  retryIngredient: (id: string) => void
+  setIngredients: React.Dispatch<React.SetStateAction<IngredientsType[]>>
 }
 
 // Per-ingredient price label from the enriched parser data. Returns '—' when
@@ -48,11 +52,13 @@ const priceLabel = (ingredient?: IngredientsType): string => {
 const IngredientItem: FC<IngredientItemProps> = ({
   ingredients,
   ingredient,
-  setLoading,
+  setItemStatus,
   loading,
+  errored,
   provided,
   snapshot,
   removeIngredient,
+  retryIngredient,
   setIngredients,
 }) => {
   const [isEditing, setIsEditing] = useState(false)
@@ -108,16 +114,31 @@ const IngredientItem: FC<IngredientItemProps> = ({
       !isLabel &&
       ingredient.parsedIngredient.originalIngredientString !== editedVal
     ) {
-      const currIndex = getIndexById(ingredients, ingredient.id)
-      setLoading({ isLoading: true, index: currIndex })
-      const ingredientDataRes = await RecipeAPI.getIngredientData(editedVal)
-      // Phase A: soft-fail by design — whether enrichment succeeded or returned
-      // an error variant, we overwrite the existing ingredient with the new
-      // parse result so the edit takes effect either way. The error is carried
-      // through on the IngredientsType payload itself; no extra handling needed
-      // here.
-      editIngredient(ingredient.id, { ...ingredientDataRes })
-      setLoading({ isLoading: false, index: -1 })
+      const id = ingredient.id
+      setItemStatus(id, 'loading')
+      try {
+        // Same timeout/exit guard as the add path: getIngredientData soft-fails
+        // but can't protect against a request that never settles, so race it
+        // against a wall clock.
+        const ingredientDataRes = await withTimeout(
+          RecipeAPI.getIngredientData(editedVal)
+        )
+        editIngredient(id, { ...ingredientDataRes })
+        setItemStatus(
+          id,
+          'error' in ingredientDataRes && ingredientDataRes.error
+            ? 'error'
+            : null
+        )
+      } catch (err: unknown) {
+        const timedOut = err instanceof IngredientEnrichTimeoutError
+        setItemStatus(id, 'error')
+        toast.error(
+          timedOut
+            ? `"${editedVal}" is taking too long to look up — kept without nutrition data. Retry or edit it.`
+            : `Couldn't fetch data for "${editedVal}" — kept without it. Retry or edit it.`
+        )
+      }
     }
 
     setIsEditing(false)
@@ -133,7 +154,7 @@ const IngredientItem: FC<IngredientItemProps> = ({
       ref={provided?.innerRef}
       className={`ingredients-container item ingredient-row ${
         snapshot?.isDragging ? 'dragging' : ''
-      }`}
+      } ${errored ? 'errored' : ''}`}
       {...provided?.draggableProps}
     >
       {/* Always-visible drag handle (the only drag target, so the row text
@@ -165,13 +186,9 @@ const IngredientItem: FC<IngredientItemProps> = ({
               </>
             )}
           </div>
-          <div className='text-container'>
-            {loading ? (
-              <Skeleton baseColor={skeletonColor} height={25} width={'35ch'} />
-            ) : (
-              renderIngredientText()
-            )}
-          </div>
+          {/* Optimistic: the parsed text is available locally, so show it
+              immediately even while enrichment (image/price) is still loading. */}
+          <div className='text-container'>{renderIngredientText()}</div>
         </button>
       ) : (
         <button className='label-text-container' onClick={handleIngrClick}>
@@ -179,7 +196,23 @@ const IngredientItem: FC<IngredientItemProps> = ({
         </button>
       )}
 
-      {!isEditing && isParsed && (
+      {!isEditing && isParsed && errored && !loading && (
+        <button
+          type='button'
+          className='ingr-retry'
+          aria-label='Retry ingredient lookup'
+          title="Couldn't fetch nutrition data — retry"
+          onClick={e => {
+            e.stopPropagation()
+            retryIngredient(ingredient.id)
+          }}
+        >
+          <FiAlertCircle className='icon warn' />
+          <FiRotateCw className='icon retry' />
+        </button>
+      )}
+
+      {!isEditing && isParsed && !errored && (
         <span className={`ingr-price ${loading ? 'na' : ''}`}>
           {loading ? '' : priceLabel(ingredient)}
         </span>

--- a/src/pages/AddRecipe/Ingredients/IngredientList/IngredientList.scss
+++ b/src/pages/AddRecipe/Ingredients/IngredientList/IngredientList.scss
@@ -115,6 +115,49 @@
       }
     }
 
+    // Shown in place of the price when enrichment failed/timed out: the row is
+    // kept (the parsed ingredient is still usable) but flagged, with a one-tap
+    // retry. The warning icon swaps to the retry icon on hover/focus.
+    .ingr-retry {
+      flex: none;
+      display: grid;
+      place-items: center;
+      min-width: 56px;
+      height: 30px;
+      border: none;
+      background: none;
+      cursor: pointer;
+      color: s.$error-red;
+      .icon {
+        grid-area: 1 / 1;
+        height: 18px;
+        width: 18px;
+        transition: opacity 0.1s linear;
+      }
+      .retry {
+        opacity: 0;
+      }
+      &:hover,
+      &:focus {
+        color: s.$primary;
+        .warn {
+          opacity: 0;
+        }
+        .retry {
+          opacity: 1;
+        }
+      }
+      &:focus {
+        @include s.outline();
+      }
+    }
+
+    // Subtle tint so a failed-enrichment row reads as needs-attention without
+    // shouting; pairs with the retry control above.
+    &.errored {
+      background: rgba(s.$error-red, 0.06);
+    }
+
     .ingr-remove {
       flex: none;
       display: grid;

--- a/src/pages/AddRecipe/Ingredients/IngredientList/IngredientList.tsx
+++ b/src/pages/AddRecipe/Ingredients/IngredientList/IngredientList.tsx
@@ -2,26 +2,25 @@ import React, { Dispatch, FC, SetStateAction } from 'react'
 import { IngredientsType } from 'types'
 import { DndContext, Drag } from 'src/pages/AddRecipe/Dnd'
 import IngredientItem from 'src/pages/AddRecipe/Ingredients/IngredientItem'
+import { IngredientStatus } from 'src/pages/AddRecipe/Ingredients/IngredientsContainer/IngredientsContainer'
 import './IngredientList.scss'
 
 type IngredientListProps = {
   ingredients: IngredientsType[]
   setIngredients: Dispatch<SetStateAction<IngredientsType[]>>
-  setIngredientLoading: Dispatch<
-    SetStateAction<{
-      isLoading: boolean
-      index: number
-    }>
-  >
-  ingredientLoading: { isLoading: boolean; index: number }
+  // Per-row enrichment state keyed by ingredient id (see IngredientsContainer).
+  statusById: Record<string, IngredientStatus>
+  setItemStatus: (id: string, status: IngredientStatus | null) => void
   removeIngredient: (id: string) => void
+  retryIngredient: (id: string) => void
 }
 const IngredientList: FC<IngredientListProps> = ({
   ingredients,
   setIngredients,
-  setIngredientLoading,
-  ingredientLoading,
+  statusById,
+  setItemStatus,
   removeIngredient,
+  retryIngredient,
 }) => {
   const handlListChange = (updatedList: IngredientsType[]) =>
     setIngredients(updatedList)
@@ -30,34 +29,22 @@ const IngredientList: FC<IngredientListProps> = ({
     <DndContext list={ingredients} handleListChange={handlListChange}>
       <>
         {ingredients.map((ingr, idx) => {
-          const isCurrIngredientLoading =
-            ingredientLoading.isLoading && ingredientLoading.index === idx
-
+          const status = ingr.id ? statusById[ingr.id] : undefined
           return (
             <Drag key={ingr.id} id={ingr.id ?? 'id'} index={idx}>
               <IngredientItem
                 ingredients={ingredients}
                 ingredient={ingr}
-                setLoading={setIngredientLoading}
-                loading={isCurrIngredientLoading}
+                setItemStatus={setItemStatus}
+                loading={status === 'loading'}
+                errored={status === 'error'}
                 removeIngredient={removeIngredient}
+                retryIngredient={retryIngredient}
                 setIngredients={setIngredients}
               />
             </Drag>
           )
         })}
-        {ingredientLoading.isLoading &&
-          ingredientLoading.index >= ingredients.length && (
-            <>
-              <IngredientItem
-                ingredients={ingredients}
-                setLoading={setIngredientLoading}
-                loading={true}
-                removeIngredient={removeIngredient}
-                setIngredients={setIngredients}
-              />
-            </>
-          )}
       </>
     </DndContext>
   )

--- a/src/pages/AddRecipe/Ingredients/IngredientsContainer/IngredientsContainer.tsx
+++ b/src/pages/AddRecipe/Ingredients/IngredientsContainer/IngredientsContainer.tsx
@@ -1,8 +1,16 @@
-import React, { FC, useState } from 'react'
-import { IngredientsType } from 'types'
+import React, { FC, useCallback, useState } from 'react'
+import { parseIngredientString } from '@jclind/ingredient-parser'
+import { v4 as uuidv4 } from 'uuid'
+import { toast } from 'react-hot-toast'
+import { IngredientsType, LabelType } from 'types'
+import RecipeAPI from 'src/api/recipes'
 import AddLabel from 'src/pages/AddRecipe/AddLabel/AddLabel'
 import IngredientList from 'src/pages/AddRecipe/Ingredients/IngredientList/IngredientList'
 import IngredientsInput from 'src/pages/AddRecipe/Ingredients/IngredientsInput'
+import {
+  IngredientEnrichTimeoutError,
+  withTimeout,
+} from 'src/pages/AddRecipe/Ingredients/ingredientEnrichment'
 import './IngredientsContainer.scss'
 
 type IngredientsContainerProps = {
@@ -10,24 +18,121 @@ type IngredientsContainerProps = {
   setIngredients: React.Dispatch<React.SetStateAction<IngredientsType[]>>
 }
 
+// Per-row enrichment state, keyed by ingredient id (not list index, so it
+// survives reorders and concurrent adds): 'loading' while the nutrition/price
+// lookup is in flight, 'error' when it failed or timed out. Rows absent from the
+// map are settled. A short label string keeps the row's display name available
+// for the failure toast even after the input has been cleared.
+export type IngredientStatus = 'loading' | 'error'
+
 const IngredientsContainer: FC<IngredientsContainerProps> = ({
   ingredients,
   setIngredients,
 }) => {
-  const [ingredientLoading, setIngredientLoading] = useState<{
-    isLoading: boolean
-    index: number
-  }>({ isLoading: false, index: -1 })
+  const [statusById, setStatusById] = useState<Record<string, IngredientStatus>>(
+    {}
+  )
 
-  const addIngredientToList = (data: IngredientsType) => {
-    setIngredients((prev: IngredientsType[]) => {
-      const update: IngredientsType[] = [...prev, data]
-      return update
-    })
-  }
-  const removeIngredient = (removeId: string) => {
-    setIngredients(prev => prev.filter(ingr => ingr.id !== removeId))
-  }
+  const setItemStatus = useCallback(
+    (id: string, status: IngredientStatus | null) => {
+      setStatusById(prev => {
+        if (status === null) {
+          if (!(id in prev)) return prev
+          const next = { ...prev }
+          delete next[id]
+          return next
+        }
+        return { ...prev, [id]: status }
+      })
+    },
+    []
+  )
+
+  // Enrich a parsed ingredient already in the list (by id) and reconcile it in
+  // place. Shared by the optimistic add path and the per-row retry. The id is
+  // preserved across reconciliation so the row's React/DnD key — and its
+  // position if the user reordered while it loaded — stay stable.
+  const enrichInPlace = useCallback(
+    async (id: string, rawValue: string, displayName: string) => {
+      setItemStatus(id, 'loading')
+      try {
+        const enriched = await withTimeout(RecipeAPI.getIngredientData(rawValue))
+        setIngredients(prev =>
+          prev.map(ingr => (ingr.id === id ? { ...enriched, id } : ingr))
+        )
+        // getIngredientData is soft-fail: it resolves with an `error` variant
+        // (parsed-only, no nutrition/price) rather than throwing. Surface that as
+        // an errored-but-usable row so the user can retry, edit, or proceed.
+        if ('error' in enriched && enriched.error) {
+          setItemStatus(id, 'error')
+        } else {
+          setItemStatus(id, null)
+        }
+      } catch (err: unknown) {
+        // The only rejection here is our own timeout (getIngredientData itself
+        // never rejects). The request is abandoned; keep the parsed-only row so
+        // the user doesn't lose their entry, mark it errored, and let them retry.
+        const timedOut = err instanceof IngredientEnrichTimeoutError
+        setItemStatus(id, 'error')
+        toast.error(
+          timedOut
+            ? `"${displayName}" is taking too long to look up — added without nutrition data. Retry or edit it.`
+            : `Couldn't fetch data for "${displayName}" — added without it. Retry or edit it.`
+        )
+      }
+    },
+    [setIngredients, setItemStatus]
+  )
+
+  // Optimistic add: parse locally (synchronous) and show the ingredient in the
+  // list immediately, then fill in nutrition/price/image when enrichment
+  // returns. The slow part is the network enrichment, never the parse.
+  const addIngredient = useCallback(
+    (rawValue: string) => {
+      const trimmed = rawValue.trim()
+      if (!trimmed) return
+
+      const id = uuidv4()
+      const parsedIngredient = parseIngredientString(trimmed)
+      const optimistic: IngredientsType = {
+        parsedIngredient,
+        ingredientData: null,
+        id,
+      }
+      setIngredients(prev => [...prev, optimistic])
+      // Fire-and-forget: the row is already on screen; reconciliation/failure is
+      // handled inside enrichInPlace via state, so callers needn't await.
+      void enrichInPlace(id, trimmed, parsedIngredient.ingredient || trimmed)
+    },
+    [enrichInPlace, setIngredients]
+  )
+
+  const retryIngredient = useCallback(
+    (id: string) => {
+      const ingr = ingredients.find(i => i.id === id)
+      if (!ingr || !('parsedIngredient' in ingr)) return
+      const raw = ingr.parsedIngredient.originalIngredientString
+      void enrichInPlace(id, raw, ingr.parsedIngredient.ingredient || raw)
+    },
+    [ingredients, enrichInPlace]
+  )
+
+  // Labels carry no nutrition data, so they're added directly with no enrichment
+  // round-trip. Also used as the reconcile target for AddLabel.
+  const addLabelToList = useCallback(
+    (data: LabelType) => {
+      setIngredients(prev => [...prev, data])
+    },
+    [setIngredients]
+  )
+
+  const removeIngredient = useCallback(
+    (removeId: string) => {
+      setIngredients(prev => prev.filter(ingr => ingr.id !== removeId))
+      setItemStatus(removeId, null)
+    },
+    [setIngredients, setItemStatus]
+  )
 
   // Sum of the enriched per-ingredient prices (cents). Shown as a subtotal so
   // the cook sees the total grocery cost; the page's summary bar handles the
@@ -42,21 +147,17 @@ const IngredientsContainer: FC<IngredientsContainerProps> = ({
 
   return (
     <div className='ingredients-container'>
-      <IngredientsInput
-        addIngredientToList={addIngredientToList}
-        setIngredientLoading={setIngredientLoading}
-        ingredientsLength={ingredients.length}
-        ingredientLoading={ingredientLoading}
-      />
+      <IngredientsInput onAdd={addIngredient} />
       <IngredientList
         ingredients={ingredients}
         setIngredients={setIngredients}
-        ingredientLoading={ingredientLoading}
-        setIngredientLoading={setIngredientLoading}
+        statusById={statusById}
+        setItemStatus={setItemStatus}
         removeIngredient={removeIngredient}
+        retryIngredient={retryIngredient}
       />
       <div className='ingredients-footer'>
-        <AddLabel addToList={addIngredientToList} />
+        <AddLabel addToList={addLabelToList} />
         {subtotalCents > 0 && (
           <span className='ingredients-subtotal'>
             Subtotal <b>${(subtotalCents / 100).toFixed(2)}</b>

--- a/src/pages/AddRecipe/Ingredients/IngredientsInput.tsx
+++ b/src/pages/AddRecipe/Ingredients/IngredientsInput.tsx
@@ -1,60 +1,31 @@
 import React, { FC, useState } from 'react'
-import { TailSpin } from 'react-loader-spinner'
-import RecipeAPI from 'src/api/recipes'
-import { IngredientsType } from 'types'
 import RecipeFormInput from 'src/pages/AddRecipe/RecipeFormInput'
-import styles from 'src/_exports.module.scss'
 
 type IngredientsInputProps = {
-  addIngredientToList: (data: IngredientsType) => void
-  setIngredientLoading: (data: { isLoading: boolean; index: number }) => void
-  ingredientsLength: number
-  ingredientLoading: { isLoading: boolean; index: number }
+  // Hands the raw entry to the container, which adds it optimistically and runs
+  // enrichment. Fire-and-forget by design — the input clears immediately so the
+  // user can keep typing while the row fills in.
+  onAdd: (rawValue: string) => void
 }
 
-const IngredientsInput: FC<IngredientsInputProps> = ({
-  addIngredientToList,
-  setIngredientLoading,
-  ingredientsLength,
-  ingredientLoading,
-}) => {
+const IngredientsInput: FC<IngredientsInputProps> = ({ onAdd }) => {
   const [inputVal, setInputVal] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [enrichmentWarning, setEnrichmentWarning] = useState('')
+  const [hint, setHint] = useState('')
 
-  const handleAddIngredient = async () => {
-    if (loading) return
-
+  const handleAddIngredient = () => {
     // Empty / whitespace-only input: close the loop with a hint instead of
-    // silently no-opping, and never fire a parse request for nothing. (Guard
-    // BEFORE touching loading state so we never strand the parent spinner.)
+    // silently no-opping, and never add an empty row.
     const trimmed = inputVal.trim()
     if (!trimmed) {
-      setEnrichmentWarning('Enter an ingredient before adding it.')
+      setHint('Enter an ingredient before adding it.')
       return
     }
 
-    setEnrichmentWarning('')
-    setLoading(true)
-    setIngredientLoading({ isLoading: true, index: ingredientsLength })
-
-    try {
-      const data: IngredientsType = await RecipeAPI.getIngredientData(trimmed)
-      // getIngredientData is soft-fail: always returns a valid IngredientsType,
-      // even on enrichment failure (ingredientData: null + error). Per the
-      // ingredient-enrichment-failures-are-non-fatal policy, we add the
-      // ingredient either way and surface a small warning if enrichment failed.
-      addIngredientToList(data)
-      setInputVal('')
-      if ('error' in data && data.error) {
-        setEnrichmentWarning(
-          `Added "${trimmed}", but couldn't fetch nutrition/image data. You can edit or remove it.`
-        )
-      }
-    } finally {
-      setLoading(false)
-      setIngredientLoading({ isLoading: false, index: -1 })
-    }
+    setHint('')
+    onAdd(trimmed)
+    // Clear immediately — the ingredient is already in the list optimistically,
+    // so the field is ready for the next entry without waiting on the network.
+    setInputVal('')
   }
 
   return (
@@ -65,19 +36,9 @@ const IngredientsInput: FC<IngredientsInputProps> = ({
         setVal={setInputVal}
         onEnter={handleAddIngredient}
       />
-      {ingredientLoading.isLoading && (
-        <div className='loading-indicator'>
-          <TailSpin
-            height='20'
-            width='20'
-            color={styles.primaryText}
-            ariaLabel='loading'
-          />
-        </div>
-      )}
-      {enrichmentWarning && (
+      {hint && (
         <div className='warning' role='status'>
-          {enrichmentWarning}
+          {hint}
         </div>
       )}
     </div>

--- a/src/pages/AddRecipe/Ingredients/ingredientEnrichment.ts
+++ b/src/pages/AddRecipe/Ingredients/ingredientEnrichment.ts
@@ -1,0 +1,44 @@
+// Client-side timeout/exit path for ingredient enrichment.
+//
+// RecipeAPI.getIngredientData soft-fails (it catches rejections and degrades to
+// a parsed-only ingredient), but it can't protect against a request that never
+// settles: the shared axios instance has no timeout, so a stalled server
+// (e.g. a slow/"not found" Spoonacular lookup) leaves the promise pending
+// forever and the add-recipe UI stuck on a loading row. This races the
+// enrichment call against a wall clock so the UI always has an exit.
+//
+// Lives under src/pages/AddRecipe/* on purpose: the fix is scoped to the
+// add-recipe flow rather than changing the global API client.
+
+export const INGREDIENT_ENRICH_TIMEOUT_MS = 12_000
+
+export class IngredientEnrichTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`Ingredient enrichment timed out after ${ms}ms`)
+    this.name = 'IngredientEnrichTimeoutError'
+  }
+}
+
+// Resolves with the wrapped promise's value if it settles first; otherwise
+// rejects with IngredientEnrichTimeoutError after `ms`. The timer is cleared as
+// soon as the promise settles so a resolved request never leaves a dangling
+// timeout. The underlying request is not aborted — it's simply abandoned — so a
+// late response is harmless (the caller has already moved on).
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number = INGREDIENT_ENRICH_TIMEOUT_MS
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new IngredientEnrichTimeoutError(ms)), ms)
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      err => {
+        clearTimeout(timer)
+        reject(err)
+      }
+    )
+  })
+}

--- a/src/pages/AddRecipe/MealTypeSelector/MealTypeSelector.tsx
+++ b/src/pages/AddRecipe/MealTypeSelector/MealTypeSelector.tsx
@@ -14,6 +14,10 @@ const mealTypeOptions: OptionType[] = mealTypesList.map(m => ({
 }))
 
 const customStyles: StylesConfig<OptionType> = {
+  // Lift the open menu above the sticky summary bar (z-index 50). Without this
+  // the Course/Cuisine dropdowns — which sit just above the bar — open partially
+  // hidden behind it.
+  menu: (provided: any) => ({ ...provided, zIndex: 60 }),
   control: (provided: any, state: any) => ({
     ...provided,
     borderColor: state.isFocused ? styles.primary : provided.borderColor,

--- a/src/test/AddRecipeSummaryBar.test.tsx
+++ b/src/test/AddRecipeSummaryBar.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AddRecipeSummaryBar from 'src/pages/AddRecipe/AddRecipeSummaryBar'
+import { calculateServingPrice } from 'src/util/calculateServingPrice'
+
+// The per-serving price is exercised by calculateServingPrice's own tests; here
+// we mock it so the bar's formatting/rollup logic is isolated.
+vi.mock('src/util/calculateServingPrice', () => ({
+  calculateServingPrice: vi.fn(() => 0),
+}))
+const mockPrice = calculateServingPrice as ReturnType<typeof vi.fn>
+
+const parsed = (id: string) => ({
+  id,
+  parsedIngredient: {
+    ingredient: 'flour',
+    quantity: 1,
+    unit: 'cup',
+    comment: null,
+    originalIngredientString: '1 cup flour',
+  },
+  ingredientData: null,
+})
+const label = (id: string) => ({ id, label: 'Section' })
+
+const baseProps = {
+  servings: 4 as number | '',
+  prepTime: { hours: 1, minutes: 30 },
+  cookTime: { hours: 0, minutes: 15 },
+  ingredients: [parsed('1'), parsed('2')],
+  isValid: true,
+  loading: false,
+  onSubmit: vi.fn(),
+}
+
+const renderBar = (overrides = {}) =>
+  render(<AddRecipeSummaryBar {...baseProps} {...overrides} />)
+
+beforeEach(() => mockPrice.mockReset().mockReturnValue(0))
+
+describe('AddRecipeSummaryBar', () => {
+  it('shows the live rollup: servings, total time, ingredient count', () => {
+    renderBar()
+    expect(screen.getByText('4')).toBeInTheDocument() // serves
+    expect(screen.getByText('1h 45m')).toBeInTheDocument() // 90 + 15 min
+    expect(screen.getByText('2')).toBeInTheDocument() // ingredient count
+  })
+
+  it('counts only parsed ingredients, not group labels', () => {
+    renderBar({ ingredients: [parsed('1'), label('2'), parsed('3'), label('4')] })
+    // Two parsed of the four rows.
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('renders em dashes when servings/time/ingredients/price are empty', () => {
+    renderBar({
+      servings: '',
+      prepTime: null,
+      cookTime: null,
+      ingredients: [],
+    })
+    // serves, total time, ingredients, est/serving all collapse to "—".
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('formats total time as minutes-only when under an hour', () => {
+    renderBar({ prepTime: { hours: 0, minutes: 25 }, cookTime: null })
+    expect(screen.getByText('25 min')).toBeInTheDocument()
+  })
+
+  it('shows the per-serving price from calculateServingPrice', () => {
+    mockPrice.mockReturnValue(250)
+    renderBar()
+    expect(screen.getByText('$2.50')).toBeInTheDocument()
+  })
+
+  it('marks the submit button valid/invalid from isValid', () => {
+    const { rerender } = renderBar({ isValid: true })
+    expect(screen.getByRole('button', { name: /create recipe/i })).toHaveClass('valid')
+    rerender(<AddRecipeSummaryBar {...baseProps} isValid={false} />)
+    expect(screen.getByRole('button', { name: /create recipe/i })).toHaveClass('invalid')
+  })
+
+  it('disables the submit button and marks it busy while loading', () => {
+    const { container } = renderBar({ loading: true })
+    const btn = container.querySelector('.submit-btn') as HTMLButtonElement
+    expect(btn).toBeDisabled()
+    expect(btn).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('fires onSubmit when the submit button is clicked', async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    renderBar({ onSubmit })
+    await user.click(screen.getByRole('button', { name: /create recipe/i }))
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses a custom submit label (edit mode)', () => {
+    renderBar({ submitLabel: 'Save Changes' })
+    expect(screen.getByRole('button', { name: 'Save Changes' })).toBeInTheDocument()
+  })
+
+  it('renders a Cancel button only when onCancel is provided, and calls it', async () => {
+    const user = userEvent.setup()
+    const onCancel = vi.fn()
+    const { rerender } = renderBar() // no onCancel
+    expect(screen.queryByRole('button', { name: /cancel/i })).toBeNull()
+    rerender(<AddRecipeSummaryBar {...baseProps} onCancel={onCancel} />)
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/test/IngredientItemEdit.test.tsx
+++ b/src/test/IngredientItemEdit.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import IngredientItem from 'src/pages/AddRecipe/Ingredients/IngredientItem'
+import RecipeAPI from 'src/api/recipes'
+import { toast } from 'react-hot-toast'
+import {
+  IngredientEnrichTimeoutError,
+  withTimeout,
+} from 'src/pages/AddRecipe/Ingredients/ingredientEnrichment'
+
+vi.mock('src/api/recipes', () => ({ default: { getIngredientData: vi.fn() } }))
+vi.mock('src/api/auth', () => ({ default: { getUID: vi.fn().mockReturnValue(null) } }))
+vi.mock('react-hot-toast', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+// Pass-through by default; the hung-edit test overrides it to reject with a
+// timeout (mirroring the add-path test), so the real timer never runs.
+vi.mock(
+  'src/pages/AddRecipe/Ingredients/ingredientEnrichment',
+  async importOriginal => {
+    const actual = await importOriginal<
+      typeof import('src/pages/AddRecipe/Ingredients/ingredientEnrichment')
+    >()
+    return { ...actual, withTimeout: vi.fn((p: Promise<unknown>) => p) }
+  }
+)
+
+const mockGetIngredientData = RecipeAPI.getIngredientData as ReturnType<typeof vi.fn>
+const mockToastError = toast.error as ReturnType<typeof vi.fn>
+const mockWithTimeout = withTimeout as ReturnType<typeof vi.fn>
+
+const parsed = (id: string, original: string) => ({
+  id,
+  parsedIngredient: {
+    ingredient: 'milk',
+    quantity: 1,
+    unit: 'cup',
+    comment: null,
+    originalIngredientString: original,
+  },
+  ingredientData: null,
+})
+
+const enriched = (original: string) => ({
+  parsedIngredient: {
+    ingredient: 'flour',
+    quantity: 2,
+    unit: 'cups',
+    comment: null,
+    originalIngredientString: original,
+  },
+  ingredientData: { totalPriceUSACents: 300, imagePath: 'https://img.test/x.png' },
+  id: 'srv',
+})
+
+const renderItem = () => {
+  const ingredient = parsed('ing-1', '1 cup milk')
+  const setItemStatus = vi.fn()
+  const setIngredients = vi.fn()
+  const { container } = render(
+    <IngredientItem
+      ingredients={[ingredient as any]}
+      ingredient={ingredient as any}
+      setItemStatus={setItemStatus}
+      loading={false}
+      errored={false}
+      removeIngredient={vi.fn()}
+      retryIngredient={vi.fn()}
+      setIngredients={setIngredients}
+    />
+  )
+  return { container, setItemStatus, setIngredients }
+}
+
+// Enter edit mode, type a new value, and submit it (Enter).
+const editTo = (container: HTMLElement, value: string) => {
+  fireEvent.click(container.querySelector('.item-btn') as HTMLElement)
+  const input = container.querySelector('input') as HTMLInputElement
+  fireEvent.change(input, { target: { value } })
+  fireEvent.keyDown(input, { key: 'Enter' })
+}
+
+beforeEach(() => {
+  mockGetIngredientData.mockReset()
+  mockToastError.mockReset()
+  mockWithTimeout.mockReset().mockImplementation((p: Promise<unknown>) => p)
+})
+
+describe('IngredientItem inline edit', () => {
+  it('re-enriches on a successful edit and clears the loading status', async () => {
+    mockGetIngredientData.mockResolvedValue(enriched('2 cups flour'))
+    const { container, setItemStatus, setIngredients } = renderItem()
+
+    editTo(container, '2 cups flour')
+
+    await waitFor(() =>
+      expect(mockGetIngredientData).toHaveBeenCalledWith('2 cups flour')
+    )
+    // Sets loading first, then clears it (null) once enrichment resolves cleanly.
+    expect(setItemStatus).toHaveBeenCalledWith('ing-1', 'loading')
+    await waitFor(() =>
+      expect(setItemStatus).toHaveBeenCalledWith('ing-1', null)
+    )
+    // Reconciled the row in place.
+    expect(setIngredients).toHaveBeenCalled()
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
+  it('flags the row errored and toasts when the edit enrichment times out', async () => {
+    // getIngredientData hangs; withTimeout rejects as if the wall clock fired.
+    mockGetIngredientData.mockReturnValue(new Promise(() => {}))
+    mockWithTimeout.mockImplementationOnce(async () => {
+      throw new IngredientEnrichTimeoutError(12000)
+    })
+    const { container, setItemStatus } = renderItem()
+
+    editTo(container, '2 cups flour')
+
+    await waitFor(() => expect(setItemStatus).toHaveBeenCalledWith('ing-1', 'error'))
+    expect(setItemStatus).toHaveBeenCalledWith('ing-1', 'loading')
+    expect(mockToastError).toHaveBeenCalledTimes(1)
+    expect(mockToastError.mock.calls[0][0]).toMatch(/too long/i)
+  })
+
+  it('does not re-enrich when the edited value is unchanged', async () => {
+    const { container, setItemStatus } = renderItem()
+    editTo(container, '1 cup milk') // same as original
+    await Promise.resolve()
+    expect(mockGetIngredientData).not.toHaveBeenCalled()
+    expect(setItemStatus).not.toHaveBeenCalled()
+  })
+})

--- a/src/test/IngredientListReorder.test.tsx
+++ b/src/test/IngredientListReorder.test.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react'
+import { vi } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import IngredientList from 'src/pages/AddRecipe/Ingredients/IngredientList/IngredientList'
+import { reorder } from 'src/util/reorder'
+
+// The real drag *gesture* (pointer events + layout measurement) can't be
+// simulated in jsdom, so we mock @hello-pangea/dnd: capture the onDragEnd
+// callback the real DndContext wires up, and render each draggable's children
+// with stub provided/snapshot. Firing the captured onDragEnd exercises the
+// genuine reorder path (DndContext -> reorder() -> setIngredients) end to end.
+vi.mock('@hello-pangea/dnd', () => ({
+  DragDropContext: ({ onDragEnd, children }: any) => {
+    ;(globalThis as any).__onDragEnd = onDragEnd
+    return <div>{children}</div>
+  },
+  Droppable: ({ children }: any) =>
+    children({ droppableProps: {}, innerRef: () => {}, placeholder: null }, {}),
+  Draggable: ({ children }: any) =>
+    children(
+      { draggableProps: {}, dragHandleProps: {}, innerRef: () => {} },
+      { isDragging: false }
+    ),
+}))
+
+vi.mock('src/api/recipes', () => ({ default: { getIngredientData: vi.fn() } }))
+vi.mock('src/api/auth', () => ({ default: { getUID: vi.fn().mockReturnValue(null) } }))
+vi.mock('react-hot-toast', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+const mkIngredient = (id: string, name: string) => ({
+  id,
+  parsedIngredient: {
+    ingredient: name,
+    quantity: 1,
+    unit: 'cup',
+    comment: null,
+    originalIngredientString: `1 cup ${name}`,
+  },
+  ingredientData: null,
+})
+
+const rowNames = () =>
+  Array.from(document.querySelectorAll('.ingredient-row')).map(
+    r => (r.querySelector('.ingredient-item-text span')?.textContent ?? '').trim()
+  )
+
+const fireReorder = async (from: number, to: number) => {
+  await act(async () => {
+    ;(globalThis as any).__onDragEnd({
+      source: { index: from, droppableId: 'droppable' },
+      destination: { index: to, droppableId: 'droppable' },
+    })
+  })
+}
+
+// A stateful host so a reorder actually re-renders the list, mirroring how
+// IngredientsContainer owns the ingredients array.
+const Host: React.FC<{
+  initial: any[]
+  statusById?: Record<string, 'loading' | 'error'>
+}> = ({ initial, statusById = {} }) => {
+  const [ingredients, setIngredients] = useState(initial)
+  return (
+    <IngredientList
+      ingredients={ingredients}
+      setIngredients={setIngredients}
+      statusById={statusById}
+      setItemStatus={() => {}}
+      removeIngredient={() => {}}
+      retryIngredient={() => {}}
+    />
+  )
+}
+
+describe('reorder util', () => {
+  it('moves an item from one index to another, preserving the rest', () => {
+    expect(reorder(['a', 'b', 'c'], 0, 2)).toEqual(['b', 'c', 'a'])
+    expect(reorder(['a', 'b', 'c'], 2, 0)).toEqual(['c', 'a', 'b'])
+    expect(reorder(['a', 'b', 'c'], 1, 1)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('IngredientList drag-to-reorder', () => {
+  it('reorders the ingredient list when a row is dragged to a new position', async () => {
+    render(
+      <Host
+        initial={[
+          mkIngredient('1', 'flour'),
+          mkIngredient('2', 'sugar'),
+          mkIngredient('3', 'salt'),
+        ]}
+      />
+    )
+    expect(rowNames()).toEqual(['flour', 'sugar', 'salt'])
+
+    // Drag the first row (flour) to the end.
+    await fireReorder(0, 2)
+    expect(rowNames()).toEqual(['sugar', 'salt', 'flour'])
+  })
+
+  it("keeps a row's enrichment status (id-keyed) after it is reordered", async () => {
+    // 'sugar' (id 2) is errored — it should carry its retry affordance with it
+    // when moved, because status is keyed by id, not list index.
+    render(
+      <Host
+        initial={[
+          mkIngredient('1', 'flour'),
+          mkIngredient('2', 'sugar'),
+          mkIngredient('3', 'salt'),
+        ]}
+        statusById={{ '2': 'error' }}
+      />
+    )
+    // Before: errored row is in the middle.
+    const rowsBefore = Array.from(document.querySelectorAll('.ingredient-row'))
+    expect(rowsBefore[1].querySelector('[aria-label="Retry ingredient lookup"]')).toBeTruthy()
+    expect(rowsBefore[0].querySelector('[aria-label="Retry ingredient lookup"]')).toBeNull()
+
+    // Move the errored 'sugar' (index 1) to the front (index 0).
+    await fireReorder(1, 0)
+    expect(rowNames()).toEqual(['sugar', 'flour', 'salt'])
+
+    // After: the retry affordance followed 'sugar' to the first row.
+    const rowsAfter = Array.from(document.querySelectorAll('.ingredient-row'))
+    expect(rowsAfter[0].querySelector('[aria-label="Retry ingredient lookup"]')).toBeTruthy()
+    expect(rowsAfter[1].querySelector('[aria-label="Retry ingredient lookup"]')).toBeNull()
+    // Exactly one row stays errored.
+    expect(screen.getAllByLabelText('Retry ingredient lookup')).toHaveLength(1)
+  })
+})

--- a/src/test/IngredientsContainer.test.tsx
+++ b/src/test/IngredientsContainer.test.tsx
@@ -1,9 +1,14 @@
 import React, { useState } from 'react'
 import { vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import IngredientsContainer from 'src/pages/AddRecipe/Ingredients/IngredientsContainer/IngredientsContainer'
-import IngredientItem from 'src/pages/AddRecipe/Ingredients/IngredientItem'
+import RecipeAPI from 'src/api/recipes'
+import { toast } from 'react-hot-toast'
+import {
+  IngredientEnrichTimeoutError,
+  withTimeout,
+} from 'src/pages/AddRecipe/Ingredients/ingredientEnrichment'
 
 vi.mock('src/api/recipes', () => ({
   default: { getIngredientData: vi.fn() },
@@ -13,111 +18,186 @@ vi.mock('src/api/auth', () => ({
   default: { getUID: vi.fn().mockReturnValue(null) },
 }))
 
-// DnD wraps render nothing in jsdom — render children directly
+vi.mock('react-hot-toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+// Pass-through by default so the timeout doesn't actually run against real time;
+// the timeout-handling test overrides it to reject with a timeout error. The
+// real IngredientEnrichTimeoutError class is preserved for `instanceof` checks.
+vi.mock(
+  'src/pages/AddRecipe/Ingredients/ingredientEnrichment',
+  async importOriginal => {
+    const actual = await importOriginal<
+      typeof import('src/pages/AddRecipe/Ingredients/ingredientEnrichment')
+    >()
+    return { ...actual, withTimeout: vi.fn((p: Promise<unknown>) => p) }
+  }
+)
+
+// DnD renders nothing in jsdom — render children directly.
 vi.mock('src/pages/AddRecipe/Dnd', () => ({
   DndContext: ({ children }: any) => <div>{children}</div>,
   Drag: ({ children }: any) => <div>{children}</div>,
   Drop: ({ children }: any) => <div>{children}</div>,
 }))
 
-// Replace IngredientsInput with a button that calls addIngredientToList directly
-vi.mock('src/pages/AddRecipe/Ingredients/IngredientsInput', () => ({
-  default: ({ addIngredientToList }: any) => (
-    <button
-      data-testid='add-btn'
-      onClick={() =>
-        addIngredientToList({
-          id: 'sugar-1',
-          parsedIngredient: {
-            ingredient: 'Sugar',
-            quantity: 1,
-            unit: 'cup',
-            comment: null,
-            originalIngredientString: '1 cup Sugar',
-          },
-          ingredientData: null,
-        })
-      }
-    >
-      Add
-    </button>
-  ),
-}))
-
-// Simplify IngredientList to show ingredient name and a Remove button per item
-vi.mock('src/pages/AddRecipe/Ingredients/IngredientList/IngredientList', () => ({
-  default: ({ ingredients, removeIngredient }: any) => (
-    <ul data-testid='ingredient-list'>
-      {ingredients.map((ingr: any) => (
-        <li key={ingr.id}>
-          {ingr.parsedIngredient?.ingredient ?? ingr.label ?? '(ingredient)'}
-          <button onClick={() => removeIngredient(ingr.id)}>Remove</button>
-        </li>
-      ))}
-    </ul>
-  ),
+// Local, synchronous parse (the real one is a library fn) — echo the input so
+// the optimistic row text is predictable.
+vi.mock('@jclind/ingredient-parser', () => ({
+  parseIngredientString: (val: string) => ({
+    ingredient: 'flour',
+    quantity: 2,
+    unit: 'cups',
+    comment: null,
+    originalIngredientString: val,
+  }),
 }))
 
 vi.mock('src/pages/AddRecipe/AddLabel/AddLabel', () => ({ default: () => null }))
 
+const mockGetIngredientData = RecipeAPI.getIngredientData as ReturnType<typeof vi.fn>
+const mockToastError = toast.error as ReturnType<typeof vi.fn>
+const mockWithTimeout = withTimeout as ReturnType<typeof vi.fn>
+
+const PLACEHOLDER = 'Add ingredients to your recipe.'
+
+// A successful enrichment payload (price + image).
+const enriched = (original: string) => ({
+  parsedIngredient: {
+    ingredient: 'flour',
+    quantity: 2,
+    unit: 'cups',
+    comment: null,
+    originalIngredientString: original,
+  },
+  ingredientData: {
+    totalPriceUSACents: 300,
+    imagePath: 'https://img.test/flour.png',
+  },
+  id: 'server-generated-id',
+})
+
+const errorVariant = (original: string) => ({
+  error: { message: 'not found' },
+  parsedIngredient: {
+    ingredient: 'flour',
+    quantity: 2,
+    unit: 'cups',
+    comment: null,
+    originalIngredientString: original,
+  },
+  ingredientData: null,
+  id: 'server-id',
+})
+
 const Wrapper = () => {
   const [ingredients, setIngredients] = useState<any[]>([])
   return (
-    <>
-      <IngredientsContainer ingredients={ingredients} setIngredients={setIngredients} />
-      <span data-testid='count'>{ingredients.length}</span>
-    </>
+    <IngredientsContainer
+      ingredients={ingredients}
+      setIngredients={setIngredients}
+    />
   )
 }
 
-describe('IngredientsContainer', () => {
-  it('adding an ingredient via the input appends it to the displayed list', async () => {
+const addIngredient = async (
+  user: ReturnType<typeof userEvent.setup>,
+  val: string
+) => {
+  await user.type(screen.getByPlaceholderText(PLACEHOLDER), `${val}{enter}`)
+}
+
+// The enriched row price and the footer subtotal both render "$3.00"; assert on
+// the row's `.ingr-price` element specifically.
+const rowPriceText = () =>
+  document.querySelector('.ingr-price')?.textContent ?? ''
+
+beforeEach(() => {
+  mockGetIngredientData.mockReset()
+  mockToastError.mockReset()
+  mockWithTimeout.mockReset()
+  mockWithTimeout.mockImplementation((p: Promise<unknown>) => p)
+})
+
+describe('IngredientsContainer — optimistic add', () => {
+  it('shows the ingredient immediately, then reconciles price when enrichment returns', async () => {
     const user = userEvent.setup()
+    // A deferred enrichment we resolve manually, so we can observe the
+    // optimistic (pre-response) state.
+    let resolve!: (v: any) => void
+    mockGetIngredientData.mockReturnValue(new Promise(r => (resolve = r)))
+
     render(<Wrapper />)
-    expect(screen.getByTestId('count').textContent).toBe('0')
-    await user.click(screen.getByTestId('add-btn'))
-    expect(screen.getByTestId('count').textContent).toBe('1')
-    expect(screen.getByText('Sugar')).toBeInTheDocument()
+    await addIngredient(user, '2 cups flour')
+
+    // Optimistic: the row text is on screen before enrichment resolves, and no
+    // price yet (it's still loading).
+    expect(screen.getByText('flour')).toBeInTheDocument()
+    expect(rowPriceText()).not.toContain('$3.00')
+
+    // Reconcile.
+    await act(async () => {
+      resolve(enriched('2 cups flour'))
+    })
+    await waitFor(() => expect(rowPriceText()).toContain('$3.00'))
+    expect(mockToastError).not.toHaveBeenCalled()
   })
 
-  it('removing an ingredient filters it out by id', async () => {
+  it('marks the row errored (with a retry) when enrichment soft-fails, keeping the ingredient', async () => {
     const user = userEvent.setup()
+    mockGetIngredientData.mockResolvedValue(errorVariant('2 cups flour'))
+
     render(<Wrapper />)
-    await user.click(screen.getByTestId('add-btn'))
-    expect(screen.getByTestId('count').textContent).toBe('1')
-    await user.click(screen.getByText('Remove'))
-    expect(screen.getByTestId('count').textContent).toBe('0')
-    expect(screen.queryByText('Sugar')).toBeNull()
-  })
+    await addIngredient(user, '2 cups flour')
 
-  // Reordering is now always available via a per-row drag handle — there is no
-  // "Reorder"/"Done" mode toggle (see IngredientItem: "Reorder is available any
-  // time — no mode"). This asserts that always-on affordance is present.
-  it('each ingredient row exposes an always-available drag-to-reorder handle', () => {
-    const sugar = {
-      id: 'sugar-1',
-      parsedIngredient: {
-        ingredient: 'Sugar',
-        quantity: 1,
-        unit: 'cup',
-        comment: null,
-        originalIngredientString: '1 cup Sugar',
-      },
-      ingredientData: null,
-    } as any
-
-    render(
-      <IngredientItem
-        ingredients={[sugar]}
-        ingredient={sugar}
-        setLoading={vi.fn()}
-        removeIngredient={vi.fn()}
-        setIngredients={vi.fn()}
-      />
+    // Row is kept and flagged for retry; a soft-fail is shown inline (no toast).
+    await waitFor(() =>
+      expect(screen.getByLabelText('Retry ingredient lookup')).toBeInTheDocument()
     )
+    expect(screen.getByText('flour')).toBeInTheDocument()
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
 
-    expect(screen.getByLabelText('Drag to reorder')).toBeInTheDocument()
-    expect(screen.queryByText('Reorder')).toBeNull()
-    expect(screen.queryByText('Done')).toBeNull()
+  it('retrying an errored row re-runs enrichment and clears the error on success', async () => {
+    const user = userEvent.setup()
+    mockGetIngredientData
+      .mockResolvedValueOnce(errorVariant('2 cups flour'))
+      .mockResolvedValueOnce(enriched('2 cups flour'))
+
+    render(<Wrapper />)
+    await addIngredient(user, '2 cups flour')
+
+    const retry = await screen.findByLabelText('Retry ingredient lookup')
+    await user.click(retry)
+
+    await waitFor(() => expect(rowPriceText()).toContain('$3.00'))
+    expect(screen.queryByLabelText('Retry ingredient lookup')).toBeNull()
+    expect(mockGetIngredientData).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('IngredientsContainer — enrichment timeout', () => {
+  it('errors the row and toasts when the request times out', async () => {
+    const user = userEvent.setup()
+    // getIngredientData is called (and ignored); withTimeout rejects as if the
+    // request hung past the wall clock.
+    mockGetIngredientData.mockReturnValue(new Promise(() => {}))
+    // Async throw so the rejected promise is created only when awaited by the
+    // container (avoids an "unhandled rejection" from an eagerly-built reject).
+    mockWithTimeout.mockImplementationOnce(async () => {
+      throw new IngredientEnrichTimeoutError(12000)
+    })
+
+    render(<Wrapper />)
+    await addIngredient(user, '2 cups flour')
+
+    // Optimistic row present, then flips to errored with a surfaced toast.
+    expect(screen.getByText('flour')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByLabelText('Retry ingredient lookup')).toBeInTheDocument()
+    )
+    expect(mockToastError).toHaveBeenCalledTimes(1)
+    expect(mockToastError.mock.calls[0][0]).toMatch(/too long/i)
   })
 })

--- a/src/test/IngredientsInput.test.tsx
+++ b/src/test/IngredientsInput.test.tsx
@@ -1,83 +1,45 @@
 import React from 'react'
 import { vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import IngredientsInput from 'src/pages/AddRecipe/Ingredients/IngredientsInput'
-import RecipeAPI from 'src/api/recipes'
 
-vi.mock('src/api/recipes', () => ({
-  default: { getIngredientData: vi.fn() },
-}))
-
-vi.mock('src/api/auth', () => ({
-  default: { getUID: vi.fn().mockReturnValue(null) },
-}))
-
-const mockGetIngredientData = RecipeAPI.getIngredientData as ReturnType<typeof vi.fn>
-
-const setup = () => {
-  const addIngredientToList = vi.fn()
-  const setIngredientLoading = vi.fn()
-  render(
-    <IngredientsInput
-      addIngredientToList={addIngredientToList}
-      setIngredientLoading={setIngredientLoading}
-      ingredientsLength={0}
-      ingredientLoading={{ isLoading: false, index: -1 }}
-    />
-  )
-  return { addIngredientToList, setIngredientLoading }
-}
-
+const PLACEHOLDER = 'Add ingredients to your recipe.'
 const HINT = 'Enter an ingredient before adding it.'
 
-describe('IngredientsInput — empty-input feedback', () => {
-  beforeEach(() => mockGetIngredientData.mockReset())
+const setup = () => {
+  const onAdd = vi.fn()
+  render(<IngredientsInput onAdd={onAdd} />)
+  return { onAdd }
+}
 
-  it('pressing Enter on an empty field shows a hint and fires no parse request', async () => {
+describe('IngredientsInput', () => {
+  it('pressing Enter on an empty field shows a hint and does not add', async () => {
     const user = userEvent.setup()
-    const { addIngredientToList } = setup()
-    await user.type(
-      screen.getByPlaceholderText('Add ingredients to your recipe.'),
-      '{enter}'
-    )
+    const { onAdd } = setup()
+    await user.type(screen.getByPlaceholderText(PLACEHOLDER), '{enter}')
     expect(screen.getByText(HINT)).toBeInTheDocument()
-    expect(mockGetIngredientData).not.toHaveBeenCalled()
-    expect(addIngredientToList).not.toHaveBeenCalled()
+    expect(onAdd).not.toHaveBeenCalled()
   })
 
   it('treats whitespace-only input as empty', async () => {
     const user = userEvent.setup()
-    const { addIngredientToList } = setup()
-    await user.type(
-      screen.getByPlaceholderText('Add ingredients to your recipe.'),
-      '   {enter}'
-    )
+    const { onAdd } = setup()
+    await user.type(screen.getByPlaceholderText(PLACEHOLDER), '   {enter}')
     expect(screen.getByText(HINT)).toBeInTheDocument()
-    expect(mockGetIngredientData).not.toHaveBeenCalled()
-    expect(addIngredientToList).not.toHaveBeenCalled()
+    expect(onAdd).not.toHaveBeenCalled()
   })
 
-  it('trims a valid entry before parsing and adds it to the list', async () => {
+  it('hands a trimmed entry to onAdd and clears the field immediately', async () => {
     const user = userEvent.setup()
-    mockGetIngredientData.mockResolvedValue({
-      id: 'x-1',
-      parsedIngredient: {
-        ingredient: 'flour',
-        quantity: 2,
-        unit: 'cups',
-        comment: null,
-        originalIngredientString: '2 cups flour',
-      },
-      ingredientData: null,
-    })
-    const { addIngredientToList } = setup()
-    await user.type(
-      screen.getByPlaceholderText('Add ingredients to your recipe.'),
-      '  2 cups flour  {enter}'
-    )
-    await waitFor(() => expect(addIngredientToList).toHaveBeenCalledTimes(1))
-    expect(mockGetIngredientData).toHaveBeenCalledWith('2 cups flour')
+    const { onAdd } = setup()
+    const input = screen.getByPlaceholderText(PLACEHOLDER) as HTMLInputElement
+    await user.type(input, '  2 cups flour  {enter}')
+    // Optimistic: the value is handed off trimmed and the field is cleared
+    // synchronously so the user can keep typing while enrichment runs.
+    expect(onAdd).toHaveBeenCalledTimes(1)
+    expect(onAdd).toHaveBeenCalledWith('2 cups flour')
+    expect(input.value).toBe('')
     expect(screen.queryByText(HINT)).toBeNull()
   })
 })

--- a/src/test/ServingsInput.test.tsx
+++ b/src/test/ServingsInput.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ServingsInput from 'src/pages/AddRecipe/ServingsInput/ServingsInput'
+
+// ServingsInput guards its setter: only an integer in [1, 99] (or empty) is
+// accepted; anything else is dropped so the field can't hold an invalid value.
+const setup = (initial: number | '' = '') => {
+  const setServings = vi.fn()
+  render(<ServingsInput servings={initial} setServings={setServings} />)
+  const input = screen.getByPlaceholderText(
+    'How many servings does your recipe make?'
+  ) as HTMLInputElement
+  return { setServings, input }
+}
+
+const change = (input: HTMLInputElement, value: string) =>
+  fireEvent.change(input, { target: { value } })
+
+describe('ServingsInput validation', () => {
+  it('accepts a valid integer in range', () => {
+    const { setServings, input } = setup()
+    change(input, '4')
+    expect(setServings).toHaveBeenCalledWith('4')
+  })
+
+  it('accepts clearing a populated field (empty)', () => {
+    const { setServings, input } = setup(4)
+    change(input, '')
+    expect(setServings).toHaveBeenCalledWith('')
+  })
+
+  it.each(['0', '-3', '100', '150'])('rejects out-of-range value %s', val => {
+    const { setServings, input } = setup()
+    change(input, val)
+    expect(setServings).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-integer (decimal)', () => {
+    const { setServings, input } = setup()
+    change(input, '3.5')
+    expect(setServings).not.toHaveBeenCalled()
+  })
+
+  it('accepts the upper bound (99) but not 100', () => {
+    const { setServings, input } = setup()
+    change(input, '99')
+    expect(setServings).toHaveBeenCalledWith('99')
+    setServings.mockClear()
+    change(input, '100')
+    expect(setServings).not.toHaveBeenCalled()
+  })
+})

--- a/src/test/TimeInput.test.tsx
+++ b/src/test/TimeInput.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import TimeInput from 'src/pages/AddRecipe/TimeInput/TimeInput'
+
+// TimeInput holds two guarded number fields: hours accept an integer in [0, 99],
+// minutes an integer in [0, 59]; out-of-range/non-integer input is dropped so the
+// field reverts to its last valid value.
+const setup = () => {
+  const setVal = vi.fn()
+  render(<TimeInput label='Prep time' val={null} setVal={setVal} />)
+  const [hours, minutes] = screen.getAllByPlaceholderText('0') as HTMLInputElement[]
+  return { setVal, hours, minutes }
+}
+const change = (input: HTMLInputElement, value: string) =>
+  fireEvent.change(input, { target: { value } })
+
+describe('TimeInput validation', () => {
+  it('accepts valid hours and emits the combined value', () => {
+    const { setVal, hours } = setup()
+    change(hours, '2')
+    expect(hours.value).toBe('2')
+    expect(setVal).toHaveBeenCalled()
+    const last = setVal.mock.calls.at(-1)![0]
+    expect(Number(last.hours)).toBe(2)
+  })
+
+  it('accepts valid minutes', () => {
+    const { minutes } = setup()
+    change(minutes, '45')
+    expect(minutes.value).toBe('45')
+  })
+
+  it('rejects hours over 99 (field reverts to empty)', () => {
+    const { hours } = setup()
+    change(hours, '100')
+    expect(hours.value).toBe('')
+  })
+
+  it('rejects minutes over 59', () => {
+    const { minutes } = setup()
+    change(minutes, '75')
+    expect(minutes.value).toBe('')
+  })
+
+  it('rejects a non-integer in either field', () => {
+    const { hours, minutes } = setup()
+    change(hours, '1.5')
+    expect(hours.value).toBe('')
+    change(minutes, '2.5')
+    expect(minutes.value).toBe('')
+  })
+
+  it('accepts the boundaries (99 hours, 59 minutes)', () => {
+    const { hours, minutes } = setup()
+    change(hours, '99')
+    change(minutes, '59')
+    expect(hours.value).toBe('99')
+    expect(minutes.value).toBe('59')
+  })
+})

--- a/src/test/ingredientEnrichment.test.ts
+++ b/src/test/ingredientEnrichment.test.ts
@@ -1,0 +1,47 @@
+import { vi } from 'vitest'
+import {
+  INGREDIENT_ENRICH_TIMEOUT_MS,
+  IngredientEnrichTimeoutError,
+  withTimeout,
+} from 'src/pages/AddRecipe/Ingredients/ingredientEnrichment'
+
+describe('withTimeout', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('resolves with the wrapped value when it settles before the timeout', async () => {
+    const p = withTimeout(Promise.resolve('flour'), 1000)
+    await expect(p).resolves.toBe('flour')
+  })
+
+  it('propagates the wrapped rejection when it rejects before the timeout', async () => {
+    const p = withTimeout(Promise.reject(new Error('boom')), 1000)
+    await expect(p).rejects.toThrow('boom')
+  })
+
+  it('rejects with IngredientEnrichTimeoutError when the promise never settles', async () => {
+    // A promise that never resolves stands in for a hung enrichment request.
+    const never = new Promise<string>(() => {})
+    const p = withTimeout(never, 5000)
+    const assertion = expect(p).rejects.toBeInstanceOf(IngredientEnrichTimeoutError)
+    await vi.advanceTimersByTimeAsync(5000)
+    await assertion
+  })
+
+  it('does not fire the timeout once the promise has resolved (timer cleared)', async () => {
+    const p = withTimeout(Promise.resolve('ok'), 1000)
+    await expect(p).resolves.toBe('ok')
+    // Advancing past the timeout must not turn a resolved promise into a
+    // rejection — the timer should already be cleared.
+    await vi.advanceTimersByTimeAsync(2000)
+    await expect(p).resolves.toBe('ok')
+  })
+
+  it('defaults to INGREDIENT_ENRICH_TIMEOUT_MS', async () => {
+    const never = new Promise<string>(() => {})
+    const p = withTimeout(never)
+    const assertion = expect(p).rejects.toBeInstanceOf(IngredientEnrichTimeoutError)
+    await vi.advanceTimersByTimeAsync(INGREDIENT_ENRICH_TIMEOUT_MS)
+    await assertion
+  })
+})


### PR DESCRIPTION
## Track 3d — Add-recipe UX

Three add-recipe UX fixes, **scoped strictly to `src/pages/AddRecipe/*`** (+ tests). Did not touch the beta tag, Navbar, or `App.tsx`.

### 1. Optimistic ingredient add
Adding an ingredient previously blocked on the parse/nutrition request before anything appeared. But `parseIngredientString` is **local and synchronous** — only the nutrition/price/image *enrichment* is a network call. Now:
- `IngredientsContainer` parses locally, inserts the row **immediately**, then reconciles it in place (by stable `id`) when enrichment returns.
- `IngredientItem` shows the parsed text instantly while the image/price fill in (skeleton on the image only).
- The add logic moved out of `IngredientsInput` (now a thin `onAdd` + empty-input guard) into the container, which owns the list.

### 2. Ingredient parser "not found" / hang
`getIngredientData` soft-fails, but can't protect against a request that **never settles** (the shared axios client has no timeout) — the spinner could hang forever. New `withTimeout` helper races enrichment against a 12s wall clock; on timeout the row is **kept**, flagged errored with a one-tap **retry**, and a toast surfaces. The same guard is applied to the edit-in-place path. Implemented at the component layer to respect the scope guardrail (the API client lives outside `src/pages/AddRecipe/*`).

### 3. Sticky bottom bar overlapped the footer
`AddRecipeSummaryBar` was `position: fixed; bottom: 0`, painting over the footer (a sibling below the form). Switched to `position: sticky` + `margin-top: auto`: it pins while the form scrolls and **releases at the page end**, so the footer is reachable. Removed the now-unneeded `padding-bottom: 130px` hack.

**Verified** with the real app (headless Chrome, authenticated) at desktop (1280×800) and mobile (390×844): scrolled to the page bottom, the bar releases above the footer (`bar.bottom ≤ footer.top`) and the full footer is visible — confirmed on both viewports.

### Implementation note
Per-row enrichment state is keyed by ingredient `id` (`Record<id, 'loading' | 'error'>`), so it survives reorders and concurrent adds.

### Tests
- Rewrote `IngredientsInput` / `IngredientsContainer` tests for the new contracts.
- Added coverage for optimistic insert, reconcile-on-success, soft-fail (errored + retry, no toast), retry-clears-error, and timeout (errored + toast).
- New `ingredientEnrichment.test.ts` unit-tests `withTimeout` (resolve / reject / timeout / timer-cleared / default).
- Full frontend suite (457 passed, 2 skipped), `tsc --noEmit`, and `npm run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)