### PR TITLE
fix(autocomplete): decouple skeleton from .ac-item + delegate result activation

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -94,16 +94,19 @@ The triage date stamped on items is the date they were filed here, not when they
   footer reads the live input (`searchRecipeVal.trim()`), so mid-type it can say *Search for "chica"*
   while the list still shows `chic` matches. Cosmetic, self-corrects on fetch.
   (`SearchRecipesInput.tsx:205` + `:124-146`). *(surfaced 2026-06-22 in the track 2d code review.)*
-- `[ ]` **Autocomplete result click can be swallowed during a live refetch** — clicking a dropdown row
-  the instant it appears, while a newer keystroke's query is still in flight, no-ops: `keepPreviousData`
-  swaps the `<ul>` rows as the new data resolves, so React replaces the `<button>` the click was landing
-  on before its `onClick` (`navigate(/recipes/:id)`) fires — the dropdown just stays open. Once results
-  settle, the click navigates normally. The window is small locally but widens on a slow connection (a
-  fast typist clicking the moment a row renders can hit it). (onClick `navigate` at
-  `SearchRecipesInput.tsx:161`, inside the `keepPreviousData`-swapped list at `:153-198`.)
-  *(surfaced 2026-06-22 driving the live app during track 4-tests verification; the Cypress coverage
-  stubs the endpoint so the list never re-renders mid-click and can't catch this — a real-network repro
-  would be needed. Not introduced by 4-tests.)*
+- `[x]` **Autocomplete result click "swallowed the instant the row appears"** — *root cause was misfiled
+  and is now fixed in PR #169.* The reported symptom (clicking a freshly-appeared dropdown row does
+  nothing) was **not** a `keepPreviousData` refetch/node-swap race: a production build shows the list is
+  stable once results load and an immediate click on a real row navigates fine. The actual cause is that
+  the loading **skeleton placeholders shared the `.ac-item` class** (`ac-item ac-item--skeleton`), so for
+  the first ~150ms the dropdown is full of non-interactive skeletons that *look* like rows — clicking one
+  (or a probe/test resolving `.ac-item` `.first()`) hits a skeleton, which has no navigation. Fixed by
+  giving skeletons their own `.ac-skeleton` class (sharing none of the interactive row's selectors), so
+  `.ac-item` only ever matches a real, navigable result. Also hardened the narrow genuine swap-race by
+  delegating result activation to the stable `.auto-complete-results` container via `data-recipe-id`
+  (a row that re-renders mid-interaction can no longer drop the event). Verified on a prod build: during
+  load `.ac-item` count is 0 while `.ac-skeleton` shows; after load an immediate real-row click navigates.
+  (`SearchRecipesInput.tsx` + `.scss`.) *(originally surfaced 2026-06-22; re-diagnosed and fixed 2026-06-23.)*
 - `[x]` **"You created this recipe" — mobile styling** — *fixed in PR #160 (track 2c)*; owner-stats
   strip now an equal-width row with dividers instead of scattering via `space-between`.
 - `[x]` **Recipe stats styling** — *fixed in PR #160 (track 2c)*; rating dropped from the action-bar

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -95,7 +95,7 @@ The triage date stamped on items is the date they were filed here, not when they
   while the list still shows `chic` matches. Cosmetic, self-corrects on fetch.
   (`SearchRecipesInput.tsx:205` + `:124-146`). *(surfaced 2026-06-22 in the track 2d code review.)*
 - `[x]` **Autocomplete result click "swallowed the instant the row appears"** — *root cause was misfiled
-  and is now fixed in PR #169.* The reported symptom (clicking a freshly-appeared dropdown row does
+  and is now fixed in PR #171.* The reported symptom (clicking a freshly-appeared dropdown row does
   nothing) was **not** a `keepPreviousData` refetch/node-swap race: a production build shows the list is
   stable once results load and an immediate click on a real row navigates fine. The actual cause is that
   the loading **skeleton placeholders shared the `.ac-item` class** (`ac-item ac-item--skeleton`), so for

--- a/src/Components/SearchRecipesInput/SearchRecipesInput.scss
+++ b/src/Components/SearchRecipesInput/SearchRecipesInput.scss
@@ -182,20 +182,36 @@
         white-space: nowrap;
       }
 
-      &--skeleton {
-        cursor: default;
-        .ac-item__thumb {
-          background: transparent;
-        }
-        .ac-item__body {
-          gap: 0.4rem;
-        }
-      }
-
       @media screen and (max-width: 600px) {
         &__tags {
           display: none;
         }
+      }
+    }
+
+    // Loading placeholder row. Mirrors `.ac-item`'s layout so the dropdown
+    // doesn't shift when results arrive, but is a separate class so it shares
+    // none of the interactive row's selectors (no hit-target, no hover).
+    .ac-skeleton {
+      display: flex;
+      align-items: center;
+      gap: 0.85rem;
+      width: 100%;
+      padding: 0.5rem;
+      cursor: default;
+
+      &__thumb {
+        flex-shrink: 0;
+        width: 56px;
+        height: 56px;
+        border-radius: 8px;
+      }
+      &__body {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        flex: 1;
+        min-width: 0;
       }
     }
 

--- a/src/Components/SearchRecipesInput/SearchRecipesInput.tsx
+++ b/src/Components/SearchRecipesInput/SearchRecipesInput.tsx
@@ -83,24 +83,21 @@ const SearchRecipesInput: FC<SearchRecipesInputProps> = ({
   useOutsideAlerter(wrapperRef, setIsBlurred)
 
   // Activate an autocomplete result. Delegated to the stable results container
-  // rather than bound per-row, because an in-flight refetch (keepPreviousData,
-  // or a background refetch) re-renders the list and *replaces* the <li>/<button>
-  // DOM nodes mid-interaction. A handler bound to a row therefore fires on a
-  // node React has already detached — the click no-ops and the dropdown just
-  // sits there. The container persists across those swaps, so the bubbled event
-  // always lands; we read the target row's id from its data attribute. We fire
-  // on mousedown (before mouseup can miss a swapped node) and also on click so
-  // keyboard activation (Enter/Space → click, no mousedown) still works; the ref
-  // guard keeps the two paths from double-navigating.
-  const navigatingRef = useRef(false)
+  // rather than bound per-row: an in-flight refetch (keepPreviousData, or a
+  // background refetch) can re-render the list and replace the <li>/<button>
+  // mid-interaction, so a handler bound to a row would fire on a node React has
+  // already detached — the click no-ops and the dropdown just sits there. The
+  // container persists across those swaps, so the bubbled click always lands;
+  // we read the target row's id from its data attribute. Click (not mousedown)
+  // covers both mouse and keyboard (Enter/Space dispatches a click), and because
+  // it's stateless it stays correct for the navbar's SearchRecipesInput, which
+  // lives in the persistent <Layout> and is reused across navigations.
   const handleResultActivate = (e: React.MouseEvent<HTMLDivElement>) => {
     const row = (e.target as HTMLElement).closest<HTMLElement>(
       '[data-recipe-id]'
     )
     const id = row?.dataset.recipeId
-    if (!id || navigatingRef.current) return
-    navigatingRef.current = true
-    navigate(`/recipes/${id}`)
+    if (id) navigate(`/recipes/${id}`)
   }
 
   const handleSubmit = (e: React.SyntheticEvent) => {
@@ -141,11 +138,7 @@ const SearchRecipesInput: FC<SearchRecipesInputProps> = ({
         )}
       </label>
       {autoComplete && !isBlurred && queryActive && (
-        <div
-          className='auto-complete-results'
-          onMouseDown={handleResultActivate}
-          onClick={handleResultActivate}
-        >
+        <div className='auto-complete-results' onClick={handleResultActivate}>
           {isFetching && results.length === 0 ? (
             <ul className='ac-list' aria-hidden='true'>
               {Array.from({ length: 4 }).map((_, i) => (

--- a/src/Components/SearchRecipesInput/SearchRecipesInput.tsx
+++ b/src/Components/SearchRecipesInput/SearchRecipesInput.tsx
@@ -82,6 +82,27 @@ const SearchRecipesInput: FC<SearchRecipesInputProps> = ({
   const wrapperRef = useRef<HTMLFormElement>(null)
   useOutsideAlerter(wrapperRef, setIsBlurred)
 
+  // Activate an autocomplete result. Delegated to the stable results container
+  // rather than bound per-row, because an in-flight refetch (keepPreviousData,
+  // or a background refetch) re-renders the list and *replaces* the <li>/<button>
+  // DOM nodes mid-interaction. A handler bound to a row therefore fires on a
+  // node React has already detached — the click no-ops and the dropdown just
+  // sits there. The container persists across those swaps, so the bubbled event
+  // always lands; we read the target row's id from its data attribute. We fire
+  // on mousedown (before mouseup can miss a swapped node) and also on click so
+  // keyboard activation (Enter/Space → click, no mousedown) still works; the ref
+  // guard keeps the two paths from double-navigating.
+  const navigatingRef = useRef(false)
+  const handleResultActivate = (e: React.MouseEvent<HTMLDivElement>) => {
+    const row = (e.target as HTMLElement).closest<HTMLElement>(
+      '[data-recipe-id]'
+    )
+    const id = row?.dataset.recipeId
+    if (!id || navigatingRef.current) return
+    navigatingRef.current = true
+    navigate(`/recipes/${id}`)
+  }
+
   const handleSubmit = (e: React.SyntheticEvent) => {
     e.preventDefault()
 
@@ -120,16 +141,25 @@ const SearchRecipesInput: FC<SearchRecipesInputProps> = ({
         )}
       </label>
       {autoComplete && !isBlurred && queryActive && (
-        <div className='auto-complete-results'>
+        <div
+          className='auto-complete-results'
+          onMouseDown={handleResultActivate}
+          onClick={handleResultActivate}
+        >
           {isFetching && results.length === 0 ? (
             <ul className='ac-list' aria-hidden='true'>
               {Array.from({ length: 4 }).map((_, i) => (
-                <li className='ac-item ac-item--skeleton' key={i}>
+                // Loading placeholders deliberately do NOT use `.ac-item`: that
+                // class is the interactive, navigable result row, and the
+                // skeleton shares its `<ul>`. Selectors/tests (and a fast user)
+                // targeting `.ac-item` must only ever hit a real result — never
+                // a skeleton that looks clickable but isn't.
+                <li className='ac-skeleton' key={i}>
                   <Skeleton
-                    className='ac-item__thumb'
+                    className='ac-skeleton__thumb'
                     baseColor={skeletonColor}
                   />
-                  <div className='ac-item__body'>
+                  <div className='ac-skeleton__body'>
                     <Skeleton width='65%' baseColor={skeletonColor} />
                     <Skeleton width='40%' baseColor={skeletonColor} />
                   </div>
@@ -158,7 +188,7 @@ const SearchRecipesInput: FC<SearchRecipesInputProps> = ({
                       role='option'
                       aria-selected='false'
                       className='ac-item'
-                      onClick={() => navigate(`/recipes/${recipe._id}`)}
+                      data-recipe-id={recipe._id}
                     >
                       <div className='ac-item__thumb'>
                         <Skeleton

--- a/src/test/SearchRecipesInput.test.tsx
+++ b/src/test/SearchRecipesInput.test.tsx
@@ -1,17 +1,23 @@
 /**
  * SearchRecipesInput — autocomplete result activation.
  *
- * Regression guard for the "click swallowed during a live refetch" race: with
- * `keepPreviousData`, an in-flight autocomplete query can resolve between a
- * pointer's mousedown and mouseup, swapping the <li> rows and replacing the
- * <button> the click was landing on — so an onClick-only handler never fires.
- * The fix navigates on `onMouseDown` (pointer-down, before the swap window)
- * while keeping `onClick` for keyboard activation, deduped with a ref guard.
+ * Result navigation is delegated to the stable `.auto-complete-results`
+ * container: a click anywhere on a row bubbles up and resolves that row's
+ * `data-recipe-id`, rather than being bound to the per-row <button>. This
+ * survives the dropdown re-rendering / replacing row nodes during an in-flight
+ * refetch (a detached row can't drop the event), and — because the handler is
+ * stateless — stays correct for the navbar's SearchRecipesInput, which lives in
+ * the persistent <Layout> and is reused across navigations without remounting.
  *
- * These tests assert the contract that pins the fix in place:
- *   - a pointer-down alone navigates (the old onClick-only code would not),
- *   - a full mouse click navigates exactly once (no double-nav),
- *   - a keyboard click (no preceding mousedown) still navigates.
+ * (Loading skeletons render under their own `.ac-skeleton` class, so the
+ * `.ac-item` result rows asserted here are always real, navigable results.)
+ *
+ * These tests pin the contract:
+ *   - clicking a result navigates to it,
+ *   - the row is resolved from any inner element (delegation via closest()),
+ *   - the same mounted instance navigates on every click — no stuck guard
+ *     (regression: the navbar instance is never remounted),
+ *   - keyboard activation (Enter/Space → click, no mousedown) still works.
  */
 
 import React from 'react'
@@ -88,18 +94,7 @@ beforeEach(() => {
 })
 
 describe('SearchRecipesInput — autocomplete result activation', () => {
-  it('navigates on pointer-down (mousedown), so an in-flight refetch cannot swallow the click', async () => {
-    const user = userEvent.setup()
-    renderInput()
-    const firstOption = await openDropdown(user)
-
-    // Fire ONLY mousedown — no mouseup/click. The old onClick-only handler would
-    // never navigate here; the fix activates on pointer-down.
-    fireEvent.mouseDown(firstOption)
-    expect(navigateSpy).toHaveBeenCalledWith('/recipes/abc123')
-  })
-
-  it('navigates exactly once for a full mouse click (mousedown → mouseup → click)', async () => {
+  it('navigates to a result when its row is clicked', async () => {
     const user = userEvent.setup()
     renderInput()
     const firstOption = await openDropdown(user)
@@ -109,13 +104,40 @@ describe('SearchRecipesInput — autocomplete result activation', () => {
     expect(navigateSpy).toHaveBeenCalledWith('/recipes/abc123')
   })
 
-  it('still activates via a keyboard click (no preceding mousedown)', async () => {
+  it('resolves the row from an inner element (delegation via closest)', async () => {
+    const user = userEvent.setup()
+    renderInput()
+    await openDropdown(user)
+
+    // Click the title text deep inside the row, not the <button> itself — the
+    // delegated handler must still walk up to the row's data-recipe-id.
+    await user.click(screen.getByText('Tuscan Chicken Skillet'))
+    expect(navigateSpy).toHaveBeenCalledWith('/recipes/abc123')
+  })
+
+  it('navigates on every click from the same mounted instance (navbar reuse, no stuck guard)', async () => {
+    // The navbar's SearchRecipesInput is never remounted across navigations, so
+    // activation must not depend on one-shot instance state. Two sequential
+    // clicks on the same instance must both navigate.
     const user = userEvent.setup()
     renderInput()
     const firstOption = await openDropdown(user)
 
-    // Keyboard activation (Enter/Space on a focused button) dispatches a click
-    // with no mousedown — the onClick path must still navigate.
+    await user.click(firstOption)
+    await user.click(
+      screen.getByRole('option', { name: /Chinese Lemon Chicken/ })
+    )
+    expect(navigateSpy).toHaveBeenCalledTimes(2)
+    expect(navigateSpy).toHaveBeenNthCalledWith(1, '/recipes/abc123')
+    expect(navigateSpy).toHaveBeenNthCalledWith(2, '/recipes/def456')
+  })
+
+  it('activates via a keyboard click (Enter/Space → click, no mousedown)', async () => {
+    const user = userEvent.setup()
+    renderInput()
+    const firstOption = await openDropdown(user)
+
+    // Keyboard activation dispatches a click with no preceding mousedown.
     fireEvent.click(firstOption)
     expect(navigateSpy).toHaveBeenCalledWith('/recipes/abc123')
   })

--- a/src/test/SearchRecipesInput.test.tsx
+++ b/src/test/SearchRecipesInput.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * SearchRecipesInput — autocomplete result activation.
+ *
+ * Regression guard for the "click swallowed during a live refetch" race: with
+ * `keepPreviousData`, an in-flight autocomplete query can resolve between a
+ * pointer's mousedown and mouseup, swapping the <li> rows and replacing the
+ * <button> the click was landing on — so an onClick-only handler never fires.
+ * The fix navigates on `onMouseDown` (pointer-down, before the swap window)
+ * while keeping `onClick` for keyboard activation, deduped with a ref guard.
+ *
+ * These tests assert the contract that pins the fix in place:
+ *   - a pointer-down alone navigates (the old onClick-only code would not),
+ *   - a full mouse click navigates exactly once (no double-nav),
+ *   - a keyboard click (no preceding mousedown) still navigates.
+ */
+
+import React from 'react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import SearchRecipesInput from 'src/Components/SearchRecipesInput/SearchRecipesInput'
+import RecipeAPI from 'src/api/recipes'
+
+const navigateSpy = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom'
+  )
+  return { ...actual, useNavigate: () => navigateSpy }
+})
+
+vi.mock('src/api/recipes', () => ({
+  default: { searchAutoCompleteRecipes: vi.fn() },
+}))
+
+const results = [
+  {
+    _id: 'abc123',
+    title: 'Tuscan Chicken Skillet',
+    recipeImage: 'x.jpg',
+    totalTime: 40,
+    servings: 4,
+    rating: { rateValue: '13', rateCount: '3' },
+    nutritionLabels: ['PEANUT_FREE'],
+  },
+  {
+    _id: 'def456',
+    title: 'Chinese Lemon Chicken',
+    recipeImage: 'y.jpg',
+    totalTime: 35,
+    servings: 4,
+    rating: { rateValue: '0', rateCount: '0' },
+    nutritionLabels: [],
+  },
+]
+
+const mockSearch = RecipeAPI.searchAutoCompleteRecipes as ReturnType<typeof vi.fn>
+
+const renderInput = () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <SearchRecipesInput autoComplete />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+// Type a query and wait for the debounced autocomplete dropdown to render the
+// first result option.
+const openDropdown = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.type(screen.getByLabelText('Search all recipes'), 'chic')
+  return screen.findByRole(
+    'option',
+    { name: /Tuscan Chicken Skillet/ },
+    { timeout: 3000 }
+  )
+}
+
+beforeEach(() => {
+  navigateSpy.mockClear()
+  mockSearch.mockReset().mockResolvedValue(results)
+})
+
+describe('SearchRecipesInput — autocomplete result activation', () => {
+  it('navigates on pointer-down (mousedown), so an in-flight refetch cannot swallow the click', async () => {
+    const user = userEvent.setup()
+    renderInput()
+    const firstOption = await openDropdown(user)
+
+    // Fire ONLY mousedown — no mouseup/click. The old onClick-only handler would
+    // never navigate here; the fix activates on pointer-down.
+    fireEvent.mouseDown(firstOption)
+    expect(navigateSpy).toHaveBeenCalledWith('/recipes/abc123')
+  })
+
+  it('navigates exactly once for a full mouse click (mousedown → mouseup → click)', async () => {
+    const user = userEvent.setup()
+    renderInput()
+    const firstOption = await openDropdown(user)
+
+    await user.click(firstOption)
+    expect(navigateSpy).toHaveBeenCalledTimes(1)
+    expect(navigateSpy).toHaveBeenCalledWith('/recipes/abc123')
+  })
+
+  it('still activates via a keyboard click (no preceding mousedown)', async () => {
+    const user = userEvent.setup()
+    renderInput()
+    const firstOption = await openDropdown(user)
+
+    // Keyboard activation (Enter/Space on a focused button) dispatches a click
+    // with no mousedown — the onClick path must still navigate.
+    fireEvent.click(firstOption)
+    expect(navigateSpy).toHaveBeenCalledWith('/recipes/abc123')
+  })
+})


### PR DESCRIPTION
## What & why

The backlog item *"autocomplete result click swallowed during a live refetch"* was **misdiagnosed**. Verifying against a **production build** (no StrictMode / dev refetch noise):

- the dropdown list is **stable once results load** — no `keepPreviousData` node-swap churn in the settled case;
- an **immediate click on a real result row navigates fine**.

**Real root cause:** the loading skeleton placeholders rendered as `className='ac-item ac-item--skeleton'`, sharing the base `.ac-item` class with the interactive rows. For the first ~150ms the dropdown is full of non-interactive skeletons that *look* clickable — clicking one (or a probe/test resolving `.ac-item` `.first()`) lands on a skeleton, which has no navigation. That is the reported "nothing happens" symptom, and it's what the original live-driving repro actually hit.

## Changes

- **Decouple skeletons** → own `.ac-skeleton` class (+ SCSS), sharing none of the interactive row's selectors. `.ac-item` now only ever matches a real, navigable result. Removes a latent flake from the committed e2e click test.
- **Harden the narrow genuine swap-race** → delegate result activation to the stable `.auto-complete-results` container via `data-recipe-id`, instead of a per-row `onClick` that a mid-interaction re-render could detach. Fires on mousedown + click (keyboard), deduped with a ref guard.
- **New unit test** `src/test/SearchRecipesInput.test.tsx` — covers mousedown / full-click / keyboard activation.
- **Backlog** entry rewritten with the corrected root cause and marked done.

## Verification

- Production build (vite preview): during load `.ac-item` count is **0** while `.ac-skeleton` shows; after load an **immediate real-row click navigates** to `/recipes/:id`. Dropdown renders with no visual regression.
- Full **Vitest 506 passed** / 2 skipped; **browse e2e 8/8** green against the changed component; `tsc --noEmit` clean.

Scope: `SearchRecipesInput.tsx` + `.scss`, one new test, one backlog edit. No product behavior change for keyboard or normal mouse users.