### PR TITLE
QA: release finishing sweep — empty/error states, a11y, copy polish (track 4-qa)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -195,6 +195,25 @@ The triage date stamped on items is the date they were filed here, not when they
   as a plain list of buttons, or implement real listbox keyboarding. *(surfaced 2026-06-22 in the track 2d
   code review; the per-result `role="option"` on a button is the new markup from this track.)*
 
+- `[ ]` **Ingredient checklist `<li role="checkbox">` is an invalid ARIA role + breaks the list** — each
+  ingredient row is a `<li role="checkbox" aria-checked tabIndex={0}>` (`SingleRecipe.tsx`
+  `renderIngredient`), but `checkbox` isn't an allowed role on `<li>`, which also makes the parent
+  `<ul class="ing-list">` "a list that doesn't contain only `<li>`" (the `<li>`s no longer carry an
+  implicit `listitem` role). Fixes Lighthouse `aria-allowed-role` + `list`. Fix: move the
+  checkbox role/keyboard handler onto an inner element (e.g. a `<div role="checkbox">` or a real
+  `<button>`) and keep the `<li>` plain — needs `.ing` CSS re-pointed and a visual re-check, so it's not
+  a blind one-liner. *(surfaced 2026-06-23 in the track 4-qa Lighthouse pass; recipe-page a11y was 80→89
+  after the cheap wins, these are the remainder.)*
+- `[ ]` **Recipe-page nav fails color-contrast (signup CTA + condensed nav link label)** — Lighthouse
+  `color-contrast` flags `.dnav__cta--signup` and `.dnav__link-label` on the solid (`darkNavLinks`) nav.
+  These are brand colors, so adjusting them is a design call, not a QA-sweep polish edit. *(The
+  `.beta-tag` is also flagged but is intentionally left for the Phase-5 beta-tag cutover. surfaced
+  2026-06-23, track 4-qa.)*
+- `[ ]` **Servings stepper input is below the 24px touch-target minimum** — the `.serv-input` in the
+  Ingredients servings pill (`SingleRecipe.tsx`) trips Lighthouse `target-size`. A label was added in
+  track 4-qa (`aria-label="Servings"`), but enlarging the tap target is a layout change to the pill.
+  *(surfaced 2026-06-23, track 4-qa.)*
+
 ## Features
 
 - `[ ]` **Press `/` to focus search** — global keyboard shortcut to bring up search. No handler exists today.

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -63,7 +63,7 @@ same commit.**
 | 4-sass | Sass `@import`→`@use` (LONER) | `[x]` | `cb2ac81` ✅ (pre-gameplan) |
 | 4-about | About rewrite (Jesse) | `[x]` | #169 ✅ |
 | 4-tests | Toast/alert + Cypress autocomplete tests | `[x]` | #168 ✅ |
-| 4-qa | Empty/error sweep + links + copy + mobile + Lighthouse | `[ ]` | — |
+| 4-qa | Empty/error sweep + links + copy + mobile + Lighthouse | `[P]` | `feat/release-qa-sweep` |
 | 5 | Cutover (beta off + 1.0.0 + deploy) | `[ ]` | — |
 
 _Doc ownership: this board owns **progress**; `RELEASE_PLAN.md` owns **launch acceptance** (audited by

--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -63,7 +63,7 @@ same commit.**
 | 4-sass | Sass `@import`→`@use` (LONER) | `[x]` | `cb2ac81` ✅ (pre-gameplan) |
 | 4-about | About rewrite (Jesse) | `[x]` | #169 ✅ |
 | 4-tests | Toast/alert + Cypress autocomplete tests | `[x]` | #168 ✅ |
-| 4-qa | Empty/error sweep + links + copy + mobile + Lighthouse | `[P]` | `feat/release-qa-sweep` |
+| 4-qa | Empty/error sweep + links + copy + mobile + Lighthouse | `[P]` | #174 |
 | 5 | Cutover (beta off + 1.0.0 + deploy) | `[ ]` | — |
 
 _Doc ownership: this board owns **progress**; `RELEASE_PLAN.md` owns **launch acceptance** (audited by

--- a/src/Components/Footer/footerData.ts
+++ b/src/Components/Footer/footerData.ts
@@ -19,7 +19,8 @@ export type FooterLink = {
 }
 export type FooterColumn = { heading: string; links: FooterLink[] }
 
-/** Primary nav columns. Links marked `external: true` are placeholders ('#'). */
+/** Primary nav columns. Links marked `external: true` render as a plain <a>
+ *  (e.g. the `mailto:` Contact link) instead of a router <Link>. */
 export const footerColumns: FooterColumn[] = [
   {
     heading: 'Discover',

--- a/src/Components/StarRating/StarRating.tsx
+++ b/src/Components/StarRating/StarRating.tsx
@@ -57,7 +57,14 @@ const StarRating: FC<StarRatingProps> = ({
   const displayRating = hovered || rating
 
   return (
-    <div style={{ display: 'inline-flex', gap: spacing }}>
+    // Display-only stars convey their value once via an img role on the row, so
+    // the individual stars below are hidden from assistive tech (otherwise each
+    // renders as an unnamed <button> — an accessibility failure).
+    <div
+      style={{ display: 'inline-flex', gap: spacing }}
+      role={interactive ? undefined : 'img'}
+      aria-label={interactive ? undefined : `Rated ${rating} out of 5`}
+    >
       {[1, 2, 3, 4, 5].map(i => (
         <button
           key={i}
@@ -74,6 +81,7 @@ const StarRating: FC<StarRatingProps> = ({
             lineHeight: 0,
           }}
           tabIndex={interactive ? 0 : -1}
+          aria-hidden={interactive ? undefined : true}
           aria-label={interactive ? `Rate ${i} out of 5` : undefined}
         >
           <StarSVG

--- a/src/pages/404/404.tsx
+++ b/src/pages/404/404.tsx
@@ -19,7 +19,7 @@ const NotFound: FC = () => {
         <span className='number'>4</span>
       </div>
       <div className='content'>
-        <h1>Something went wrong!</h1>
+        <h1>Page not found</h1>
         <p className='text'>
           It seems like we can't find the page you are looking for, if you think
           this is a mistake, please{' '}

--- a/src/pages/PublicProfile/PublicProfile.tsx
+++ b/src/pages/PublicProfile/PublicProfile.tsx
@@ -121,6 +121,10 @@ const PublicProfile: FC = () => {
   if (isError || !data) {
     return (
       <div className='page public-profile pp-centered'>
+        <Helmet>
+          <title>Profile not found · Prepify</title>
+          <meta name='robots' content='noindex' />
+        </Helmet>
         <div className='pp-notfound'>
           <h1>Profile not found</h1>
           <p>We couldn’t find a cook with the username “{username}”.</p>

--- a/src/pages/Settings/sections/ProfileSection.tsx
+++ b/src/pages/Settings/sections/ProfileSection.tsx
@@ -110,7 +110,7 @@ const ProfileSection: FC = () => {
     const file = event.target.files?.[0]
     if (file && /\.(jpe?g|png)$/i.test(file.name)) {
       if (file.size > MAX_FILE_SIZE) {
-        toast.error('File cannot be more than 5mb in size')
+        toast.error('Image cannot be more than 5MB in size.')
         return
       }
       setImgFile(file)

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -427,6 +427,7 @@ const SingleRecipe: FC = () => {
                     <button
                       type='button'
                       className='step-btn'
+                      aria-label='Decrease servings'
                       onClick={() => changeServings((servingSize || 1) - 1)}
                     >
                       −
@@ -434,6 +435,7 @@ const SingleRecipe: FC = () => {
                     <input
                       type='tel'
                       className='serv-input'
+                      aria-label='Servings'
                       value={servDraft}
                       onChange={e => {
                         const raw = e.target.value
@@ -449,6 +451,7 @@ const SingleRecipe: FC = () => {
                     <button
                       type='button'
                       className='step-btn'
+                      aria-label='Increase servings'
                       onClick={() => changeServings((servingSize || 0) + 1)}
                     >
                       +

--- a/src/test/ProfileSection.test.tsx
+++ b/src/test/ProfileSection.test.tsx
@@ -267,7 +267,7 @@ describe('Profile settings — avatar', () => {
     fireEvent.change(input, { target: { files: [big] } })
 
     expect(mockToastError).toHaveBeenCalledWith(
-      'File cannot be more than 5mb in size'
+      'Image cannot be more than 5MB in size.'
     )
   })
 

--- a/src/test/SingleRecipe.test.tsx
+++ b/src/test/SingleRecipe.test.tsx
@@ -176,8 +176,8 @@ describe('SingleRecipe page', () => {
     // Wait for initial load
     await screen.findByText('Chicken Tacos')
 
-    // The Ingredients component has + button to increment
-    const incButton = screen.getByRole('button', { name: '+' })
+    // The Ingredients component has a + button to increment
+    const incButton = screen.getByRole('button', { name: 'Increase servings' })
     await user.click(incButton)
 
     await waitFor(() => {


### PR DESCRIPTION
Late, app-wide finishing sweep (track **4-qa**), run on the stabilized app after 3b / 4-about / 4-tests and the Sass `@use` migration merged. Scope per the gameplan: empty/error/loading states, broken-link click-through, copy/typo, mobile hand-pass, and Lighthouse. **Polish only — no redesign, beta tag untouched.** Driven headlessly against a real logged-out and logged-in session.

## What was checked

**1. Empty / error / loading states** — clicked through every public page + private routes (logged-out) + error/empty variants:
- ✅ Recipe-not-found (`/recipes/<bad-id>`) → proper "Recipe not found" page + title.
- ✅ Profile-not-found (`/u/<missing>`) → "Profile not found" + Browse-recipes CTA. **Fixed:** it was rendering with an empty `<title>` → now sets `Profile not found · Prepify` + noindex.
- ✅ Recipes no-results (typed a no-match query) → "No recipes found / Browse all recipes".
- ✅ 404 route. **Fixed:** h1 said "Something went wrong!" (reads like a crash) → "Page not found", matching its `<title>` and body.
- ✅ Logged-out `/account`, `/settings`, `/add-recipe` redirect to `/login`; `/admin` → `/`. No infinite spinners, blank flashes, or unhandled error walls.

**2. Broken-link click-through** — crawled every nav/footer/in-page link across 11 seed pages (24 internal routes): **0 dead links / 404s, no `#` placeholders.** Logged-out vs logged-in visibility verified (nav: Recipes / Log in / Sign up when out; Recipes / Create Recipe / Saved when in; footer auth-gated links correct). **Fixed:** stale `footerData` comment (external links are `mailto:`, not `#`).

**3. Copy / typo review** — proofread headings, empty states, buttons, toasts, legal/help/about. No code-copy typos. **Fixed:** avatar size toast `5mb` → `5MB` (+ trailing period) to match the recipe-image copy. *(Two typos live in MongoDB recipe **data** — "Egg Friend Rice", a granola "Tt's" — out of scope for a code PR; not fixed.)*

**4. Mobile hand-pass (390px)** — walked Add Recipe + Account + all 4 Settings sections logged-in. **No horizontal overflow, no console errors, tap targets adequate** across the board. No fixes needed — the 2a/2d/2e/3d redesign work holds up on mobile.

**5. Lighthouse (desktop, production preview build)**

| Page | Perf | A11y | Best-Practices | SEO |
|------|------|------|----------------|-----|
| Home — before | 94 | 96 | 100 | 100 |
| Home — after | **97** | **96** | **100** | **100** |
| Recipe — before | 89 | 80 | 100 | 100 |
| Recipe — after | **88** | **89** | **100** | **100** |

Recipe **a11y 80 → 89** from the cheap wins below (perf ±1 is run-to-run noise). Home unchanged (no regression).

## Accessibility fixes (cheap wins)
- **StarRating** — display-only star rows expose their value once via `role="img"` + `aria-label`, and the redundant unnamed `<button>`s are hidden from AT (fixes Lighthouse `button-name`). Interactive rating unchanged.
- **Servings stepper** — `aria-label="Servings"` on the input (fixes `label`) + labels on the −/+ buttons.

## Filed to backlog (larger — not safe as polish edits)
[`docs/BACKLOG.md` → Accessibility](docs/BACKLOG.md):
- Ingredient checklist `<li role="checkbox">` invalid ARIA role + breaks the `<ul>` (fixes `aria-allowed-role` + `list`) — needs the role moved to an inner element + `.ing` CSS re-point + visual re-check.
- Recipe-nav `color-contrast` on `.dnav__cta--signup` / `.dnav__link-label` — brand colors, a design call. *(`.beta-tag` also flagged but deliberately left for the Phase-5 beta-tag cutover.)*
- Servings input `target-size` (below 24px) — layout change to the pill.

## Guardrails
- ✅ tsc clean · ✅ tests green (510 passed / 2 skipped; updated 2 assertions for the new aria labels) · ✅ `npm run build` passes.
- Beta tag untouched (Phase-5 cutover). No visual redesign.

Board: flips **4-qa → `[P]`** in `RELEASE_GAMEPLAN.md`.