### PR TITLE
feat(about): 1.0 rewrite of the About page (track 4-about)

### DIFF
--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -3,97 +3,300 @@
 .about-page {
   // Fills the flexbox app-main so the footer stays at the viewport bottom on
   // short pages (see Layout.scss); nav is position:absolute, so offset content
-  // past it with top padding ≈ the nav height.
+  // past it with top padding ≈ the nav height. Mirrors the legal/Help pages.
   flex: 1 0 auto;
   padding: calc(#{s.$nav-height} + 2rem) 1.5rem 4rem;
   font-family: s.$font-family;
 
   .about-inner {
-    max-width: s.$recipe-body-max-width;
+    // Wider than the legal prose column so the step/feature grids breathe;
+    // individual prose blocks are re-constrained to a readable measure below.
+    max-width: s.$recipe-page-max-width;
     margin: 0 auto;
   }
 
+  // ── Hero ──────────────────────────────────────────────────────────────────
   .about-hero {
-    margin-bottom: 2.5rem;
+    text-align: center;
+    margin-bottom: 4rem;
+
+    .eyebrow {
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.8rem;
+      font-weight: 700;
+      color: s.$secondary;
+      margin-bottom: 0.75rem;
+    }
 
     h1 {
-      font-size: 2.5rem;
+      font-size: 2.75rem;
       font-weight: 800;
       letter-spacing: -0.02em;
+      line-height: 1.1;
       color: s.$primary-text;
-      margin-bottom: 0.75rem;
+      margin: 0 auto 1rem;
+      max-width: 18ch;
     }
 
     .tagline {
       color: s.$secondary-text;
-      font-size: 1.15rem;
+      font-size: 1.2rem;
       line-height: 1.6;
+      max-width: 60ch;
+      margin: 0 auto;
+    }
+
+    .hero-cta {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 1rem;
+      margin-top: 2rem;
     }
   }
 
-  section {
-    margin-bottom: 2rem;
+  // ── Section scaffolding ─────────────────────────────────────────────────────
+  .about-section {
+    margin-bottom: 4rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    .section-head {
+      text-align: center;
+      max-width: 62ch;
+      margin: 0 auto 2rem;
+
+      h2 {
+        font-size: 1.8rem;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+        color: s.$primary-text;
+        margin-bottom: 0.6rem;
+      }
+
+      p {
+        color: s.$secondary-text;
+        font-size: 1.1rem;
+        line-height: 1.7;
+        margin: 0;
+      }
+    }
+  }
+
+  // ── How it works: numbered step cards ───────────────────────────────────────
+  .how-it-works .steps-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+
+    .step-card {
+      position: relative;
+      background: s.$white;
+      border: 1px solid s.$gray-300;
+      border-radius: s.$border-radius;
+      padding: 2rem 1.5rem 1.5rem;
+      text-align: center;
+
+      .step-num {
+        position: absolute;
+        top: -0.85rem;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 1.7rem;
+        height: 1.7rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 50%;
+        background: s.$primary;
+        color: s.$white;
+        font-size: 0.85rem;
+        font-weight: 700;
+      }
+
+      .step-icon {
+        display: inline-flex;
+        font-size: 2.25rem;
+        color: s.$secondary;
+        margin-bottom: 0.75rem;
+      }
+
+      h3 {
+        font-size: 1.2rem;
+        font-weight: 700;
+        color: s.$primary-text;
+        margin-bottom: 0.5rem;
+      }
+
+      p {
+        color: s.$secondary-text;
+        font-size: 0.98rem;
+        line-height: 1.6;
+        margin: 0;
+      }
+    }
+  }
+
+  // ── Features: icon + text cards ─────────────────────────────────────────────
+  .features .features-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.25rem;
+
+    .feature-card {
+      display: flex;
+      align-items: flex-start;
+      gap: 1rem;
+      background: s.$white;
+      border: 1px solid s.$gray-300;
+      border-radius: s.$border-radius;
+      padding: 1.5rem;
+
+      .feature-icon {
+        display: inline-flex;
+        flex-shrink: 0;
+        font-size: 1.6rem;
+        color: s.$primary;
+        background: rgba(s.$primary, 0.1);
+        border-radius: s.$border-radius;
+        padding: 0.6rem;
+      }
+
+      .feature-text {
+        h3 {
+          font-size: 1.08rem;
+          font-weight: 700;
+          color: s.$primary-text;
+          margin-bottom: 0.35rem;
+        }
+
+        p {
+          color: s.$secondary-text;
+          font-size: 0.95rem;
+          line-height: 1.6;
+          margin: 0;
+        }
+      }
+    }
+  }
+
+  // ── Story prose ─────────────────────────────────────────────────────────────
+  .about-story {
+    text-align: center;
+
+    p {
+      color: s.$secondary-text;
+      font-size: 1.08rem;
+      line-height: 1.8;
+      max-width: 65ch;
+      margin: 0 auto 1.25rem;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  // ── Closing CTA ─────────────────────────────────────────────────────────────
+  .about-cta {
+    text-align: center;
+    background: s.$gray-50;
+    border: 1px solid s.$gray-300;
+    border-radius: s.$border-radius;
+    padding: 3rem 1.5rem;
 
     h2 {
-      font-size: 1.5rem;
-      font-weight: 700;
+      font-size: 1.8rem;
+      font-weight: 800;
+      letter-spacing: -0.01em;
       color: s.$primary-text;
-      margin-bottom: 0.75rem;
+      margin-bottom: 0.5rem;
     }
 
     p {
       color: s.$secondary-text;
-      font-size: 1.05rem;
-      line-height: 1.7;
-      margin-bottom: 1rem;
+      font-size: 1.1rem;
+      line-height: 1.6;
+      margin-bottom: 1.75rem;
     }
 
-    ul {
-      margin: 0 0 1rem 1.25rem;
-      padding: 0;
-      color: s.$secondary-text;
-      font-size: 1.05rem;
-      line-height: 1.7;
-
-      li {
-        margin-bottom: 0.5rem;
-      }
-    }
-
-    strong {
-      color: s.$primary-text;
-      font-weight: 700;
+    .cta-actions {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 1rem;
     }
   }
 
-  .about-cta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    margin-top: 2.5rem;
+  // ── Shared button vocabulary (filled primary / outlined secondary) ──────────
+  .btn-primary,
+  .btn-secondary {
+    display: inline-block;
+    padding: 0.8rem 1.75rem;
+    border-radius: s.$border-radius;
+    font-weight: 700;
+    font-size: 1rem;
+    text-decoration: none;
+    transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+  }
 
-    .cta-primary,
-    .cta-secondary {
-      display: inline-block;
-      padding: 0.75rem 1.5rem;
-      border-radius: s.$border-radius;
-      font-weight: 700;
-      text-decoration: none;
-      transition: opacity 0.15s ease;
+  .btn-primary {
+    background: s.$primary;
+    color: s.$white;
 
-      &:hover {
-        opacity: 0.9;
+    &:hover {
+      opacity: 0.9;
+    }
+  }
+
+  .btn-secondary {
+    border: 2px solid s.$primary;
+    color: s.$primary;
+
+    &:hover {
+      background: rgba(s.$primary, 0.08);
+    }
+  }
+
+  // ── Mobile ──────────────────────────────────────────────────────────────────
+  @media (max-width: 600px) {
+    padding: calc(#{s.$nav-height} + 1rem) 1.1rem 3rem;
+
+    .about-hero {
+      margin-bottom: 3rem;
+
+      h1 {
+        font-size: 2.1rem;
+      }
+
+      .tagline {
+        font-size: 1.05rem;
       }
     }
 
-    .cta-primary {
-      background: s.$primary;
-      color: s.$white;
+    .about-section {
+      margin-bottom: 3rem;
+
+      .section-head h2 {
+        font-size: 1.5rem;
+      }
     }
 
-    .cta-secondary {
-      border: 2px solid s.$primary;
-      color: s.$primary;
+    .about-cta {
+      padding: 2.25rem 1.25rem;
+
+      h2 {
+        font-size: 1.5rem;
+      }
     }
   }
 }

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -10,6 +10,12 @@
   overflow-x: hidden;
   padding-top: calc(#{s.$nav-height} + 1.5rem);
 
+  // The closing CTA is a full-bleed tinted band designed to lead straight into
+  // the footer, so cancel the global $footer-margin gap (the footer keeps it on
+  // every other page). The closing section's own bottom padding is the breathing
+  // room. Kept in terms of the token so it tracks any future change.
+  margin-bottom: calc(-1 * #{s.$footer-margin});
+
   // ---- Shared building blocks ----
   .about-eyebrow,
   .about-section-eyebrow,
@@ -159,6 +165,18 @@
     background: linear-gradient(135deg, #ffd9c9 0%, #ffe9c2 100%);
   }
 
+  // Faint glyph so the gradient reads as "a recipe photo goes here" rather than
+  // an empty block. Sits under the price pill (which keeps its own stacking).
+  .about-card-media-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 2.75rem;
+    height: 2.75rem;
+    color: rgba(255, 87, 34, 0.28);
+  }
+
   .about-card-price {
     position: absolute;
     top: 0.65rem;
@@ -265,7 +283,7 @@
 
   .about-showcase-caption {
     font-size: 0.875rem;
-    color: s.$tertiary-text;
+    color: s.$secondary-text;
     max-width: 460px;
     margin: 1.85rem auto 0;
     line-height: 1.6;
@@ -463,6 +481,22 @@
 
     .about-closing-icons {
       gap: 1.4rem;
+    }
+  }
+
+  // Respect users who ask for less motion: no lift, no icon slide.
+  @media (prefers-reduced-motion: reduce) {
+    .about-btn,
+    .about-btn svg {
+      transition: none;
+    }
+
+    .about-btn:hover {
+      transform: none;
+    }
+
+    .about-btn-primary:hover svg {
+      transform: none;
     }
   }
 }

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -1,279 +1,400 @@
 @use '../../helpers.scss' as s;
 
-// Shared card shell — mirrors the app's elevated card language (soft shadow +
-// rounded corners, like the Home recipe cards) instead of a flat hairline box,
-// so About reads as the same product.
-%about-card {
-  background: s.$white;
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  border-radius: 14px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.05);
-}
-
 .about-page {
-  // Fills the flexbox app-main so the footer stays at the viewport bottom on
-  // short pages (see Layout.scss); nav is position:absolute, so offset content
-  // past it with top padding ≈ the nav height. Mirrors the legal/Help pages.
   flex: 1 0 auto;
-  padding: calc(#{s.$nav-height} + 2rem) 1.5rem 4rem;
   font-family: s.$font-family;
+  color: s.$primary-text;
+  background-color: s.$white;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+  padding-top: calc(#{s.$nav-height} + 1.5rem);
 
-  .about-inner {
-    // Wider than the legal prose column so the step/feature grids breathe;
-    // prose blocks are re-constrained to a readable measure below.
-    max-width: s.$recipe-page-max-width;
+  // ---- Shared building blocks ----
+  .about-eyebrow,
+  .about-section-eyebrow,
+  .about-moment-kicker {
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: s.$primary;
+    margin: 0 0 0.65rem;
+  }
+
+  .about-section-head {
+    max-width: 760px;
+    margin: 0 auto 2.25rem;
+  }
+
+  .about-section-title {
+    font-size: clamp(1.6rem, 3.5vw, 2.1rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+    margin: 0;
+    color: s.$primary-text;
+  }
+
+  .about-cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+  }
+
+  .about-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.65rem 1.35rem;
+    border-radius: 999px;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.18s ease, background-color 0.18s ease,
+      box-shadow 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
+    svg {
+      font-size: 1.05em;
+      transition: transform 0.18s ease;
+    }
+
+    &:hover {
+      transform: translateY(-2px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid s.$primary;
+      outline-offset: 2px;
+    }
+  }
+
+  .about-btn-primary {
+    background-color: s.$primary;
+    color: s.$white;
+    box-shadow: 0 6px 16px rgba(255, 87, 34, 0.22);
+
+    &:hover svg {
+      transform: translateX(3px);
+    }
+  }
+
+  .about-btn-ghost {
+    background-color: transparent;
+    color: s.$primary-text;
+    border: 1px solid s.$gray-300;
+
+    &:hover {
+      background-color: s.$gray-50;
+      border-color: s.$gray-200;
+    }
+  }
+
+  // ---- Sections (even vertical rhythm + hairline separators) ----
+  .about-section {
+    padding: clamp(3rem, 7vw, 5rem) 1.5rem;
+    text-align: center;
+    border-top: 1px solid s.$gray-200;
+  }
+
+  // One subtle tinted band reused for steps + closing.
+  .about-section-tint {
+    background-color: s.$gray-50;
+  }
+
+  // ---- Hero ----
+  .about-hero {
+    text-align: center;
+    padding: clamp(2rem, 5vw, 3.5rem) 1.5rem clamp(2.75rem, 6vw, 4rem);
+    max-width: 760px;
     margin: 0 auto;
   }
 
-  // ── Hero ──────────────────────────────────────────────────────────────────
-  // ── Hero — split: copy on the left, a product-proof card on the right ───────
-  .about-hero {
-    display: grid;
-    grid-template-columns: 1.05fr 0.95fr;
-    align-items: center;
-    gap: clamp(2rem, 5vw, 4rem);
-    margin-bottom: clamp(3rem, 6vw, 4.5rem);
-
-    .eyebrow {
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      font-size: 0.8rem;
-      font-weight: 700;
-      color: s.$secondary;
-      margin-bottom: 0.75rem;
-    }
-
-    h1 {
-      // Fluid headline: scales smoothly from phone to desktop.
-      font-size: clamp(2rem, 5.5vw, 2.85rem);
-      font-weight: 800;
-      letter-spacing: -0.02em;
-      line-height: 1.1;
-      color: s.$primary-text;
-      margin: 0 0 1rem;
-      max-width: 16ch;
-    }
-
-    .tagline {
-      color: s.$secondary-text;
-      font-size: clamp(1rem, 2.4vw, 1.2rem);
-      line-height: 1.6;
-      max-width: 52ch;
-      margin: 0;
-    }
-
-    .hero-cta {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: flex-start;
-      gap: 1rem;
-      margin-top: 2rem;
-    }
+  .about-hero-title {
+    font-size: clamp(2.25rem, 5vw, 3.1rem);
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    line-height: 1.07;
+    margin: 0 0 1.1rem;
+    color: s.$primary-text;
   }
 
-  // Product proof — two real Prepify surfaces shown side by side: a faithful
-  // browse card (price only, like the real thumbnail) and the recipe page's
-  // Nutrition panel floated over its corner. Honest about where each lives.
-  .hero-proof {
+  .about-hero-tagline {
+    font-size: clamp(1rem, 1.6vw, 1.1rem);
+    line-height: 1.6;
+    color: s.$secondary-text;
+    max-width: 600px;
+    margin: 0 auto 1.85rem;
+  }
+
+  // ---- Product showcase ----
+  .about-showcase-inner {
+    max-width: 760px;
+    margin: 0 auto;
+  }
+
+  .about-mock {
     display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem;
     justify-content: center;
+    align-items: stretch;
+  }
 
-    // Shrink-wraps the card so the nutrition panel can overhang its corner
-    // while staying in flow (no absolute positioning → never overlaps the next
-    // section, never causes horizontal overflow).
-    .proof-stack {
-      position: relative;
-      width: 100%;
-      max-width: 330px;
-    }
+  .about-card {
+    background-color: s.$white;
+    border-radius: s.$border-radius;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    border: 1px solid s.$gray-200;
+    overflow: hidden;
+    width: 280px;
+    max-width: 100%;
+    text-align: left;
+  }
 
-    .proof-card {
-      width: 100%;
-      background: s.$white;
-      border-radius: 16px;
-      overflow: hidden;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05), 0 18px 40px rgba(0, 0, 0, 0.12);
-    }
+  .about-card-media {
+    position: relative;
+    height: 150px;
+    background: linear-gradient(135deg, #ffd9c9 0%, #ffe9c2 100%);
+  }
 
-    .proof-thumb {
-      position: relative;
-      aspect-ratio: 4 / 3;
-      display: flex;
+  .about-card-price {
+    position: absolute;
+    top: 0.65rem;
+    left: 0.65rem;
+    background-color: s.$primary;
+    color: s.$white;
+    font-weight: 700;
+    font-size: 0.8125rem;
+    padding: 0.3rem 0.65rem;
+    border-radius: 999px;
+  }
+
+  .about-card-body {
+    padding: 1.1rem;
+  }
+
+  .about-card-title {
+    font-size: 1.0625rem;
+    font-weight: 700;
+    margin: 0 0 0.6rem;
+    color: s.$primary-text;
+  }
+
+  .about-card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.8125rem;
+    color: s.$secondary-text;
+
+    span {
+      display: inline-flex;
       align-items: center;
-      justify-content: center;
-      // Warm, appetizing stand-in for a dish photo (no asset needed).
-      background: linear-gradient(135deg, #ff9a6c 0%, #ff5722 60%, #f0481a 100%);
-
-      .proof-dish {
-        font-size: 4.5rem;
-        color: rgba(255, 255, 255, 0.92);
-      }
-
-      .proof-price {
-        position: absolute;
-        bottom: 0.7rem;
-        right: 0.7rem;
-        background: rgba(255, 255, 255, 0.95);
-        color: s.$primary;
-        font-weight: 800;
-        font-size: 0.82rem;
-        padding: 0.3rem 0.65rem;
-        border-radius: 999px;
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
-      }
+      gap: 0.28rem;
     }
 
-    .proof-body {
-      padding: 1rem 1.1rem 1.2rem;
-      text-align: left;
-
-      h3 {
-        font-size: 1.1rem;
-        font-weight: 700;
-        color: s.$primary-text;
-        margin-bottom: 0.5rem;
-      }
+    svg {
+      color: s.$secondary;
     }
+  }
 
-    .proof-meta {
-      display: flex;
-      align-items: center;
-      gap: 0.85rem;
-      flex-wrap: wrap;
-      font-size: 0.82rem;
+  .about-nutrition {
+    background-color: s.$white;
+    border-radius: s.$border-radius;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    border: 1px solid s.$gray-200;
+    padding: 1.25rem;
+    width: 280px;
+    max-width: 100%;
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .about-nutrition-label {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: s.$tertiary-text;
+    margin: 0 0 0.45rem;
+  }
+
+  .about-nutrition-cal {
+    font-size: 2rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: s.$primary-text;
+    margin: 0 0 1rem;
+    line-height: 1;
+
+    span {
+      font-size: 0.875rem;
       font-weight: 600;
-      color: s.$secondary-text;
-
-      svg {
-        vertical-align: -2px;
-        margin-right: 0.15rem;
-      }
-
-      .proof-cuisine {
-        margin-left: auto;
-        color: s.$tertiary-text;
-      }
-    }
-
-    // Floating Nutrition panel — mirrors the recipe page's nutrition card
-    // (heading + "per serving", a calories line, and labelled macro bars).
-    .proof-nutrition {
-      width: 70%;
-      margin: -1rem -0.75rem 0 auto; // tuck under the card's bottom-right corner
-      position: relative;
-      z-index: 2;
-      background: s.$white;
-      border: 1px solid rgba(0, 0, 0, 0.05);
-      border-radius: 14px;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06), 0 12px 28px rgba(0, 0, 0, 0.14);
-      padding: 0.85rem 0.95rem;
-
-      .pn-head {
-        display: flex;
-        align-items: baseline;
-        justify-content: space-between;
-        margin-bottom: 0.5rem;
-
-        h4 {
-          font-size: 0.95rem;
-          font-weight: 800;
-          color: s.$primary-text;
-        }
-
-        .pn-per {
-          font-size: 0.66rem;
-          font-weight: 600;
-          text-transform: uppercase;
-          letter-spacing: 0.03em;
-          color: s.$tertiary-text;
-        }
-      }
-
-      .pn-cal {
-        font-size: 0.85rem;
-        color: s.$secondary-text;
-        margin-bottom: 0.6rem;
-
-        strong {
-          font-size: 1.05rem;
-          font-weight: 800;
-          color: s.$primary-text;
-        }
-      }
-
-      .pn-macros {
-        display: flex;
-        flex-direction: column;
-        gap: 0.45rem;
-      }
-
-      .pn-macro-top {
-        display: flex;
-        justify-content: space-between;
-        font-size: 0.72rem;
-        font-weight: 600;
-        color: s.$secondary-text;
-        margin-bottom: 0.2rem;
-      }
-
-      .pn-track {
-        height: 5px;
-        border-radius: 999px;
-        background: s.$gray-200;
-        overflow: hidden;
-
-        .pn-fill {
-          height: 100%;
-          border-radius: 999px;
-          background: s.$secondary; // teal — the page's icon/accent colour
-        }
-      }
+      color: s.$tertiary-text;
     }
   }
 
-  // ── Section scaffolding ─────────────────────────────────────────────────────
-  .about-section {
-    margin-bottom: clamp(3rem, 6vw, 4.5rem);
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-
-    // Section heading + optional short subtitle — always centered for a steady
-    // navigational rhythm. Longer prose underneath left-aligns (see .about-story).
-    .section-head {
-      text-align: center;
-      max-width: 62ch;
-      margin: 0 auto 2rem;
-
-      h2 {
-        font-size: clamp(1.5rem, 3.5vw, 1.85rem);
-        font-weight: 800;
-        letter-spacing: -0.01em;
-        color: s.$primary-text;
-        margin-bottom: 0.6rem;
-      }
-
-      p {
-        color: s.$secondary-text;
-        font-size: clamp(1rem, 2.2vw, 1.1rem);
-        line-height: 1.6;
-        margin: 0;
-      }
-    }
+  .about-nutrition-macros {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.65rem;
   }
 
-  // ── Prose sections (What Prepify is / Why we built it) ──────────────────────
-  // Left-aligned body in a readable centered column — easier to read than
-  // centered multi-line paragraphs, and consistent with the legal pages.
-  .about-story {
+  .about-macro {
+    display: flex;
+    flex-direction: column;
+    padding: 0.5rem 0.65rem;
+    background-color: s.$gray-50;
+    border-radius: 8px;
+  }
+
+  .about-macro-value {
+    font-size: 1rem;
+    font-weight: 700;
+    color: s.$primary-text;
+  }
+
+  .about-macro-label {
+    font-size: 0.6875rem;
+    color: s.$secondary-text;
+  }
+
+  .about-showcase-caption {
+    font-size: 0.875rem;
+    color: s.$tertiary-text;
+    max-width: 460px;
+    margin: 1.85rem auto 0;
+    line-height: 1.6;
+  }
+
+  // ---- Moment (what Prepify is) ----
+  .about-moment {
+    max-width: 760px;
+    margin: 0 auto;
+  }
+
+  .about-moment-kicker {
+    margin-bottom: 0.85rem;
+  }
+
+  .about-moment-line {
+    font-size: clamp(1.2rem, 2.4vw, 1.55rem);
+    font-weight: 600;
+    line-height: 1.45;
+    letter-spacing: -0.01em;
+    color: s.$primary-text;
+    margin: 0;
+  }
+
+  // ---- Steps ----
+  .about-steps-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.75rem;
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0;
+    list-style: none;
+  }
+
+  .about-step {
+    text-align: center;
+  }
+
+  .about-step-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 999px;
+    background-color: s.$white;
+    box-shadow: s.$card-box-shadow;
+    color: s.$primary;
+    font-weight: 800;
+    font-size: 1.0625rem;
+    margin-bottom: 1rem;
+  }
+
+  .about-step-label {
+    font-size: 1.1875rem;
+    font-weight: 700;
+    margin: 0 0 0.55rem;
+    color: s.$primary-text;
+  }
+
+  .about-step-body {
+    font-size: 0.9375rem;
+    line-height: 1.6;
+    color: s.$secondary-text;
+    margin: 0 auto;
+    max-width: 300px;
+  }
+
+  // ---- Features ----
+  .about-features-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.75rem 1.5rem;
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0;
+    list-style: none;
+  }
+
+  .about-feature {
+    display: flex;
+    gap: 0.85rem;
+    text-align: left;
+    align-items: flex-start;
+  }
+
+  .about-feature-icon {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: s.$border-radius;
+    background-color: rgba(255, 87, 34, 0.08);
+    color: s.$primary;
+    font-size: 1.2rem;
+  }
+
+  .about-feature-text {
+    min-width: 0;
+  }
+
+  .about-feature-title {
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0.15rem 0 0.35rem;
+    color: s.$primary-text;
+  }
+
+  .about-feature-body {
+    font-size: 0.875rem;
+    line-height: 1.55;
+    color: s.$secondary-text;
+    margin: 0;
+  }
+
+  // ---- Story ----
+  .about-story-body {
+    max-width: 680px;
+    margin: 0 auto;
+    text-align: left;
+
     p {
+      font-size: 1rem;
+      line-height: 1.7;
       color: s.$secondary-text;
-      font-size: clamp(1rem, 2.2vw, 1.08rem);
-      line-height: 1.8;
-      max-width: 68ch;
-      margin: 0 auto 1.25rem;
-      text-align: left;
+      margin: 0 0 1.25rem;
 
       &:last-child {
         margin-bottom: 0;
@@ -281,253 +402,67 @@
     }
   }
 
-  // ── How it works — tinted band so the section reads as one grouped step ──────
-  .how-it-works {
-    background: s.$gray-50;
-    border: 1px solid rgba(0, 0, 0, 0.05);
-    border-radius: 18px;
-    padding: clamp(2rem, 4vw, 3rem) clamp(1.25rem, 3vw, 2.5rem);
-
-    .section-head {
-      margin-bottom: 2.25rem;
-    }
-
-    .steps-grid {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: clamp(1rem, 2vw, 1.5rem);
-
-      .step-card {
-        @extend %about-card;
-        position: relative;
-        padding: 2.25rem 1.5rem 1.5rem;
-        text-align: center;
-
-        .step-num {
-          position: absolute;
-          top: -0.85rem;
-          left: 50%;
-          transform: translateX(-50%);
-          width: 1.7rem;
-          height: 1.7rem;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          border-radius: 50%;
-          background: s.$primary; // orange = sequence marker, echoes the CTAs
-          color: s.$white;
-          font-size: 0.85rem;
-          font-weight: 700;
-        }
-
-        .step-icon {
-          display: inline-flex;
-          font-size: 2.25rem;
-          color: s.$secondary; // teal = the single icon accent (see features)
-          margin-bottom: 0.75rem;
-        }
-
-        h3 {
-          font-size: 1.2rem;
-          font-weight: 700;
-          color: s.$primary-text;
-          margin-bottom: 0.5rem;
-        }
-
-        p {
-          color: s.$secondary-text;
-          font-size: 0.98rem;
-          line-height: 1.6;
-          margin: 0;
-        }
-      }
-    }
+  // ---- Closing ----
+  .about-closing-title {
+    font-size: clamp(1.7rem, 4vw, 2.35rem);
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    line-height: 1.12;
+    margin: 0 0 0.85rem;
+    color: s.$primary-text;
   }
 
-  // ── Features grid ───────────────────────────────────────────────────────────
-  .features .features-grid {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: clamp(1rem, 2vw, 1.25rem);
-
-    .feature-card {
-      @extend %about-card;
-      display: flex;
-      align-items: flex-start;
-      gap: 1rem;
-      padding: 1.5rem;
-
-      .feature-icon {
-        display: inline-flex;
-        flex-shrink: 0;
-        font-size: 1.6rem;
-        color: s.$secondary; // unified teal icon accent
-        background: rgba(s.$secondary, 0.1);
-        border-radius: 12px;
-        padding: 0.6rem;
-      }
-
-      .feature-text {
-        h3 {
-          font-size: 1.08rem;
-          font-weight: 700;
-          color: s.$primary-text;
-          margin-bottom: 0.35rem;
-        }
-
-        p {
-          color: s.$secondary-text;
-          font-size: 0.95rem;
-          line-height: 1.6;
-          margin: 0;
-        }
-      }
-    }
+  .about-closing-line {
+    font-size: clamp(1rem, 1.6vw, 1.15rem);
+    color: s.$secondary-text;
+    margin: 0 auto 1.85rem;
+    max-width: 520px;
+    line-height: 1.6;
   }
 
-  // ── Closing CTA — brand-tinted, the visual climax ───────────────────────────
-  .about-cta {
-    text-align: center;
-    background: linear-gradient(135deg, #fff6f3, #eefafa);
-    border: 1px solid rgba(s.$primary, 0.12);
-    border-radius: 18px;
-    padding: clamp(2.5rem, 5vw, 3.5rem) clamp(1.25rem, 4vw, 2.5rem);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03), 0 12px 32px rgba(0, 0, 0, 0.05);
-
-    h2 {
-      font-size: clamp(1.6rem, 4vw, 2rem);
-      font-weight: 800;
-      letter-spacing: -0.01em;
-      color: s.$primary-text;
-      margin-bottom: 0.5rem;
-    }
-
-    p {
-      color: s.$secondary-text;
-      font-size: clamp(1rem, 2.4vw, 1.15rem);
-      line-height: 1.6;
-      margin-bottom: 1.75rem;
-    }
-
-    .cta-actions {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 1rem;
-    }
+  .about-closing-icons {
+    display: flex;
+    justify-content: center;
+    gap: 1.75rem;
+    margin-top: 2.5rem;
+    color: s.$gray-300;
+    font-size: 1.4rem;
   }
 
-  // ── Shared button vocabulary (filled primary / outlined secondary) ──────────
-  .btn-primary,
-  .btn-secondary {
-    display: inline-block;
-    padding: 0.8rem 1.75rem;
-    border-radius: s.$border-radius;
-    font-weight: 700;
-    font-size: 1rem;
-    text-decoration: none;
-    transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease,
-      box-shadow 0.15s ease;
-
-    &:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 3px rgba(s.$primary, 0.35);
-    }
-  }
-
-  .btn-primary {
-    background: s.$primary;
-    color: s.$white;
-
-    &:hover {
-      opacity: 0.9;
-    }
-  }
-
-  .btn-secondary {
-    border: 2px solid s.$primary;
-    color: s.$primary;
-
-    &:hover {
-      background: rgba(s.$primary, 0.08);
-    }
-  }
-
-  // ── Hero stacks below the split breakpoint ──────────────────────────────────
-  @media (max-width: 900px) {
-    .about-hero {
+  // ---- Responsive ----
+  @media (max-width: 768px) {
+    .about-steps-grid {
       grid-template-columns: 1fr;
-      text-align: center;
-      gap: clamp(2rem, 5vw, 3rem);
-
-      h1 {
-        max-width: 20ch;
-        margin-left: auto;
-        margin-right: auto;
-      }
-
-      .tagline {
-        max-width: 56ch;
-        margin-left: auto;
-        margin-right: auto;
-      }
-
-      .hero-cta {
-        justify-content: center;
-      }
+      gap: 2.25rem;
+      max-width: 400px;
     }
-  }
 
-  // ── Tablet ──────────────────────────────────────────────────────────────────
-  @media (max-width: 1023px) {
-    // 6 features → 2 columns (3 balanced rows).
-    .features .features-grid {
+    .about-features-grid {
       grid-template-columns: repeat(2, 1fr);
+      gap: 1.75rem 1.25rem;
+      max-width: 640px;
     }
   }
 
-  // ── Mobile ──────────────────────────────────────────────────────────────────
-  @media (max-width: 600px) {
-    padding: calc(#{s.$nav-height} + 1rem) 1.1rem 3rem;
+  @media (max-width: 480px) {
+    padding-top: calc(#{s.$nav-height} + 1rem);
 
-    .about-hero {
-      .hero-cta {
-        flex-direction: column;
-        align-items: stretch;
-      }
-    }
-
-    // Centre the nutrition panel under the card on phones (no corner overhang),
-    // so it never crowds the padding on the narrowest screens.
-    .hero-proof .proof-nutrition {
-      width: 85%;
-      margin: -1rem auto 0;
-    }
-
-    // Single column for both grids so each card gets full width and tap area.
-    .how-it-works .steps-grid,
-    .features .features-grid {
+    .about-features-grid {
       grid-template-columns: 1fr;
+      max-width: 360px;
     }
 
-    // Full-width, comfortably tappable CTAs (≥44px target) on phones.
-    .btn-primary,
-    .btn-secondary {
+    .about-btn {
       width: 100%;
-      box-sizing: border-box;
-      text-align: center;
-      padding: 0.9rem 1.5rem;
+      justify-content: center;
     }
 
-    .about-cta .cta-actions {
-      flex-direction: column;
-      align-items: stretch;
+    .about-cta {
+      width: 100%;
+    }
+
+    .about-closing-icons {
+      gap: 1.4rem;
     }
   }
 }

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -1,5 +1,15 @@
 @use '../../helpers.scss' as s;
 
+// Shared card shell — mirrors the app's elevated card language (soft shadow +
+// rounded corners, like the Home recipe cards) instead of a flat hairline box,
+// so About reads as the same product.
+%about-card {
+  background: s.$white;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  border-radius: 14px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.05);
+}
+
 .about-page {
   // Fills the flexbox app-main so the footer stays at the viewport bottom on
   // short pages (see Layout.scss); nav is position:absolute, so offset content
@@ -10,7 +20,7 @@
 
   .about-inner {
     // Wider than the legal prose column so the step/feature grids breathe;
-    // individual prose blocks are re-constrained to a readable measure below.
+    // prose blocks are re-constrained to a readable measure below.
     max-width: s.$recipe-page-max-width;
     margin: 0 auto;
   }
@@ -18,7 +28,7 @@
   // ── Hero ──────────────────────────────────────────────────────────────────
   .about-hero {
     text-align: center;
-    margin-bottom: 4rem;
+    margin-bottom: clamp(3rem, 6vw, 4.5rem);
 
     .eyebrow {
       text-transform: uppercase;
@@ -30,7 +40,8 @@
     }
 
     h1 {
-      font-size: 2.75rem;
+      // Fluid headline: scales smoothly from phone to desktop.
+      font-size: clamp(2rem, 5.5vw, 2.85rem);
       font-weight: 800;
       letter-spacing: -0.02em;
       line-height: 1.1;
@@ -41,9 +52,9 @@
 
     .tagline {
       color: s.$secondary-text;
-      font-size: 1.2rem;
+      font-size: clamp(1rem, 2.4vw, 1.2rem);
       line-height: 1.6;
-      max-width: 60ch;
+      max-width: 58ch;
       margin: 0 auto;
     }
 
@@ -58,19 +69,21 @@
 
   // ── Section scaffolding ─────────────────────────────────────────────────────
   .about-section {
-    margin-bottom: 4rem;
+    margin-bottom: clamp(3rem, 6vw, 4.5rem);
 
     &:last-child {
       margin-bottom: 0;
     }
 
+    // Section heading + optional short subtitle — always centered for a steady
+    // navigational rhythm. Longer prose underneath left-aligns (see .about-story).
     .section-head {
       text-align: center;
       max-width: 62ch;
       margin: 0 auto 2rem;
 
       h2 {
-        font-size: 1.8rem;
+        font-size: clamp(1.5rem, 3.5vw, 1.85rem);
         font-weight: 800;
         letter-spacing: -0.01em;
         color: s.$primary-text;
@@ -79,95 +92,120 @@
 
       p {
         color: s.$secondary-text;
-        font-size: 1.1rem;
-        line-height: 1.7;
-        margin: 0;
-      }
-    }
-  }
-
-  // ── How it works: numbered step cards ───────────────────────────────────────
-  .how-it-works .steps-grid {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.25rem;
-
-    .step-card {
-      position: relative;
-      background: s.$white;
-      border: 1px solid s.$gray-300;
-      border-radius: s.$border-radius;
-      padding: 2rem 1.5rem 1.5rem;
-      text-align: center;
-
-      .step-num {
-        position: absolute;
-        top: -0.85rem;
-        left: 50%;
-        transform: translateX(-50%);
-        width: 1.7rem;
-        height: 1.7rem;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border-radius: 50%;
-        background: s.$primary;
-        color: s.$white;
-        font-size: 0.85rem;
-        font-weight: 700;
-      }
-
-      .step-icon {
-        display: inline-flex;
-        font-size: 2.25rem;
-        color: s.$secondary;
-        margin-bottom: 0.75rem;
-      }
-
-      h3 {
-        font-size: 1.2rem;
-        font-weight: 700;
-        color: s.$primary-text;
-        margin-bottom: 0.5rem;
-      }
-
-      p {
-        color: s.$secondary-text;
-        font-size: 0.98rem;
+        font-size: clamp(1rem, 2.2vw, 1.1rem);
         line-height: 1.6;
         margin: 0;
       }
     }
   }
 
-  // ── Features: icon + text cards ─────────────────────────────────────────────
+  // ── Prose sections (What Prepify is / Why we built it) ──────────────────────
+  // Left-aligned body in a readable centered column — easier to read than
+  // centered multi-line paragraphs, and consistent with the legal pages.
+  .about-story {
+    p {
+      color: s.$secondary-text;
+      font-size: clamp(1rem, 2.2vw, 1.08rem);
+      line-height: 1.8;
+      max-width: 68ch;
+      margin: 0 auto 1.25rem;
+      text-align: left;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  // ── How it works — tinted band so the section reads as one grouped step ──────
+  .how-it-works {
+    background: s.$gray-50;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    border-radius: 18px;
+    padding: clamp(2rem, 4vw, 3rem) clamp(1.25rem, 3vw, 2.5rem);
+
+    .section-head {
+      margin-bottom: 2.25rem;
+    }
+
+    .steps-grid {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: clamp(1rem, 2vw, 1.5rem);
+
+      .step-card {
+        @extend %about-card;
+        position: relative;
+        padding: 2.25rem 1.5rem 1.5rem;
+        text-align: center;
+
+        .step-num {
+          position: absolute;
+          top: -0.85rem;
+          left: 50%;
+          transform: translateX(-50%);
+          width: 1.7rem;
+          height: 1.7rem;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border-radius: 50%;
+          background: s.$primary; // orange = sequence marker, echoes the CTAs
+          color: s.$white;
+          font-size: 0.85rem;
+          font-weight: 700;
+        }
+
+        .step-icon {
+          display: inline-flex;
+          font-size: 2.25rem;
+          color: s.$secondary; // teal = the single icon accent (see features)
+          margin-bottom: 0.75rem;
+        }
+
+        h3 {
+          font-size: 1.2rem;
+          font-weight: 700;
+          color: s.$primary-text;
+          margin-bottom: 0.5rem;
+        }
+
+        p {
+          color: s.$secondary-text;
+          font-size: 0.98rem;
+          line-height: 1.6;
+          margin: 0;
+        }
+      }
+    }
+  }
+
+  // ── Features grid ───────────────────────────────────────────────────────────
   .features .features-grid {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1.25rem;
+    grid-template-columns: repeat(3, 1fr);
+    gap: clamp(1rem, 2vw, 1.25rem);
 
     .feature-card {
+      @extend %about-card;
       display: flex;
       align-items: flex-start;
       gap: 1rem;
-      background: s.$white;
-      border: 1px solid s.$gray-300;
-      border-radius: s.$border-radius;
       padding: 1.5rem;
 
       .feature-icon {
         display: inline-flex;
         flex-shrink: 0;
         font-size: 1.6rem;
-        color: s.$primary;
-        background: rgba(s.$primary, 0.1);
-        border-radius: s.$border-radius;
+        color: s.$secondary; // unified teal icon accent
+        background: rgba(s.$secondary, 0.1);
+        border-radius: 12px;
         padding: 0.6rem;
       }
 
@@ -189,33 +227,17 @@
     }
   }
 
-  // ── Story prose ─────────────────────────────────────────────────────────────
-  .about-story {
-    text-align: center;
-
-    p {
-      color: s.$secondary-text;
-      font-size: 1.08rem;
-      line-height: 1.8;
-      max-width: 65ch;
-      margin: 0 auto 1.25rem;
-
-      &:last-child {
-        margin-bottom: 0;
-      }
-    }
-  }
-
-  // ── Closing CTA ─────────────────────────────────────────────────────────────
+  // ── Closing CTA — brand-tinted, the visual climax ───────────────────────────
   .about-cta {
     text-align: center;
-    background: s.$gray-50;
-    border: 1px solid s.$gray-300;
-    border-radius: s.$border-radius;
-    padding: 3rem 1.5rem;
+    background: linear-gradient(135deg, #fff6f3, #eefafa);
+    border: 1px solid rgba(s.$primary, 0.12);
+    border-radius: 18px;
+    padding: clamp(2.5rem, 5vw, 3.5rem) clamp(1.25rem, 4vw, 2.5rem);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03), 0 12px 32px rgba(0, 0, 0, 0.05);
 
     h2 {
-      font-size: 1.8rem;
+      font-size: clamp(1.6rem, 4vw, 2rem);
       font-weight: 800;
       letter-spacing: -0.01em;
       color: s.$primary-text;
@@ -224,7 +246,7 @@
 
     p {
       color: s.$secondary-text;
-      font-size: 1.1rem;
+      font-size: clamp(1rem, 2.4vw, 1.15rem);
       line-height: 1.6;
       margin-bottom: 1.75rem;
     }
@@ -246,7 +268,13 @@
     font-weight: 700;
     font-size: 1rem;
     text-decoration: none;
-    transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+    transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease,
+      box-shadow 0.15s ease;
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(s.$primary, 0.35);
+    }
   }
 
   .btn-primary {
@@ -267,36 +295,43 @@
     }
   }
 
+  // ── Tablet ──────────────────────────────────────────────────────────────────
+  @media (max-width: 1023px) {
+    // 5 features → 2 columns (last card trails left-aligned, reads intentional).
+    .features .features-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
   // ── Mobile ──────────────────────────────────────────────────────────────────
   @media (max-width: 600px) {
     padding: calc(#{s.$nav-height} + 1rem) 1.1rem 3rem;
 
     .about-hero {
-      margin-bottom: 3rem;
-
-      h1 {
-        font-size: 2.1rem;
-      }
-
-      .tagline {
-        font-size: 1.05rem;
+      .hero-cta {
+        flex-direction: column;
+        align-items: stretch;
       }
     }
 
-    .about-section {
-      margin-bottom: 3rem;
-
-      .section-head h2 {
-        font-size: 1.5rem;
-      }
+    // Single column for both grids so each card gets full width and tap area.
+    .how-it-works .steps-grid,
+    .features .features-grid {
+      grid-template-columns: 1fr;
     }
 
-    .about-cta {
-      padding: 2.25rem 1.25rem;
+    // Full-width, comfortably tappable CTAs (≥44px target) on phones.
+    .btn-primary,
+    .btn-secondary {
+      width: 100%;
+      box-sizing: border-box;
+      text-align: center;
+      padding: 0.9rem 1.5rem;
+    }
 
-      h2 {
-        font-size: 1.5rem;
-      }
+    .about-cta .cta-actions {
+      flex-direction: column;
+      align-items: stretch;
     }
   }
 }

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -26,8 +26,12 @@
   }
 
   // ── Hero ──────────────────────────────────────────────────────────────────
+  // ── Hero — split: copy on the left, a product-proof card on the right ───────
   .about-hero {
-    text-align: center;
+    display: grid;
+    grid-template-columns: 1.05fr 0.95fr;
+    align-items: center;
+    gap: clamp(2rem, 5vw, 4rem);
     margin-bottom: clamp(3rem, 6vw, 4.5rem);
 
     .eyebrow {
@@ -46,24 +50,130 @@
       letter-spacing: -0.02em;
       line-height: 1.1;
       color: s.$primary-text;
-      margin: 0 auto 1rem;
-      max-width: 18ch;
+      margin: 0 0 1rem;
+      max-width: 16ch;
     }
 
     .tagline {
       color: s.$secondary-text;
       font-size: clamp(1rem, 2.4vw, 1.2rem);
       line-height: 1.6;
-      max-width: 58ch;
-      margin: 0 auto;
+      max-width: 52ch;
+      margin: 0;
     }
 
     .hero-cta {
       display: flex;
       flex-wrap: wrap;
-      justify-content: center;
+      justify-content: flex-start;
       gap: 1rem;
       margin-top: 2rem;
+    }
+  }
+
+  // Product-proof card — shows the value prop (per-serving price + nutrition)
+  // rather than only describing it. Mirrors the Home recipe-card vocabulary.
+  .hero-proof {
+    display: flex;
+    justify-content: center;
+
+    .proof-card {
+      width: 100%;
+      max-width: 330px;
+      background: s.$white;
+      border-radius: 16px;
+      overflow: hidden;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05), 0 18px 40px rgba(0, 0, 0, 0.12);
+    }
+
+    .proof-thumb {
+      position: relative;
+      aspect-ratio: 4 / 3;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      // Warm, appetizing stand-in for a dish photo (no asset needed).
+      background: linear-gradient(135deg, #ff9a6c 0%, #ff5722 60%, #f0481a 100%);
+
+      .proof-dish {
+        font-size: 4.5rem;
+        color: rgba(255, 255, 255, 0.92);
+      }
+
+      .proof-price {
+        position: absolute;
+        bottom: 0.7rem;
+        right: 0.7rem;
+        background: rgba(255, 255, 255, 0.95);
+        color: s.$primary;
+        font-weight: 800;
+        font-size: 0.82rem;
+        padding: 0.3rem 0.65rem;
+        border-radius: 999px;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+      }
+    }
+
+    .proof-body {
+      padding: 1rem 1.1rem 1.2rem;
+      text-align: left;
+
+      h3 {
+        font-size: 1.1rem;
+        font-weight: 700;
+        color: s.$primary-text;
+        margin-bottom: 0.5rem;
+      }
+    }
+
+    .proof-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.85rem;
+      flex-wrap: wrap;
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: s.$secondary-text;
+      margin-bottom: 0.9rem;
+
+      svg {
+        vertical-align: -2px;
+        margin-right: 0.15rem;
+      }
+
+      .proof-cuisine {
+        margin-left: auto;
+        color: s.$tertiary-text;
+      }
+    }
+
+    .proof-nutrition {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 0.4rem;
+      padding-top: 0.9rem;
+      border-top: 1px solid s.$gray-200;
+
+      .macro {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.15rem;
+
+        .val {
+          font-weight: 800;
+          font-size: 0.95rem;
+          color: s.$primary-text;
+        }
+
+        .lbl {
+          font-size: 0.66rem;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.03em;
+          color: s.$tertiary-text;
+        }
+      }
     }
   }
 
@@ -295,9 +405,34 @@
     }
   }
 
+  // ── Hero stacks below the split breakpoint ──────────────────────────────────
+  @media (max-width: 900px) {
+    .about-hero {
+      grid-template-columns: 1fr;
+      text-align: center;
+      gap: clamp(2rem, 5vw, 3rem);
+
+      h1 {
+        max-width: 20ch;
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      .tagline {
+        max-width: 56ch;
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      .hero-cta {
+        justify-content: center;
+      }
+    }
+  }
+
   // ── Tablet ──────────────────────────────────────────────────────────────────
   @media (max-width: 1023px) {
-    // 5 features → 2 columns (last card trails left-aligned, reads intentional).
+    // 6 features → 2 columns (3 balanced rows).
     .features .features-grid {
       grid-template-columns: repeat(2, 1fr);
     }

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -71,15 +71,24 @@
     }
   }
 
-  // Product-proof card — shows the value prop (per-serving price + nutrition)
-  // rather than only describing it. Mirrors the Home recipe-card vocabulary.
+  // Product proof — two real Prepify surfaces shown side by side: a faithful
+  // browse card (price only, like the real thumbnail) and the recipe page's
+  // Nutrition panel floated over its corner. Honest about where each lives.
   .hero-proof {
     display: flex;
     justify-content: center;
 
-    .proof-card {
+    // Shrink-wraps the card so the nutrition panel can overhang its corner
+    // while staying in flow (no absolute positioning → never overlaps the next
+    // section, never causes horizontal overflow).
+    .proof-stack {
+      position: relative;
       width: 100%;
       max-width: 330px;
+    }
+
+    .proof-card {
+      width: 100%;
       background: s.$white;
       border-radius: 16px;
       overflow: hidden;
@@ -134,7 +143,6 @@
       font-size: 0.82rem;
       font-weight: 600;
       color: s.$secondary-text;
-      margin-bottom: 0.9rem;
 
       svg {
         vertical-align: -2px;
@@ -147,31 +155,77 @@
       }
     }
 
+    // Floating Nutrition panel — mirrors the recipe page's nutrition card
+    // (heading + "per serving", a calories line, and labelled macro bars).
     .proof-nutrition {
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      gap: 0.4rem;
-      padding-top: 0.9rem;
-      border-top: 1px solid s.$gray-200;
+      width: 70%;
+      margin: -1rem -0.75rem 0 auto; // tuck under the card's bottom-right corner
+      position: relative;
+      z-index: 2;
+      background: s.$white;
+      border: 1px solid rgba(0, 0, 0, 0.05);
+      border-radius: 14px;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06), 0 12px 28px rgba(0, 0, 0, 0.14);
+      padding: 0.85rem 0.95rem;
 
-      .macro {
+      .pn-head {
         display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 0.15rem;
+        align-items: baseline;
+        justify-content: space-between;
+        margin-bottom: 0.5rem;
 
-        .val {
-          font-weight: 800;
+        h4 {
           font-size: 0.95rem;
+          font-weight: 800;
           color: s.$primary-text;
         }
 
-        .lbl {
+        .pn-per {
           font-size: 0.66rem;
           font-weight: 600;
           text-transform: uppercase;
           letter-spacing: 0.03em;
           color: s.$tertiary-text;
+        }
+      }
+
+      .pn-cal {
+        font-size: 0.85rem;
+        color: s.$secondary-text;
+        margin-bottom: 0.6rem;
+
+        strong {
+          font-size: 1.05rem;
+          font-weight: 800;
+          color: s.$primary-text;
+        }
+      }
+
+      .pn-macros {
+        display: flex;
+        flex-direction: column;
+        gap: 0.45rem;
+      }
+
+      .pn-macro-top {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.72rem;
+        font-weight: 600;
+        color: s.$secondary-text;
+        margin-bottom: 0.2rem;
+      }
+
+      .pn-track {
+        height: 5px;
+        border-radius: 999px;
+        background: s.$gray-200;
+        overflow: hidden;
+
+        .pn-fill {
+          height: 100%;
+          border-radius: 999px;
+          background: s.$secondary; // teal — the page's icon/accent colour
         }
       }
     }
@@ -447,6 +501,13 @@
         flex-direction: column;
         align-items: stretch;
       }
+    }
+
+    // Centre the nutrition panel under the card on phones (no corner overhang),
+    // so it never crowds the padding on the narrowest screens.
+    .hero-proof .proof-nutrition {
+      width: 85%;
+      margin: -1rem auto 0;
     }
 
     // Single column for both grids so each card gets full width and tap area.

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -24,17 +24,17 @@ const STEPS: Step[] = [
   {
     icon: <MdOutlineSearch />,
     title: 'Plan',
-    body: 'Browse recipes with the price and nutrition already on the card. Filter by cuisine, diet, or meal type and build around your budget and your goals.',
+    body: 'Browse recipes with prices and nutrition already on the card. Filter by cuisine, diet, or meal type, and build your plan around your budget and goals.',
   },
   {
     icon: <MdOutlineShoppingCart />,
     title: 'Shop',
-    body: 'Every recipe breaks down to a real per-serving cost, so you can fill your cart with a clear total — no mental math in the aisle.',
+    body: 'Every recipe breaks down to a real cost per serving — no more mental math in the aisle. Fill your cart with a clear total.',
   },
   {
     icon: <MdOutlineRestaurantMenu />,
     title: 'Cook',
-    body: 'Follow clear, step-by-step recipes. Rate what you make, save your favorites, and come back to the meals that earn a spot in the rotation.',
+    body: 'Follow clear, step-by-step recipes. Rate what you make, save your favorites, and come back to the ones you love.',
   },
 ]
 
@@ -47,28 +47,28 @@ type Feature = {
 const FEATURES: Feature[] = [
   {
     icon: <MdOutlineSell />,
-    title: 'Real per-serving prices',
-    body: 'Costs are calculated from the actual ingredients — shown up front, on every recipe.',
+    title: 'Real price per serving',
+    body: 'We show you the real price per serving, calculated from the actual ingredients.',
   },
   {
     icon: <MdOutlineMonitorHeart />,
     title: 'Full nutrition, automatically',
-    body: 'Calories and macros are computed for you, so you can see how a meal fits your day.',
+    body: 'Calories and macros are computed for you — no spreadsheets required.',
   },
   {
     icon: <MdOutlineTune />,
     title: 'Search & filter that works',
-    body: 'Narrow by cuisine, diet, and meal type to find something that fits right now.',
+    body: 'Search and filter by cuisine, diet, and meal type to find something that fits.',
   },
   {
     icon: <MdOutlineEditNote />,
     title: 'Add your own recipes',
-    body: 'Paste your ingredients and let automatic parsing handle the price and nutrition math.',
+    body: 'Add your own recipes and let us handle the price and nutrition math.',
   },
   {
     icon: <MdOutlineBookmarkBorder />,
     title: 'Save & revisit',
-    body: 'Keep the meals you love a click away, and rate and review the ones worth sharing.',
+    body: 'Save and revisit your favorite meals — the ones you love, a click away.',
   },
 ]
 
@@ -91,7 +91,7 @@ const About: FC = () => (
       <meta property='og:title' content='About Prepify' />
       <meta
         property='og:description'
-        content='Every recipe comes with its real per-serving price and full nutrition built in — so you always know what a meal costs and what is in it before you cook.'
+        content='No more surprises. Every recipe on Prepify shows its real price per serving and full nutrition up front — so you always know what you are getting into before you start cooking.'
       />
       <meta property='og:type' content='website' />
       <meta property='og:url' content='https://www.prepifymeals.com/about' />
@@ -100,11 +100,11 @@ const About: FC = () => (
     <div className='about-inner'>
       <header className='about-hero'>
         <p className='eyebrow'>About Prepify</p>
-        <h1>Recipes that tell you the whole story.</h1>
+        <h1>Prepify&rsquo;s got your back.</h1>
         <p className='tagline'>
-          Every recipe on Prepify comes with its real per-serving price and full
-          nutrition built right in &mdash; so you always know what a meal costs,
-          and what&rsquo;s in it, before you start cooking.
+          No more surprises. Every recipe on the site shows its real price per
+          serving and full nutrition, upfront &mdash; so you always know what
+          you&rsquo;re getting into before you start cooking.
         </p>
         <div className='hero-cta'>
           <Link to='/recipes' className='btn-primary'>
@@ -120,11 +120,10 @@ const About: FC = () => (
         <div className='section-head'>
           <h2>What Prepify is</h2>
           <p>
-            Prepify is a recipe site with one promise: no surprises. The price
-            and nutrition aren&rsquo;t an afterthought buried at the bottom of
-            the page &mdash; they&rsquo;re calculated from the real ingredients
-            and shown up front, on every recipe. Search, save, and cook knowing
-            exactly what each meal costs and how it fits your day.
+            Prepify is all about transparency. We&rsquo;re a recipe site that
+            keeps it real &mdash; no buried costs, no missing nutrition info.
+            It&rsquo;s all calculated from the actual ingredients and shown right
+            there on the recipe.
           </p>
         </div>
       </section>
@@ -132,7 +131,7 @@ const About: FC = () => (
       <section className='about-section how-it-works'>
         <div className='section-head'>
           <h2>How it works</h2>
-          <p>Plan, shop, and cook with zero guesswork.</p>
+          <p>Three simple steps: plan, shop, and cook.</p>
         </div>
         <ol className='steps-grid'>
           {STEPS.map((step, i) => (
@@ -151,6 +150,7 @@ const About: FC = () => (
       <section className='about-section features'>
         <div className='section-head'>
           <h2>What you can do</h2>
+          <p>Here&rsquo;s the good stuff.</p>
         </div>
         <ul className='features-grid'>
           {FEATURES.map(feature => (
@@ -172,24 +172,23 @@ const About: FC = () => (
           <h2>Why we built it</h2>
         </div>
         <p>
-          Most recipes tell you how to cook a dish &mdash; but never what it
-          actually costs. We got tired of scrolling between tabs, guessing at
-          grocery totals, and hoping a meal would fit the budget. So we built
-          the recipe site we actually wanted to use: cost and nutrition
-          transparency on every recipe, by default.
+          We built Prepify because we were tired of guessing. Most recipes
+          don&rsquo;t tell you what they actually cost, so we got tired of
+          scrolling between tabs and hoping a meal would fit the budget. So we
+          built the recipe site we wanted to use: cost and nutrition
+          transparency, on every recipe, by default.
         </p>
         <p>
-          Honestly, we built Prepify for ourselves &mdash; to surface the
-          information we genuinely care about. I&rsquo;m Jesse, a self-taught
-          developer who cooks at home. I lift, so I like to keep an eye on my
-          nutrition &mdash; but more than that, I never want to get excited
-          about a new recipe only to find it doesn&rsquo;t fit my budget.
-          That&rsquo;s exactly why Prepify works the way it does.
+          I&rsquo;m Jesse, a self-taught developer who cooks at home. I built
+          Prepify for myself &mdash; to surface the info I actually care about. I
+          like to keep an eye on my nutrition, but I also don&rsquo;t want to get
+          excited about a recipe only to find it doesn&rsquo;t fit my budget.
+          That&rsquo;s why Prepify works the way it does.
         </p>
         <p>
-          Prepify is an independent project, built and maintained with care by
-          people who cook at home just like you. We&rsquo;re always improving
-          it, and we read every piece of feedback that comes our way.
+          We&rsquo;re independent &mdash; built and maintained with care by
+          people who cook at home. We&rsquo;re always improving, and we read
+          every piece of feedback that comes our way.
         </p>
       </section>
 

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -29,7 +29,7 @@ const STEPS: Step[] = [
   {
     icon: <MdOutlineShoppingCart />,
     title: 'Shop',
-    body: 'Every recipe breaks down to a real cost per serving — no more mental math in the aisle. Fill your cart with a clear total.',
+    body: 'Every recipe breaks down to a real cost per serving. No more mental math in the aisle. Fill your cart with a clear total.',
   },
   {
     icon: <MdOutlineRestaurantMenu />,
@@ -53,7 +53,7 @@ const FEATURES: Feature[] = [
   {
     icon: <MdOutlineMonitorHeart />,
     title: 'Full nutrition, automatically',
-    body: 'Calories and macros are computed for you — no spreadsheets required.',
+    body: 'Calories and macros are computed for you. No spreadsheets required.',
   },
   {
     icon: <MdOutlineTune />,
@@ -68,7 +68,7 @@ const FEATURES: Feature[] = [
   {
     icon: <MdOutlineBookmarkBorder />,
     title: 'Save & revisit',
-    body: 'Save and revisit your favorite meals — the ones you love, a click away.',
+    body: 'Save and revisit your favorite meals. The ones you love, a click away.',
   },
 ]
 
@@ -85,13 +85,13 @@ const About: FC = () => (
       <title>Prepify | About</title>
       <meta
         name='description'
-        content='Prepify is a recipe site where every recipe shows its real per-serving price and full nutrition up front — so you can plan, shop, and cook with zero guesswork.'
+        content='Prepify is a recipe site where every recipe shows its real per-serving price and full nutrition up front, so you can plan, shop, and cook with zero guesswork.'
       />
       <link rel='canonical' href='https://www.prepifymeals.com/about' />
       <meta property='og:title' content='About Prepify' />
       <meta
         property='og:description'
-        content='No more surprises. Every recipe on Prepify shows its real price per serving and full nutrition up front — so you always know what you are getting into before you start cooking.'
+        content='No more surprises. Every recipe on Prepify shows its real price per serving and full nutrition up front. You always know what you are getting into before you start cooking.'
       />
       <meta property='og:type' content='website' />
       <meta property='og:url' content='https://www.prepifymeals.com/about' />
@@ -103,7 +103,7 @@ const About: FC = () => (
         <h1>Prepify&rsquo;s got your back.</h1>
         <p className='tagline'>
           No more surprises. Every recipe on the site shows its real price per
-          serving and full nutrition, upfront &mdash; so you always know what
+          serving and full nutrition, upfront. You always know what
           you&rsquo;re getting into before you start cooking.
         </p>
         <div className='hero-cta'>
@@ -121,7 +121,7 @@ const About: FC = () => (
           <h2>What Prepify is</h2>
           <p>
             Prepify is all about transparency. We&rsquo;re a recipe site that
-            keeps it real &mdash; no buried costs, no missing nutrition info.
+            keeps it real. No buried costs, no missing nutrition info.
             It&rsquo;s all calculated from the actual ingredients and shown right
             there on the recipe.
           </p>
@@ -180,21 +180,21 @@ const About: FC = () => (
         </p>
         <p>
           I&rsquo;m Jesse, a self-taught developer who cooks at home. I built
-          Prepify for myself &mdash; to surface the info I actually care about. I
-          like to keep an eye on my nutrition, but I also don&rsquo;t want to get
+          Prepify for myself, to surface the info I actually care about. I like
+          to keep an eye on my nutrition, but I also don&rsquo;t want to get
           excited about a recipe only to find it doesn&rsquo;t fit my budget.
           That&rsquo;s why Prepify works the way it does.
         </p>
         <p>
-          We&rsquo;re independent &mdash; built and maintained with care by
-          people who cook at home. We&rsquo;re always improving, and we read
-          every piece of feedback that comes our way.
+          We&rsquo;re independent, built and maintained with care by people who
+          cook at home. We&rsquo;re always improving, and we read every piece of
+          feedback that comes our way.
         </p>
       </section>
 
       <section className='about-section about-cta'>
         <h2>Ready to cook with zero guesswork?</h2>
-        <p>Find your next meal &mdash; price and nutrition included.</p>
+        <p>Find your next meal. Price and nutrition included.</p>
         <div className='cta-actions'>
           <Link to='/recipes' className='btn-primary'>
             Browse recipes

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -85,46 +85,64 @@ const FEATURES: Feature[] = [
   },
 ]
 
-// A small, illustrative recipe card that shows the value prop instead of just
-// describing it: the per-serving price chip and the nutrition row are the whole
-// point of Prepify. It mirrors the real Home recipe card vocabulary (rounded
-// card, soft shadow, price chip) but is decorative sample data, so it's hidden
-// from assistive tech.
+// Macro bars for the nutrition panel — mirrors the real recipe-page nutrition
+// component (label + per-serving value + a bar scaled to the largest macro, so
+// protein at 42g is the full-width reference here).
+const PROOF_MACROS = [
+  { label: 'Protein', value: '42g', pct: 100 },
+  { label: 'Fat', value: '18g', pct: 43 },
+  { label: 'Carbs', value: '30g', pct: 71 },
+  { label: 'Fiber', value: '6g', pct: 14 },
+]
+
+// Two real Prepify surfaces, shown rather than described — kept honest:
+//  • the browse card (faithful to the actual recipe thumbnail: image, title,
+//    per-serving PRICE, time, rating — thumbnails never show nutrition), and
+//  • the recipe page's Nutrition panel (where per-serving nutrition actually
+//    lives) floated alongside it.
+// Decorative sample data, so the whole composition is hidden from assistive tech.
 const ProofCard: FC = () => (
   <div className='hero-proof' aria-hidden='true'>
-    <div className='proof-card'>
-      <div className='proof-thumb'>
-        <MdOutlineDinnerDining className='proof-dish' />
-        <span className='proof-price'>$3.18/serv</span>
-      </div>
-      <div className='proof-body'>
-        <h3>Tuscan Chicken Skillet</h3>
-        <div className='proof-meta'>
-          <span>
-            <CgTimer /> 45m
-          </span>
-          <span>
-            <AiOutlineStar /> 4.8
-          </span>
-          <span className='proof-cuisine'>Italian</span>
+    <div className='proof-stack'>
+      <div className='proof-card'>
+        <div className='proof-thumb'>
+          <MdOutlineDinnerDining className='proof-dish' />
+          <span className='proof-price'>$3.18/serv</span>
         </div>
-        <div className='proof-nutrition'>
-          <div className='macro'>
-            <span className='val'>520</span>
-            <span className='lbl'>cal</span>
+        <div className='proof-body'>
+          <h3>Tuscan Chicken Skillet</h3>
+          <div className='proof-meta'>
+            <span>
+              <CgTimer /> 45m
+            </span>
+            <span>
+              <AiOutlineStar /> 4.8
+            </span>
+            <span className='proof-cuisine'>Italian</span>
           </div>
-          <div className='macro'>
-            <span className='val'>42g</span>
-            <span className='lbl'>protein</span>
-          </div>
-          <div className='macro'>
-            <span className='val'>30g</span>
-            <span className='lbl'>carbs</span>
-          </div>
-          <div className='macro'>
-            <span className='val'>18g</span>
-            <span className='lbl'>fat</span>
-          </div>
+        </div>
+      </div>
+
+      <div className='proof-nutrition'>
+        <div className='pn-head'>
+          <h4>Nutrition</h4>
+          <span className='pn-per'>per serving</span>
+        </div>
+        <div className='pn-cal'>
+          <strong>520</strong> calories
+        </div>
+        <div className='pn-macros'>
+          {PROOF_MACROS.map(m => (
+            <div className='pn-macro' key={m.label}>
+              <div className='pn-macro-top'>
+                <span>{m.label}</span>
+                <span>{m.value}</span>
+              </div>
+              <div className='pn-track'>
+                <div className='pn-fill' style={{ width: `${m.pct}%` }} />
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -116,16 +116,16 @@ const About: FC = () => (
         </div>
       </header>
 
-      <section className='about-section'>
+      <section className='about-section about-story'>
         <div className='section-head'>
           <h2>What Prepify is</h2>
-          <p>
-            Prepify is all about transparency. We&rsquo;re a recipe site that
-            keeps it real. No buried costs, no missing nutrition info.
-            It&rsquo;s all calculated from the actual ingredients and shown right
-            there on the recipe.
-          </p>
         </div>
+        <p>
+          Prepify is all about transparency. We&rsquo;re a recipe site that
+          keeps it real. No buried costs, no missing nutrition info.
+          It&rsquo;s all calculated from the actual ingredients and shown right
+          there on the recipe.
+        </p>
       </section>
 
       <section className='about-section how-it-works'>

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -1,6 +1,8 @@
 import React, { FC, ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
+import { CgTimer } from 'react-icons/cg'
+import { AiOutlineStar } from 'react-icons/ai'
 import {
   MdOutlineSearch,
   MdOutlineShoppingCart,
@@ -10,6 +12,8 @@ import {
   MdOutlineTune,
   MdOutlineEditNote,
   MdOutlineBookmarkBorder,
+  MdOutlineStarBorder,
+  MdOutlineDinnerDining,
 } from 'react-icons/md'
 import './About.scss'
 
@@ -19,22 +23,24 @@ type Step = {
   body: string
 }
 
-// Plan → shop → cook: the three-beat promise the whole product is built around.
+// "How it works" is the journey — what you actually do, in order. It stays
+// outcome-focused so it doesn't just re-list the capabilities in the feature
+// grid below (which owns the specifics).
 const STEPS: Step[] = [
   {
     icon: <MdOutlineSearch />,
     title: 'Plan',
-    body: 'Browse recipes with prices and nutrition already on the card. Filter by cuisine, diet, or meal type, and build your plan around your budget and goals.',
+    body: 'Browse recipes with the price and nutrition right on the card, and build around your budget and your goals.',
   },
   {
     icon: <MdOutlineShoppingCart />,
     title: 'Shop',
-    body: 'Every recipe breaks down to a real cost per serving. No more mental math in the aisle. Fill your cart with a clear total.',
+    body: 'Head to the store with a clear per-serving total. No surprises at checkout, no math in the aisle.',
   },
   {
     icon: <MdOutlineRestaurantMenu />,
     title: 'Cook',
-    body: 'Follow clear, step-by-step recipes. Rate what you make, save your favorites, and come back to the ones you love.',
+    body: 'Follow the step-by-step recipe, then save the winners so they are easy to find again.',
   },
 ]
 
@@ -44,33 +50,86 @@ type Feature = {
   body: string
 }
 
+// "What you can do" is the capability set — the specifics behind the journey.
+// Six, so the grid stays balanced (3×2 desktop, 2×3 tablet, 1-up mobile).
 const FEATURES: Feature[] = [
   {
     icon: <MdOutlineSell />,
-    title: 'Real price per serving',
-    body: 'We show you the real price per serving, calculated from the actual ingredients.',
+    title: 'Real per-serving prices',
+    body: 'Worked out from the actual ingredients, not rough estimates, and shown on every recipe.',
   },
   {
     icon: <MdOutlineMonitorHeart />,
-    title: 'Full nutrition, automatically',
-    body: 'Calories and macros are computed for you. No spreadsheets required.',
+    title: 'Nutrition, automatically',
+    body: 'Calories and macros are computed for you. No spreadsheets, no guesswork.',
   },
   {
     icon: <MdOutlineTune />,
-    title: 'Search & filter that works',
-    body: 'Search and filter by cuisine, diet, and meal type to find something that fits.',
+    title: 'Smart search & filters',
+    body: 'Narrow by cuisine, diet, and meal type to find something that fits in seconds.',
   },
   {
     icon: <MdOutlineEditNote />,
-    title: 'Add your own recipes',
-    body: 'Add your own recipes and let us handle the price and nutrition math.',
+    title: 'Build your own recipes',
+    body: 'Paste your ingredients and we handle the price and nutrition math for you.',
+  },
+  {
+    icon: <MdOutlineStarBorder />,
+    title: 'Ratings & reviews',
+    body: 'See what the community thinks, and share your own take on what you cook.',
   },
   {
     icon: <MdOutlineBookmarkBorder />,
-    title: 'Save & revisit',
-    body: 'Save and revisit your favorite meals. The ones you love, a click away.',
+    title: 'Save your favorites',
+    body: 'Keep the meals you love a click away, ready for the next time you cook.',
   },
 ]
+
+// A small, illustrative recipe card that shows the value prop instead of just
+// describing it: the per-serving price chip and the nutrition row are the whole
+// point of Prepify. It mirrors the real Home recipe card vocabulary (rounded
+// card, soft shadow, price chip) but is decorative sample data, so it's hidden
+// from assistive tech.
+const ProofCard: FC = () => (
+  <div className='hero-proof' aria-hidden='true'>
+    <div className='proof-card'>
+      <div className='proof-thumb'>
+        <MdOutlineDinnerDining className='proof-dish' />
+        <span className='proof-price'>$3.18/serv</span>
+      </div>
+      <div className='proof-body'>
+        <h3>Tuscan Chicken Skillet</h3>
+        <div className='proof-meta'>
+          <span>
+            <CgTimer /> 45m
+          </span>
+          <span>
+            <AiOutlineStar /> 4.8
+          </span>
+          <span className='proof-cuisine'>Italian</span>
+        </div>
+        <div className='proof-nutrition'>
+          <div className='macro'>
+            <span className='val'>520</span>
+            <span className='lbl'>cal</span>
+          </div>
+          <div className='macro'>
+            <span className='val'>42g</span>
+            <span className='lbl'>protein</span>
+          </div>
+          <div className='macro'>
+            <span className='val'>30g</span>
+            <span className='lbl'>carbs</span>
+          </div>
+          <div className='macro'>
+            <span className='val'>18g</span>
+            <span className='lbl'>fat</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+)
 
 // About / marketing page. Storytelling, not legal — what Prepify is, how it
 // works, why it exists, and a closing call to action. This page owns its own
@@ -99,21 +158,24 @@ const About: FC = () => (
 
     <div className='about-inner'>
       <header className='about-hero'>
-        <p className='eyebrow'>About Prepify</p>
-        <h1>Prepify&rsquo;s got your back.</h1>
-        <p className='tagline'>
-          No more surprises. Every recipe on the site shows its real price per
-          serving and full nutrition, upfront. You always know what
-          you&rsquo;re getting into before you start cooking.
-        </p>
-        <div className='hero-cta'>
-          <Link to='/recipes' className='btn-primary'>
-            Browse recipes
-          </Link>
-          <Link to='/signup' className='btn-secondary'>
-            Create an account
-          </Link>
+        <div className='hero-copy'>
+          <p className='eyebrow'>About Prepify</p>
+          <h1>Prepify&rsquo;s got your back.</h1>
+          <p className='tagline'>
+            No more surprises. Every recipe on the site shows its real price per
+            serving and full nutrition, upfront. You always know what
+            you&rsquo;re getting into before you start cooking.
+          </p>
+          <div className='hero-cta'>
+            <Link to='/recipes' className='btn-primary'>
+              Browse recipes
+            </Link>
+            <Link to='/signup' className='btn-secondary'>
+              Create an account
+            </Link>
+          </div>
         </div>
+        <ProofCard />
       </header>
 
       <section className='about-section about-story'>
@@ -150,7 +212,7 @@ const About: FC = () => (
       <section className='about-section features'>
         <div className='section-head'>
           <h2>What you can do</h2>
-          <p>Here&rsquo;s the good stuff.</p>
+          <p>Everything Prepify gives you, in one place.</p>
         </div>
         <ul className='features-grid'>
           {FEATURES.map(feature => (

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -1,48 +1,19 @@
 import React, { FC, ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
-import { CgTimer } from 'react-icons/cg'
-import { AiOutlineStar } from 'react-icons/ai'
 import {
-  MdOutlineSearch,
-  MdOutlineShoppingCart,
-  MdOutlineRestaurantMenu,
-  MdOutlineSell,
-  MdOutlineMonitorHeart,
-  MdOutlineTune,
-  MdOutlineEditNote,
-  MdOutlineBookmarkBorder,
-  MdOutlineStarBorder,
-  MdOutlineDinnerDining,
-} from 'react-icons/md'
+  FiDollarSign,
+  FiPieChart,
+  FiSearch,
+  FiEdit3,
+  FiStar,
+  FiHeart,
+  FiClock,
+  FiArrowRight,
+  FiShoppingCart,
+  FiBookOpen,
+} from 'react-icons/fi'
 import './About.scss'
-
-type Step = {
-  icon: ReactElement
-  title: string
-  body: string
-}
-
-// "How it works" is the journey — what you actually do, in order. It stays
-// outcome-focused so it doesn't just re-list the capabilities in the feature
-// grid below (which owns the specifics).
-const STEPS: Step[] = [
-  {
-    icon: <MdOutlineSearch />,
-    title: 'Plan',
-    body: 'Browse recipes with the price and nutrition right on the card, and build around your budget and your goals.',
-  },
-  {
-    icon: <MdOutlineShoppingCart />,
-    title: 'Shop',
-    body: 'Head to the store with a clear per-serving total. No surprises at checkout, no math in the aisle.',
-  },
-  {
-    icon: <MdOutlineRestaurantMenu />,
-    title: 'Cook',
-    body: 'Follow the step-by-step recipe, then save the winners so they are easy to find again.',
-  },
-]
 
 type Feature = {
   icon: ReactElement
@@ -50,100 +21,108 @@ type Feature = {
   body: string
 }
 
-// "What you can do" is the capability set — the specifics behind the journey.
-// Six, so the grid stays balanced (3×2 desktop, 2×3 tablet, 1-up mobile).
+// "What you can do" is the capability set behind the journey. Six, so the grid
+// stays balanced (3×2 desktop, 2×3 tablet, 1-up mobile).
 const FEATURES: Feature[] = [
   {
-    icon: <MdOutlineSell />,
+    icon: <FiDollarSign aria-hidden='true' />,
     title: 'Real per-serving prices',
     body: 'Worked out from the actual ingredients, not rough estimates, and shown on every recipe.',
   },
   {
-    icon: <MdOutlineMonitorHeart />,
+    icon: <FiPieChart aria-hidden='true' />,
     title: 'Nutrition, automatically',
     body: 'Calories and macros are computed for you. No spreadsheets, no guesswork.',
   },
   {
-    icon: <MdOutlineTune />,
+    icon: <FiSearch aria-hidden='true' />,
     title: 'Smart search & filters',
     body: 'Narrow by cuisine, diet, and meal type to find something that fits in seconds.',
   },
   {
-    icon: <MdOutlineEditNote />,
+    icon: <FiEdit3 aria-hidden='true' />,
     title: 'Build your own recipes',
     body: 'Paste your ingredients and we handle the price and nutrition math for you.',
   },
   {
-    icon: <MdOutlineStarBorder />,
+    icon: <FiStar aria-hidden='true' />,
     title: 'Ratings & reviews',
     body: 'See what the community thinks, and share your own take on what you cook.',
   },
   {
-    icon: <MdOutlineBookmarkBorder />,
+    icon: <FiHeart aria-hidden='true' />,
     title: 'Save your favorites',
     body: 'Keep the meals you love a click away, ready for the next time you cook.',
   },
 ]
 
-// Macro bars for the nutrition panel — mirrors the real recipe-page nutrition
-// component (label + per-serving value + a bar scaled to the largest macro, so
-// protein at 42g is the full-width reference here).
-const PROOF_MACROS = [
-  { label: 'Protein', value: '42g', pct: 100 },
-  { label: 'Fat', value: '18g', pct: 43 },
-  { label: 'Carbs', value: '30g', pct: 71 },
-  { label: 'Fiber', value: '6g', pct: 14 },
+type Step = {
+  label: string
+  body: string
+}
+
+// "How it works" is the journey, in order. Outcome-focused so it doesn't just
+// re-list the capabilities in the feature grid below.
+const STEPS: Step[] = [
+  {
+    label: 'Plan',
+    body: 'Browse recipes with the price and nutrition right on the card, and build around your budget and your goals.',
+  },
+  {
+    label: 'Shop',
+    body: 'Head to the store with a clear per-serving total. No surprises at checkout, no math in the aisle.',
+  },
+  {
+    label: 'Cook',
+    body: 'Follow the step-by-step recipe, then save the winners so they are easy to find again.',
+  },
 ]
 
-// Two real Prepify surfaces, shown rather than described — kept honest:
+const MACROS = [
+  { label: 'Protein', value: '42g' },
+  { label: 'Fat', value: '18g' },
+  { label: 'Carbs', value: '30g' },
+  { label: 'Fiber', value: '6g' },
+]
+
+// Two real Prepify surfaces, shown rather than described, and kept honest:
 //  • the browse card (faithful to the actual recipe thumbnail: image, title,
 //    per-serving PRICE, time, rating — thumbnails never show nutrition), and
 //  • the recipe page's Nutrition panel (where per-serving nutrition actually
-//    lives) floated alongside it.
+//    lives) alongside it.
 // Decorative sample data, so the whole composition is hidden from assistive tech.
-const ProofCard: FC = () => (
-  <div className='hero-proof' aria-hidden='true'>
-    <div className='proof-stack'>
-      <div className='proof-card'>
-        <div className='proof-thumb'>
-          <MdOutlineDinnerDining className='proof-dish' />
-          <span className='proof-price'>$3.18/serv</span>
-        </div>
-        <div className='proof-body'>
-          <h3>Tuscan Chicken Skillet</h3>
-          <div className='proof-meta'>
-            <span>
-              <CgTimer /> 45m
-            </span>
-            <span>
-              <AiOutlineStar /> 4.8
-            </span>
-            <span className='proof-cuisine'>Italian</span>
-          </div>
+const ProductShowcase: FC = () => (
+  <div className='about-mock' aria-hidden='true'>
+    <div className='about-card'>
+      <div className='about-card-media'>
+        <span className='about-card-price'>$3.18/serv</span>
+      </div>
+      <div className='about-card-body'>
+        <h3 className='about-card-title'>Tuscan Chicken Skillet</h3>
+        <div className='about-card-meta'>
+          <span>
+            <FiClock aria-hidden='true' /> 45m
+          </span>
+          <span>
+            <FiStar aria-hidden='true' /> 4.8
+          </span>
+          <span>Italian</span>
         </div>
       </div>
+    </div>
 
-      <div className='proof-nutrition'>
-        <div className='pn-head'>
-          <h4>Nutrition</h4>
-          <span className='pn-per'>per serving</span>
-        </div>
-        <div className='pn-cal'>
-          <strong>520</strong> calories
-        </div>
-        <div className='pn-macros'>
-          {PROOF_MACROS.map(m => (
-            <div className='pn-macro' key={m.label}>
-              <div className='pn-macro-top'>
-                <span>{m.label}</span>
-                <span>{m.value}</span>
-              </div>
-              <div className='pn-track'>
-                <div className='pn-fill' style={{ width: `${m.pct}%` }} />
-              </div>
-            </div>
-          ))}
-        </div>
+    <div className='about-nutrition'>
+      <p className='about-nutrition-label'>Nutrition per serving</p>
+      <p className='about-nutrition-cal'>
+        520 <span>cal</span>
+      </p>
+      <div className='about-nutrition-macros'>
+        {MACROS.map(m => (
+          <div className='about-macro' key={m.label}>
+            <span className='about-macro-value'>{m.value}</span>
+            <span className='about-macro-label'>{m.label}</span>
+          </div>
+        ))}
       </div>
     </div>
   </div>
@@ -174,83 +153,86 @@ const About: FC = () => (
       <meta property='og:url' content='https://www.prepifymeals.com/about' />
     </Helmet>
 
-    <div className='about-inner'>
-      <header className='about-hero'>
-        <div className='hero-copy'>
-          <p className='eyebrow'>About Prepify</p>
-          <h1>Prepify&rsquo;s got your back.</h1>
-          <p className='tagline'>
-            No more surprises. Every recipe on the site shows its real price per
-            serving and full nutrition, upfront. You always know what
-            you&rsquo;re getting into before you start cooking.
-          </p>
-          <div className='hero-cta'>
-            <Link to='/recipes' className='btn-primary'>
-              Browse recipes
-            </Link>
-            <Link to='/signup' className='btn-secondary'>
-              Create an account
-            </Link>
-          </div>
-        </div>
-        <ProofCard />
-      </header>
+    <header className='about-hero'>
+      <p className='about-eyebrow'>About Prepify</p>
+      <h1 className='about-hero-title'>Prepify&rsquo;s got your back.</h1>
+      <p className='about-hero-tagline'>
+        No more surprises. Every recipe on the site shows its real price per
+        serving and full nutrition, upfront. You always know what you&rsquo;re
+        getting into before you start cooking.
+      </p>
+      <div className='about-cta'>
+        <Link to='/recipes' className='about-btn about-btn-primary'>
+          Browse recipes
+        </Link>
+        <Link to='/signup' className='about-btn about-btn-ghost'>
+          Create an account
+        </Link>
+      </div>
+    </header>
 
-      <section className='about-section about-story'>
-        <div className='section-head'>
-          <h2>What Prepify is</h2>
-        </div>
-        <p>
-          Prepify is all about transparency. We&rsquo;re a recipe site that
-          keeps it real. No buried costs, no missing nutrition info.
-          It&rsquo;s all calculated from the actual ingredients and shown right
-          there on the recipe.
+    <section className='about-section about-showcase'>
+      <div className='about-showcase-inner'>
+        <ProductShowcase />
+        <p className='about-showcase-caption'>
+          The price lives on the card. The full nutrition lives on the recipe.
+          Always there, always upfront.
         </p>
-      </section>
+      </div>
+    </section>
 
-      <section className='about-section how-it-works'>
-        <div className='section-head'>
-          <h2>How it works</h2>
-          <p>Three simple steps: plan, shop, and cook.</p>
-        </div>
-        <ol className='steps-grid'>
-          {STEPS.map((step, i) => (
-            <li key={step.title} className='step-card'>
-              <span className='step-num'>{i + 1}</span>
-              <span className='step-icon' aria-hidden='true'>
-                {step.icon}
-              </span>
-              <h3>{step.title}</h3>
-              <p>{step.body}</p>
-            </li>
-          ))}
-        </ol>
-      </section>
+    <section className='about-section about-moment'>
+      <p className='about-moment-kicker'>Transparency, by default.</p>
+      <p className='about-moment-line'>
+        Prepify is all about transparency. We&rsquo;re a recipe site that keeps
+        it real. No buried costs, no missing nutrition info. It&rsquo;s all
+        calculated from the actual ingredients and shown right there on the
+        recipe.
+      </p>
+    </section>
 
-      <section className='about-section features'>
-        <div className='section-head'>
-          <h2>What you can do</h2>
-          <p>Everything Prepify gives you, in one place.</p>
-        </div>
-        <ul className='features-grid'>
-          {FEATURES.map(feature => (
-            <li key={feature.title} className='feature-card'>
-              <span className='feature-icon' aria-hidden='true'>
-                {feature.icon}
-              </span>
-              <div className='feature-text'>
-                <h3>{feature.title}</h3>
-                <p>{feature.body}</p>
-              </div>
-            </li>
-          ))}
-        </ul>
-      </section>
+    <section className='about-section about-section-tint about-steps'>
+      <div className='about-section-head'>
+        <p className='about-section-eyebrow'>How it works</p>
+        <h2 className='about-section-title'>Three simple steps.</h2>
+      </div>
+      <ol className='about-steps-grid'>
+        {STEPS.map((step, i) => (
+          <li className='about-step' key={step.label}>
+            <span className='about-step-num'>{i + 1}</span>
+            <h3 className='about-step-label'>{step.label}</h3>
+            <p className='about-step-body'>{step.body}</p>
+          </li>
+        ))}
+      </ol>
+    </section>
 
-      <section className='about-section about-story'>
-        <div className='section-head'>
-          <h2>Why we built it</h2>
-        </div>
+    <section className='about-section about-features'>
+      <div className='about-section-head'>
+        <p className='about-section-eyebrow'>Everything you need</p>
+        <h2 className='about-section-title'>Built for the way you cook.</h2>
+      </div>
+      <ul className='about-features-grid'>
+        {FEATURES.map(f => (
+          <li className='about-feature' key={f.title}>
+            <span className='about-feature-icon' aria-hidden='true'>
+              {f.icon}
+            </span>
+            <div className='about-feature-text'>
+              <h3 className='about-feature-title'>{f.title}</h3>
+              <p className='about-feature-body'>{f.body}</p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+
+    <section className='about-section about-story'>
+      <div className='about-section-head'>
+        <p className='about-section-eyebrow'>Why we built it</p>
+        <h2 className='about-section-title'>We were tired of guessing.</h2>
+      </div>
+      <div className='about-story-body'>
         <p>
           We built Prepify because we were tired of guessing. Most recipes
           don&rsquo;t tell you what they actually cost, so we got tired of
@@ -270,21 +252,29 @@ const About: FC = () => (
           cook at home. We&rsquo;re always improving, and we read every piece of
           feedback that comes our way.
         </p>
-      </section>
+      </div>
+    </section>
 
-      <section className='about-section about-cta'>
-        <h2>Ready to cook with zero guesswork?</h2>
-        <p>Find your next meal. Price and nutrition included.</p>
-        <div className='cta-actions'>
-          <Link to='/recipes' className='btn-primary'>
-            Browse recipes
-          </Link>
-          <Link to='/signup' className='btn-secondary'>
-            Create an account
-          </Link>
-        </div>
-      </section>
-    </div>
+    <section className='about-section about-section-tint about-closing'>
+      <h2 className='about-closing-title'>Ready to cook with zero guesswork?</h2>
+      <p className='about-closing-line'>
+        Find your next meal. Price and nutrition included.
+      </p>
+      <div className='about-cta'>
+        <Link to='/recipes' className='about-btn about-btn-primary'>
+          Browse recipes
+          <FiArrowRight aria-hidden='true' />
+        </Link>
+        <Link to='/signup' className='about-btn about-btn-ghost'>
+          Create an account
+        </Link>
+      </div>
+      <div className='about-closing-icons' aria-hidden='true'>
+        <FiShoppingCart />
+        <FiBookOpen />
+        <FiHeart />
+      </div>
+    </section>
   </div>
 )
 

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -13,6 +13,7 @@ import {
   FiShoppingCart,
   FiBookOpen,
 } from 'react-icons/fi'
+import { LuUtensils } from 'react-icons/lu'
 import './About.scss'
 
 type Feature = {
@@ -95,10 +96,11 @@ const ProductShowcase: FC = () => (
   <div className='about-mock' aria-hidden='true'>
     <div className='about-card'>
       <div className='about-card-media'>
+        <LuUtensils className='about-card-media-icon' aria-hidden='true' />
         <span className='about-card-price'>$3.18/serv</span>
       </div>
       <div className='about-card-body'>
-        <h3 className='about-card-title'>Tuscan Chicken Skillet</h3>
+        <p className='about-card-title'>Tuscan Chicken Skillet</p>
         <div className='about-card-meta'>
           <span>
             <FiClock aria-hidden='true' /> 45m
@@ -164,6 +166,7 @@ const About: FC = () => (
       <div className='about-cta'>
         <Link to='/recipes' className='about-btn about-btn-primary'>
           Browse recipes
+          <FiArrowRight aria-hidden='true' />
         </Link>
         <Link to='/signup' className='about-btn about-btn-ghost'>
           Create an account
@@ -184,10 +187,8 @@ const About: FC = () => (
     <section className='about-section about-moment'>
       <p className='about-moment-kicker'>Transparency, by default.</p>
       <p className='about-moment-line'>
-        Prepify is all about transparency. We&rsquo;re a recipe site that keeps
-        it real. No buried costs, no missing nutrition info. It&rsquo;s all
-        calculated from the actual ingredients and shown right there on the
-        recipe.
+        Every price and nutrition figure is calculated straight from the real
+        ingredients. Never estimated, never left for you to work out.
       </p>
     </section>
 

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -1,89 +1,205 @@
-import React, { FC } from 'react'
+import React, { FC, ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
+import {
+  MdOutlineSearch,
+  MdOutlineShoppingCart,
+  MdOutlineRestaurantMenu,
+  MdOutlineSell,
+  MdOutlineMonitorHeart,
+  MdOutlineTune,
+  MdOutlineEditNote,
+  MdOutlineBookmarkBorder,
+} from 'react-icons/md'
 import './About.scss'
 
-// About / marketing page. Storytelling, not legal — what Prepify is, why it
-// exists, its key features, and calls to action.
+type Step = {
+  icon: ReactElement
+  title: string
+  body: string
+}
+
+// Plan → shop → cook: the three-beat promise the whole product is built around.
+const STEPS: Step[] = [
+  {
+    icon: <MdOutlineSearch />,
+    title: 'Plan',
+    body: 'Browse recipes with the price and nutrition already on the card. Filter by cuisine, diet, or meal type and build around your budget and your goals.',
+  },
+  {
+    icon: <MdOutlineShoppingCart />,
+    title: 'Shop',
+    body: 'Every recipe breaks down to a real per-serving cost, so you can fill your cart with a clear total — no mental math in the aisle.',
+  },
+  {
+    icon: <MdOutlineRestaurantMenu />,
+    title: 'Cook',
+    body: 'Follow clear, step-by-step recipes. Rate what you make, save your favorites, and come back to the meals that earn a spot in the rotation.',
+  },
+]
+
+type Feature = {
+  icon: ReactElement
+  title: string
+  body: string
+}
+
+const FEATURES: Feature[] = [
+  {
+    icon: <MdOutlineSell />,
+    title: 'Real per-serving prices',
+    body: 'Costs are calculated from the actual ingredients — shown up front, on every recipe.',
+  },
+  {
+    icon: <MdOutlineMonitorHeart />,
+    title: 'Full nutrition, automatically',
+    body: 'Calories and macros are computed for you, so you can see how a meal fits your day.',
+  },
+  {
+    icon: <MdOutlineTune />,
+    title: 'Search & filter that works',
+    body: 'Narrow by cuisine, diet, and meal type to find something that fits right now.',
+  },
+  {
+    icon: <MdOutlineEditNote />,
+    title: 'Add your own recipes',
+    body: 'Paste your ingredients and let automatic parsing handle the price and nutrition math.',
+  },
+  {
+    icon: <MdOutlineBookmarkBorder />,
+    title: 'Save & revisit',
+    body: 'Keep the meals you love a click away, and rate and review the ones worth sharing.',
+  },
+]
+
+// About / marketing page. Storytelling, not legal — what Prepify is, how it
+// works, why it exists, and a closing call to action. This page owns its own
+// <title> + og:* meta on purpose: the global meta/SEO pass (Track 3b) skips
+// About to avoid a collision here. NOTE: index.html ships static og:* defaults
+// that react-helmet-async can't dedupe, so these page-level og tags coexist with
+// the generic ones until 3b reconciles index.html site-wide.
 const About: FC = () => (
   <div className='about-page'>
     <Helmet>
+      <meta charSet='utf-8' />
       <title>Prepify | About</title>
       <meta
         name='description'
-        content='Prepify is a recipe site where every recipe ships with real per-serving price and nutrition data, so you can plan, shop, and cook with zero guesswork.'
+        content='Prepify is a recipe site where every recipe shows its real per-serving price and full nutrition up front — so you can plan, shop, and cook with zero guesswork.'
       />
+      <link rel='canonical' href='https://www.prepifymeals.com/about' />
+      <meta property='og:title' content='About Prepify' />
+      <meta
+        property='og:description'
+        content='Every recipe comes with its real per-serving price and full nutrition built in — so you always know what a meal costs and what is in it before you cook.'
+      />
+      <meta property='og:type' content='website' />
+      <meta property='og:url' content='https://www.prepifymeals.com/about' />
     </Helmet>
+
     <div className='about-inner'>
       <header className='about-hero'>
-        <h1>About Prepify</h1>
+        <p className='eyebrow'>About Prepify</p>
+        <h1>Recipes that tell you the whole story.</h1>
         <p className='tagline'>
-          Real recipes with the prices and nutrition baked in. Plan, shop, and
-          cook with zero guesswork.
+          Every recipe on Prepify comes with its real per-serving price and full
+          nutrition built right in &mdash; so you always know what a meal costs,
+          and what&rsquo;s in it, before you start cooking.
         </p>
+        <div className='hero-cta'>
+          <Link to='/recipes' className='btn-primary'>
+            Browse recipes
+          </Link>
+          <Link to='/signup' className='btn-secondary'>
+            Create an account
+          </Link>
+        </div>
       </header>
 
-      <section>
-        <h2>What Prepify is</h2>
-        <p>
-          Prepify is a recipe site where every recipe ships with real
-          per-serving <strong>price</strong> and <strong>nutrition</strong> data.
-          Instead of guessing what a meal will cost or how it fits your goals,
-          you see the numbers up front — so you can plan, shop, and cook with
-          confidence.
-        </p>
+      <section className='about-section'>
+        <div className='section-head'>
+          <h2>What Prepify is</h2>
+          <p>
+            Prepify is a recipe site with one promise: no surprises. The price
+            and nutrition aren&rsquo;t an afterthought buried at the bottom of
+            the page &mdash; they&rsquo;re calculated from the real ingredients
+            and shown up front, on every recipe. Search, save, and cook knowing
+            exactly what each meal costs and how it fits your day.
+          </p>
+        </div>
       </section>
 
-      <section>
-        <h2>Why it exists</h2>
-        <p>
-          Most recipes tell you how to cook, but not what it costs or what&rsquo;s
-          in it. That leaves you scrolling between tabs, doing mental math at the
-          grocery store, and hoping a meal fits your budget and your diet. Prepify
-          was built to close that gap: cost and nutrition transparency, on every
-          recipe, by default.
-        </p>
+      <section className='about-section how-it-works'>
+        <div className='section-head'>
+          <h2>How it works</h2>
+          <p>Plan, shop, and cook with zero guesswork.</p>
+        </div>
+        <ol className='steps-grid'>
+          {STEPS.map((step, i) => (
+            <li key={step.title} className='step-card'>
+              <span className='step-num'>{i + 1}</span>
+              <span className='step-icon' aria-hidden='true'>
+                {step.icon}
+              </span>
+              <h3>{step.title}</h3>
+              <p>{step.body}</p>
+            </li>
+          ))}
+        </ol>
       </section>
 
-      <section>
-        <h2>What you can do</h2>
-        <ul>
-          <li>
-            <strong>Create recipes</strong> with automatic ingredient parsing and
-            nutrition data.
-          </li>
-          <li>
-            <strong>Search and filter</strong> by cuisine, diet, meal type, and
-            more.
-          </li>
-          <li>
-            See <strong>per-serving price and nutrition</strong> on every recipe.
-          </li>
-          <li>
-            <strong>Rate and review</strong> recipes and read what others think.
-          </li>
-          <li>
-            <strong>Save recipes</strong> to come back to the meals you love.
-          </li>
+      <section className='about-section features'>
+        <div className='section-head'>
+          <h2>What you can do</h2>
+        </div>
+        <ul className='features-grid'>
+          {FEATURES.map(feature => (
+            <li key={feature.title} className='feature-card'>
+              <span className='feature-icon' aria-hidden='true'>
+                {feature.icon}
+              </span>
+              <div className='feature-text'>
+                <h3>{feature.title}</h3>
+                <p>{feature.body}</p>
+              </div>
+            </li>
+          ))}
         </ul>
       </section>
 
-      <section>
-        <h2>Who&rsquo;s behind it</h2>
+      <section className='about-section about-story'>
+        <div className='section-head'>
+          <h2>Why we built it</h2>
+        </div>
         <p>
-          Prepify is an independent project built by a small team of home cooks
-          and developers who wanted a smarter way to plan meals. We&rsquo;re
-          always improving it — and we&rsquo;d love your feedback.
+          Most recipes tell you how to cook a dish &mdash; but never what it
+          actually costs. We got tired of scrolling between tabs, guessing at
+          grocery totals, and hoping a meal would fit the budget. So we built
+          the recipe site we wanted to use: cost and nutrition transparency on
+          every recipe, by default.
+        </p>
+        <p>
+          Prepify is an independent project, built and maintained with a lot of
+          care by people who cook at home just like you.{' '}
+          {/* TODO(Jesse): add 1–2 sentences of personal background here —
+              who you are, what you do, and why this project matters to you.
+              Kept as a placeholder rather than inventing bio details. */}
+          We&rsquo;re always improving it, and we read every piece of feedback
+          that comes our way.
         </p>
       </section>
 
-      <section className='about-cta'>
-        <Link to='/recipes' className='cta-primary'>
-          Browse recipes
-        </Link>
-        <Link to='/signup' className='cta-secondary'>
-          Create an account
-        </Link>
+      <section className='about-section about-cta'>
+        <h2>Ready to cook with zero guesswork?</h2>
+        <p>Find your next meal &mdash; price and nutrition included.</p>
+        <div className='cta-actions'>
+          <Link to='/recipes' className='btn-primary'>
+            Browse recipes
+          </Link>
+          <Link to='/signup' className='btn-secondary'>
+            Create an account
+          </Link>
+        </div>
       </section>
     </div>
   </div>

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -175,17 +175,21 @@ const About: FC = () => (
           Most recipes tell you how to cook a dish &mdash; but never what it
           actually costs. We got tired of scrolling between tabs, guessing at
           grocery totals, and hoping a meal would fit the budget. So we built
-          the recipe site we wanted to use: cost and nutrition transparency on
-          every recipe, by default.
+          the recipe site we actually wanted to use: cost and nutrition
+          transparency on every recipe, by default.
         </p>
         <p>
-          Prepify is an independent project, built and maintained with a lot of
-          care by people who cook at home just like you.{' '}
-          {/* TODO(Jesse): add 1–2 sentences of personal background here —
-              who you are, what you do, and why this project matters to you.
-              Kept as a placeholder rather than inventing bio details. */}
-          We&rsquo;re always improving it, and we read every piece of feedback
-          that comes our way.
+          Honestly, we built Prepify for ourselves &mdash; to surface the
+          information we genuinely care about. I&rsquo;m Jesse, a self-taught
+          developer who cooks at home. I lift, so I like to keep an eye on my
+          nutrition &mdash; but more than that, I never want to get excited
+          about a new recipe only to find it doesn&rsquo;t fit my budget.
+          That&rsquo;s exactly why Prepify works the way it does.
+        </p>
+        <p>
+          Prepify is an independent project, built and maintained with care by
+          people who cook at home just like you. We&rsquo;re always improving
+          it, and we read every piece of feedback that comes our way.
         </p>
       </section>
 

--- a/src/test/LegalPages.test.tsx
+++ b/src/test/LegalPages.test.tsx
@@ -19,15 +19,26 @@ const renderPage = (ui: ReactElement) =>
 describe('Legal / company pages', () => {
   it('About renders its heading and calls to action', () => {
     renderPage(<About />)
+    // "About Prepify" is the eyebrow; the marketing headline is the <h1>.
     expect(
-      screen.getByRole('heading', { level: 1, name: 'About Prepify' })
+      screen.getByRole('heading', {
+        level: 1,
+        name: /recipes that tell you the whole story/i,
+      })
     ).toBeInTheDocument()
-    expect(
-      screen.getByRole('link', { name: 'Browse recipes' })
-    ).toHaveAttribute('href', '/recipes')
-    expect(
-      screen.getByRole('link', { name: 'Create an account' })
-    ).toHaveAttribute('href', '/signup')
+    expect(screen.getByText('About Prepify')).toBeInTheDocument()
+    // The CTAs appear twice (hero + closing section); assert every instance
+    // points where it should rather than requiring a single match.
+    const browseLinks = screen.getAllByRole('link', { name: 'Browse recipes' })
+    expect(browseLinks.length).toBeGreaterThan(0)
+    browseLinks.forEach(link =>
+      expect(link).toHaveAttribute('href', '/recipes')
+    )
+    const signupLinks = screen.getAllByRole('link', {
+      name: 'Create an account',
+    })
+    expect(signupLinks.length).toBeGreaterThan(0)
+    signupLinks.forEach(link => expect(link).toHaveAttribute('href', '/signup'))
   })
 
   it('Privacy renders its heading and the draft/professional-review note', () => {

--- a/src/test/LegalPages.test.tsx
+++ b/src/test/LegalPages.test.tsx
@@ -23,7 +23,7 @@ describe('Legal / company pages', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: /recipes that tell you the whole story/i,
+        name: /got your back/i,
       })
     ).toBeInTheDocument()
     expect(screen.getByText('About Prepify')).toBeInTheDocument()


### PR DESCRIPTION
## Track 4-about · About page 1.0 rewrite

Rewrites the thin/placeholder About page into a real launch-audience page, laid out in the site's existing design vocabulary (reuses `helpers.scss` tokens; mirrors the polished Help/legal pages).

### What changed
- **Hero** — eyebrow (`About Prepify`) + marketing headline + tagline + dual CTAs
- **What Prepify is** — leads with cost/nutrition transparency
- **How it works** — `plan → shop → cook` numbered step cards
- **What you can do** — feature grid (prices, nutrition, search/filter, add recipes, save/review)
- **Why we built it** — short, warm origin story (cost-transparency angle) with a light personal touch: Jesse's bio (self-taught developer who cooks at home) and the lifting/nutrition + affordability angle behind why Prepify works the way it does
- **Closing CTA** — browse recipes / create an account

### Meta (own `<title>` + og:*)
Per the gameplan, **About owns its own meta** (track 3b deliberately skips `About.tsx`). Sets `<title>`, description, canonical, and `og:title`/`og:description`/`og:type`/`og:url` via Helmet.

⚠️ **Known caveat:** `index.html` ships static `og:*` defaults that react-helmet-async can't dedupe, so these page-level og tags coexist with the generic ones until **track 3b** reconciles `index.html` site-wide. Flagged in a code comment (consistent with the existing note in `SingleRecipe.tsx`). I'm scoped to `src/pages/About/*`, so I didn't touch `index.html`.

### Voice / content decisions (confirmed with Jesse)
- Solo project, written in the softer **"we"** voice
- **Light** personal touch (product-forward, with a short personal note + bio at the end)
- The **"why"** leads with **cost transparency**

### Reachability & scope
- About is **already linked** (footer `footerData.ts`) and routed (`App.tsx`) → no nav/footer change needed.
- Scope held to `src/pages/About/*` plus one necessary test update: `src/test/LegalPages.test.tsx` asserted the old `<h1>` text (`About Prepify`) and single CTAs; updated to match the new headline (now the `<h1>`; `About Prepify` is the eyebrow) and the dual CTAs. No overlap with track 4-tests' additions.

### Verification
- `tsc --noEmit` clean, `npm run build` passing, **495 tests pass** (2 skipped)
- Rendered headless and screenshotted at **desktop (1280px)** and **mobile (390px)** — clean layout, no console errors, correct `<title>`/`<h1>`. Screenshots captured locally at desktop + mobile widths (drag-and-drop into the thread if you want them inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

