### PR TITLE
a11y: WCAG AA sweep — names, landmarks, roles, headings, reduced-motion

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -202,24 +202,40 @@ The triage date stamped on items is the date they were filed here, not when they
   as a plain list of buttons, or implement real listbox keyboarding. *(surfaced 2026-06-22 in the track 2d
   code review; the per-result `role="option"` on a button is the new markup from this track.)*
 
-- `[ ]` **Ingredient checklist `<li role="checkbox">` is an invalid ARIA role + breaks the list** — each
-  ingredient row is a `<li role="checkbox" aria-checked tabIndex={0}>` (`SingleRecipe.tsx`
-  `renderIngredient`), but `checkbox` isn't an allowed role on `<li>`, which also makes the parent
-  `<ul class="ing-list">` "a list that doesn't contain only `<li>`" (the `<li>`s no longer carry an
-  implicit `listitem` role). Fixes Lighthouse `aria-allowed-role` + `list`. Fix: move the
-  checkbox role/keyboard handler onto an inner element (e.g. a `<div role="checkbox">` or a real
-  `<button>`) and keep the `<li>` plain — needs `.ing` CSS re-pointed and a visual re-check, so it's not
-  a blind one-liner. *(surfaced 2026-06-23 in the track 4-qa Lighthouse pass; recipe-page a11y was 80→89
-  after the cheap wins, these are the remainder.)*
-- `[ ]` **Recipe-page nav fails color-contrast (signup CTA + condensed nav link label)** — Lighthouse
-  `color-contrast` flags `.dnav__cta--signup` and `.dnav__link-label` on the solid (`darkNavLinks`) nav.
-  These are brand colors, so adjusting them is a design call, not a QA-sweep polish edit. *(The
-  `.beta-tag` is also flagged but is intentionally left for the Phase-5 beta-tag cutover. surfaced
-  2026-06-23, track 4-qa.)*
+- `[x]` **Ingredient checklist `<li role="checkbox">` is an invalid ARIA role + breaks the list** —
+  **done (accessibility sweep, 2026-06-25):** the checkbox role + keyboard handler moved onto an inner
+  `<div role="checkbox">`, leaving each `<li>` plain (`SingleRecipe.tsx` `renderIngredient`). `.ing`
+  styling stayed on the now-inner element, so the 2-column grid is visually unchanged (verified by
+  screenshot). Clears Lighthouse `aria-allowed-role` + `list`; recipe page **89 → 97**. Keyboard toggle
+  (Enter/Space → `aria-checked`) re-verified.
+- `[ ]` **Text + brand colors fail WCAG AA contrast (token-level decision)** — the widest remaining a11y
+  gap. Two token families, both needing a design call (not a blind QA recolor), confirmed across Home,
+  Recipes, single-recipe, profile, about/privacy/help, auth, and the logged-in Account/Settings:
+  - **Muted-grey body/meta text** `#979ba0` (and `#8a8f99` on `.bug-report-trigger`) lands at **2.4:1 on
+    `#eeeeee`** and **2.79:1 on `#ffffff`** — well under 4.5:1. Used pervasively: section subtitles
+    (`.home-section-header p`, Recipes `header p`), `.author-text`, `.effective-date`, `.pp-name`,
+    `.pp-counts span`, `.hr-count`, recipe-card meta (time/cuisine/rating `.count`/`.recipe-card__cuisine`),
+    `.price-line`, `.footer-copy`/`.footer-version`, `.about-nutrition-label`, the meal-plan `.m-l` labels,
+    and `.acct-meta`/`.acct-bio-empty`/`.settings-navlabel`/`.banner-sub` when logged in. A single token
+    bump (e.g. `#979ba0`→~`#6b7280`, ≈4.6:1 on white) clears the bulk of the per-page `color-contrast`
+    flags at once — it's the one change that moves every page off ~96.
+  - **Brand colors as text/CTAs**: orange `#ff5722` (`.see-all`, `.dnav__link-label`/`.dnav__cta--signup`
+    on the solid nav, `.cook-suggestion-btn`, `.about-eyebrow`/`.about-btn-primary`/`.about-card-price`,
+    `.save-control__trigger`, `.price-line strong`, `.pp-lvl`, meal-col headers) at **2.7–3.2:1**, and teal
+    `#00adb5` (`.eyebrow` on the recipe page, the `.form-action-btn` login/signup buttons at white-on-teal
+    **2.74:1**). These are the identity palette — adjusting them (or pairing a darker on-light variant) is a
+    brand decision. Propose tokenizing an accessible "on-light" orange/teal rather than recoloring inline.
+  - *(The `.beta-tag` `#eeeeee`-on-`#00adb5` is also flagged but is intentionally left for the Phase-5
+    beta-tag cutover — leave it.)* *(Original `.dnav__*` entry surfaced 2026-06-23 in track 4-qa; broadened
+    to the full token inventory 2026-06-25 in the accessibility sweep.)*
+- `[ ]` **Autocomplete dropdown isn't a valid ARIA listbox + has no keyboard nav** — re-confirmed in the
+  2026-06-25 accessibility sweep, still as filed above (the `<ul role="listbox"><li><button role="option">`
+  shape + no arrow-key/`aria-activedescendant`). Tab-reachable and operable by mouse/Enter, so left for the
+  listbox refactor rather than a sweep polish edit. See the dedicated entry earlier in this section.
 - `[ ]` **Servings stepper input is below the 24px touch-target minimum** — the `.serv-input` in the
   Ingredients servings pill (`SingleRecipe.tsx`) trips Lighthouse `target-size`. A label was added in
   track 4-qa (`aria-label="Servings"`), but enlarging the tap target is a layout change to the pill.
-  *(surfaced 2026-06-23, track 4-qa.)*
+  *(surfaced 2026-06-23, track 4-qa; re-confirmed 2026-06-25 in the accessibility sweep.)*
 
 ## Features
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -259,6 +259,15 @@ The triage date stamped on items is the date they were filed here, not when they
 
 ## Tech debt / process / infra
 
+- `[ ]` **Account tab heading duplicates SegmentedNav's route map** — the visually-hidden per-tab `<h2>`
+  in `Account.tsx` (added for heading-order in the a11y sweep) derives its label from an inline
+  `location.pathname.includes(...)` chain that re-encodes the four account route strings
+  (`saved-recipes`/`ratings`/`your-recipes`/`drafts`) already defined in
+  `src/pages/Account/components/SegmentedNav.tsx`. Low severity — the SR headings are intentionally
+  fuller than the short tab labels, so they can't just reuse the labels — but if a tab's route is
+  renamed in SegmentedNav, this heading silently goes stale. Fix: derive both from a single
+  route→label source. *(surfaced 2026-06-25 in the accessibility-sweep code review, PR #179; not worth
+  blocking the merge.)*
 - `[ ]` **One-off rating-aggregate reconciliation** — stored `recipes.rating` aggregates can drift from
   the actual `ratings` docs (confirmed live: *Homemade Granola* stored `5/4.6` vs true `4/4.5`). Likely
   legacy/pre-recompute data or a past silent best-effort failure. Write a script (alongside

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -75,6 +75,19 @@ a feature flag. Do these together:
   buttons, toasts, and the legal/help/about copy site-wide. Only fix needed: the avatar size-limit toast
   `5mb` → `5MB`. *(Two typos live in MongoDB recipe **data** — "Egg Friend Rice", a granola "Tt's" — not
   code; out of scope for a code change.)* **(nice-to-have)**
+- `[~]` **Accessibility (WCAG 2.1 AA) sweep** — **deep pass done (PR #179, 2026-06-25); contrast remainder
+  filed.** Structured axe-core + Lighthouse audit of **every** page, logged-out **and** logged-in (Account
+  tabs / all 4 Settings sections / Add Recipe via the Cypress token bridge), plus keyboard + a11y-tree
+  spot-checks. Lighthouse a11y per page: **logged-out +0→+8** (single recipe **89 → 97**), **logged-in
+  +4→+12** (Add Recipe **84 → 96**); every page now at **96–97**. Cheap wins applied in place: hamburger
+  accessible name, StarRating `nested-interactive`, ingredient `<li role=checkbox>` → inner `<div>`, Add
+  Recipe button-name + react-select labels, heading order, RecipeCard label-in-name, auth-page `<main>`
+  landmarks, skip-to-content link, global `prefers-reduced-motion`. Modals (react-modal) verified for
+  focus-trap + Esc + focus-restore. **Remaining (`[~]`): the only outstanding flag site-wide is
+  `color-contrast`** — the muted-grey body-text token `#979ba0` (2.4–2.8:1) and the brand orange/teal
+  CTAs — a **token-level design decision filed to `BACKLOG.md` → Accessibility**, not a blind recolour.
+  *(SR checks were programmatic, headless — no live VoiceOver in CI. `.beta-tag` contrast intentionally
+  left for the Phase-5 beta-tag cutover.)* **(nice-to-have; contrast tokens still open)**
 - `[ ]` **Favicon, page titles, social/OG meta** — verify `index.html` + per-page titles
   (`react-helmet-async` is already a dependency) and an OG image for link previews. **(nice-to-have)**
 - `[x]` **Remove dev-only UI from production** — `@tanstack/react-query-devtools` is a devDependency;
@@ -216,7 +229,8 @@ a feature flag. Do these together:
   preview build (desktop) — **Home 97/96/100/100**, **recipe 88/89/100/100** (perf/a11y/best-practices/seo);
   recipe a11y **80 → 89** from the cheap a11y wins. The bundle-size win (>500 kB single chunk → route-level
   code-splitting) is real but structural — **filed to `BACKLOG.md`** (Tech debt) rather than done here.
-  **(nice-to-have)**
+  *(A11y was taken further in the dedicated WCAG AA sweep — recipe **89 → 97**, every page to 96–97; see
+  the Accessibility item in Section A + PR #179.)* **(nice-to-have)**
 - `[x]` **README cleanup** *(done — PR #151, 2026-06-17)* — replaced the placeholder `your-username`
   clone URL with `jclind/prepify` and refreshed setup steps for the two-service architecture.
   **(nice-to-have)**
@@ -358,5 +372,20 @@ app (desktop + mobile) via the run-prepify skill.
   `:87`); `RELEASE_DATE` still stale `3/31/2023`; `VITE_OPEN_AI_API_KEY` + `VITE_INGREDIENT_PARSER_URL`
   still in `.env.example` with zero `src` callers; README still has `your-username` placeholder; npm
   audit: root 3 high / server 3 high.
+
+### 2026-06-25 — accessibility (WCAG 2.1 AA) sweep
+Deep a11y pass over every page, logged-out + logged-in, via axe-core + Lighthouse (logged-in routes driven
+through the Cypress custom-token bridge) plus keyboard / a11y-tree spot-checks. PR **#179**.
+- **Scores moved:** Lighthouse a11y now **96–97 on every page** — logged-out +0→+8 (single recipe 89 → 97),
+  logged-in +4→+12 (Add Recipe 84 → 96). Flipped the Section A **Accessibility** item to `[~]` (sweep done,
+  contrast remainder filed).
+- **Cheap wins shipped:** hamburger accessible name, StarRating `nested-interactive`, ingredient
+  `<li role=checkbox>` → inner `<div>`, Add-Recipe button-name + react-select labels, heading order,
+  RecipeCard label-in-name, auth-page `<main>` landmarks, skip-to-content link, global
+  `prefers-reduced-motion`. tsc clean · 516 Vitest pass · build clean.
+- **Remaining (filed to `BACKLOG.md` → Accessibility):** the only site-wide flag left is `color-contrast`
+  — muted-grey body-text token `#979ba0` (2.4–2.8:1) + brand orange/teal CTAs (2.7–3.2:1), a token-level
+  design decision. Autocomplete-listbox refactor + servings target-size re-confirmed. `.beta-tag` contrast
+  left for the Phase-5 cutover.
 
 _`/release-readiness` appends dated run summaries here._

--- a/src/Components/Layout/Layout.scss
+++ b/src/Components/Layout/Layout.scss
@@ -1,3 +1,5 @@
+@use '../../helpers.scss' as s;
+
 // App shell: a flexbox sticky-footer column so the footer sits at the bottom of
 // the viewport on short pages and flows after the content on long ones — without
 // any page needing to subtract the footer's height. The footer is content-driven
@@ -13,4 +15,29 @@
   display: flex;
   flex-direction: column;
   flex: 1 0 auto;
+  // Programmatic skip-link target — don't paint a ring when focused via the
+  // skip link (keyboard Tab still rings real controls inside).
+  &:focus {
+    outline: none;
+  }
+}
+
+// Skip-to-content: off-screen until it receives keyboard focus, then pinned to
+// the top-left above the nav so the first Tab on any page jumps past the header.
+.skip-to-content {
+  position: absolute;
+  left: 0.5rem;
+  top: -3rem;
+  z-index: 1000;
+  padding: 0.6rem 1rem;
+  background: s.$white;
+  color: s.$primary;
+  font-weight: 600;
+  border-radius: s.$border-radius;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  transition: top 0.15s ease-in-out;
+
+  &:focus {
+    top: 0.5rem;
+  }
 }

--- a/src/Components/Layout/Layout.tsx
+++ b/src/Components/Layout/Layout.tsx
@@ -18,12 +18,17 @@ const Layout: FC<LayoutProps> = ({
 }) => {
   return (
     <div className='app-shell'>
+      <a href='#main-content' className='skip-to-content'>
+        Skip to content
+      </a>
       <Navbar
         darkNavLinks={darkNavLinks}
         navBackgroundColor={navBackgroundColor}
       />
       <AccountStatusBanner />
-      <main className='app-main'>{children}</main>
+      <main id='main-content' className='app-main' tabIndex={-1}>
+        {children}
+      </main>
       <Footer />
     </div>
   )

--- a/src/Components/Navbar/Navbar.tsx
+++ b/src/Components/Navbar/Navbar.tsx
@@ -51,7 +51,11 @@ const Navbar: FC<NavbarProps> = ({ darkNavLinks, navBackgroundColor }) => {
           <div className='nav-header'>
             <PrepifyLogo />
             <div className={!navOpen && !darkNavLinks ? 'hamburger light' : 'hamburger'}>
-              <Hamburger toggled={navOpen} toggle={setNavOpen} />
+              <Hamburger
+                toggled={navOpen}
+                toggle={setNavOpen}
+                label={navOpen ? 'Close menu' : 'Open menu'}
+              />
             </div>
           </div>
 

--- a/src/Components/RecipeCard/RecipeCard.tsx
+++ b/src/Components/RecipeCard/RecipeCard.tsx
@@ -81,16 +81,17 @@ const RecipeCard: FC<RecipeCardProps> = ({ recipe, loading, onMutated }) => {
 
   return (
     <article className='recipe-card'>
-      <Link
-        to={`/recipes/${recipe._id}`}
-        className='recipe-card__link'
-        aria-label={recipe.title}
-      >
+      {/* No aria-label here: it would override the link's name to just the
+          title while the visible card text (cuisine, time, rating) stays
+          unread — a WCAG 2.5.3 label-in-name mismatch. Letting the content name
+          the link keeps the visible text and the accessible name in sync. The
+          thumbnail is decorative (the title sits right beside it), so alt=''. */}
+      <Link to={`/recipes/${recipe._id}`} className='recipe-card__link'>
         <div className='recipe-card__thumb'>
           {recipe.recipeImage && !imgError ? (
             <img
               src={recipe.recipeImage}
-              alt={recipe.title}
+              alt=''
               loading='lazy'
               width={300}
               height={225}

--- a/src/Components/StarRating/StarRating.tsx
+++ b/src/Components/StarRating/StarRating.tsx
@@ -58,40 +58,51 @@ const StarRating: FC<StarRatingProps> = ({
 
   return (
     // Display-only stars convey their value once via an img role on the row, so
-    // the individual stars below are hidden from assistive tech (otherwise each
-    // renders as an unnamed <button> — an accessibility failure).
+    // the individual stars below render as plain <span>s (not <button>s). A
+    // focusable <button> inside the row's `role="img"` is a nested-interactive
+    // a11y failure, and the stars carry no name of their own.
     <div
       style={{ display: 'inline-flex', gap: spacing }}
       role={interactive ? undefined : 'img'}
       aria-label={interactive ? undefined : `Rated ${rating} out of 5`}
     >
-      {[1, 2, 3, 4, 5].map(i => (
-        <button
-          key={i}
-          type='button'
-          onClick={interactive ? () => onChange?.(i) : undefined}
-          onMouseEnter={interactive ? () => setHovered(i) : undefined}
-          onMouseLeave={interactive ? () => setHovered(0) : undefined}
-          style={{
-            background: 'none',
-            border: 'none',
-            padding: 0,
-            cursor: interactive ? 'pointer' : 'default',
-            display: 'flex',
-            lineHeight: 0,
-          }}
-          tabIndex={interactive ? 0 : -1}
-          aria-hidden={interactive ? undefined : true}
-          aria-label={interactive ? `Rate ${i} out of 5` : undefined}
-        >
+      {[1, 2, 3, 4, 5].map(i => {
+        const star = (
           <StarSVG
             fill={displayRating - (i - 1)}
             color={color}
             size={size}
             gradientId={`${baseId}-${i}`}
           />
-        </button>
-      ))}
+        )
+        if (!interactive) {
+          return (
+            <span key={i} style={{ display: 'flex', lineHeight: 0 }}>
+              {star}
+            </span>
+          )
+        }
+        return (
+          <button
+            key={i}
+            type='button'
+            onClick={() => onChange?.(i)}
+            onMouseEnter={() => setHovered(i)}
+            onMouseLeave={() => setHovered(0)}
+            style={{
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              cursor: 'pointer',
+              display: 'flex',
+              lineHeight: 0,
+            }}
+            aria-label={`Rate ${i} out of 5`}
+          >
+            {star}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -64,6 +64,35 @@ a {
   }
 }
 
+// Visually hidden but exposed to assistive tech — for headings/labels that give
+// screen-reader structure without altering the visual layout.
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// Honor the OS "reduce motion" setting globally: near-instant animations and
+// transitions (the nav condense, star hover, skip-link slide, modal fades, …)
+// for users who've opted out of motion. Opt-in only — the default experience is
+// unchanged. Functional transforms still apply; only their duration collapses.
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 .btn {
   background: none;
   outline: none;

--- a/src/pages/Account/Account.tsx
+++ b/src/pages/Account/Account.tsx
@@ -173,6 +173,17 @@ const Account: FC = () => {
           <SegmentedNav counts={counts} />
 
           <div className='account-body'>
+            {/* Heading for the active tab's panel (visually hidden) so the card
+                <h3>s inside don't skip a level under the profile <h1>. */}
+            <h2 className='sr-only'>
+              {location.pathname.includes('ratings')
+                ? 'Your ratings'
+                : location.pathname.includes('your-recipes')
+                ? 'Recipes you created'
+                : location.pathname.includes('drafts')
+                ? 'Your drafts'
+                : 'Saved recipes'}
+            </h2>
             <Outlet />
           </div>
         </div>

--- a/src/pages/AddRecipe/CuisineSelector/CuisineSelector.tsx
+++ b/src/pages/AddRecipe/CuisineSelector/CuisineSelector.tsx
@@ -66,6 +66,7 @@ const CuisineSelector: FC<CuisineSelectorProps> = ({ cuisine, setCuisine }) => {
         options={cuisineOptions}
         styles={customStyles}
         placeholder='Select a cuisine...'
+        aria-label='Cuisine'
       />
     </div>
   )

--- a/src/pages/AddRecipe/DietSelector/DietSelector.tsx
+++ b/src/pages/AddRecipe/DietSelector/DietSelector.tsx
@@ -70,6 +70,7 @@ const DietSelector: FC<DietSelectorProps> = ({
         styles={customStyles}
         placeholder='Select diet tag(s)...'
         closeMenuOnSelect={false}
+        aria-label='Diet'
       />
     </div>
   )

--- a/src/pages/AddRecipe/ImagePicker/ImagePicker.tsx
+++ b/src/pages/AddRecipe/ImagePicker/ImagePicker.tsx
@@ -108,7 +108,12 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
         }
         onClick={handleClick}
       >
-        <button className='remove-btn option-btn' onClick={removeImage}>
+        <button
+          type='button'
+          className='remove-btn option-btn'
+          aria-label='Remove image'
+          onClick={removeImage}
+        >
           <AiOutlineClose className='icon' />
         </button>
         <input

--- a/src/pages/AddRecipe/MealTypeSelector/MealTypeSelector.tsx
+++ b/src/pages/AddRecipe/MealTypeSelector/MealTypeSelector.tsx
@@ -79,6 +79,7 @@ const MealTypeSelector: FC<MealTypeSelectorProps> = ({
         styles={customStyles}
         placeholder='Select meal type(s)...'
         closeMenuOnSelect={false}
+        aria-label='Course'
       />
     </div>
   )

--- a/src/pages/ForgotPassword/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword/ForgotPassword.tsx
@@ -32,7 +32,7 @@ const ForgotPassword: FC = () => {
         <meta charSet='utf-8' />
         <title>Reset Password · Prepify</title>
       </Helmet>
-      <div className='forgot-password-page form-format'>
+      <main className='forgot-password-page form-format'>
         <div className='login-form-container'>
           <div className='brand-mark'>P</div>
           <form onSubmit={handleChangePasswordFormSubmit} className='form'>
@@ -76,7 +76,7 @@ const ForgotPassword: FC = () => {
             </Link>
           </p>
         </div>
-      </div>
+      </main>
     </>
   )
 }

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -35,7 +35,7 @@ const Login: FC = () => {
         <meta charSet='utf-8' />
         <title>Log In · Prepify</title>
       </Helmet>
-      <div className='login-page form-format'>
+      <main className='login-page form-format'>
         <div className='form-container'>
           <div className='brand-mark'>P</div>
           <form onSubmit={handleEmailAndPasswordFormSubmit} className='form'>
@@ -108,7 +108,7 @@ const Login: FC = () => {
             </Link>
           </p>
         </div>
-      </div>
+      </main>
     </>
   )
 }

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -299,6 +299,9 @@ const Recipes: FC = () => {
           </div>
         ) : (
           <>
+            {/* Gives the results grid a heading so the card <h3>s don't skip a
+                level under the page <h1> (visually hidden). */}
+            <h2 className='sr-only'>Recipe results</h2>
             <div className='recipes-grid'>
               {isInitialLoading
                 ? Array.from({ length: 8 }).map((_, i) => (

--- a/src/pages/Settings/sections/AccountSection.tsx
+++ b/src/pages/Settings/sections/AccountSection.tsx
@@ -186,7 +186,7 @@ const AccountSection: FC = () => {
       {/* Change password — only meaningful for password-based accounts. */}
       {hasPasswordProvider && (
         <div className='sr-subsection'>
-          <h4 className='sr-subhead'>Change password</h4>
+          <h3 className='sr-subhead'>Change password</h3>
           <div className='sr-grid-2'>
             <TextField
               label='Current password'
@@ -227,7 +227,7 @@ const AccountSection: FC = () => {
 
       {/* Connected accounts — display only. */}
       <div className='sr-subsection'>
-        <h4 className='sr-subhead'>Connected accounts</h4>
+        <h3 className='sr-subhead'>Connected accounts</h3>
         {providers.length === 0 ? (
           <p className='sr-hint'>No sign-in methods found.</p>
         ) : (

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -45,7 +45,7 @@ const Signup: FC = () => {
         <meta charSet='utf-8' />
         <title>Sign Up · Prepify</title>
       </Helmet>
-      <div className='signup-page form-format'>
+      <main className='signup-page form-format'>
         <div className='form-container'>
           <div className='brand-mark'>P</div>
           <form onSubmit={handleEmailAndPasswordFormSubmit} className='form'>
@@ -128,7 +128,7 @@ const Signup: FC = () => {
             </Link>
           </p>
         </div>
-      </div>
+      </main>
     </>
   )
 }

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -161,38 +161,43 @@ const SingleRecipe: FC = () => {
       const isChecked = checked.has(ingr.id)
       const image = ingr.ingredientData?.imagePath
       return (
-        <li
-          key={ingr.id}
-          className={`ing ${isChecked ? 'checked' : ''}`}
-          role='checkbox'
-          aria-checked={isChecked}
-          tabIndex={0}
-          onClick={() => toggleChecked(ingr.id)}
-          onKeyDown={e => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault()
-              toggleChecked(ingr.id)
-            }
-          }}
-        >
-          <span className='box'>{isChecked ? <BiCheckCircle /> : null}</span>
-          <span className='thumb'>
-            {image ? (
-              <img src={image} alt={ingredient ?? ''} loading='lazy' />
-            ) : (
-              <CiShoppingBasket className='no-img' />
-            )}
-          </span>
-          <span className='ing-text'>
-            <span className='qty'>
-              {quantity ? closestFraction(quantity) : ''}
-              {unit ? ` ${unit}` : ''}
-            </span>{' '}
-            <span className='name'>
-              {ingredient}
-              {comment ? `, ${comment}` : ''}
+        // The checkbox role/keyboard handler lives on an inner <div>, not the
+        // <li>: `role="checkbox"` isn't allowed on a list item and stripping the
+        // <li>'s implicit listitem role breaks the parent <ul>. The `.ing`
+        // styling stays on the interactive element, so layout is unchanged.
+        <li key={ingr.id}>
+          <div
+            className={`ing ${isChecked ? 'checked' : ''}`}
+            role='checkbox'
+            aria-checked={isChecked}
+            tabIndex={0}
+            onClick={() => toggleChecked(ingr.id)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                toggleChecked(ingr.id)
+              }
+            }}
+          >
+            <span className='box'>{isChecked ? <BiCheckCircle /> : null}</span>
+            <span className='thumb'>
+              {image ? (
+                <img src={image} alt={ingredient ?? ''} loading='lazy' />
+              ) : (
+                <CiShoppingBasket className='no-img' />
+              )}
             </span>
-          </span>
+            <span className='ing-text'>
+              <span className='qty'>
+                {quantity ? closestFraction(quantity) : ''}
+                {unit ? ` ${unit}` : ''}
+              </span>{' '}
+              <span className='name'>
+                {ingredient}
+                {comment ? `, ${comment}` : ''}
+              </span>
+            </span>
+          </div>
         </li>
       )
     }


### PR DESCRIPTION
## Accessibility sweep — WCAG 2.1 AA

A deep, structured a11y pass over **every** Prepify page, logged-out **and** logged-in, driven by **axe-core + Lighthouse** through a copy of the run-prepify driver (logged-in routes via the Cypress custom-token bridge). Small/safe wins applied in place; structural + contrast work filed to [`docs/BACKLOG.md` → Accessibility](docs/BACKLOG.md).

### Lighthouse a11y — before → after (per page)

| Page | Before | After | Δ |
|---|---:|---:|---:|
| **Logged-out** | | | |
| Home | 93 | 96 | +3 |
| Recipes | 91 | 96 | +5 |
| Single recipe | 89 | **97** | +8 |
| Public profile | 92 | 96 | +4 |
| About | 92 | 96 | +4 |
| Privacy | 92 | 96 | +4 |
| Terms | 92 | 96 | +4 |
| Help | 92 | 96 | +4 |
| Login | 95 | 95 | 0 |
| Signup | 95 | 95 | 0 |
| Forgot password | 95 | 95 | 0 |
| 404 / NotFound | 92 | 96 | +4 |
| **Logged-in** | | | |
| Account (Saved) | 92 | 96 | +4 |
| Account · Ratings | 92 | 96 | +4 |
| Account · Your Recipes | 92 | 96 | +4 |
| Account · Drafts | 90 | 96 | +6 |
| Settings · Profile | 92 | 96 | +4 |
| Settings · Account | 91 | 96 | +5 |
| Settings · Privacy | 92 | 96 | +4 |
| Settings · Danger | 92 | 96 | +4 |
| Add Recipe | 84 | **96** | +12 |

After the sweep, **every page's only remaining Lighthouse flag is `color-contrast`** (brand + muted-grey text tokens), which is a token-level design decision — filed, not blindly recoloured.

> The three auth pages stay at 95 because their only flag is the brand-teal `.form-action-btn` (contrast → backlog). The `<main>`-landmark fix they got isn't a Lighthouse-scored audit, but it does clear the axe `region` / `landmark-one-main` best-practice violations.

### Cheap wins applied (names, labels, alt, valid roles — no CSS re-point / brand decision)

- **Hamburger menu accessible name** — `hamburger-react` `label` prop, reflecting open/close state. Clears `aria-command-name` on ~10 pages. (`Navbar.tsx`)
- **StarRating `nested-interactive`** — display-mode stars render `<span>`s instead of focusable `<button>`s inside the row's `role="img"`. (`StarRating.tsx`)
- **Ingredient checklist role** — `role="checkbox"` + keyboard handler moved onto an inner `<div>`; the `<li>` is now plain, so the `<ul>` is a valid list. Clears `aria-allowed-role` + `list`; `.ing` grid is visually unchanged (screenshot-verified). (`SingleRecipe.tsx`)
- **Add Recipe form labels** — image remove button gets `aria-label` (clears `button-name`); the Cuisine / Course / Diet `react-select`s get `aria-label`s (clears `label` + `label-title-only`). (`ImagePicker`, `CuisineSelector`, `MealTypeSelector`, `DietSelector`)
- **Heading order** — visually-hidden `<h2>` for the Recipes results grid and each Account tab panel; Settings `h4.sr-subhead` → `h3`. (`Recipes.tsx`, `Account.tsx`, `AccountSection.tsx`)
- **RecipeCard label-in-name** — dropped the redundant `aria-label` (visible card text now matches the accessible name) and marked the adjacent thumbnail decorative (`alt=""`). (`RecipeCard.tsx`)
- **Auth-page landmarks** — Login / Signup / ForgotPassword content wrapped in `<main>`. (clears axe `region` / `landmark-one-main`)
- **Skip-to-content link** + a global `.sr-only` utility. (`Layout.tsx`, `Layout.scss`, `index.scss`)
- **`prefers-reduced-motion`** — global reset honouring the OS setting (nav condense, star hover, skip-link slide, modal fades …). Previously only `About.scss` honoured it.

### Keyboard + screen-reader spot-checks

Driven through headless Chromium (axe + the accessibility tree / DOM state — **no live VoiceOver in this environment**, so SR semantics were verified programmatically, not by ear):

- **Skip link** is the first Tab stop, reveals on focus, and Enter moves focus into `<main#main-content>`. ✅
- **Ingredient check-off** — inner `role="checkbox"`, parent `<ul>` all-`<li>`, Enter/Space toggles `aria-checked`. ✅
- **Modal (react-modal, bug-report)** — `role="dialog"`, `aria-modal="true"`, focus trap holds through 10 Tabs, Esc closes, focus **restored to the trigger**. ✅
- **Mobile hamburger** — `aria-label` flips Open↔Close, `aria-expanded` reflects state. ✅
- **Autocomplete** — listbox + options reachable (the *missing arrow-key nav* remains a backlog listbox refactor). ✅
- **320px reflow** — no horizontal overflow on Home / Recipes / single recipe. ✅

### Filed to BACKLOG (structural / token-level)

- **Text + brand contrast** — broadened the existing nav-contrast item into the full inventory: muted-grey body/meta token `#979ba0` (2.4–2.8:1, used pervasively) + brand orange `#ff5722` / teal `#00adb5` CTAs (2.7–3.2:1). One muted-grey token bump clears most pages; brand colours need a design call.
- **Autocomplete listbox refactor** + **servings stepper target-size** — re-confirmed, unchanged.
- **`.beta-tag`** contrast — left for the Phase-5 beta-tag cutover (untouched).

### Gates

`npx tsc --noEmit` clean · **516 Vitest pass** (2 pre-existing skips) · `npm run build` clean.
