### PR TITLE
feat(recipes): author-selected diet tags instead of Edamam-derived

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -24,6 +24,13 @@ The triage date stamped on items is the date they were filed here, not when they
 
 ## Bugs
 
+- `[ ]` **`Received NaN for the \`value\` attribute` console warning on the Edit Recipe form** — React
+  dev warning observed while editing an existing recipe (`/recipes/:id/edit`); a numeric input renders
+  with `value={NaN}` for a render or two before the recipe data settles. No user-visible effect (form
+  fills and saves correctly) — cosmetic console noise only. Likely a numeric field on the edit form
+  (servings / prep-cook time / fridge-freezer life) or the summary bar's est-per-serving math computing
+  before its inputs are populated; coerce/guard the value (`Number.isNaN(x) ? '' : x`). Discovered during
+  the author-selected diet-labels smoke test (2026-06-24); not seen on the create form, only edit. **(nice-to-have)**
 - `[x]` **Deleting a review leaves the star rating behind** — **fixed in PR #150 (merged, track 1a)**:
   added `DELETE /removeRating` (clears just the star; keeps any review; deletes the doc when
   rating-only), and `deleteReview` now keeps the rating and deletes the doc when there's nothing left —

--- a/docs/HIGH_VALUE_PROMPTS.md
+++ b/docs/HIGH_VALUE_PROMPTS.md
@@ -1,61 +1,104 @@
 # High-Value Claude Code Prompts
 
-Big, token-heavy prompts worth running when there's budget to spare. Compiled 2026-06-11
-based on repo state: three finished-but-unmerged worktrees, open release-plan blockers.
+Big, token-heavy prompts worth running when there's budget to spare. Refreshed 2026-06-24.
 Listed in priority order.
 
-## 1. Land the merge backlog ⭐ top pick
+> **What changed since 2026-06-11:** the old top pick ("land the merge backlog") shipped
+> (#174–#177) and is removed. The `docs/sweeps/` playbooks (added 2026-06-23) are now the top
+> pick because they're built for exactly this and have never been run. SEO structured data is
+> implemented (`buildRecipeJsonLd.ts`), so SEO dropped to a small item. The dead-config /
+> Edamam-key cleanup is folded into a single external-API hardening item.
 
-Converts months of finished work into shipped code. Three rebases, six test-suite runs,
-three reviews — wide but autonomous.
+## 1. Run the unexecuted sweeps ⭐ top pick
 
-> Take the three unmerged worktrees (recipes-page-refresh, account-page-redesign including
-> its P6 teardown of the redesign/ dir and /account-redesign route, and admin-service) and
-> get them merged into development one at a time: rebase each onto latest development,
-> resolve conflicts, run the full frontend + server test suites, run /code-review on each
-> diff at high effort and fix what it finds, then open PRs. Note the worktrees were cut at
-> different points so later rebases will conflict with earlier merges — handle that.
+The five `docs/sweeps/*.md` files are ready-to-run playbooks that have **never been executed**.
+Each is written for the worktree + `run-prepify` headless-browser flow, one PR per sweep — i.e.
+purpose-built for "no need to skimp." The scoping work is already done, so this is the most value
+per prompt.
 
-Tip: `/code-review ultra` on each PR runs the review in the cloud instead of burning
-local tokens.
+> Run the docs/sweeps/ playbooks one at a time (start with security.md, then performance.md,
+> accessibility.md, code-quality.md, design-consistency.md). For each: spin up a worktree, follow
+> the sweep's method (read-and-report first, fix only clearly-safe ones, file the rest to
+> BACKLOG.md), use the run-prepify skill to verify in the browser, run the relevant test suites,
+> and open one PR per sweep.
+
+Tip: these are independent — run them across separate end-of-week sessions to keep each context fresh.
 
 ## 2. Release-blocker burn-down
 
-> /release-readiness, then work through every remaining `[ ]` blocker in
-> docs/RELEASE_PLAN.md that doesn't need a decision from me, on a branch, with tests.
-> For `[?]` items, list the decisions at the end.
+17 open `[ ]` items in RELEASE_PLAN.md, none currently needing a decision — mostly polish + verification.
 
-## 3. Empty/error/loading states sweep
+> /release-readiness, then work through every remaining `[ ]` item in docs/RELEASE_PLAN.md that
+> doesn't need a decision from me, on a branch, with tests. List anything that does need a decision
+> at the end.
 
-Called out in RELEASE_PLAN.md Section A as high-impact. Token-heavy because it drives
-the headless browser repeatedly via the run-prepify skill.
+Note: the empty/error/loading states sweep (old item #3) lives in RELEASE_PLAN §A and is covered here.
 
-> Do the empty/error/loading states sweep from RELEASE_PLAN.md Section A: for every
-> data-fetching page (Home, Recipes, SingleRecipe, Account, /u/:username), run the app
-> with the API down and with empty data, screenshot each state, then implement sensible
-> empty states, error states, and skeletons where missing. Add tests.
+## 3. Full multi-agent bug hunt
 
-## 4. Full-codebase security + auth audit
+The canonical token-heavy "spend for confidence" workflow. Adversarial verification kills the
+plausible-but-wrong findings that make broad bug hunts noisy.
 
-> /security-review, then go deeper: audit the Express server end-to-end — every route's
-> auth middleware coverage, the admin-claims checks, CORS config, rate limiting, input
-> validation on recipe/review/report endpoints, and Firebase token handling. Cross-check
-> against docs/server-audit.md for regressions. Write findings to docs/, fix the
-> clear-cut ones.
+> ultracode — Do a comprehensive bug hunt across the codebase using a multi-agent workflow: fan
+> out finders across each subsystem (auth middleware, recipe CRUD, ingredient parsing,
+> serving-price calc, content moderation, gamification, drafts/autosave, saved-recipes), then
+> adversarially verify every finding with independent skeptics so I only get confirmed bugs. Write
+> confirmed findings to docs/ with repro steps; fix the clear-cut ones on a branch with tests.
 
-## 5. Test-gap analysis with backfill
+Tip: the leading "ultracode" opts into the multi-agent orchestration.
 
-> Map every exported function/component in src/ and server/routes/ against the existing
-> Vitest/Jest/Cypress suites, identify the riskiest untested paths (auth flows, ingredient
-> parsing, serving-price calc, review CRUD), and write tests for the top 10 gaps.
+## 4. External-API hardening (Edamam / Spoonacular / Firebase)
 
-## 6. Dependency + dead-code sweep
+Confirmed open: the Edamam app id/key ship in the client bundle (`src/api/recipes.ts:406`,
+RELEASE_PLAN §B.3). Spoonacular is already server-proxied (`server/routes/ingredients.js`) — mirror
+that pattern for Edamam. Also sweeps up the dead config flags CLAUDE.md once listed.
 
-> /dep-audit, then apply the safe upgrades, and also remove the dead config CLAUDE.md
-> flags (VITE_OPEN_AI_API_KEY, VITE_INGREDIENT_PARSER_URL) plus any unused
-> exports/components you find. Tests must stay green.
+> Lock down external API usage: proxy the Edamam nutrition call through the Express server (mirror
+> the Spoonacular ingredient-parse proxy in server/routes/ingredients.js) so the keys leave the
+> client bundle, add caching/dedupe where calls repeat, and audit every VITE_* env var for public
+> safety (remove any dead ones). Branch + tests.
+
+## 5. Test-suite *quality* audit (not coverage)
+
+~130 test files already exist; the gap is meaningfulness, not count.
+
+> Audit the existing Vitest/Jest/Cypress suites for quality, not coverage: find tests that pass
+> trivially or assert nothing meaningful, flaky tests, and high-risk paths (auth, ingredient
+> parsing, serving-price, review/rating CRUD, moderation) whose tests don't actually exercise the
+> failure modes. Strengthen the worst offenders and add the missing edge cases.
+
+## 6. API contract three-way reconciliation
+
+> Reconcile docs/API_CONTRACT.md against the actual server/routes/ handlers and the src/api/ client
+> modules. Find drift in params, response shapes, status/error codes, and auth requirements across
+> all three. Write a diff report to docs/ and fix the clear mismatches.
+
+## 7. End-to-end user-journey simulation
+
+Token-heavy because it drives the headless browser repeatedly through real flows that unit tests miss.
+
+> Using the run-prepify skill, drive a full end-to-end journey in the headless browser — signup →
+> create a recipe (image + nutrition) → rate → save → report → admin-moderate → delete — with the
+> API both up and down, screenshotting every step. Flag any broken/ugly state and fix what you find.
+
+## 8. SEO finish + social previews
+
+JSON-LD already exists (`src/pages/SingleRecipe/buildRecipeJsonLd.ts`); two gaps remain.
+
+> Add a test that validates the Recipe JSON-LD from buildRecipeJsonLd.ts against Google's Rich
+> Results required fields, then lay out options for social-link previews (the SPA serves generic
+> index.html to non-JS crawlers — RELEASE_PLAN §C): prerender vs. accept the generic card for 1.0.
+> Recommend one.
+
+## 9. Docs reconciliation
+
+~6,400 lines of docs (REFACTOR_NOTES alone is 1,405). Cheap insurance against acting on stale audits.
+
+> Reconcile the docs/ folder against current code: mark stale sections, reconcile the audit docs
+> (server-audit, SECURITY_AUDIT, DATA_INTEGRITY_AUDIT) against what's actually been fixed, and flag
+> anything contradicted by the code. Don't delete — annotate.
 
 ## Not worth tokens right now
 
-- **Mobile-nav redesign** — blocked on a human decision (picking one of the 10 variants
-  on feat/mobile-nav-redesign), not on Claude doing work.
+- **Mobile-nav redesign** — blocked on a human decision (picking one of the variants on
+  feat/mobile-nav-redesign), not on Claude doing work.

--- a/server/util/recipeFields.js
+++ b/server/util/recipeFields.js
@@ -14,6 +14,10 @@ const RECIPE_CONTENT_FIELDS = [
   'instructions',
   'cuisine',
   'mealTypes',
+  // Author-selected diet/health tags (VEGAN, GLUTEN_FREE…). A user content field
+  // so drafts persist it too; it used to be Edamam-computed and lived only in the
+  // edit whitelist below.
+  'nutritionLabels',
 ]
 
 // Editing a published recipe also writes the image and the server-/client-
@@ -22,7 +26,6 @@ const EDITABLE_RECIPE_FIELDS = [
   ...RECIPE_CONTENT_FIELDS,
   'recipeImage',
   'nutritionData',
-  'nutritionLabels',
   'servingPrice',
   'totalTime',
 ]

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -1,7 +1,6 @@
 import { parseIngredientString } from '@jclind/ingredient-parser'
 import axios, { type AxiosResponse } from 'axios'
 import { getDownloadURL, getStorage, ref, uploadBytes } from 'firebase/storage'
-import dietLabels from 'src/recipeData/dietLabels'
 import { calculateServingPrice } from 'src/util/calculateServingPrice'
 import {
   AccountTabCounts,
@@ -207,7 +206,6 @@ class RecipeAPIClass {
     computed: {
       recipeImage: string
       nutritionData: NutritionDataType | null
-      nutritionLabels: string[] | null
       servingPrice: number
       totalTime: number
     }
@@ -224,9 +222,11 @@ class RecipeAPIClass {
       instructions: data.instructions,
       cuisine: data.cuisine,
       mealTypes: data.mealTypes,
+      // Author-selected diet tags. Unlike nutritionData (still computed from
+      // Edamam), these come straight from the form.
+      nutritionLabels: data.nutritionLabels,
       recipeImage: computed.recipeImage,
       nutritionData: computed.nutritionData,
-      nutritionLabels: computed.nutritionLabels,
       servingPrice: computed.servingPrice,
       totalTime: computed.totalTime,
     }
@@ -250,16 +250,13 @@ class RecipeAPIClass {
       )
       setProgress(80)
       const totalTime: number = recipeData.prepTime + (recipeData.cookTime ?? 0)
-      const nutritionDataRes = await this.getRecipeNutrition(
-        recipeData.ingredients
-      )
-      const nutritionData = nutritionDataRes.nutritionData
-      const nutritionLabels = nutritionDataRes.dietLabels
+      // Diet labels now come from the form (recipeData.nutritionLabels); Edamam
+      // only supplies the numeric nutrition facts.
+      const nutritionData = await this.getRecipeNutrition(recipeData.ingredients)
       const returnRecipeData: Omit<RecipeType, '_id'> = {
         ...this.buildEditableRecipeFields(recipeData, {
           recipeImage,
           nutritionData,
-          nutritionLabels,
           servingPrice,
           totalTime,
         }),
@@ -325,10 +322,11 @@ class RecipeAPIClass {
       )
       const totalTime: number = recipeData.prepTime + (recipeData.cookTime ?? 0)
 
-      // Nutrition is a paid Edamam call, so only re-run it when the ingredient set
-      // actually changed; minor edits (title, instructions, times) reuse the
-      // stored nutrition data and labels. Compare the exact strings the lookup
-      // would send, element-wise.
+      // Numeric nutrition is a paid Edamam call, so only re-run it when the
+      // ingredient set actually changed; minor edits (title, instructions, times)
+      // reuse the stored nutrition data. Diet labels are author-supplied via the
+      // form, so they're not part of this check. Compare the exact strings the
+      // lookup would send, element-wise.
       const newIngredients = this.buildNutritionIngredients(recipeData.ingredients)
       const oldIngredients = this.buildNutritionIngredients(originalRecipe.ingredients)
       const ingredientsChanged =
@@ -336,18 +334,16 @@ class RecipeAPIClass {
         newIngredients.some((ingr, i) => ingr !== oldIngredients[i])
 
       let nutritionData = originalRecipe.nutritionData
-      let nutritionLabels = originalRecipe.nutritionLabels
       if (ingredientsChanged) {
-        const nutritionDataRes = await this.getRecipeNutrition(
-          recipeData.ingredients
-        )
         // getRecipeNutrition soft-fails to null when Edamam is unreachable. Only
         // overwrite when it actually returned data — otherwise a transient lookup
         // failure during an ingredient edit would erase the recipe's existing
         // nutrition facts for all viewers.
-        if (nutritionDataRes.nutritionData) {
-          nutritionData = nutritionDataRes.nutritionData
-          nutritionLabels = nutritionDataRes.dietLabels
+        const freshNutritionData = await this.getRecipeNutrition(
+          recipeData.ingredients
+        )
+        if (freshNutritionData) {
+          nutritionData = freshNutritionData
         }
       }
       setProgress(90)
@@ -356,7 +352,6 @@ class RecipeAPIClass {
       const payload = this.buildEditableRecipeFields(recipeData, {
         recipeImage,
         nutritionData,
-        nutritionLabels,
         servingPrice,
         totalTime,
       })
@@ -395,7 +390,13 @@ class RecipeAPIClass {
     })
     return ingr
   }
-  async getRecipeNutrition(ingrArr: IngredientsType[]): Promise<{ nutritionData: NutritionDataType | null; dietLabels: string[] | null }> {
+  // Fetches the numeric nutrition facts (calories, macros…) from Edamam for the
+  // given ingredients. Diet/health labels are no longer derived here — authors
+  // set those manually on the form. Soft-fails to null so a lookup outage never
+  // blocks recipe creation/editing.
+  async getRecipeNutrition(
+    ingrArr: IngredientsType[]
+  ): Promise<NutritionDataType | null> {
     try {
       const ingrData: { title: string; ingr: string[] } = {
         title: 'recipe 1',
@@ -408,25 +409,10 @@ class RecipeAPIClass {
 
       const nutritionResult: NutritionDataType = nutritionResultRes.data
 
-      if (!nutritionResult) return { nutritionData: null, dietLabels: null }
-
-      const currDietLabels: string[] = []
-
-      const returnedNutritionLabels = [
-        ...nutritionResult.dietLabels,
-        ...nutritionResult.healthLabels,
-      ]
-
-      dietLabels.forEach(l => {
-        if (returnedNutritionLabels.includes(l.toUpperCase())) {
-          currDietLabels.push(l)
-        }
-      })
-
-      return { nutritionData: nutritionResult, dietLabels: currDietLabels }
+      return nutritionResult ?? null
     } catch (error: unknown) {
       console.error('getRecipeNutrition failed:', error)
-      return { nutritionData: null, dietLabels: null }
+      return null
     }
   }
 

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -24,6 +24,7 @@ import IngredientsContainer from 'src/pages/AddRecipe/Ingredients/IngredientsCon
 import InstructionsContainer from 'src/pages/AddRecipe/Instructions/InstructionsContainer'
 import CuisineSelector from 'src/pages/AddRecipe/CuisineSelector/CuisineSelector'
 import MealTypeSelector from 'src/pages/AddRecipe/MealTypeSelector/MealTypeSelector'
+import DietSelector from 'src/pages/AddRecipe/DietSelector/DietSelector'
 import { hrMinToMin } from 'src/util/hrMinToMin'
 import { minToHrMin } from 'src/util/minToHrMin'
 import {
@@ -100,6 +101,12 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
   const [mealTypes, setMealTypes] = useState<string[]>(
     initialRecipe?.mealTypes ?? []
   )
+  // Author-selected diet tags (optional). In edit mode this pre-fills from the
+  // recipe's existing nutritionLabels — including ones Edamam set on older
+  // recipes — so the author can keep or correct them.
+  const [nutritionLabels, setNutritionLabels] = useState<string[]>(
+    initialRecipe?.nutritionLabels ?? []
+  )
   const [errors, setErrors] = useState<Partial<AddRecipeErrorType>>({})
 
   const [isFormValid, setIsFormValid] = useState(false)
@@ -154,6 +161,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
           setInstructions(draft.instructions ?? [])
           setCuisine(draft.cuisine ?? '')
           setMealTypes(draft.mealTypes ?? [])
+          setNutritionLabels(draft.nutritionLabels ?? [])
           setResumedFromDraft(true)
         }
         setHydrated(true)
@@ -203,6 +211,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
       instructions,
       cuisine,
       mealTypes,
+      nutritionLabels,
     }),
     [
       title,
@@ -216,6 +225,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
       instructions,
       cuisine,
       mealTypes,
+      nutritionLabels,
     ]
   )
 
@@ -327,6 +337,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
       instructions,
       cuisine,
       mealTypes,
+      nutritionLabels,
     }
     if (isEditMode && initialRecipe) {
       const editData: RecipeEditFormType = { ...formData, recipeImage }
@@ -529,6 +540,13 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
               <MealTypeSelector
                 mealTypes={mealTypes}
                 setMealTypes={setMealTypes}
+              />
+            </div>
+            <div className='diet input-field'>
+              <SectionHeader label='Diet' />
+              <DietSelector
+                nutritionLabels={nutritionLabels}
+                setNutritionLabels={setNutritionLabels}
               />
             </div>
           </div>

--- a/src/pages/AddRecipe/DietSelector/DietSelector.tsx
+++ b/src/pages/AddRecipe/DietSelector/DietSelector.tsx
@@ -1,0 +1,78 @@
+import React, { FC } from 'react'
+import Select, { ActionMeta, MultiValue, StylesConfig } from 'react-select'
+import { dietLabelsOptions } from 'src/recipeData/dietLabels'
+import styles from 'src/_exports.module.scss'
+
+type OptionType = {
+  value: string
+  label: string
+}
+
+const customStyles: StylesConfig<OptionType> = {
+  // Lift the open menu above the sticky summary bar (z-index 50), matching the
+  // Course/Cuisine selectors which sit in the same region of the form.
+  menu: (provided: any) => ({ ...provided, zIndex: 60 }),
+  control: (provided: any, state: any) => ({
+    ...provided,
+    borderColor: state.isFocused ? styles.primary : provided.borderColor,
+    borderWidth: '2px',
+    backgroundColor: 'none',
+    '&:hover': {
+      borderColor: 'primary',
+    },
+    boxShadow: 'none',
+    fontWeight: '500',
+  }),
+  option: (provided: any, state: any) => ({
+    ...provided,
+    backgroundColor: state.isSelected ? styles.primary : 'transparent',
+    color: state.isSelected ? 'white' : 'inherit',
+    fontWeight: '500',
+    '&:hover': {
+      backgroundColor: state.isSelected ? 'primary' : 'lightgray',
+      color: state.isSelected ? 'white' : 'inherit',
+    },
+  }),
+}
+
+type DietSelectorProps = {
+  nutritionLabels: string[]
+  setNutritionLabels: React.Dispatch<React.SetStateAction<string[]>>
+}
+
+// Map the stored label values (e.g. 'GLUTEN_FREE') back to their option objects
+// so the control shows the friendly labels when editing an existing recipe.
+const getDietLabelsByValue = (values: string[]): OptionType[] =>
+  dietLabelsOptions.filter(option => values.includes(option.value))
+
+const DietSelector: FC<DietSelectorProps> = ({
+  nutritionLabels,
+  setNutritionLabels,
+}) => {
+  const handleChange = (
+    newValue: MultiValue<OptionType> | null,
+    _actionMeta: ActionMeta<OptionType>
+  ) => {
+    if (newValue) {
+      setNutritionLabels(newValue.map(option => option.value))
+    } else {
+      setNutritionLabels([])
+    }
+  }
+
+  return (
+    <div>
+      <Select
+        value={getDietLabelsByValue(nutritionLabels)}
+        isMulti={true}
+        onChange={handleChange}
+        options={dietLabelsOptions}
+        styles={customStyles}
+        placeholder='Select diet tag(s)...'
+        closeMenuOnSelect={false}
+      />
+    </div>
+  )
+}
+
+export default DietSelector

--- a/src/test/DietSelector.test.tsx
+++ b/src/test/DietSelector.test.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react'
+import { vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DietSelector from 'src/pages/AddRecipe/DietSelector/DietSelector'
+
+// Mirror the repo convention (ReviewsContainer.test): rather than drive the real
+// react-select widget, swap it for a controllable double that surfaces the exact
+// props DietSelector wires up — `value`, `options`, `placeholder`, `onChange` —
+// so the test exercises DietSelector's own logic (value<->option mapping) and not
+// react-select internals.
+vi.mock('react-select', () => ({
+  default: ({ value, onChange, options, placeholder }: any) => (
+    <div>
+      <span data-testid='placeholder'>{placeholder}</span>
+      {/* The friendly labels react-select would render for the current value —
+          this is what getDietLabelsByValue resolves the stored values to. */}
+      <span data-testid='selected'>
+        {(value ?? []).map((o: any) => o.label).join(',')}
+      </span>
+      {options.map((opt: any) => (
+        <button
+          key={opt.value}
+          data-testid={`opt-${opt.value}`}
+          // Emulate an isMulti selection: append the chosen option to the current
+          // selection and hand the full MultiValue array back, as react-select does.
+          onClick={() => onChange([...(value ?? []), opt], { action: 'select-option' })}
+        >
+          {opt.label}
+        </button>
+      ))}
+      <button
+        data-testid='clear'
+        onClick={() => onChange(null, { action: 'clear' })}
+      >
+        clear
+      </button>
+    </div>
+  ),
+}))
+
+// Stateful host so DietSelector behaves as the controlled component it is on the
+// form: selections flow back through setNutritionLabels and re-render value.
+const Harness = ({ initial = [] as string[] }) => {
+  const [labels, setLabels] = useState<string[]>(initial)
+  return (
+    <>
+      <span data-testid='labels'>{labels.join(',')}</span>
+      <DietSelector nutritionLabels={labels} setNutritionLabels={setLabels} />
+    </>
+  )
+}
+
+describe('DietSelector', () => {
+  it('renders the diet-tag placeholder', () => {
+    render(<Harness />)
+    expect(screen.getByTestId('placeholder')).toHaveTextContent(
+      'Select diet tag(s)...'
+    )
+  })
+
+  it('pre-fills the friendly labels for existing stored values (edit mode)', () => {
+    render(<Harness initial={['GLUTEN_FREE', 'VEGAN']} />)
+    // getDietLabelsByValue maps the raw stored values back to their option objects
+    // so an edited recipe shows "Gluten Free" / "Vegan", not the raw enum strings.
+    expect(screen.getByTestId('selected')).toHaveTextContent('Gluten Free,Vegan')
+  })
+
+  it('ignores stored values with no matching option', () => {
+    render(<Harness initial={['VEGAN', 'NOT_A_REAL_LABEL']} />)
+    // Unknown values are dropped from the displayed selection rather than crashing.
+    expect(screen.getByTestId('selected')).toHaveTextContent('Vegan')
+  })
+
+  it('stores the option value (not the label) when a tag is selected', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    await user.click(screen.getByTestId('opt-VEGAN'))
+    expect(screen.getByTestId('labels')).toHaveTextContent('VEGAN')
+  })
+
+  it('accumulates multiple selected tags', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    await user.click(screen.getByTestId('opt-VEGAN'))
+    await user.click(screen.getByTestId('opt-GLUTEN_FREE'))
+    expect(screen.getByTestId('labels')).toHaveTextContent('VEGAN,GLUTEN_FREE')
+  })
+
+  it('resets to an empty selection when cleared', async () => {
+    const user = userEvent.setup()
+    render(<Harness initial={['VEGAN']} />)
+    expect(screen.getByTestId('labels')).toHaveTextContent('VEGAN')
+    // The null-newValue branch of handleChange must yield [], not crash.
+    await user.click(screen.getByTestId('clear'))
+    expect(screen.getByTestId('labels')).toHaveTextContent('')
+  })
+})

--- a/src/test/RecipesApi.test.ts
+++ b/src/test/RecipesApi.test.ts
@@ -63,6 +63,8 @@ const makeFormData = (): RecipeFormType => ({
   recipeImage: new File([''], 'photo.jpg', { type: 'image/jpeg' }),
   cuisine: '',
   mealTypes: ['Dinner'],
+  // Author-selected diet tags now come from the form, independent of Edamam.
+  nutritionLabels: ['VEGAN'],
 })
 
 describe('RecipeAPI.addRecipe — nutrition soft-fail (High #4)', () => {
@@ -84,10 +86,12 @@ describe('RecipeAPI.addRecipe — nutrition soft-fail (High #4)', () => {
     expect(httpPost).toHaveBeenCalledTimes(1)
     expect(httpPost.mock.calls[0][0]).toBe('api/addRecipe')
 
-    // The submitted payload carries null nutrition fields (soft-fail degradation)
+    // The submitted payload carries null numeric nutrition (soft-fail
+    // degradation), but the author-selected diet labels are unaffected by the
+    // Edamam outage — they come straight from the form.
     const submittedRecipe = httpPost.mock.calls[0][1]
     expect(submittedRecipe.nutritionData).toBeNull()
-    expect(submittedRecipe.nutritionLabels).toBeNull()
+    expect(submittedRecipe.nutritionLabels).toEqual(['VEGAN'])
   })
 
   it('still POSTs the recipe and returns the _id when getRecipeNutrition resolves with empty data', async () => {
@@ -160,6 +164,8 @@ describe('RecipeAPI.editRecipe', () => {
     recipeImage: undefined,
     cuisine: '',
     mealTypes: ['Dinner'],
+    // Mirrors the edit form, which pre-fills from the recipe's existing labels.
+    nutritionLabels: ['Vegan'],
     ...overrides,
   })
 
@@ -268,7 +274,8 @@ describe('RecipeAPI.editRecipe', () => {
 
     expect(nutritionPost).toHaveBeenCalledTimes(1)
     const payload = httpPut.mock.calls[0][1]
-    // The soft-fail must NOT erase the recipe's stored nutrition.
+    // The soft-fail must NOT erase the recipe's stored numeric nutrition; diet
+    // labels are form-driven and pass through regardless.
     expect(payload.nutritionData).toEqual({ uri: 'orig' })
     expect(payload.nutritionLabels).toEqual(['Vegan'])
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,10 @@ export type RecipeFormType = {
   recipeImage: File
   cuisine: string
   mealTypes: string[]
+  // Diet/health tags the author selects manually (e.g. VEGAN, GLUTEN_FREE).
+  // Drives the recipes-page diet filter. Empty array = no diet tags. Previously
+  // derived from Edamam; now author-supplied so the values are accurate.
+  nutritionLabels: string[]
 }
 
 // Same shape as RecipeFormType, but the image is optional: when editing, an
@@ -87,6 +91,7 @@ export type RecipeDraftContent = {
   instructions?: InstructionsType[]
   cuisine?: string
   mealTypes?: string[]
+  nutritionLabels?: string[]
 }
 
 export type RecipeDraftType = RecipeDraftContent & {


### PR DESCRIPTION
## Summary

Recipe authors now choose diet/health tags (Vegan, Gluten Free, Peanut Free, Kosher, etc.) **directly on the Add/Edit Recipe form**, instead of those tags being auto-derived from Edamam's nutrition response. The Edamam-derived labels were unreliable; author-supplied values are accurate and drive the recipes-page diet filter.

## Changes

- **New `DietSelector` component** — a `react-select` multi-select wired to `dietLabelsOptions`. Maps stored values (`GLUTEN_FREE`) ↔ friendly labels (`Gluten Free`) so editing an existing recipe pre-fills its current tags (including any Edamam set on older recipes, so the author can keep or correct them).
- **`nutritionLabels` is now an author-supplied content field**:
  - Added to `RecipeFormType` and `RecipeDraftContent` (`src/types.ts`).
  - Moved into the server's `RECIPE_CONTENT_FIELDS` (`server/util/recipeFields.js`) so **drafts persist it** on autosave, not just edits.
  - `AddRecipe` holds the new state, hydrates it from drafts and from `initialRecipe`, and includes it in submit + autosave payloads.
- **`getRecipeNutrition` simplified** — returns only the numeric `NutritionDataType | null`; diet labels are no longer derived there. The edit-flow's "only re-run the paid Edamam call when ingredients changed" guard is unaffected, since labels now flow straight from the form.

## Tests

- **New `DietSelector.test.tsx`** — value↔label mapping, multi-select accumulation, clearing, edit-mode pre-fill, and ignoring unknown stored values. Follows the repo convention of mocking `react-select` with a controllable double.
- **`RecipesApi.test.ts` updated** — author-selected labels now survive an Edamam outage (form-driven, not computed) and pass through on edit.
- Full suites green locally: **frontend 516 passed / 2 skipped**, **server 683 passed**.

## Notes

- Also logs a cosmetic `Received NaN for the value attribute` console warning on the Edit Recipe form to `docs/BACKLOG.md` (nice-to-have, no user-visible effect), and refreshes `docs/HIGH_VALUE_PROMPTS.md`.