### PR TITLE
docs(release): reconcile track 4-qa → merged ([x] #174 ✅)

### DIFF
--- a/docs/RELEASE_GAMEPLAN.md
+++ b/docs/RELEASE_GAMEPLAN.md
@@ -63,7 +63,7 @@ same commit.**
 | 4-sass | Sass `@import`→`@use` (LONER) | `[x]` | `cb2ac81` ✅ (pre-gameplan) |
 | 4-about | About rewrite (Jesse) | `[x]` | #169 ✅ |
 | 4-tests | Toast/alert + Cypress autocomplete tests | `[x]` | #168 ✅ |
-| 4-qa | Empty/error sweep + links + copy + mobile + Lighthouse | `[P]` | #174 |
+| 4-qa | Empty/error sweep + links + copy + mobile + Lighthouse | `[x]` | #174 ✅ |
 | 5 | Cutover (beta off + 1.0.0 + deploy) | `[ ]` | — |
 
 _Doc ownership: this board owns **progress**; `RELEASE_PLAN.md` owns **launch acceptance** (audited by
@@ -509,6 +509,23 @@ Append a one-liner when a track changes state (started / PR / merged). Keeps ses
   the `BACKLOG.md` Tech-debt item are the only changes (docs-only reconcile). The Rule-1 "everyone rebases
   after the Sass loner" step is a **no-op** (no stylesheet churn). **Remaining: 4-qa finishing sweep (Part 3)
   → Phase 5 cutover.**
+- _2026-06-23_ — **4-qa (release QA finishing sweep) → merged (`[x]` #174 ✅).** The late, app-wide pass on
+  the stabilized post-Sass app, driven headlessly logged-out **and** logged-in (a real Firebase custom-token
+  session). **Empty/error/loading:** every page + error/empty variant has a sane state — no infinite spinners,
+  blank flashes, or unhandled error walls; **fixed** the 404 heading ("Something went wrong!" → "Page not
+  found", which read like a crash) and gave the PublicProfile not-found branch a real `<title>` + `noindex`
+  (it was rendering with an empty title). **Links:** crawled every nav/footer/in-page link across 24 internal
+  routes — **0 dead routes / 404s / `#` placeholders**; logged-out vs logged-in visibility correct; fixed a
+  stale `footerData` comment. **Copy:** avatar size toast `5mb` → `5MB` for consistency (the rest read clean).
+  **Mobile (390px):** hand-walked Add Recipe + Account + all 4 Settings sections — **no overflow, no console
+  errors**, tap targets ok; no fixes needed (the 2a/2d/2e/3d redesigns hold up). **Lighthouse (prod preview,
+  desktop):** Home **97/96/100/100**, recipe **88/89/100/100** — recipe a11y **80 → 89** from cheap wins
+  (StarRating display rows expose their value once via `role="img"` and hide the redundant unnamed `<button>`s;
+  servings input + stepper labelled). **Three larger a11y items filed → `BACKLOG.md`** (ingredient
+  `<li role="checkbox">` refactor, recipe-nav brand-color contrast, servings target-size). The matching
+  `RELEASE_PLAN.md` §B acceptance items (broken-link, mobile, copy, Lighthouse) flipped `[x]` in the same
+  reconcile. All CI green; tsc clean; build passes; **beta tag untouched**. Reusable sweep playbooks added
+  under `docs/sweeps/` (#175). **Remaining: Phase 5 cutover only.**
 
 ---
 

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -55,19 +55,23 @@ a feature flag. Do these together:
 - `[ ]` **Empty / error / loading states sweep** — every page that fetches data (Recipes, SingleRecipe,
   Account, Home) should have a sensible empty state, an error state, and a loading skeleton. Spot-check
   by loading with the API down. **(nice-to-have, but high-impact)**
-- `[~]` **Broken-link & dead-route check** — click every nav item, footer link, and CTA; confirm no
-  404s or dead `href="#"`. **Fixed 2026-06-09:** the 404 page's "contact our support team" link now
-  points to `/help` instead of `/` (`src/pages/404/404.tsx`) — the Help page is now public + redesigned
-  (Section D, PR #158 merged), so that dependency is addressed. Still to verify: the "View All Release
-  Notes" link in `ReleaseNotes.tsx:145` (`github.com/jclind/prepify/releases`). **(blocker)**
+- `[x]` **Broken-link & dead-route check** — **done (track 4-qa, PR #174 ✅):** crawled every nav/footer/
+  in-page link across 24 internal routes — **0 dead routes, 404s, or `#` placeholders** — and confirmed
+  logged-out vs logged-in link visibility is correct. The earlier **2026-06-09** fix (the 404's "contact
+  our support team" link → `/help`, `src/pages/404/404.tsx`) holds, and the "View All Release Notes" link
+  (`ReleaseNotes.tsx:145` → `github.com/jclind/prepify/releases`) resolves 200. **(blocker → done)**
 - `[x]` **404 / not-found page** — a real designed 404 exists (`src/pages/404/404.tsx` — food-plate
-  graphic, Return Home button) and renders correctly on an unknown route. *Copy nit:* the heading
-  reads "Something went wrong!", which sounds like a crash rather than a missing page — consider
-  "Page not found." **(blocker → done; copy tweak is nice-to-have)**
-- `[~]` **Mobile pass** — runtime audit at 390px confirmed Home, Recipes browse, Single Recipe (incl.
-  the Nutrition card) and the hamburger menu all render cleanly with **zero console errors**. Still to
-  eyeball by hand: Add Recipe and Account/Settings flows. **(blocker)**
-- `[ ]` **Copy / typo review** — read every user-facing string once with fresh eyes. **(nice-to-have)**
+  graphic, Return Home button) and renders correctly on an unknown route. The copy nit (heading read
+  "Something went wrong!", which sounded like a crash) was **fixed → "Page not found"** in track 4-qa
+  (PR #174). **(blocker → done)**
+- `[x]` **Mobile pass** — **done (track 4-qa, PR #174 ✅):** the earlier 390px audit (Home, Recipes browse,
+  Single Recipe, hamburger — zero console errors) plus the remaining hand-walk of **Add Recipe + Account +
+  all four Settings sections** logged-in at 390px — **no horizontal overflow, no console errors**, tap
+  targets ok. No layout fixes needed. **(blocker → done)**
+- `[x]` **Copy / typo review** — **done (track 4-qa, PR #174 ✅):** proofread headings, empty states,
+  buttons, toasts, and the legal/help/about copy site-wide. Only fix needed: the avatar size-limit toast
+  `5mb` → `5MB`. *(Two typos live in MongoDB recipe **data** — "Egg Friend Rice", a granola "Tt's" — not
+  code; out of scope for a code change.)* **(nice-to-have)**
 - `[ ]` **Favicon, page titles, social/OG meta** — verify `index.html` + per-page titles
   (`react-helmet-async` is already a dependency) and an OG image for link previews. **(nice-to-have)**
 - `[x]` **Remove dev-only UI from production** — `@tanstack/react-query-devtools` is a devDependency;
@@ -188,8 +192,11 @@ a feature flag. Do these together:
   - **Backend (Railway, optional):** `MODERATION_IMAGE_HIGH` / `MODERATION_IMAGE_MEDIUM` — override the
     default SafeSearch likelihood cutoffs (`VERY_LIKELY` / `LIKELY`). Leave unset for defaults.
   Shares the `MODERATION_ENABLED` master switch. No DB migration. See `docs/CONTENT_MODERATION.md`.
-- `[ ]` **Performance / Lighthouse pass** — run Lighthouse on the prod build; address obvious image-size
-  and bundle-size wins. **(nice-to-have)**
+- `[x]` **Performance / Lighthouse pass** — **done (track 4-qa, PR #174 ✅):** Lighthouse on the prod
+  preview build (desktop) — **Home 97/96/100/100**, **recipe 88/89/100/100** (perf/a11y/best-practices/seo);
+  recipe a11y **80 → 89** from the cheap a11y wins. The bundle-size win (>500 kB single chunk → route-level
+  code-splitting) is real but structural — **filed to `BACKLOG.md`** (Tech debt) rather than done here.
+  **(nice-to-have)**
 - `[x]` **README cleanup** *(done — PR #151, 2026-06-17)* — replaced the placeholder `your-username`
   clone URL with `jclind/prepify` and refreshed setup steps for the two-service architecture.
   **(nice-to-have)**


### PR DESCRIPTION
Docs-only reconcile now that **#174** (track 4-qa) has merged.

- **`RELEASE_GAMEPLAN.md`** — Track Board row `4-qa` flipped `[P]` → `[x] #174 ✅`, plus a dated changelog entry summarizing the sweep. Board now shows **Phase 5 cutover** as the only remaining item.
- **`RELEASE_PLAN.md` §B** — flipped the acceptance items the sweep completed: Broken-link & dead-route check (`[~]`→`[x]`), Mobile pass (`[~]`→`[x]`), Copy/typo review (`[ ]`→`[x]`), Performance/Lighthouse pass (`[ ]`→`[x]`, with scores). Updated the 404 copy-nit note to reflect the "Page not found" fix.

Follows the gameplan's merge rule ("flip the box here **and** the underlying `RELEASE_PLAN.md`/`BACKLOG.md` item"). No code changes.