### PR TITLE
docs(release): reconcile 4-sass → already migrated in cb2ac81 ([x])

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -242,8 +242,13 @@ The triage date stamped on items is the date they were filed here, not when they
   rename would silently break suppression in two places with no compile error. Extract a shared
   `RECIPES_PATH` const (or a small hook) and have `browseAll` call `clearFilters`.
   *(surfaced 2026-06-22 in the track 2d code review.)*
-- `[ ]` **Migrate Sass `@import` → `@use`** — build emits Sass `@import` deprecation warnings
-  (pre-existing; Sass 1.x warns `@import` is going away in 3.x). Cosmetic now, worth migrating.
+- `[x]` **Migrate Sass `@import` → `@use`** — **already done in `cb2ac81` (2026-05-09), reconciled
+  2026-06-23.** Converted all 36 component/page stylesheets from `@import 'helpers.scss'` to
+  `@use 'helpers.scss' as s` and namespaced every var/mixin under `s.`. This predates the release gameplan
+  (created 2026-06-17), so the open box was stale, not pending work. Verified: `npm run build` emits **zero**
+  Sass deprecation warnings and all 73 `.scss` compile clean. The only remaining `@import` is the plain CSS
+  `@import url('…Montserrat…')` font load in `src/index.scss` — not a Sass partial import, not deprecated.
+  *(See the 2026-06-23 4-sass status-log entry in `RELEASE_GAMEPLAN.md`.)*
 - `[ ]` **Point Railway at the production branch** — currently not deploying from production.
 - `[ ]` **Social link previews need server-side prerendering (CSR-SPA limitation)** — track 3b (PR #170)
   added per-route OG/Twitter tags + a branded 1200×630 card and strips the static `index.html` fallbacks on JS

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -60,7 +60,7 @@ same commit.**
 | 3c | Username validation + report-user | `[x]` | #166 ✅ |
 | 3d | Add-recipe UX | `[x]` | #164 ✅ |
 | 3e | create-username revamp | `[x]` | #131 + #98 (+ #162 reconcile/test) ✅ |
-| 4-sass | Sass `@import`→`@use` (LONER) | `[ ]` | — |
+| 4-sass | Sass `@import`→`@use` (LONER) | `[x]` | `cb2ac81` ✅ (pre-gameplan) |
 | 4-about | About rewrite (Jesse) | `[x]` | #169 ✅ |
 | 4-tests | Toast/alert + Cypress autocomplete tests | `[x]` | #168 ✅ |
 | 4-qa | Empty/error sweep + links + copy + mobile + Lighthouse | `[ ]` | — |
@@ -493,6 +493,22 @@ Append a one-liner when a track changes state (started / PR / merged). Keeps ses
   for social link previews (CSR-SPA limitation; release-gating copy in `RELEASE_PLAN.md` §C) and a missing
   `onError` placeholder fallback in `RecipeThumbnail`. **Wave 4 Part 1 complete (3b + 4-about + 4-tests);
   remaining: the 4-sass loner (Part 2), then the 4-qa finishing sweep (Part 3) → Phase 5 cutover.**
+- _2026-06-23_ — **4-sass (Sass `@import`→`@use` migration) → reconciled `[x]` (already done in `cb2ac81`).**
+  Spun up the loner worktree to do the migration and found it **already complete** — the work landed
+  **2026-05-09** in `cb2ac81` *"fix: migrate all SCSS from deprecated @import to @use"* (already an ancestor
+  of `development`), a full month before this gameplan was even created (2026-06-17), so the `[ ]` box was
+  stale, not a pending task. That commit converted all 36 component/page stylesheets from
+  `@import 'helpers.scss'` → `@use 'helpers.scss' as s`, namespaced every var/mixin reference under `s.`
+  (the `s.outline()` seen site-wide), fixed a `NutritionData.scss` path, and reordered `index.scss` so `@use`
+  precedes the CSS `@import url()`. **Verified the goal is met, not just trusting git:** `npm run build` exits
+  0 with **zero** Sass deprecation warnings (only the unrelated chunk-size note), and compiling all **73**
+  `.scss` files individually through the Sass CLI yields **0** deprecation warnings of any category. The lone
+  remaining `@import` is `src/index.scss:3` — a plain CSS `@import url('…Montserrat…')` font load, which Sass
+  passes through verbatim; it is **not** the deprecated Sass import and must stay (you can't `@use` a remote
+  CSS URL). **No `.scss` touched** — the loner's collision risk was moot. This entry + the Track Board box +
+  the `BACKLOG.md` Tech-debt item are the only changes (docs-only reconcile). The Rule-1 "everyone rebases
+  after the Sass loner" step is a **no-op** (no stylesheet churn). **Remaining: 4-qa finishing sweep (Part 3)
+  → Phase 5 cutover.**
 
 ---
 


### PR DESCRIPTION
## Summary

Track **4-sass** (Sass `@import`→`@use` migration, the "loner") was already **complete** — and this PR is **docs-only** to reflect that. No `.scss` is touched.

I spun up the loner worktree to *do* the migration and found the work already landed **2026-05-09** in [`cb2ac81`](../commit/cb2ac81) *"fix: migrate all SCSS from deprecated @import to @use"* — already an ancestor of `development`, a full month before this gameplan was created (2026-06-17). The `[ ]` box was **stale**, not a pending task.

`cb2ac81` converted all 36 component/page stylesheets from `@import 'helpers.scss'` → `@use 'helpers.scss' as s`, namespaced every var/mixin under `s.` (the `s.outline()` seen site-wide), fixed a `NutritionData.scss` path, and reordered `index.scss` so `@use` precedes the CSS `@import url()`.

## Verification — the goal (zero Sass `@import` deprecation warnings) holds

Verified the live state, not just the git box:

| Check | Result |
|---|---|
| `npm run build` | exit 0, **zero** Sass deprecation warnings (only the unrelated chunk-size note) |
| All **73** `.scss` compiled individually via Sass CLI (`sass@1.99.0`, no silencing in `vite.config.ts`) | **0** files with deprecations of any category |
| Sass partial `@import` anywhere in repo | **none** |
| Remaining `@import` | only `src/index.scss:3` — a plain CSS `@import url('…Montserrat…')` font load. Sass passes `@import url(...)` through verbatim; it is **not** the deprecated partial import and **must stay** (you can't `@use` a remote CSS URL — converting it would break font loading) |

No screenshots / page spot-checks: since **no stylesheet changed**, rendered output is byte-identical to `development` by construction.

## Changes (docs only)

- `RELEASE_GAMEPLAN.md` Track Board: 4-sass `[ ]` → `[x]` (`cb2ac81`, pre-gameplan)
- `RELEASE_GAMEPLAN.md` status log: entry documenting the find + verification
- `BACKLOG.md` Tech debt: *"Migrate Sass `@import` → `@use`"* `[ ]` → `[x]`

## Rule-1 note

The gameplan's "everyone rebases after the Sass loner" step is a **no-op** here — no `.scss` churn means no open branch needs rebasing. Remaining release work: **4-qa** finishing sweep → Phase 5 cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)