### PR TITLE
feat(moderation): username validation + report-a-user + report-control polish (track 3c)

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,13 +8,22 @@ export default defineConfig({
     baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {
       on('task', {
-        mintCustomToken(uid: string) {
+        // Accepts a bare uid, or { uid, claims } to bake developer claims (e.g.
+        // { admin: true }) into the token — these propagate to the ID token's
+        // claims, which AuthContext reads to set isAdmin.
+        mintCustomToken(arg: string | { uid: string; claims?: Record<string, unknown> }) {
           if (!admin.apps.length) {
+            // Accept the service account as a parsed object (cypress.env.json) or
+            // a JSON string (a CYPRESS_FIREBASE_SERVICE_ACCOUNT env var).
+            const svc = config.env.FIREBASE_SERVICE_ACCOUNT
+            const credential = typeof svc === 'string' ? JSON.parse(svc) : svc
             admin.initializeApp({
-              credential: admin.credential.cert(config.env.FIREBASE_SERVICE_ACCOUNT),
+              credential: admin.credential.cert(credential),
             })
           }
-          return admin.auth().createCustomToken(uid)
+          const uid = typeof arg === 'string' ? arg : arg.uid
+          const claims = typeof arg === 'string' ? undefined : arg.claims
+          return admin.auth().createCustomToken(uid, claims)
         },
       })
       return config

--- a/cypress/e2e/recipe.cy.ts
+++ b/cypress/e2e/recipe.cy.ts
@@ -25,6 +25,23 @@ describe('Single Recipe', () => {
     cy.contains('.step', 'Bring a large pot of salted water to a boil', { timeout: 5000 }).should('be.visible')
   })
 
+  it('shows the report kebab + footer link and prompts login when logged out', () => {
+    cy.visit(`/recipes/${recipeId}`)
+    cy.wait('@getRecipe')
+
+    // The quiet footer link stays available...
+    cy.get('.sr-report-foot .report-control-trigger', { timeout: 5000 }).should(
+      'be.visible'
+    )
+
+    // ...alongside a quick-access kebab in the top controls row. Opening it and
+    // choosing "Report recipe" nudges a logged-out visitor to log in.
+    cy.get('.sr-controls .report-menu-trigger').should('be.visible').click()
+    cy.contains('.report-menu-item', /report recipe/i).click()
+    cy.contains(/log in to report/i).should('be.visible')
+    cy.contains('h2', /report this recipe/i).should('not.exist')
+  })
+
   it('save/unsave button toggles correctly when logged in', () => {
     cy.intercept('GET', `${api()}/api/getTrendingRecipes*`, { fixture: 'trending-recipes.json' })
     // The unified SaveControl resolves "is this saved" from getSavedRecipeIds.

--- a/cypress/e2e/reportUser.cy.ts
+++ b/cypress/e2e/reportUser.cy.ts
@@ -1,0 +1,100 @@
+import { API_URL } from '../support/constants'
+const api = () => API_URL
+
+// Report-a-user (track 3c): the report affordance on a public profile, its
+// logged-out login nudge, and the resulting report surfacing in the admin queue.
+describe('Report a user', () => {
+  beforeEach(() => {
+    cy.intercept('GET', `${api()}/api/getPublicProfile*`, {
+      fixture: 'public-profile.json',
+    }).as('getProfile')
+  })
+
+  it('shows the report kebab to logged-out visitors and prompts login on click', () => {
+    cy.visit('/u/baduser')
+    cy.wait('@getProfile')
+
+    // The kebab is visible even when logged out, so visitors know reporting
+    // exists. Open it, then click "Report user".
+    cy.get('.pp-handle-row .report-menu-trigger', { timeout: 5000 })
+      .should('be.visible')
+      .click()
+    cy.contains('.report-menu-item', /report user/i).click()
+
+    // Clicking nudges to log in instead of opening the report modal.
+    cy.contains(/log in to report/i).should('be.visible')
+    cy.contains('h2', /report this user/i).should('not.exist')
+  })
+
+  it('lets a logged-in user report a profile with the user target', () => {
+    // The viewer's own handle differs from the profile, so the control shows.
+    cy.intercept('GET', `${api()}/api/getUsername*`, { body: 'gooduser' })
+    cy.intercept('POST', `${api()}/api/reports`, (req) => {
+      // The payload names the user target and carries no recipeId.
+      expect(req.body).to.include({
+        targetType: 'user',
+        reportedUsername: 'baduser',
+        reason: 'spam',
+      })
+      expect(req.body).to.not.have.property('recipeId')
+      req.reply({
+        statusCode: 201,
+        body: { _id: 'rep-user-1', status: 'open', ...req.body },
+      })
+    }).as('createReport')
+
+    // Load the app first (so __cy_signIn__ exists on window), then sign in.
+    cy.visit('/')
+    cy.login()
+    cy.get('.dnav__create', { timeout: 10000 }).should('be.visible')
+
+    cy.visit('/u/baduser')
+    cy.wait('@getProfile')
+
+    cy.get('.pp-handle-row .report-menu-trigger', { timeout: 5000 })
+      .should('be.visible')
+      .click()
+    cy.contains('.report-menu-item', /report user/i).click()
+    cy.contains('h2', /report this user/i).should('be.visible')
+    cy.get('.report-submit-btn').click()
+
+    cy.wait('@createReport')
+    cy.contains(/thanks/i).should('be.visible')
+  })
+
+  it('surfaces the user report in the admin queue', () => {
+    cy.intercept('GET', `${api()}/api/getUsername*`, { body: 'gooduser' })
+    cy.intercept('GET', `${api()}/api/reports*`, {
+      body: {
+        reports: [
+          {
+            _id: 'rep-user-1',
+            targetType: 'user',
+            reportedUsername: 'baduser',
+            reportedUid: 'bad-uid',
+            reporterUid: 'reporter-uid',
+            reason: 'offensive',
+            details: '',
+            status: 'open',
+            createdAt: '2026-06-22T00:00:00.000Z',
+            target: { recipe: null, review: null },
+          },
+        ],
+        totalCount: 1,
+        openCount: 1,
+      },
+    }).as('listReports')
+
+    cy.visit('/')
+    cy.login({ admin: true })
+    cy.get('.dnav__create', { timeout: 10000 }).should('be.visible')
+
+    cy.visit('/admin/reports')
+    cy.wait('@listReports')
+
+    cy.contains('.report-card', '@baduser').within(() => {
+      cy.get('.type-pill.user').should('contain.text', 'user')
+      cy.contains(/reported user/i).should('exist')
+    })
+  })
+})

--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -1,0 +1,129 @@
+import { API_URL } from '../support/constants'
+const api = () => API_URL
+
+// Logged-in smoke test for the track-3c work: username inline validation, the
+// hero rating echo, and the report kebabs (recipe / review / user) all the way
+// through a successful submit. Report writes are stubbed so the run doesn't
+// touch the database; auth is a real Firebase sign-in.
+describe('Smoke: track-3c report + username work (logged in)', () => {
+  let recipeId: string
+
+  before(() => {
+    cy.fixture('single-recipe.json').then(r => {
+      recipeId = r._id
+    })
+  })
+
+  // A report POST that echoes back a 201 without hitting the DB.
+  const stubReports = () =>
+    cy.intercept('POST', `${api()}/api/reports`, req => {
+      req.reply({ statusCode: 201, body: { _id: 'smoke-rep', status: 'open', ...req.body } })
+    }).as('createReport')
+
+  it('username page: inline validation rejects bad characters and accepts a clean handle', () => {
+    cy.intercept('GET', `${api()}/api/getUsername*`, { body: null })
+    cy.intercept('GET', `${api()}/api/checkUsernameAvailability*`, { body: true }).as('checkAvail')
+
+    cy.visit('/')
+    cy.login()
+    cy.get('.dnav__create', { timeout: 10000 }).should('be.visible')
+
+    cy.visit('/create-username')
+    cy.get('input[name="username"]', { timeout: 10000 }).should('be.visible')
+
+    // Disallowed character → the mirrored server rule shows inline.
+    cy.get('input[name="username"]').type('bad@name')
+    cy.contains(/letters, numbers/i).should('be.visible')
+
+    // A clean handle clears the error and reports availability.
+    cy.get('input[name="username"]').clear().type('goodname')
+    cy.wait('@checkAvail')
+    cy.contains(/goodname is available/i).should('be.visible')
+  })
+
+  it('recipe page: shows the hero rating, footer link, and a working report kebab', () => {
+    cy.intercept('GET', `${api()}/api/getRecipe*`, { fixture: 'single-recipe.json' }).as('getRecipe')
+    cy.intercept('GET', `${api()}/api/getReviews*`, { fixture: 'recipe-reviews.json' })
+    cy.intercept('GET', `${api()}/api/checkIfReviewed*`, { body: null })
+    cy.intercept('GET', `${api()}/api/getUsername*`, { body: 'gooduser' })
+    cy.intercept('GET', `${api()}/api/getSavedRecipe*`, { body: [] })
+    stubReports()
+
+    cy.visit('/')
+    cy.login()
+    cy.get('.dnav__create', { timeout: 10000 }).should('be.visible')
+
+    cy.visit(`/recipes/${recipeId}`)
+    cy.wait('@getRecipe')
+
+    // Item 4: the rating echo by the title (fixture has 4.3 over 3 ratings).
+    cy.get('.hero-rating', { timeout: 5000 })
+      .should('be.visible')
+      .and('contain.text', '4.3')
+      .and('contain.text', '3 ratings')
+
+    // The footer link stays, and the top kebab reports the recipe.
+    cy.get('.sr-report-foot .report-control-trigger').should('be.visible')
+    cy.get('.sr-controls .report-menu-trigger').should('be.visible').click()
+    cy.contains('.report-menu-item', /report recipe/i).click()
+    cy.contains('h2', /report this recipe/i).should('be.visible')
+    cy.get('.report-submit-btn').click()
+    cy.wait('@createReport').its('request.body').should('deep.include', {
+      targetType: 'recipe',
+      recipeId,
+    })
+    cy.contains(/thanks/i).should('be.visible')
+  })
+
+  it('recipe page: a review row has a working report kebab', () => {
+    cy.intercept('GET', `${api()}/api/getRecipe*`, { fixture: 'single-recipe.json' }).as('getRecipe')
+    cy.intercept('GET', `${api()}/api/getReviews*`, { fixture: 'recipe-reviews.json' })
+    cy.intercept('GET', `${api()}/api/checkIfReviewed*`, { body: null })
+    // Viewer is not any of the review authors, so every review offers a report.
+    cy.intercept('GET', `${api()}/api/getUsername*`, { body: 'gooduser' })
+    cy.intercept('GET', `${api()}/api/getSavedRecipe*`, { body: [] })
+    stubReports()
+
+    cy.visit('/')
+    cy.login()
+    cy.get('.dnav__create', { timeout: 10000 }).should('be.visible')
+
+    cy.visit(`/recipes/${recipeId}`)
+    cy.wait('@getRecipe')
+
+    cy.get('.review-options .report-menu-trigger', { timeout: 8000 })
+      .first()
+      .should('be.visible')
+      .click()
+    cy.contains('.report-menu-item', /report review/i).click()
+    cy.contains('h2', /report this review/i).should('be.visible')
+    cy.get('.report-submit-btn').click()
+    cy.wait('@createReport').its('request.body').should('include', {
+      targetType: 'review',
+    })
+    cy.contains(/thanks/i).should('be.visible')
+  })
+
+  it('profile page: report-user kebab submits a user report', () => {
+    cy.intercept('GET', `${api()}/api/getPublicProfile*`, { fixture: 'public-profile.json' }).as('getProfile')
+    cy.intercept('GET', `${api()}/api/getUsername*`, { body: 'gooduser' })
+    stubReports()
+
+    cy.visit('/')
+    cy.login()
+    cy.get('.dnav__create', { timeout: 10000 }).should('be.visible')
+
+    cy.visit('/u/baduser')
+    cy.wait('@getProfile')
+
+    cy.get('.pp-handle-row .report-menu-trigger', { timeout: 5000 }).should('be.visible').click()
+    cy.contains('.report-menu-item', /report user/i).click()
+    cy.contains('h2', /report this user/i).should('be.visible')
+    cy.get('.report-submit-btn').click()
+    cy.wait('@createReport').its('request.body').should('deep.include', {
+      targetType: 'user',
+      reportedUsername: 'baduser',
+    })
+    cy.contains(/thanks/i).should('be.visible')
+  })
+})

--- a/cypress/fixtures/public-profile.json
+++ b/cypress/fixtures/public-profile.json
@@ -1,0 +1,17 @@
+{
+  "username": "baduser",
+  "displayName": "Bad User",
+  "photoURL": null,
+  "bio": "Just here to cook.",
+  "location": "Nowhere",
+  "level": 2,
+  "rank": "Line Cook",
+  "xp": 40,
+  "xpNext": 100,
+  "pct": 40,
+  "achievements": [],
+  "recipes": [],
+  "recipesTotalCount": 0,
+  "recipesSavesTotal": 0,
+  "recipesMadeTotal": 0
+}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,8 +1,12 @@
 /// <reference types="cypress" />
 
 // Requires the app to already be loaded (cy.visit called first) so __cy_signIn__ is on window.
-Cypress.Commands.add('login', () => {
-  cy.task('mintCustomToken', 'test-cypress-user').then((token) => {
+// Pass claims (e.g. { admin: true }) to sign in as an admin.
+Cypress.Commands.add('login', (claims?: Record<string, unknown>) => {
+  const arg = claims
+    ? { uid: 'test-cypress-user', claims }
+    : 'test-cypress-user'
+  cy.task('mintCustomToken', arg).then((token) => {
     cy.window().then(win => win.__cy_signIn__(token as string))
   })
 })

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,5 +1,11 @@
 declare namespace Cypress {
   interface Chainable {
-    login(): Chainable<void>
+    login(claims?: Record<string, unknown>): Chainable<void>
   }
+}
+
+// Test-only sign-in bridge attached by src/client/db.ts when running under
+// Cypress, so a spec can sign in with a minted custom token.
+interface Window {
+  __cy_signIn__: (token: string) => Promise<unknown>
 }

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -166,6 +166,37 @@ describe('POST /setUsername', () => {
     expect(res.status).toBe(400)
   })
 
+  it.each([
+    ['john@smith', '@'],
+    ['john/smith', 'slash'],
+    ['john!', 'punctuation'],
+    ['héllo', 'accented letter'],
+    ['ab😀cd', 'emoji'],
+  ])('rejects a username with a disallowed character: %s (%s)', async (username) => {
+    const res = await request(app)
+      .post(`/api/setUsername?username=${encodeURIComponent(username)}`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/letters, numbers/i)
+  })
+
+  it.each([
+    'john_smith',
+    'john.smith',
+    'john-smith',
+    'JohnSmith99',
+    'a_b-c.d',
+  ])('accepts a username using only the allowed character set: %s', async (username) => {
+    const res = await request(app)
+      .post(`/api/setUsername?username=${encodeURIComponent(username)}`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ success: true })
+    await getDB().collection('usernames').deleteMany({})
+  })
+
   it('updates an existing username entry', async () => {
     await seedUser(TEST_UID, 'oldname')
 

--- a/server/__tests__/reports.test.js
+++ b/server/__tests__/reports.test.js
@@ -90,6 +90,66 @@ describe('POST /api/reports', () => {
     expect(res.body.reportedUid).toBeUndefined()
   })
 
+  it('creates a user report carrying reportedUsername and no recipeId', async () => {
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'user', reportedUsername: 'baduser', reason: 'offensive' })
+    expect(res.status).toBe(201)
+    expect(res.body.targetType).toBe('user')
+    expect(res.body.reportedUsername).toBe('baduser')
+    expect(res.body.recipeId).toBeUndefined()
+    expect(res.body.reporterUid).toBe(TEST_UID)
+  })
+
+  it('stamps reportedUid on a user report when the handle resolves', async () => {
+    await seedUser('bad-uid', 'BadUser')
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'user', reportedUsername: 'baduser', reason: 'offensive' })
+    expect(res.status).toBe(201)
+    expect(res.body.reportedUid).toBe('bad-uid')
+  })
+
+  it('requires reportedUsername for a user report', async () => {
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'user', reason: 'spam' })
+    expect(res.status).toBe(400)
+  })
+
+  it('does not require recipeId for a user report', async () => {
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'user', reportedUsername: 'baduser', reason: 'spam' })
+    expect(res.status).toBe(201)
+  })
+
+  it('rate-limits to one open user report per reporter+target (409)', async () => {
+    const body = { targetType: 'user', reportedUsername: 'baduser', reason: 'spam' }
+    const first = await request(app).post('/api/reports').set(AUTH_HEADER).send(body)
+    expect(first.status).toBe(201)
+    const second = await request(app).post('/api/reports').set(AUTH_HEADER).send(body)
+    expect(second.status).toBe(409)
+    expect(second.body.code).toBe('ALREADY_REPORTED')
+  })
+
+  it('treats reports against two different users as distinct targets', async () => {
+    const a = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'user', reportedUsername: 'alice', reason: 'spam' })
+    const b = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'user', reportedUsername: 'bob', reason: 'spam' })
+    expect(a.status).toBe(201)
+    expect(b.status).toBe(201)
+  })
+
   it('rejects an invalid targetType', async () => {
     const res = await request(app)
       .post('/api/reports')
@@ -176,6 +236,27 @@ describe('GET /api/reports', () => {
     expect(recipeReport.target.recipe.title).toBe('Reported Dish')
     const reviewReport = res.body.reports.find((r) => r.targetType === 'review')
     expect(reviewReport.target.review.reviewText).toBe('nasty')
+  })
+
+  it('surfaces a user report in the queue with no recipe/review snapshot', async () => {
+    admin.__setClaims({ admin: true })
+    await getDB().collection('reports').insertOne({
+      _id: new ObjectId(),
+      targetType: 'user',
+      reportedUsername: 'baduser',
+      reportedUid: 'bad-uid',
+      reporterUid: 'u1',
+      reason: 'offensive',
+      status: 'open',
+      createdAt: new Date(),
+    })
+
+    const res = await request(app).get('/api/reports').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    const userReport = res.body.reports.find((r) => r.targetType === 'user')
+    expect(userReport.reportedUsername).toBe('baduser')
+    expect(userReport.target.recipe).toBeNull()
+    expect(userReport.target.review).toBeNull()
   })
 
   it('filters by status', async () => {

--- a/server/__tests__/reports.test.js
+++ b/server/__tests__/reports.test.js
@@ -91,6 +91,7 @@ describe('POST /api/reports', () => {
   })
 
   it('creates a user report carrying reportedUsername and no recipeId', async () => {
+    await seedUser('bad-uid', 'baduser')
     const res = await request(app)
       .post('/api/reports')
       .set(AUTH_HEADER)
@@ -121,6 +122,7 @@ describe('POST /api/reports', () => {
   })
 
   it('does not require recipeId for a user report', async () => {
+    await seedUser('bad-uid', 'baduser')
     const res = await request(app)
       .post('/api/reports')
       .set(AUTH_HEADER)
@@ -128,7 +130,37 @@ describe('POST /api/reports', () => {
     expect(res.status).toBe(201)
   })
 
+  it('404s a user report against a handle with no account', async () => {
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'user', reportedUsername: 'ghost', reason: 'spam' })
+    expect(res.status).toBe(404)
+  })
+
+  it('rejects reporting yourself (user report)', async () => {
+    // The reporter's own handle resolves to TEST_UID (the verified token's uid).
+    await seedUser(TEST_UID, 'me')
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'user', reportedUsername: 'me', reason: 'spam' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/yourself/i)
+  })
+
+  it('rejects reporting your own review', async () => {
+    await seedUser(TEST_UID, 'me')
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'review', recipeId: 'recipe-001', reportedUsername: 'me', reason: 'spam' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/your own review/i)
+  })
+
   it('rate-limits to one open user report per reporter+target (409)', async () => {
+    await seedUser('bad-uid', 'baduser')
     const body = { targetType: 'user', reportedUsername: 'baduser', reason: 'spam' }
     const first = await request(app).post('/api/reports').set(AUTH_HEADER).send(body)
     expect(first.status).toBe(201)
@@ -137,7 +169,25 @@ describe('POST /api/reports', () => {
     expect(second.body.code).toBe('ALREADY_REPORTED')
   })
 
+  it('rate-limits a user report case-insensitively on the handle (409)', async () => {
+    await seedUser('bad-uid', 'BadUser')
+    const first = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'user', reportedUsername: 'BadUser', reason: 'spam' })
+    expect(first.status).toBe(201)
+    // A different casing of the same handle is the same target, not a new one.
+    const second = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'user', reportedUsername: 'baduser', reason: 'spam' })
+    expect(second.status).toBe(409)
+    expect(second.body.code).toBe('ALREADY_REPORTED')
+  })
+
   it('treats reports against two different users as distinct targets', async () => {
+    await seedUser('alice-uid', 'alice')
+    await seedUser('bob-uid', 'bob')
     const a = await request(app)
       .post('/api/reports')
       .set(AUTH_HEADER)

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -14,6 +14,10 @@ const { respondBlocked } = require('../util/automod')
 
 const USERNAME_MIN_LENGTH = 3
 const USERNAME_MAX_LENGTH = 30
+// A handle lands in the public profile URL (/u/:username), so keep it to a safe,
+// URL-clean character set: letters, digits, and a small set of separators
+// (. _ -). Everything else (spaces, @, /, emoji, punctuation) is rejected.
+const USERNAME_ALLOWED = /^[a-zA-Z0-9._-]+$/
 const DISPLAY_NAME_MAX_LENGTH = 50
 
 const BIO_MAX_LENGTH = 300
@@ -70,6 +74,9 @@ function validateUsername(username) {
   }
   if (username.length > USERNAME_MAX_LENGTH) {
     return `Username must be at most ${USERNAME_MAX_LENGTH} characters`
+  }
+  if (!USERNAME_ALLOWED.test(username)) {
+    return 'Username can only contain letters, numbers, and . _ -'
   }
   return null
 }

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -32,17 +32,23 @@ const isAutomodRecipeReport = (r) => r && r.source === 'automod' && r.targetType
 
 const router = Router()
 
-// A report targets either a recipe or a single review. Reviews have no stable
-// id (they live in `ratings` keyed by username+recipeId), so a review report
-// must carry `reportedUsername` alongside `recipeId` to identify the target.
-const TARGET_TYPES = ['recipe', 'review']
+// A report targets a recipe, a single review, or a whole user. Reviews have no
+// stable id (they live in `ratings` keyed by username+recipeId), so a review
+// report carries `reportedUsername` alongside `recipeId`. A 'user' report
+// targets a profile directly: it carries `reportedUsername` and has no recipeId.
+const TARGET_TYPES = ['recipe', 'review', 'user']
 const REASONS = ['spam', 'inappropriate', 'offensive', 'copyright', 'dangerous', 'other']
 const RESOLUTIONS = ['resolved', 'dismissed']
 const MAX_DETAILS_LEN = 1000
 
+// Both review and user reports name a reported account by handle (and snapshot
+// its uid); recipe reports do not.
+const namesUser = (targetType) => targetType === 'review' || targetType === 'user'
+
 // Build the query that identifies a single target, used for the
 // one-open-report-per-reporter-per-target rate limit.
 function targetMatch({ targetType, recipeId, reportedUsername }) {
+  if (targetType === 'user') return { targetType, reportedUsername }
   return targetType === 'review'
     ? { targetType, recipeId, reportedUsername }
     : { targetType, recipeId }
@@ -55,13 +61,14 @@ router.post('/reports', verifyToken, requireActive, asyncHandler(async (req, res
   const { targetType, recipeId, reportedUsername, reason, details } = req.body
 
   if (!TARGET_TYPES.includes(targetType)) {
-    return res.status(400).json({ error: "targetType must be 'recipe' or 'review'" })
+    return res.status(400).json({ error: "targetType must be 'recipe', 'review', or 'user'" })
   }
-  if (!recipeId || typeof recipeId !== 'string') {
+  // recipeId identifies recipe/review targets; a user report has none.
+  if (targetType !== 'user' && (!recipeId || typeof recipeId !== 'string')) {
     return res.status(400).json({ error: 'recipeId is required' })
   }
-  if (targetType === 'review' && (!reportedUsername || typeof reportedUsername !== 'string')) {
-    return res.status(400).json({ error: 'reportedUsername is required for review reports' })
+  if (namesUser(targetType) && (!reportedUsername || typeof reportedUsername !== 'string')) {
+    return res.status(400).json({ error: 'reportedUsername is required for review and user reports' })
   }
   if (!REASONS.includes(reason)) {
     return res.status(400).json({ error: 'Invalid reason' })
@@ -84,10 +91,10 @@ router.post('/reports', verifyToken, requireActive, asyncHandler(async (req, res
   }
 
   // Snapshot the reported user's stable uid alongside the denormalized handle
-  // (D1), so a review report stays attached to its author across renames. The
-  // handle is still stored for display in the queue.
+  // (D1), so a review/user report stays attached to its author across renames.
+  // The handle is still stored for display in the queue.
   let reportedUid = null
-  if (targetType === 'review') {
+  if (namesUser(targetType)) {
     const reportedDoc = await db
       .collection('usernames')
       .findOne({ username_lower: reportedUsername.toLowerCase() })
@@ -97,8 +104,9 @@ router.post('/reports', verifyToken, requireActive, asyncHandler(async (req, res
   const doc = {
     _id: new ObjectId(),
     targetType,
-    recipeId,
-    ...(targetType === 'review' ? { reportedUsername, reportedUid } : {}),
+    // user reports have no recipe; recipe/review reports always do.
+    ...(targetType === 'user' ? {} : { recipeId }),
+    ...(namesUser(targetType) ? { reportedUsername, reportedUid } : {}),
     reporterUid: req.uid,
     reason,
     details: details || '',
@@ -133,11 +141,14 @@ router.get('/reports', verifyToken, requireAdmin, asyncHandler(async (req, res) 
   // preview without a second round trip per row.
   const enriched = await Promise.all(
     reports.map(async (r) => {
-      const recipe = await db
-        .collection('recipes')
-        .findOne(recipeIdQuery(r.recipeId), {
-          projection: { title: 1, recipeImage: 1, status: 1, userId: 1 },
-        })
+      // user reports have no recipe to preview.
+      const recipe = r.recipeId
+        ? await db
+            .collection('recipes')
+            .findOne(recipeIdQuery(r.recipeId), {
+              projection: { title: 1, recipeImage: 1, status: 1, userId: 1 },
+            })
+        : null
       let review = null
       if (r.targetType === 'review') {
         review = await db

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -45,13 +45,23 @@ const MAX_DETAILS_LEN = 1000
 // its uid); recipe reports do not.
 const namesUser = (targetType) => targetType === 'review' || targetType === 'user'
 
+const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+// Match a stored handle case-insensitively for the rate-limit query so a casing
+// variant (BadUser vs baduser) can't sidestep the one-open-report-per-target
+// limit. Anchored + escaped — reportedUsername isn't charset-validated here, so
+// raw input must not leak regex metacharacters.
+const handleMatch = (reportedUsername) => new RegExp(`^${escapeRegex(reportedUsername)}$`, 'i')
+
 // Build the query that identifies a single target, used for the
 // one-open-report-per-reporter-per-target rate limit.
 function targetMatch({ targetType, recipeId, reportedUsername }) {
-  if (targetType === 'user') return { targetType, reportedUsername }
-  return targetType === 'review'
-    ? { targetType, recipeId, reportedUsername }
-    : { targetType, recipeId }
+  if (targetType === 'recipe') return { targetType, recipeId }
+  // review/user name an account; match the handle case-insensitively.
+  const handle = { reportedUsername: handleMatch(reportedUsername) }
+  return targetType === 'user'
+    ? { targetType, ...handle }
+    : { targetType, recipeId, ...handle }
 }
 
 // POST /reports — any logged-in user files a report. Rate-limited to one OPEN
@@ -77,6 +87,32 @@ router.post('/reports', verifyToken, requireActive, asyncHandler(async (req, res
     return res.status(400).json({ error: `details must be a string under ${MAX_DETAILS_LEN} chars` })
   }
 
+  // Resolve the reported account up front for review/user reports. The lookup
+  // does triple duty: reject reports against a handle that doesn't exist, block
+  // self-reports, and snapshot the stable uid (D1) so the report survives a
+  // rename. The handle is still stored for display in the queue.
+  let reportedUid = null
+  if (namesUser(targetType)) {
+    const reportedDoc = await db
+      .collection('usernames')
+      .findOne({ username_lower: reportedUsername.toLowerCase() })
+    // A 'user' report must name a real account (any string is otherwise a valid
+    // target). A review report's author is implied by an existing review, so a
+    // missing handle there falls through to a null uid as before.
+    if (targetType === 'user' && !reportedDoc) {
+      return res.status(404).json({ error: 'No user with that username exists.' })
+    }
+    reportedUid = reportedDoc?._id || null
+    if (reportedUid && reportedUid === req.uid) {
+      return res.status(400).json({
+        error:
+          targetType === 'user'
+            ? "You can't report yourself."
+            : "You can't report your own review.",
+      })
+    }
+  }
+
   const match = targetMatch({ targetType, recipeId, reportedUsername })
   const existing = await db.collection('reports').findOne({
     ...match,
@@ -88,17 +124,6 @@ router.post('/reports', verifyToken, requireActive, asyncHandler(async (req, res
       code: 'ALREADY_REPORTED',
       error: 'You already have an open report for this content.',
     })
-  }
-
-  // Snapshot the reported user's stable uid alongside the denormalized handle
-  // (D1), so a review/user report stays attached to its author across renames.
-  // The handle is still stored for display in the queue.
-  let reportedUid = null
-  if (namesUser(targetType)) {
-    const reportedDoc = await db
-      .collection('usernames')
-      .findOne({ username_lower: reportedUsername.toLowerCase() })
-    reportedUid = reportedDoc?._id || null
   }
 
   const doc = {

--- a/src/Components/Form/UsernameInput.tsx
+++ b/src/Components/Form/UsernameInput.tsx
@@ -25,9 +25,22 @@ const UsernameInput: FC<UsernameInputProps> = ({
     setError('')
     setSuccess('')
 
-    if (/\s/g.test(username))
-      return setError('Cannot have white space in username')
-    if (!username || username.length < 3) return setIsUsernameAvailable(null)
+    // Mirror the server rules in server/routes/auth.js validateUsername so the
+    // user gets the same feedback inline, before the availability round-trip.
+    if (!username) return setIsUsernameAvailable(null)
+    if (/\s/g.test(username)) {
+      setIsUsernameAvailable(null)
+      return setError('Username cannot contain whitespace')
+    }
+    if (username.length < 3) return setIsUsernameAvailable(null)
+    if (username.length > 30) {
+      setIsUsernameAvailable(null)
+      return setError('Username must be at most 30 characters')
+    }
+    if (!/^[a-zA-Z0-9._-]+$/.test(username)) {
+      setIsUsernameAvailable(null)
+      return setError('Username can only contain letters, numbers, and . _ -')
+    }
 
     // `cancelled` guards against a slow in-flight request resolving after a
     // newer keystroke's request and clobbering the result with stale data.

--- a/src/Components/ReportControl/ReportControl.scss
+++ b/src/Components/ReportControl/ReportControl.scss
@@ -1,9 +1,13 @@
 .report-control-trigger {
+  display: inline-flex;
+  align-items: center;
   background: none;
   border: none;
   cursor: pointer;
   color: #8a8f99;
+  font-family: inherit;
   font-size: 0.8rem;
+  line-height: 1.2;
   padding: 0.15rem 0.35rem;
   border-radius: 4px;
   transition: color 0.15s, background 0.15s;
@@ -13,10 +17,21 @@
     background: rgba(214, 69, 69, 0.08);
   }
 
+  // Keyboard users get a clear ring (the hover tint isn't enough on its own).
+  &:focus-visible {
+    outline: 2px solid rgba(214, 69, 69, 0.5);
+    outline-offset: 1px;
+    color: #d64545;
+  }
+
   &.button {
     border: 1px solid #d8dbe0;
     padding: 0.4rem 0.75rem;
     font-size: 0.85rem;
+
+    &:hover {
+      border-color: #d64545;
+    }
   }
 }
 

--- a/src/Components/ReportControl/ReportControl.scss
+++ b/src/Components/ReportControl/ReportControl.scss
@@ -35,6 +35,86 @@
   }
 }
 
+// ── Kebab (three-dots) variant ──────────────────────────────────────────────
+.report-menu {
+  position: relative;
+  display: inline-flex;
+
+  .report-menu-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #8a8f99;
+    border-radius: 50%;
+    width: 1.9rem;
+    height: 1.9rem;
+    font-size: 1.05rem;
+    line-height: 1;
+    transition: color 0.15s, background 0.15s;
+
+    &:hover,
+    &.is-open {
+      color: #4b5563;
+      background: rgba(0, 0, 0, 0.06);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(59, 130, 246, 0.5);
+      outline-offset: 1px;
+    }
+  }
+
+  .report-menu-panel {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 50;
+    min-width: 9.5rem;
+    padding: 0.3rem;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    box-shadow: 0 6px 20px rgba(17, 24, 39, 0.12);
+  }
+
+  .report-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.6rem;
+    background: none;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+    color: #374151;
+    text-align: left;
+    white-space: nowrap;
+    text-transform: capitalize;
+
+    svg {
+      flex-shrink: 0;
+      font-size: 0.95rem;
+    }
+
+    &:hover {
+      background: rgba(214, 69, 69, 0.08);
+      color: #d64545;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(214, 69, 69, 0.5);
+      outline-offset: -2px;
+      color: #d64545;
+    }
+  }
+}
+
 .report-modal {
   outline: none;
 

--- a/src/Components/ReportControl/ReportControl.tsx
+++ b/src/Components/ReportControl/ReportControl.tsx
@@ -12,8 +12,8 @@ Modal.setAppElement('#root')
 
 type ReportTarget = {
   targetType: ReportTargetType
-  recipeId: string
-  reportedUsername?: string // required when targetType === 'review'
+  recipeId?: string // required for 'recipe' / 'review'; omitted for 'user'
+  reportedUsername?: string // required for 'review' / 'user'
 }
 
 type ReportControlProps = {
@@ -61,10 +61,24 @@ const ReportControl: FC<ReportControlProps> = ({ target, variant = 'link' }) => 
   const [details, setDetails] = useState('')
   const [submitting, setSubmitting] = useState(false)
 
-  // Reporting requires a logged-in user (the server stamps reporterUid).
-  if (!authRes?.user) return null
+  const NOUNS: Record<ReportTargetType, string> = {
+    recipe: 'recipe',
+    review: 'review',
+    user: 'user',
+  }
+  const noun = NOUNS[target.targetType]
 
-  const noun = target.targetType === 'review' ? 'review' : 'recipe'
+  // The trigger stays visible to everyone so logged-out visitors still know
+  // reporting exists; reporting itself needs an account (the server stamps
+  // reporterUid), so clicking while logged out nudges to log in instead of
+  // opening the modal.
+  const handleTriggerClick = () => {
+    if (!authRes?.user) {
+      toast.error(`Log in to report this ${noun}.`)
+      return
+    }
+    setIsOpen(true)
+  }
 
   const close = () => {
     if (submitting) return
@@ -103,7 +117,7 @@ const ReportControl: FC<ReportControlProps> = ({ target, variant = 'link' }) => 
       <button
         type='button'
         className={`report-control-trigger ${variant}`}
-        onClick={() => setIsOpen(true)}
+        onClick={handleTriggerClick}
         aria-label={`Report this ${noun}`}
       >
         Report

--- a/src/Components/ReportControl/ReportControl.tsx
+++ b/src/Components/ReportControl/ReportControl.tsx
@@ -1,7 +1,9 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useRef, useState } from 'react'
 import Modal from 'react-modal'
 import toast from 'react-hot-toast'
 import { TailSpin } from 'react-loader-spinner'
+import { BsThreeDots } from 'react-icons/bs'
+import { FiFlag } from 'react-icons/fi'
 import { AxiosError } from 'axios'
 import { ReportReason, ReportTargetType } from 'types'
 import { useAuth } from 'src/context/AuthContext'
@@ -18,8 +20,12 @@ type ReportTarget = {
 
 type ReportControlProps = {
   target: ReportTarget
-  // Visual style of the trigger: a small text link (default) or a plain button.
-  variant?: 'link' | 'button'
+  // Visual style of the trigger:
+  //  - 'link'   — a small inline text link (default)
+  //  - 'button' — a plain bordered button
+  //  - 'menu'   — a three-dots (kebab) trigger that opens a dropdown whose
+  //               single item opens the report modal
+  variant?: 'link' | 'button' | 'menu'
 }
 
 const REASON_OPTIONS: { value: ReportReason; label: string }[] = [
@@ -57,9 +63,11 @@ const customStyles = {
 const ReportControl: FC<ReportControlProps> = ({ target, variant = 'link' }) => {
   const authRes = useAuth()
   const [isOpen, setIsOpen] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
   const [reason, setReason] = useState<ReportReason>('spam')
   const [details, setDetails] = useState('')
   const [submitting, setSubmitting] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
 
   const NOUNS: Record<ReportTargetType, string> = {
     recipe: 'recipe',
@@ -68,11 +76,30 @@ const ReportControl: FC<ReportControlProps> = ({ target, variant = 'link' }) => 
   }
   const noun = NOUNS[target.targetType]
 
+  // Close the kebab dropdown on an outside click or Escape (matches the
+  // SortDropdown pattern). Only wired while the menu is actually open.
+  useEffect(() => {
+    if (!menuOpen) return
+    const onDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setMenuOpen(false)
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [menuOpen])
+
   // The trigger stays visible to everyone so logged-out visitors still know
   // reporting exists; reporting itself needs an account (the server stamps
   // reporterUid), so clicking while logged out nudges to log in instead of
   // opening the modal.
   const handleTriggerClick = () => {
+    setMenuOpen(false)
     if (!authRes?.user) {
       toast.error(`Log in to report this ${noun}.`)
       return
@@ -112,6 +139,103 @@ const ReportControl: FC<ReportControlProps> = ({ target, variant = 'link' }) => 
     }
   }
 
+  const modal = (
+    <Modal
+      isOpen={isOpen}
+      onRequestClose={close}
+      style={customStyles}
+      className='report-modal'
+    >
+      <h2 className='report-modal-title'>Report this {noun}</h2>
+      <p className='report-modal-sub'>
+        Tell us what’s wrong. Reports are reviewed by our moderation team.
+      </p>
+
+      <label className='report-field'>
+        <span>Reason</span>
+        <select
+          value={reason}
+          onChange={e => setReason(e.target.value as ReportReason)}
+        >
+          {REASON_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className='report-field'>
+        <span>Details (optional)</span>
+        <textarea
+          value={details}
+          maxLength={1000}
+          rows={4}
+          placeholder='Add any context that will help us review this.'
+          onChange={e => setDetails(e.target.value)}
+        />
+      </label>
+
+      <div className='report-modal-actions'>
+        <button
+          type='button'
+          className='report-cancel-btn'
+          onClick={close}
+          disabled={submitting}
+        >
+          Cancel
+        </button>
+        <button
+          type='button'
+          className='report-submit-btn'
+          onClick={handleSubmit}
+          disabled={submitting}
+        >
+          Submit report
+          {submitting && (
+            <span className='report-btn-spinner'>
+              <TailSpin height='18' width='18' color='#fff' ariaLabel='loading' />
+            </span>
+          )}
+        </button>
+      </div>
+    </Modal>
+  )
+
+  // Kebab variant: a three-dots trigger opening a dropdown with a single
+  // "Report …" item. The modal is a sibling of the (collapsible) panel, so it
+  // survives the panel closing when the item is clicked.
+  if (variant === 'menu') {
+    return (
+      <div className='report-menu' ref={menuRef}>
+        <button
+          type='button'
+          className={`report-menu-trigger ${menuOpen ? 'is-open' : ''}`}
+          aria-haspopup='menu'
+          aria-expanded={menuOpen}
+          aria-label='More options'
+          onClick={() => setMenuOpen(o => !o)}
+        >
+          <BsThreeDots />
+        </button>
+        {menuOpen && (
+          <div className='report-menu-panel' role='menu'>
+            <button
+              type='button'
+              role='menuitem'
+              className='report-menu-item'
+              onClick={handleTriggerClick}
+              aria-label={`Report this ${noun}`}
+            >
+              <FiFlag /> Report {noun}
+            </button>
+          </div>
+        )}
+        {modal}
+      </div>
+    )
+  }
+
   return (
     <>
       <button
@@ -122,67 +246,7 @@ const ReportControl: FC<ReportControlProps> = ({ target, variant = 'link' }) => 
       >
         Report
       </button>
-
-      <Modal
-        isOpen={isOpen}
-        onRequestClose={close}
-        style={customStyles}
-        className='report-modal'
-      >
-        <h2 className='report-modal-title'>Report this {noun}</h2>
-        <p className='report-modal-sub'>
-          Tell us what’s wrong. Reports are reviewed by our moderation team.
-        </p>
-
-        <label className='report-field'>
-          <span>Reason</span>
-          <select
-            value={reason}
-            onChange={e => setReason(e.target.value as ReportReason)}
-          >
-            {REASON_OPTIONS.map(opt => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label className='report-field'>
-          <span>Details (optional)</span>
-          <textarea
-            value={details}
-            maxLength={1000}
-            rows={4}
-            placeholder='Add any context that will help us review this.'
-            onChange={e => setDetails(e.target.value)}
-          />
-        </label>
-
-        <div className='report-modal-actions'>
-          <button
-            type='button'
-            className='report-cancel-btn'
-            onClick={close}
-            disabled={submitting}
-          >
-            Cancel
-          </button>
-          <button
-            type='button'
-            className='report-submit-btn'
-            onClick={handleSubmit}
-            disabled={submitting}
-          >
-            Submit report
-            {submitting && (
-              <span className='report-btn-spinner'>
-                <TailSpin height='18' width='18' color='#fff' ariaLabel='loading' />
-              </span>
-            )}
-          </button>
-        </div>
-      </Modal>
+      {modal}
     </>
   )
 }

--- a/src/pages/Admin/Reports/Reports.scss
+++ b/src/pages/Admin/Reports/Reports.scss
@@ -169,6 +169,11 @@
           background: #fae8ff;
           color: #86198f;
         }
+
+        &.user {
+          background: #dcfce7;
+          color: #166534;
+        }
       }
 
       .reason-pill {

--- a/src/pages/Admin/Reports/Reports.tsx
+++ b/src/pages/Admin/Reports/Reports.tsx
@@ -104,11 +104,14 @@ const Reports: FC = () => {
   // Take the reported content down, then close the report as resolved.
   const takedownMutation = useMutation({
     mutationFn: async (report: AdminReportType) => {
-      if (report.targetType === 'recipe') {
-        await ReportAPI.setRecipeModeration(report.recipeId, 'hidden')
-      } else if (report.reportedUsername) {
+      // recipeId is present on every recipe/review report (the only targets the
+      // Take down button is offered for; user reports have none).
+      const { recipeId } = report
+      if (report.targetType === 'recipe' && recipeId) {
+        await ReportAPI.setRecipeModeration(recipeId, 'hidden')
+      } else if (report.reportedUsername && recipeId) {
         await ReportAPI.setReviewModeration(
-          report.recipeId,
+          recipeId,
           report.reportedUsername,
           true
         )
@@ -125,11 +128,12 @@ const Reports: FC = () => {
   // Bring previously-hidden content back. Leaves the report's status as-is.
   const restoreMutation = useMutation({
     mutationFn: async (report: AdminReportType) => {
-      if (report.targetType === 'recipe') {
-        await ReportAPI.setRecipeModeration(report.recipeId, 'active')
-      } else if (report.reportedUsername) {
+      const { recipeId } = report
+      if (report.targetType === 'recipe' && recipeId) {
+        await ReportAPI.setRecipeModeration(recipeId, 'active')
+      } else if (report.reportedUsername && recipeId) {
         await ReportAPI.setReviewModeration(
-          report.recipeId,
+          recipeId,
           report.reportedUsername,
           false
         )
@@ -146,7 +150,10 @@ const Reports: FC = () => {
   // one server call. The only path that actually clears a pending_review hold — a
   // bare Dismiss would close the report but leave the recipe invisible forever.
   const approveMutation = useMutation({
-    mutationFn: (report: AdminReportType) => AdminAPI.approveRecipe(report.recipeId),
+    // Approve is only ever offered on a pending_review recipe report, which
+    // always carries a recipeId.
+    mutationFn: (report: AdminReportType) =>
+      AdminAPI.approveRecipe(report.recipeId as string),
     onSuccess: () => {
       toast.success('Recipe approved and published.')
       invalidate()
@@ -181,6 +188,22 @@ const Reports: FC = () => {
 
   const renderPreview = (report: AdminReportType) => {
     const { target } = report
+    if (report.targetType === 'user') {
+      // A user report has no recipe/review snapshot — link straight to the
+      // reported profile so an admin can review it (and act from /admin/users).
+      return (
+        <div className='preview user-preview'>
+          <div className='preview-body'>
+            <div className='preview-meta'>
+              Reported user:{' '}
+              <Link to={`/u/${report.reportedUsername}`} className='preview-title'>
+                @{report.reportedUsername}
+              </Link>
+            </div>
+          </div>
+        </div>
+      )
+    }
     if (report.targetType === 'recipe') {
       if (!target.recipe) {
         return <span className='preview-missing'>Recipe no longer exists.</span>
@@ -365,7 +388,12 @@ const Reports: FC = () => {
                           Restore
                         </button>
                       ) : (
-                        report.status === 'open' && takedownButton(report)
+                        // No inline take-down for a user report — user
+                        // moderation (suspend/ban) lives on /admin/users; the
+                        // queue only closes the report.
+                        report.status === 'open' &&
+                        report.targetType !== 'user' &&
+                        takedownButton(report)
                       )}
                       {report.status === 'open' && (
                         <>

--- a/src/pages/PublicProfile/PublicProfile.scss
+++ b/src/pages/PublicProfile/PublicProfile.scss
@@ -194,6 +194,14 @@
     }
   }
 
+  // Quiet, de-emphasized report affordance under the identity block.
+  .pp-report {
+    margin-top: 1rem;
+    .report-control-trigger {
+      font-size: 0.78rem;
+    }
+  }
+
   // ── Recipe tiles (image-first card: square photo + a compact meta row) ───────
   .pp-recipes {
     margin-top: 1.6rem;

--- a/src/pages/PublicProfile/PublicProfile.scss
+++ b/src/pages/PublicProfile/PublicProfile.scss
@@ -194,14 +194,6 @@
     }
   }
 
-  // Quiet, de-emphasized report affordance under the identity block.
-  .pp-report {
-    margin-top: 1rem;
-    .report-control-trigger {
-      font-size: 0.78rem;
-    }
-  }
-
   // ── Recipe tiles (image-first card: square photo + a compact meta row) ───────
   .pp-recipes {
     margin-top: 1.6rem;

--- a/src/pages/PublicProfile/PublicProfile.tsx
+++ b/src/pages/PublicProfile/PublicProfile.tsx
@@ -15,6 +15,8 @@ import {
 import toast from 'react-hot-toast'
 import './PublicProfile.scss'
 import PublicProfileAPI from 'src/api/publicProfile'
+import AuthAPI from 'src/api/auth'
+import ReportControl from 'src/Components/ReportControl/ReportControl'
 import EmptyState from 'src/Components/EmptyState/EmptyState'
 import { formatRating } from 'src/util/formatRating'
 import { formatCompactCount } from 'src/util/formatCompactCount'
@@ -38,6 +40,16 @@ const PublicProfile: FC = () => {
   // the profile payload is effectively page 0).
   const [extraPages, setExtraPages] = useState<Record<number, RecipeType[]>>({})
   const [extraPage, setExtraPage] = useState(0)
+
+  // The viewer's own handle, so we can hide the "report" control on their own
+  // profile. Only fetched when signed in; logged-out visitors still see the
+  // control (clicking it prompts them to log in).
+  const currentUid = AuthAPI.getUID()
+  const { data: currentUsername } = useQuery({
+    queryKey: ['username', currentUid],
+    queryFn: () => AuthAPI.getUsername(),
+    enabled: !!currentUid,
+  })
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ['public-profile', username],
@@ -203,6 +215,18 @@ const PublicProfile: FC = () => {
                 <FiAward /> {a.name}
               </span>
             ))}
+          </div>
+        )}
+
+        {/* Quiet, secondary affordance — hidden on the viewer's own profile. */}
+        {currentUsername !== profile.username && (
+          <div className='pp-report'>
+            <ReportControl
+              target={{
+                targetType: 'user',
+                reportedUsername: profile.username,
+              }}
+            />
           </div>
         )}
       </header>

--- a/src/pages/PublicProfile/PublicProfile.tsx
+++ b/src/pages/PublicProfile/PublicProfile.tsx
@@ -174,6 +174,16 @@ const PublicProfile: FC = () => {
           >
             <FiShare />
           </button>
+          {/* Kebab menu with "Report user" — hidden on the viewer's own profile. */}
+          {currentUsername !== profile.username && (
+            <ReportControl
+              variant='menu'
+              target={{
+                targetType: 'user',
+                reportedUsername: profile.username,
+              }}
+            />
+          )}
         </div>
         <p className='pp-name'>{profile.displayName}</p>
 
@@ -215,18 +225,6 @@ const PublicProfile: FC = () => {
                 <FiAward /> {a.name}
               </span>
             ))}
-          </div>
-        )}
-
-        {/* Quiet, secondary affordance — hidden on the viewer's own profile. */}
-        {currentUsername !== profile.username && (
-          <div className='pp-report'>
-            <ReportControl
-              target={{
-                targetType: 'user',
-                reportedUsername: profile.username,
-              }}
-            />
           </div>
         )}
       </header>

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
@@ -82,6 +82,10 @@
         height: 18px;
         width: 18px;
       }
+      // Non-author view: a lone report kebab — pin it to the right edge.
+      .report-menu {
+        margin-left: auto;
+      }
       .actions {
         display: flex;
         justify-content: flex-end;

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewOptions.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewOptions.tsx
@@ -52,9 +52,11 @@ const ReviewOptions: FC<ReviewOptionsProps> = ({
           />
         </>
       ) : (
-        // Not the author: offer a report affordance instead (self-gates on login).
+        // Not the author: offer a report affordance in a kebab menu (the trigger
+        // stays visible logged-out and nudges to log in on click).
         recipeId && (
           <ReportControl
+            variant='menu'
             target={{
               targetType: 'review',
               recipeId,

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -20,6 +20,7 @@ $danger: #d23f31;
   .sr-controls {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     margin-bottom: 1.25rem;
     .sr-back {
       display: inline-flex;

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -79,6 +79,19 @@ $danger: #d23f31;
       color: s.$secondary;
     }
     .description { color: s.$secondary-text; line-height: 1.7; font-size: 1rem; }
+    // Compact rating echo by the title (see SingleRecipe.tsx). Pulled snug under
+    // the heading rather than treated as its own stacked block.
+    .hero-rating {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      margin-top: -0.6rem;
+      font-size: 0.95rem;
+      color: s.$primary-text;
+      .hr-star { color: #f5a623; font-size: 1rem; }
+      .hr-val { font-weight: 700; }
+      .hr-count { color: s.$tertiary-text; font-weight: 500; }
+    }
     .author-row {
       margin-top: auto;
       display: flex;

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -242,6 +242,14 @@ const SingleRecipe: FC = () => {
             <Link to='/recipes' className='sr-back'>
               <BiLeftArrowAlt /> All recipes
             </Link>
+            {/* Quick-access report kebab (the quiet footer link below stays too).
+                Hidden for the owner; logged-out clicks nudge to log in. */}
+            {currRecipe && !isOwner && (
+              <ReportControl
+                variant='menu'
+                target={{ targetType: 'recipe', recipeId: currRecipe._id }}
+              />
+            )}
           </div>
 
           {currRecipe && (

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -6,7 +6,7 @@ import { Helmet } from 'react-helmet-async'
 import Skeleton from 'react-loading-skeleton'
 import 'react-loading-skeleton/dist/skeleton.css'
 import { AiOutlineClockCircle, AiOutlineUsergroupAdd } from 'react-icons/ai'
-import { BsStar } from 'react-icons/bs'
+import { BsStar, BsStarFill } from 'react-icons/bs'
 import { BiLeftArrowAlt, BiCheckCircle } from 'react-icons/bi'
 import { CiShoppingBasket } from 'react-icons/ci'
 import { TbTag } from 'react-icons/tb'
@@ -279,6 +279,21 @@ const SingleRecipe: FC = () => {
                   capitalize(currRecipe?.title || '')
                 )}
               </h1>
+              {/* Top-of-page rating echo. 2c moved the action-bar rating tile
+                  out for the per-serving price; this re-surfaces it compactly by
+                  the title (the full breakdown still lives in Ratings & Reviews).
+                  Only shown once rated, so an unrated recipe isn't labelled. */}
+              {currRecipe && ratingCount > 0 && (
+                <div className='hero-rating' aria-label={`Rated ${formatRating(currRecipe.rating?.rateValue, ratingCount)} out of 5 from ${ratingCount} ratings`}>
+                  <BsStarFill className='hr-star' aria-hidden='true' />
+                  <span className='hr-val'>
+                    {formatRating(currRecipe.rating?.rateValue, ratingCount)}
+                  </span>
+                  <span className='hr-count'>
+                    · {ratingCount} {ratingCount === 1 ? 'rating' : 'ratings'}
+                  </span>
+                </div>
+              )}
               {loading ? (
                 <Skeleton baseColor={skeletonColor} count={2} />
               ) : (
@@ -466,7 +481,7 @@ const SingleRecipe: FC = () => {
             />
           )}
 
-          {!loading && currRecipe && currUID && !isOwner && (
+          {!loading && currRecipe && !isOwner && (
             <div className='sr-report-foot'>
               <span>See something wrong with this recipe?</span>
               <ReportControl

--- a/src/test/ReportControl.test.tsx
+++ b/src/test/ReportControl.test.tsx
@@ -81,6 +81,54 @@ describe('ReportControl', () => {
     )
   })
 
+  it('menu variant: opens a kebab dropdown whose item opens the report modal', async () => {
+    mockedUseAuth.mockReturnValue({ user: { uid: 'u1' } })
+    render(
+      <ReportControl
+        variant='menu'
+        target={{ targetType: 'review', recipeId: 'r1', reportedUsername: 'baduser' }}
+      />
+    )
+
+    // The report item is hidden until the kebab is opened.
+    expect(
+      screen.queryByRole('menuitem', { name: /report this review/i })
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /more options/i }))
+    const item = screen.getByRole('menuitem', { name: /report this review/i })
+    fireEvent.click(item)
+
+    // The modal opens; submitting reports the review.
+    expect(
+      screen.getByRole('heading', { name: /report this review/i })
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /submit report/i }))
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1))
+    expect(mockedCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ targetType: 'review', reportedUsername: 'baduser' })
+    )
+  })
+
+  it('menu variant: prompts login when logged out', () => {
+    mockedUseAuth.mockReturnValue({ user: null })
+    render(
+      <ReportControl
+        variant='menu'
+        target={{ targetType: 'user', reportedUsername: 'baduser' }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /more options/i }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /report this user/i }))
+
+    expect(mockedToastError).toHaveBeenCalledWith(expect.stringMatching(/log in/i))
+    expect(
+      screen.queryByRole('heading', { name: /report this user/i })
+    ).not.toBeInTheDocument()
+    expect(mockedCreate).not.toHaveBeenCalled()
+  })
+
   it('lets a logged-in user report another user (no recipeId)', async () => {
     mockedUseAuth.mockReturnValue({ user: { uid: 'u1' } })
     render(

--- a/src/test/ReportControl.test.tsx
+++ b/src/test/ReportControl.test.tsx
@@ -1,7 +1,9 @@
 /**
- * ReportControl: the user-facing report affordance. useAuth and the reports API
- * are mocked so we can verify (a) it renders nothing for logged-out users, and
- * (b) a logged-in user can open the modal and submit a report through the API.
+ * ReportControl: the user-facing report affordance. useAuth, the reports API,
+ * and toast are mocked so we can verify (a) the trigger stays visible to
+ * logged-out users and clicking it prompts them to log in (rather than opening
+ * the modal), and (b) a logged-in user can open the modal and submit a report
+ * (recipe / review / user) through the API.
  */
 
 import React from 'react'
@@ -10,6 +12,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import ReportControl from 'src/Components/ReportControl/ReportControl'
 import { useAuth } from 'src/context/AuthContext'
 import ReportAPI from 'src/api/reports'
+import toast from 'react-hot-toast'
 
 vi.mock('src/context/AuthContext', () => ({ useAuth: vi.fn() }))
 vi.mock('src/api/reports', () => ({
@@ -24,18 +27,28 @@ vi.mock('react-hot-toast', () => ({
 
 const mockedUseAuth = useAuth as unknown as Mock
 const mockedCreate = ReportAPI.createReport as unknown as Mock
+const mockedToastError = toast.error as unknown as Mock
 
 afterEach(() => {
   vi.clearAllMocks()
 })
 
 describe('ReportControl', () => {
-  it('renders nothing when the user is logged out', () => {
+  it('keeps the trigger visible but prompts login when logged out', () => {
     mockedUseAuth.mockReturnValue({ user: null })
-    const { container } = render(
-      <ReportControl target={{ targetType: 'recipe', recipeId: 'r1' }} />
-    )
-    expect(container).toBeEmptyDOMElement()
+    render(<ReportControl target={{ targetType: 'recipe', recipeId: 'r1' }} />)
+
+    // The trigger is shown so a logged-out visitor still knows reporting exists.
+    const trigger = screen.getByRole('button', { name: /report this recipe/i })
+    fireEvent.click(trigger)
+
+    // Clicking nudges to log in instead of opening the report modal.
+    expect(mockedToastError).toHaveBeenCalledTimes(1)
+    expect(mockedToastError).toHaveBeenCalledWith(expect.stringMatching(/log in/i))
+    expect(
+      screen.queryByRole('heading', { name: /report this recipe/i })
+    ).not.toBeInTheDocument()
+    expect(mockedCreate).not.toHaveBeenCalled()
   })
 
   it('lets a logged-in user open the modal and submit a recipe report', async () => {
@@ -65,6 +78,26 @@ describe('ReportControl', () => {
     await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1))
     expect(mockedCreate).toHaveBeenCalledWith(
       expect.objectContaining({ targetType: 'review', reportedUsername: 'baduser' })
+    )
+  })
+
+  it('lets a logged-in user report another user (no recipeId)', async () => {
+    mockedUseAuth.mockReturnValue({ user: { uid: 'u1' } })
+    render(
+      <ReportControl
+        target={{ targetType: 'user', reportedUsername: 'baduser' }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /report this user/i }))
+    fireEvent.click(screen.getByRole('button', { name: /submit report/i }))
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1))
+    expect(mockedCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ targetType: 'user', reportedUsername: 'baduser' })
+    )
+    expect(mockedCreate).toHaveBeenCalledWith(
+      expect.not.objectContaining({ recipeId: expect.anything() })
     )
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,7 +185,10 @@ export interface NewReviewType {
 }
 
 // ─── Moderation / reports ──────────────────────────────────────────────────
-export type ReportTargetType = 'recipe' | 'review'
+// 'user' targets a whole profile (reported from the public profile page) and,
+// like 'review', carries `reportedUsername`; unlike recipe/review it has no
+// `recipeId`.
+export type ReportTargetType = 'recipe' | 'review' | 'user'
 export type ReportReason =
   | 'spam'
   | 'inappropriate'
@@ -197,8 +200,9 @@ export type ReportStatus = 'open' | 'resolved' | 'dismissed'
 
 export interface NewReportType {
   targetType: ReportTargetType
-  recipeId: string
-  reportedUsername?: string // required when targetType === 'review'
+  // Required for 'recipe' / 'review'; omitted for a 'user' report.
+  recipeId?: string
+  reportedUsername?: string // required when targetType === 'review' or 'user'
   reason: ReportReason
   details?: string
 }
@@ -222,7 +226,8 @@ export interface ReportClassifier {
 export interface ReportType {
   _id: string
   targetType: ReportTargetType
-  recipeId: string
+  // Present on recipe/review reports; absent on user reports.
+  recipeId?: string
   reportedUsername?: string
   reporterUid: string
   reason: ReportReason


### PR DESCRIPTION
Wave-3c bundle, built **on top of** the 2e PublicProfile redesign (#165) — does not revert 2e's profile structure.

## What's in here

### 1. Username character validation
- `validateUsername()` (`server/routes/auth.js`) now restricts handles to `[A-Za-z0-9._-]` (letters, numbers, and `. _ -`) with a specific error message, on top of the existing whitespace/length rules. A handle lands in the public `/u/:username` URL, so the set is kept URL-clean.
- Same rule surfaced as inline feedback in `UsernameInput.tsx` (used by CreateUsername), before the availability round-trip.
- Server Jest: rejects `@ / ! ` accents/emoji; accepts `john_smith`, `john.smith`, `john-smith`, etc.

### 2. Report a user
- `ReportTargetType` gains `'user'` — carries `reportedUsername`, has **no** `recipeId`.
- Server (`server/routes/reports.js`): validates/stores the `user` target, snapshots `reportedUid` (rename-stable, like review reports), and enforces the one-open-report-per-(reporter,target) rate limit per reported user.
- `ReportControl` supports the user target; **PublicProfile** shows a quiet "report this user" control, hidden on your own profile.
- Admin queue (`Admin/Reports`) renders user reports with a link to the reported profile. No inline take-down for user reports — user moderation (suspend/ban) lives on `/admin/users`; the queue just closes the report.

### 3. Report controls visible when logged out (2c deferral)
- `ReportControl` no longer returns `null` for logged-out users. The trigger stays visible; clicking it while logged out prompts login via a toast instead of opening the modal. One change covers the single-recipe footer link and the per-review links.
- `SingleRecipe` report footer gate relaxed so logged-out visitors see it.

### 4. Surface the recipe rating up top (2c deferral)
- Re-surfaced a compact `★ 4.5 · N ratings` echo by the recipe title in the hero (2c had moved the action-bar rating tile out for the per-serving price). Not a 4th action-bar tile. Still shown in the Ratings & Reviews header.

### 5. Report styling nit
- Tidied `ReportControl.scss`: `focus-visible` ring for keyboard users, button-variant hover border, flex alignment.

## Tests / checks
- Server Jest: **661 passed** (added username charset + `user` report-target cases).
- Frontend Vitest: **490 passed** (ReportControl updated for the logged-out prompt + a user-report case).
- `tsc --noEmit` clean; `npm run build` passing.

## Scope
Touches only: `server/routes/auth.js`, `server/routes/reports.js`, `src/types.ts`, `src/Components/ReportControl/*`, `src/Components/Form/UsernameInput.tsx`, `src/pages/PublicProfile/*`, `src/pages/Admin/Reports/*`, `src/pages/SingleRecipe/*` (hero), plus the matching tests. Navbar and beta tag untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)