### PR TITLE
docs: reusable assurance sweep playbooks (performance, security, a11y, design, code-quality)

### DIFF
--- a/docs/sweeps/README.md
+++ b/docs/sweeps/README.md
@@ -1,0 +1,54 @@
+# Assurance sweeps
+
+Reusable prompts for full-coverage, "is everything actually in order?" passes over Prepify. Each
+sweep is a self-contained brief you can hand to Claude Code (or run yourself) to audit one dimension
+of the app end-to-end, fix the small stuff in place, and file the larger stuff to the backlog.
+
+These are modelled on **track 4-qa** in [`../RELEASE_GAMEPLAN.md`](../RELEASE_GAMEPLAN.md) — the release
+QA sweep that established this pattern (run on a stabilized app, structured pass, fix-small / file-large,
+one PR with a checklist + before/after metrics).
+
+## The sweeps
+
+| Sweep | Audits | File |
+|---|---|---|
+| **Performance** | Lighthouse, bundle size/splitting, images, data-fetching waterfalls, render cost | [`performance.md`](performance.md) |
+| **Security** | secrets, authN/authZ + IDOR, input validation, rate limits, CORS, Firebase rules, deps, XSS/PII | [`security.md`](security.md) |
+| **Accessibility** | axe/Lighthouse a11y, keyboard, screen reader, ARIA correctness, contrast, zoom/motion | [`accessibility.md`](accessibility.md) |
+| **Design consistency** | tokens (color/spacing/type), component reuse, states, responsive breakpoints, voice | [`design-consistency.md`](design-consistency.md) |
+| **Code quality & tests** | coverage gaps, E2E journeys, flaky/skipped, types, dead code, error handling | [`code-quality.md`](code-quality.md) |
+
+Related, already-built tooling: `/release-readiness` (audits the launch checklist in `RELEASE_PLAN.md`),
+`/code-review` and `/security-review` (diff-scoped), and the **run-prepify** skill (headless driver).
+
+## The shared method (applies to every sweep)
+
+1. **Isolate.** Run in a fresh worktree off the latest `development` so the sweep can fix-as-it-goes
+   without colliding with feature work: `/worktree-create <sweep> — <one-line goal>`. The worktree-create
+   skill imports env files and boots the client + server on free ports (never 3000/4000).
+2. **Run the app.** Use the **run-prepify** skill. The headless harness lives at
+   `.claude/skills/run-prepify/driver.mjs` (plain `playwright-core`); copy it for click/fill/assert flows.
+   Always read the `errors:` line — a rendered shell with 500'd fetches still screenshots.
+3. **Drive logged-in flows when needed.** The app exposes a Firebase custom-token bridge
+   (`window.__cy_signIn__`) **only** when built with `VITE_CYPRESS=true` (see `src/client/db.ts`). To drive
+   a real authenticated session headlessly: add `VITE_CYPRESS=true` to a `.env` the dev server loads, mint a
+   custom token with `firebase-admin` + the `FIREBASE_SERVICE_ACCOUNT` from `server/.env` (mirror
+   `cypress.config.ts`'s `mintCustomToken`; silence the dotenv banner so the token isn't polluted), then
+   `page.evaluate(t => window.__cy_signIn__(t), token)`. Revert the flag and remove the mint script before
+   committing. *(Note: `.env.test` has fake Firebase config + points at :4000 — don't sign in against it.)*
+4. **Pass structurally.** Work the numbered areas in the sweep doc. For each finding, decide: small + safe
+   → fix here; larger/riskier → file to [`../BACKLOG.md`](../BACKLOG.md) under the right section with a
+   file ref + a "surfaced YYYY-MM-DD in the <sweep> sweep" note.
+5. **Keep the gates green.** `npx tsc --noEmit`, `npm test` (Vitest), `npm run build`; `cd server && npm test`
+   (Jest) for backend changes. Don't touch the **beta tag** — that's the Phase-5 cutover.
+6. **Ship one PR** into `development` with a short checklist of what was checked, before/after metrics where
+   they exist, and links to any backlog items filed.
+
+## Guardrails common to all sweeps
+
+- **Polish, not redesign.** Small, safe, surgical fixes. Anything that needs CSS re-pointing, a layout
+  change, a brand-color decision, or a refactor goes to the backlog — don't do it blind.
+- **Report faithfully.** If something is broken and you didn't fix it, say so and file it. Don't mark a
+  sweep "clean" because the cheap wins are done — list what remains.
+- **Don't weaken anything to make a check pass** (especially in the security sweep).
+- Convert relative dates to absolute when filing backlog items.

--- a/docs/sweeps/accessibility.md
+++ b/docs/sweeps/accessibility.md
@@ -1,0 +1,68 @@
+# Accessibility sweep
+
+Deep WCAG 2.1 AA pass over every Prepify page, logged-out **and** logged-in: automated (Lighthouse +
+axe), keyboard, screen-reader semantics, ARIA correctness, contrast, and zoom/motion. This goes beyond
+the cheap a11y wins in track 4-qa — it's the thorough audit.
+
+> Read [`README.md`](README.md) first (esp. §3 — driving a logged-in session). Some open a11y items are
+> already filed in [`../BACKLOG.md`](../BACKLOG.md) → Accessibility; start by reconciling against those.
+
+## Kickoff
+
+```
+/worktree-create a11y sweep — axe, keyboard, screen reader, ARIA, contrast
+
+Read docs/sweeps/accessibility.md and docs/sweeps/README.md. Run the app and do a structured WCAG AA pass
+on every page (logged-out + logged-in). Fix small, safe a11y wins (labels, names, alt, roles that don't
+need CSS changes); file layout/contrast/refactor items to docs/BACKLOG.md → Accessibility. Open a PR with
+before/after Lighthouse a11y scores per page.
+```
+
+## The pass
+
+1. **Automated baseline.** Lighthouse `accessibility` + `axe-core` on every route: Home, Recipes, single
+   recipe, public profile, about/privacy/terms/help, login/signup/forgot, 404, and the logged-in Account
+   (+ tabs) / Settings (all 4 sections) / Add Recipe. Record per-page scores. *(Track 4-qa already took the
+   recipe page 80 → 89; the remainder — ingredient `<li role="checkbox">`, recipe-nav contrast,
+   servings-input target-size — are in the backlog. Confirm them and look for what the cheap pass missed.)*
+2. **Keyboard.** Tab through every page: logical focus order, **visible** focus ring everywhere (track 3a
+   moved rings to `:focus-visible` — verify no element lost its ring), no keyboard traps, modals
+   (react-modal) trap + restore focus and close on Esc, the mobile nav menu is operable and returns focus to
+   its trigger, and every interactive control (cards, the ingredient check-off, star rating, dropdowns) is
+   reachable and activatable with Enter/Space. Add a skip-to-content link if missing.
+3. **Screen-reader semantics.** One `<h1>` per page and a sane heading hierarchy (no skipped levels);
+   landmarks (`<nav>/<main>/<footer>`, `<main>` present once); **alt text** on every meaningful image
+   (recipe images, avatars) and `alt=""`/`aria-hidden` on decorative ones (the SVG icons); accessible names
+   on all buttons/links (icon-only buttons need `aria-label`); and `aria-live` for async UI — toasts
+   (`react-hot-toast`), inline form validation, "Load more" results, save/rating state changes.
+4. **ARIA correctness.** Roles only on elements that allow them and only when native semantics won't do.
+   Known offenders to verify/fix: the ingredient list `<li role="checkbox">` (invalid — breaks the list;
+   move the role to an inner element) and the autocomplete dropdown's `<ul role="listbox"><li><button
+   role="option">` (a `<li>` between listbox and options + no arrow-key nav / `aria-activedescendant` —
+   both in BACKLOG). Check `aria-checked`/`aria-expanded`/`aria-current` reflect real state.
+5. **Contrast.** WCAG AA (4.5:1 text / 3:1 large + UI). Lighthouse flags the recipe-nav `.dnav__cta--signup`
+   and `.dnav__link-label` on the solid nav — these are **brand colors**, so propose a token-level fix and
+   file it (don't recolor blind). The `.beta-tag` is also low-contrast but is **deliberately deferred** to
+   the Phase-5 beta-tag cutover — leave it.
+6. **Forms.** Every input has an associated `<label>` (or `aria-label` — e.g. the servings input got one in
+   4-qa); required fields are programmatically marked; validation errors are associated with their field
+   (`aria-describedby`) and announced; the file-upload and dropdowns are labelled.
+7. **Zoom, reflow, motion.** 200% browser zoom and 320px-wide reflow without loss of content/function;
+   `prefers-reduced-motion` honored for the nav condense, the star-hover, and any transitions; target sizes
+   ≥24×24 (the servings stepper input is under — backlog).
+
+## Tooling & where to look
+
+- Lighthouse (`--only-categories=accessibility`) + `@axe-core/playwright` driven through a copy of
+  `.claude/skills/run-prepify/driver.mjs`. Parse the failing `auditRefs` to get exact node snippets.
+- Real screen-reader spot-checks (VoiceOver on macOS) for the critical flows: browse → recipe → save,
+  and Add Recipe.
+- Hot spots: `src/Components/Navbar/*`, `src/Components/StarRating/StarRating.tsx`,
+  `src/Components/SearchRecipesInput/SearchRecipesInput.tsx`, `src/pages/SingleRecipe/SingleRecipe.tsx`,
+  `src/index.scss` (focus/outline mixins).
+
+## Deliverable
+
+A PR with a per-page before/after a11y-score table, the cheap wins applied (names, labels, alt, valid
+roles that don't need CSS), and backlog entries for everything structural (contrast tokens, the role
+refactors, target-size). Note which pages were screen-reader spot-checked vs automated-only.

--- a/docs/sweeps/code-quality.md
+++ b/docs/sweeps/code-quality.md
@@ -1,0 +1,66 @@
+# Code quality & test sweep
+
+Full-coverage health check of the codebase itself: test coverage on the critical paths, E2E journey
+coverage, flaky/skipped tests, type safety, dead code, and error handling. The "is the codebase in
+good shape under the hood?" pass.
+
+> Read [`README.md`](README.md) first. This sweep is mostly static analysis + running the suites; it
+> needs the app only for the E2E (Cypress) leg.
+
+## Kickoff
+
+```
+/worktree-create code-quality sweep — coverage, E2E, types, dead code, error handling
+
+Read docs/sweeps/code-quality.md and docs/sweeps/README.md. Audit test coverage (Vitest + Jest), E2E
+journeys (Cypress), type safety, dead code, and error handling. Add small high-value tests, remove clearly
+dead code, tighten obvious types; file larger gaps to docs/BACKLOG.md (Testing / Tech debt). Keep all
+suites green. Open a PR with a coverage summary.
+```
+
+## The pass
+
+1. **Unit/integration coverage.** Run Vitest with coverage (`npx vitest run --coverage`) and Jest in
+   `server/` (`cd server && npm test -- --coverage`). Don't chase a number — find **critical-path gaps**:
+   auth (`AuthContext`, token attach/refresh), save-recipe, serving-price math
+   (`src/util/calculateServingPrice.ts`), ingredient-quantity validation, rating average
+   (`util/recipeRating` + `server/routes/reviews.js`), and the authz checks on mutating server routes. Add
+   focused tests where a regression would be expensive; note bigger gaps for the backlog.
+2. **E2E journeys.** Review the Cypress specs (`cypress/e2e/`: auth, addRecipe, browse, recipe,
+   reportUser, smoke) against the real critical journeys: sign-up → create username → add recipe → view it;
+   browse → filter → open → save → rate; password reset; report. Flag any critical journey with no E2E. The
+   harness mocks Firebase via `__cy_signIn__` + a minted custom token and intercepts the API with
+   fixtures — keep that pattern.
+3. **Flaky / skipped / slow.** There are 2 skipped frontend tests — confirm they're intentionally skipped
+   (and why), not quietly broken. Look for time/order-dependent tests, real-network calls that should be
+   mocked, and any spec that's a known flake. Note slow suites.
+4. **Type safety.** `npx tsc --noEmit` must be clean (it is). Then hunt the soft spots: `any` /
+   `as unknown as` / `@ts-ignore` / `@ts-expect-error`, untyped API responses (do `src/api/*` return typed
+   shapes that match `src/types.ts`?), and non-null assertions (`!`) on values that can actually be null.
+   Tighten the cheap ones; file the rest.
+5. **Dead / commented code.** The repo carries intentional dead code — `RecipeContext` (commented out,
+   migrated to `RecipeAPI`) and the `RecipeAI` route (commented in `App.tsx`). Decide per item: delete if
+   truly abandoned, or leave a one-line note on why it stays. Also: unused exports/imports, unreachable
+   branches, leftover `console.log`, and orphaned files. (Don't delete something load-bearing because it
+   "looks" dead — verify no importer first.)
+6. **Error handling.** Confirm the Sentry boundary (`AppErrorFallback`) covers the app and that async
+   failures surface as user-facing states, not silent catches or unhandled rejections. Server: every route
+   is wrapped in `asyncHandler` (verify) and the error middleware returns sane status codes without leaking
+   stack traces in prod. Each data fetch on the client has a loading + error + empty branch (the 4-qa sweep
+   verified the UI side — this checks the code paths behind them).
+7. **Lint/format & conventions.** Run the linter/formatter if configured; flag inconsistent patterns
+   (mixed import styles, the `src/`/`types` aliases used unevenly, naming drift). Don't reformat the world
+   in this PR — note systemic issues.
+
+## Tooling & where to look
+
+- `npx vitest run --coverage`, `cd server && npm test`, `npx cypress run` (or `open`), `npx tsc --noEmit`.
+- Dead-code/typing greps: `grep -rn "any\|@ts-ignore\|@ts-expect-error\|console.log\|TODO\|FIXME" src server --include=*.ts --include=*.tsx | grep -v test`.
+- Config: `vite.config.ts` (Vitest), `server/jest.config.js`, `cypress.config.ts`, `tsconfig.json`.
+
+## Deliverable
+
+A PR with: a coverage summary (front + back) calling out the critical-path gaps, any small high-value
+tests added, dead code removed (with proof it was unused) or annotated, and backlog items for the larger
+gaps (missing E2E journeys, modules needing tests, a typing cleanup). All suites green, tsc clean, build
+passing.

--- a/docs/sweeps/design-consistency.md
+++ b/docs/sweeps/design-consistency.md
@@ -1,0 +1,67 @@
+# Design consistency sweep
+
+Full-coverage visual/UX consistency audit: are colors, spacing, typography, radii, shadows, components,
+states, and copy voice drawn from a shared system — or has each page drifted? Catch the drift, unify the
+cheap cases (point a stray hex at the token), file the systemic ones.
+
+> Read [`README.md`](README.md) first. Runs best **after** the Sass `@import`→`@use` migration (already
+> merged) so shared partials are the single source of truth. This is a visual sweep — screenshots are the
+> primary evidence.
+
+## Kickoff
+
+```
+/worktree-create design sweep — tokens, component reuse, states, responsive, voice
+
+Read docs/sweeps/design-consistency.md and docs/sweeps/README.md. Run the app, screenshot the key pages at
+desktop + mobile (logged-out + logged-in), and do a structured consistency pass. Unify cheap drift (stray
+hex/px → token); file systemic refactors to docs/BACKLOG.md (UX / visual polish). PR with before/after
+screenshots of anything changed. Polish only — no redesign.
+```
+
+## The pass
+
+1. **Design tokens.** Inventory the SCSS variables/maps/mixins (the shared partials under `src/` that
+   `@use` exposes — colors, spacing scale, type scale, radii, shadows, breakpoints). Then grep the codebase
+   for **hardcoded** values that bypass them: raw hex (`#ff5722` is the brand orange, the teal beta accent),
+   pixel spacing/radii, `rgba()` shadows, font sizes. Each hardcoded value that has a token equivalent is a
+   cheap fix; a *missing* token (a one-off color used in 3 places) is a "promote to token" backlog item.
+2. **Color palette.** Confirm one brand orange, one accent, a consistent neutral ramp, and consistent
+   semantic colors (success/error/warning — cross-check the toast styles). Flag near-duplicates
+   (`#ff5722` vs `#ff5621` vs `#f60`) that should collapse to one token.
+3. **Typography.** One type scale and weight set; headings consistent across pages (the `h1`/`h2` sizes on
+   About vs Privacy vs Account); button text and labels use a consistent size/weight/letter-spacing; no
+   ad-hoc `font-size` literals.
+4. **Component reuse.** Are shared primitives actually reused, or re-implemented per page? Check: buttons
+   (`.btn` + variants vs bespoke `<button>` styles — e.g. the About CTAs, the `home-btn`, the
+   `pp-browse-btn`), cards, the `Form`/`FormInput` components, modals (react-modal config), empty states
+   (recipe empty, profile empty, 404, profile-not-found — same visual language?), and the
+   `RecipeCard` vs `RecipeThumbnail` overlap. Note duplication to consolidate.
+5. **States.** For each interactive component, are hover / focus-visible / active / disabled / loading /
+   empty / error styled consistently? Loading especially — skeletons vs spinners (`TailSpin`) vs nothing,
+   used consistently for the same kind of wait. Empty/error states share a layout + tone.
+6. **Iconography.** `react-icons` pulls from several sets (`Bs`, `Fi`, `Lu`, `Ci`, …) — check the same
+   concept doesn't use different icons in different places (two different "star"s, two "edit"s), and sizes
+   are consistent within a context.
+7. **Responsive.** One set of breakpoints (the nav flips at ~725px — is that value shared or repeated?);
+   no ad-hoc media queries; the master-detail Settings, the Account tabs, Add Recipe, and the recipe grid
+   all reflow consistently. Screenshot at 390 / 768 / 1280 and compare alignment, gutters, and card sizing.
+8. **Copy voice.** Consistency of tone (the "zero guesswork" / budget-friendly voice), heading case (Title
+   Case vs sentence case — pick one for buttons, one for headings, apply uniformly), and toast punctuation
+   (some end with a period, some don't — 4-qa fixed one; sweep the rest). Don't rewrite intentional authored
+   prose (the About page is Jesse's voice by design).
+
+## Tooling & where to look
+
+- Screenshots: `.claude/skills/run-prepify/driver.mjs` and the `shotVariants.mjs` / `shot_scroll.mjs`
+  helpers — capture every key page at 390/768/1280, logged-out and logged-in.
+- Grep for drift: hex (`grep -rniE "#[0-9a-f]{3,6}" src --include=*.scss`), px literals, `font-size:`,
+  `box-shadow:`, and compare against the token partials.
+- Hot spots: the shared SCSS partials, `src/Components/` (Form, buttons, cards, modals), `src/index.scss`.
+
+## Deliverable
+
+A PR with: an inventory of the token system + the top drift offenders, the cheap unifications applied
+(stray value → token) with before/after screenshots, and backlog items for systemic work (promote a
+one-off to a token, consolidate `RecipeCard`/`RecipeThumbnail`, unify a state pattern). Pixel-identical
+rendering for anything you "just" re-pointed at a token — verify with a screenshot diff.

--- a/docs/sweeps/performance.md
+++ b/docs/sweeps/performance.md
@@ -1,0 +1,67 @@
+# Performance sweep
+
+Full-coverage performance audit of the Prepify client + API: Lighthouse on the key pages, bundle
+weight and code-splitting, image delivery, data-fetching waterfalls, and render cost. Knock out the
+cheap wins; file the structural ones (code-splitting, indexes) to the backlog.
+
+> Read [`README.md`](README.md) first — the shared method (worktree, run-prepify, fix-small/file-large,
+> green gates) applies. This doc is the performance-specific brief.
+
+## Kickoff
+
+```
+/worktree-create perf sweep — lighthouse, bundle, images, data-fetching
+
+Read docs/sweeps/performance.md and docs/sweeps/README.md. Run the app (run-prepify skill) and do a
+structured performance pass. Fix the cheap wins; file structural items to docs/BACKLOG.md (Tech debt).
+Open a PR into development with before/after Lighthouse scores and a bundle-size note.
+```
+
+## The pass
+
+1. **Lighthouse on the key pages, both form factors.** Home (`/`), Recipes browse (`/recipes`), a single
+   recipe (`/recipes/:id`), and a logged-in Account page. **Run against a production preview, not the dev
+   server** — `npm run build` then `npx vite preview --port <p> --outDir build`; dev bundles are unminified
+   and score misleadingly low. Capture perf / a11y / best-practices / SEO for each. Use `--preset=desktop`
+   and a mobile run. (`npx -y lighthouse@12 <url> --preset=desktop --only-categories=performance,...`.)
+2. **Bundle size & code-splitting.** `npm run build` warns that the main chunk is >500 kB
+   (`build/assets/index-*.js` ≈ 1.2 MB raw / ~390 kB gzip) — the whole app ships in one chunk with no
+   route-level splitting. Investigate: route-level `React.lazy()` + `Suspense` for the heavy/rare routes
+   (Admin/* , AddRecipe, EditRecipe, the chart/analytics views); audit heavy deps (firebase, the full
+   `react-icons` sets, any chart lib). Visualize with `rollup-plugin-visualizer` or `source-map-explorer`.
+   This is almost certainly a **backlog** item (needs `App.tsx` route changes + verification), not a blind fix.
+3. **Images.** Recipe images come from Firebase Storage. Check: are they sized/compressed (WebP vs
+   original JPEG/PNG), do `<img>`s carry width/height (or aspect-ratio) to avoid CLS, is `loading="lazy"`
+   used below the fold (ingredient thumbs already are — verify cards, hero, avatars), and is the largest
+   contentful image on Home/recipe pages reasonably sized for the slot? Cheap wins: add `loading`/dimensions;
+   structural (a Storage resize pipeline / `srcset`) → backlog.
+4. **Data-fetching & waterfalls.** Trace the network on Home and a recipe page. Look for: request
+   waterfalls (sequential fetches that could parallelize), over-fetching (payloads with fields the page
+   doesn't use), N+1 patterns (recipe → reviews → per-review user), and whether React Query caching is
+   doing its job (`staleTime`, no duplicate keys — see `useNavMenu`'s `['username', uid]` pattern). The
+   facets/trending/for-you endpoints (`server/routes/recipes.js`) are the heaviest — check their Mongo
+   queries hit indexes.
+5. **Server response times.** With the API on :4000/its worktree port, time the hot endpoints
+   (`/api/recipes`, `/api/recipes/facets`, `/api/getTrendingRecipes`, `/api/getRecipe`). Slow ones usually
+   mean a missing MongoDB index or a collection scan — confirm with `.explain()`. Index additions are a
+   backend change → file with the query + the proposed index.
+6. **Render cost.** Long lists (the recipes grid, the reviews list) — are rows memoized, is the list
+   virtualized if it grows unbounded ("Load more" pagination already caps it)? Watch for unnecessary
+   re-renders from context/provider churn (`AuthProvider`, React Query) and the local ingredient parser
+   (`@jclind/ingredient-parser`) running on the main thread during Add Recipe.
+7. **Delivery.** Confirm the host serves gzip/brotli + sensible cache headers for hashed assets, and that
+   fonts don't block render (font-display, preconnect/preload for the brand font if self-hosted).
+
+## Tooling & where to look
+
+- `npm run build` (chunk warning), `npx vite preview` (prod-like serve), `npx -y lighthouse@12`.
+- Headless: `.claude/skills/run-prepify/driver.mjs` (screenshots + console/network) — copy it to capture
+  request timings (`page.on('request'/'response')`).
+- Bundle: `rollup-plugin-visualizer` (Vite uses rolldown — `build.rolldownOptions`), or `source-map-explorer build/assets/*.js`.
+- Backend: `server/routes/recipes.js`, `server/db.js` (pool `maxPoolSize: 10`), Mongo `.explain()`.
+
+## Deliverable
+
+A PR with: before/after Lighthouse table (Home + recipe, desktop+mobile), the current bundle size and a
+recommendation, any cheap wins applied (image dims/lazy, meta), and backlog items for code-splitting +
+any missing indexes. Don't claim a perf win you didn't measure.

--- a/docs/sweeps/security.md
+++ b/docs/sweeps/security.md
@@ -1,0 +1,77 @@
+# Security sweep
+
+Full-coverage security audit of the Prepify client + API: secrets, authentication/authorization (incl.
+IDOR), input validation, rate limiting, CORS, Firebase rules, dependency CVEs, and data exposure /
+XSS. **Read-and-report first** — surface findings, fix only the clearly-safe ones, never weaken a check.
+
+> Read [`README.md`](README.md) first. This is the security-specific brief. For a focused review of just
+> the current diff, prefer the `/security-review` skill instead.
+
+## Kickoff
+
+```
+/worktree-create security sweep — secrets, authz, validation, deps, CORS, firebase rules
+
+Read docs/sweeps/security.md and docs/sweeps/README.md. Do a structured security pass over the client and
+server. Report every finding with severity + a file ref; fix only small, unambiguous hardening; file the
+rest to docs/BACKLOG.md and (if launch-gating) flag it in RELEASE_PLAN.md §C. Do NOT weaken any existing
+control. Open a PR with the findings table.
+```
+
+## The pass
+
+1. **Secrets & key exposure.** `.env` / `server/.env` are gitignored — confirm none are committed
+   (`git log -p` for leaked keys; the repo had a track-0a hygiene pass). Remember **every `VITE_`-prefixed
+   var is shipped to the browser** by design, so verify no *server* secret hides behind a `VITE_` name. Flag
+   client-exposed third-party keys that should be proxied: `VITE_OPEN_AI_API_KEY` and the Edamam app
+   id/key live in the client `.env` and ride along in the bundle — these belong behind the server. Confirm
+   `.env.example` carries no real values.
+2. **Authentication.** Firebase ID tokens are verified server-side via the auth middleware
+   (`server/middleware/*`, Admin SDK) which sets `req.uid`. Check: every state-changing route is behind
+   `verifyToken` (and `requireActive` where it matters), tokens are actually *verified* (not just decoded),
+   and expired/forged tokens are rejected. The `optionalAuth` paths (`/getRecipe`, `/recipes/random`) must
+   degrade safely, never trust a client-supplied uid.
+3. **Authorization & IDOR.** This is the highest-value check. For every route that mutates or returns
+   user-owned data, confirm it scopes by `req.uid` server-side — not by an id from the request body. Probe:
+   can user A edit/delete user B's recipe (`editRecipe`/`deleteRecipe` — do they check `authorId === req.uid`?),
+   read B's drafts/saved/ratings, or hit an admin route without the admin claim? Admin is gated by
+   `AdminRoute` (client) **and** an `isAdmin` claim server-side — the client gate is cosmetic; the server
+   check is the real one. Verify moderation/report/user-admin endpoints all re-check the claim.
+4. **Input validation & uploads.** Validate/clamp recipe + review + profile payloads server-side (lengths,
+   types, numeric ranges — don't trust the client). File uploads: enforce size (the 5 MB check) and MIME/
+   extension on **both** ends (client check is UX only). Username rules (track 3c) and the report/contact
+   forms. Confirm Mongo queries are built from typed/validated values, never string-concatenated user input
+   (`recipeIdQuery` etc. should cast/validate the id).
+5. **Rate limiting & abuse.** `recipeWriteLimiter` guards recipe writes — check the rest: login/signup
+   (credential stuffing), password reset, review/rating spam, report spam, the contact form, and the
+   ingredient-parse / nutrition proxy endpoints (cost-bearing). Note anything unprotected.
+6. **CORS.** `server/app.js` builds `allowedOrigins` from `FRONTEND_URLS`, plus a Netlify-preview pattern
+   and a **non-prod** localhost:3000–3010 allowance (regex, never applied when `NODE_ENV=production`).
+   Verify prod genuinely locks to the real origin(s), credentials handling is correct, and the dev pattern
+   can't leak into prod.
+7. **Firebase Storage / rules.** Review Storage rules: who can upload (size/type/path constraints, auth
+   required), who can read, and whether a user can overwrite another user's avatar/recipe image path. (The
+   gameplan's track-0c covers dashboard-side key referrer + quota lockdown — cross-check it's done.)
+8. **Dependency CVEs.** `npm audit` at root and in `server/` (the gameplan noted ~3 high each). Triage:
+   real exploit path vs transitive/dev-only; bump or document. Don't `--force` fix blindly.
+9. **Data exposure & XSS.** Do API responses leak PII or internal fields (emails, uids, moderation state,
+   report contents) to the wrong audience — especially the **public** profile + recipe payloads? React
+   escapes by default, so hunt the exceptions: `dangerouslySetInnerHTML`, user-controlled `href`/`src`
+   (block `javascript:`/`data:` in bios, links, share URLs), and Markdown/rich-text if any. Check the
+   `noindex`/robots story on private + not-found pages.
+
+## Tooling & where to look
+
+- `server/middleware/`, `server/routes/*.js` (the `verifyToken` / `requireActive` / `optionalAuth` /
+  `requireAdmin` decorators per route), `server/app.js` (CORS), `server/db.js`.
+- Client: `src/context/AuthContext.tsx`, `src/api/http-common.ts` (Bearer attach), `src/api/*`.
+- `npm audit` (root + server), `git log -p -- '*.env*'`, Firebase Storage/Firestore rules files.
+- For exploit-style probing, drive authenticated requests with a minted custom token (README §3) as two
+  different uids and try to cross the boundary.
+
+## Deliverable
+
+A PR (or report, if no code changed) with a **findings table**: severity (crit/high/med/low) · area ·
+file:line · what · fix-or-filed. Launch-gating items also get flagged in `RELEASE_PLAN.md` §C. Apply only
+the unambiguous hardening (e.g. add a missing `verifyToken`, tighten a MIME check); everything debatable
+gets reported, not silently changed.


### PR DESCRIPTION
Adds `docs/sweeps/` — five self-contained, reusable "is everything in order?" sweep playbooks plus an
index, modelled on the **track 4-qa** release QA sweep (the pattern: run on a stable app in a worktree,
structured pass, fix-small / file-large-to-backlog, one PR with metrics).

| Doc | Audits |
|---|---|
| `README.md` | Index + the shared method (worktree → run-prepify → one PR) + common guardrails. Documents the Firebase custom-token harness for driving logged-in flows headlessly. |
| `performance.md` | Lighthouse (prod preview), bundle/code-splitting, images, fetch waterfalls, Mongo indexes, render cost. |
| `security.md` | Secrets/`VITE_`-exposure, authN, IDOR/authz, input validation + uploads, rate limits, CORS, Firebase rules, `npm audit`, XSS/PII. |
| `accessibility.md` | Deep WCAG AA: axe/Lighthouse, keyboard, screen reader, ARIA correctness, contrast, zoom/motion. |
| `design-consistency.md` | Token drift, palette/type, component reuse, states, responsive, voice. |
| `code-quality.md` | Coverage gaps, E2E journeys, flaky/skipped, types, dead code, error handling. |

Each doc is Prepify-specific: real file paths, the actual tooling (`driver.mjs`, `vite preview`, the
`__cy_signIn__` bridge), known issues (the >500 kB chunk, the open backlog a11y items), and the standing
guardrails (polish-not-redesign, beta tag untouched).

**Docs only** — no code, no behavior change. Separated from the QA-fix PR (#174) to keep that one scoped.