### PR TITLE
Design sweep: tokenize $primary-hover + $surface-warm-border, file systemic drift

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -176,6 +176,38 @@ The triage date stamped on items is the date they were filed here, not when they
   broken-image glyph there (`src/Components/RecipeThumbnail/RecipeThumbnail.tsx`). Mirror RecipeCard: add a
   `useState` + `onError` that flips to `<RecipePlaceholder />`. Low severity (thumbnails are a secondary
   surface and seeded data all has images). *(surfaced 2026-06-23 in the track 3b code review.)*
+- `[ ]` **Consolidate the bespoke pill buttons into a real `.btn` system** — `.btn` in `src/index.scss`
+  only strips defaults (no visual style), so nearly every page re-implements its own orange/ghost pill:
+  `home-btn` (`404.scss`), `pp-browse-btn` (`PublicProfile.scss`), `about-btn`/`about-btn-primary`/
+  `about-btn-ghost` (`About.scss`), `search-recipes-btn`, the Recipes toolbar pills, HomeCookSuggestion
+  `.primary`/`.ghost`, etc. — same shape, slightly different padding/weight/hover each time. Promote
+  `.btn--primary` / `.btn--ghost` / `.btn--pill` variants and migrate the bespoke buttons onto them.
+  *(surfaced 2026-06-25 in the design-consistency sweep.)*
+- `[ ]` **Unify `RecipeCard` and `RecipeThumbnail`** — ~80% duplicate (image + price + rating/time meta);
+  they differ mostly in `<Link>` vs `<button>` wrapper and `AiFillStar` vs `AiOutlineStar`. Same data, two
+  components, two loading-skeleton implementations. Merge into one card with a layout/interaction variant.
+  *(surfaced 2026-06-25 in the design-consistency sweep; pairs with the RecipeThumbnail broken-image item above.)*
+- `[ ]` **One icon per concept (react-icons drift)** — the same concept is drawn from different icon sets:
+  star = `AiFillStar` / `AiOutlineStar` / `BsStar(Fill)` / `FiStar`; close = `AiOutlineClose` / `FiX` /
+  `IoClose`; bookmark = `Bs*` and `Bi*` outline/filled pairs; time = `CgTimer` and `AiOutlineClockCircle`.
+  Pick one icon per concept and re-export from a single `src/Components/icons` module so callers can't drift.
+  *(surfaced 2026-06-25 in the design-consistency sweep.)*
+- `[ ]` **Share one react-modal style config** — each modal repeats its own `customStyles`/overlay inline,
+  and they disagree: `BugReportModal` uses `#fff` + `8px` radius while `ConfirmDeleteReviewModal` /
+  `ReleaseNotes` use `#eeeeee` + `5px`. Extract a shared `modalStyles` constant (content + overlay) and a
+  thin wrapper so every dialog reads the same. *(surfaced 2026-06-25 in the design-consistency sweep.)*
+- `[ ]` **Codify the loading-state pattern (skeleton vs spinner)** — content grids use
+  `react-loading-skeleton`, button actions use `TailSpin`, and several async waits show nothing; the choice
+  is per-developer and `TailSpin` sizes vary (18–30px). Write down the rule (skeleton for content
+  placeholders, spinner for discrete actions/auth) and align the outliers. *(surfaced 2026-06-25 in the
+  design-consistency sweep.)*
+- `[ ]` **Toast copy: consistent terminal punctuation + dedupe strings** — toasts disagree on trailing
+  punctuation (`'Could not copy link'`, `'Could not update collections'`, `'Profile link copied'` have no
+  period; most others end with `.`/`!`) and on phrasing (`'Profile link copied'` vs `'Profile link copied
+  to clipboard'`). Pick one convention (terminal punctuation everywhere is the dominant pattern) and sweep
+  the ~10 call sites; lift duplicated strings (`'Email already in use.'`, `'Password incorrect, please try
+  again.'`, `'Image cannot be more than 5MB in size.'`) into shared constants. *(surfaced 2026-06-25 in the
+  design-consistency sweep; continues the toast-punctuation fix started in track 4-qa.)*
 
 ## Accessibility
 
@@ -346,6 +378,40 @@ The triage date stamped on items is the date they were filed here, not when they
   `withTimeout` (12s) races the enrichment request so a hung/"not found" lookup no longer sticks the UI; on
   timeout the row is kept, flagged errored with a retry, and a toast surfaces. Applied to both add and
   inline-edit paths.
+- `[~]` **Promote the remaining hardcoded design values into `helpers.scss` tokens** — the
+  design-consistency sweep (2026-06-25) applied the two pixel-identical cheap wins from the
+  [2026-06-13 audit](./DESIGN_CONSISTENCY_AUDIT_2026-06-13.md): `$primary-hover` (`#e74e1d`, was hardcoded
+  in 5 spots + a Footer local var) and `$surface-warm-border` (`#ece2d6`, 11 spots across 8 files). The
+  systemic scales remain un-tokenized and need design sign-off because they touch many files / pixels:
+    - **Type scale** — ~367 raw `font-size:` literals, no scale token. Define a small ramp (e.g.
+      `$fs-sm`/`$fs-base`/`$fs-lg`/…) and migrate the common sizes.
+    - **Radius scale** — only `$border-radius: 10px` exists; cards use 10/12/14/16/20px + `999px` pills
+      ad-hoc (audit F4). Define `$radius-sm/md/lg/pill` and map each surface.
+    - **Elevation/shadow scale** — `$card-box-shadow` is used ~twice vs ~31 inline `box-shadow`s, several
+      near-duplicates; the avatar-glow `rgba(255,87,34,0.18)` is repeated verbatim in Account + PublicProfile
+      (audit F5). Define `$shadow-card`/`$shadow-card-hover`/`$shadow-glow-primary`.
+    - **Breakpoint tokens/mixin** — no shared breakpoints; ~77 ad-hoc media queries repeat 725px (navbar
+      flip), 768px, 600px, 560px, 640px… Add a `$bp-*` set or a `respond-to()` mixin and converge.
+  *(surfaced 2026-06-25 in the design-consistency sweep; cheap wins applied, scales deferred.)*
+- `[ ]` **Collapse near-duplicate brand shades to one value** — now that `$primary-hover` exists, the
+  Drafts primary-button hover `#f4501e` (`Drafts.scss:138`) should point at it, and the avatar/XP gradient
+  stops `#ff8a5c` (`Account.scss:163,186`) vs `#ff8a65` (`RecipePlaceholder.scss:13`) should collapse to a
+  single `$primary-tint` token. Each is a (tiny) visible pixel change, so it's a brand-color call, not a
+  blind repoint. *(surfaced 2026-06-25 in the design-consistency sweep; left out of the repoint-only PR by
+  decision.)*
+- `[ ]` **One danger-red token** — three reds mean the same thing: `$error-red #dc3545` (token), local
+  `$danger #d23f31` (`SingleRecipe.scss`), and `#d64545` (`ReportControl`/`Reports`). Consolidate onto the
+  token. *(audit F6; surfaced 2026-06-25 in the design-consistency sweep.)*
+- `[ ]` **Name the admin/“cool” sub-palette and wire the token-less files into `helpers.scss`** — Admin +
+  moderation surfaces hardcode a Tailwind-ish slate/blue palette (`#3b82f6`/`#2563eb` action blue exists
+  nowhere in the brand) and several files (`Admin/*`, `ReportControl`, `SavedFilterBar`,
+  `AdminRecipeControls`, `AccountStatusBanner`, `Layout`) `@use` nothing at all (audit F1/F2). Define a
+  documented `$admin-*` token group and migrate the literals so the warm/cool split is a decision, not 200+
+  loose hexes. *(surfaced 2026-06-25 in the design-consistency sweep; the bulk of the remaining token work.)*
+- `[ ]` **`RecipeFormInput` duplicates the shared `FormInput`** — AddRecipe ships its own ~85%-identical
+  input/textarea (`RecipeFormInput`/`RecipeFormTextArea`) instead of the shared `Components/Form/FormInput`,
+  and Settings/BugReport use raw `<input>`/`<textarea>`/`<select>`. Converge on one input primitive.
+  *(surfaced 2026-06-25 in the design-consistency sweep.)*
 
 ## Testing
 

--- a/src/Components/AddToCollection/AddToCollection.scss
+++ b/src/Components/AddToCollection/AddToCollection.scss
@@ -54,7 +54,7 @@
 .add-to-collection-popover {
   width: 230px;
   background: #fff;
-  border: 1px solid #ece2d6;
+  border: 1px solid s.$surface-warm-border;
   border-radius: 14px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
   padding: 0.6rem;

--- a/src/Components/Footer/Footer.scss
+++ b/src/Components/Footer/Footer.scss
@@ -6,7 +6,6 @@
 // ===========================================================================
 $footer-surface: #ffffff;
 $footer-border: #e6e6e6;
-$primary-hover: #e74e1d;
 // Match the navbar (.nav-center) and page content (.page) bounds so the footer
 // edges line up with them on wide screens — all three are width:90% capped here.
 $inner-max: s.$max-width;
@@ -70,7 +69,7 @@ $inner-max: s.$max-width;
   letter-spacing: -0.02em;
   color: s.$primary;
   text-decoration: none;
-  &:hover { color: $primary-hover; }
+  &:hover { color: s.$primary-hover; }
 }
 
 // ---- Link columns ---------------------------------------------------------

--- a/src/helpers.scss
+++ b/src/helpers.scss
@@ -1,4 +1,5 @@
 $primary: #ff5722; // Also located in TrendingRecipes.js
+$primary-hover: #e74e1d; // darkened orange for primary-button/link hover
 $secondary: #00adb5;
 
 $primary-text: #303841;
@@ -37,6 +38,9 @@ $alert-warning-amber-text: #856404;
 $primary-background: #eeeeee;
 $secondary-background: #d6d6d6;
 $tertiary-background: #b1b1b1;
+
+// Warm-cream surface family (Account, Public Profile, Home cards)
+$surface-warm-border: #ece2d6;
 
 // Navbar
 $nav-height: 6.25rem;

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -25,7 +25,7 @@
     gap: 1.75rem;
     align-items: center;
     background: #fff;
-    border: 1px solid #ece2d6;
+    border: 1px solid s.$surface-warm-border;
     border-radius: 20px;
     padding: 1.5rem;
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
@@ -264,7 +264,7 @@
     flex-direction: column;
     gap: 0.3rem;
     background: #fff;
-    border: 1px solid #ece2d6;
+    border: 1px solid s.$surface-warm-border;
     border-radius: 16px;
     padding: 0.6rem;
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);

--- a/src/pages/Account/Drafts/Drafts.scss
+++ b/src/pages/Account/Drafts/Drafts.scss
@@ -33,7 +33,7 @@
     min-width: 0;
     height: 100%;
     background: s.$white;
-    border: 1px solid #ece2d6;
+    border: 1px solid s.$surface-warm-border;
     border-radius: 16px;
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
     padding: 1.15rem 1.25rem;

--- a/src/pages/Account/SavedRecipes/SavedRecipes.scss
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.scss
@@ -22,7 +22,7 @@
     box-sizing: border-box;
     height: 158px;
     overflow: hidden;
-    border: 1px solid #ece2d6;
+    border: 1px solid s.$surface-warm-border;
     border-radius: 12px;
     background: #fff;
     cursor: pointer;

--- a/src/pages/Account/UserRatings/UserRatings.scss
+++ b/src/pages/Account/UserRatings/UserRatings.scss
@@ -14,7 +14,7 @@
     flex-direction: column;
     margin: 0 0 2rem;
     background: #fff;
-    border: 1px solid #ece2d6;
+    border: 1px solid s.$surface-warm-border;
     border-radius: 16px;
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
     overflow: hidden;
@@ -53,7 +53,7 @@
       overflow: hidden;
       flex-shrink: 0;
       border: 2px solid #fff;
-      box-shadow: 0 0 0 1px #ece2d6;
+      box-shadow: 0 0 0 1px s.$surface-warm-border;
       .img {
         width: 52px;
         height: 52px;

--- a/src/pages/Account/UserRecipes/UserRecipeThumbnail.scss
+++ b/src/pages/Account/UserRecipes/UserRecipeThumbnail.scss
@@ -10,7 +10,7 @@
   box-sizing: border-box; // keep padding within the grid cell (no overflow)
   padding: 1.15rem;
   background: #fff;
-  border: 1px solid #ece2d6;
+  border: 1px solid s.$surface-warm-border;
   border-radius: 18px;
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
   text-decoration: none;

--- a/src/pages/Home/Home.scss
+++ b/src/pages/Home/Home.scss
@@ -172,6 +172,6 @@
     text-decoration: none;
     transition: background 0.12s ease, transform 0.12s ease;
     svg { font-size: 1.3rem; }
-    &:hover { background: #e74e1d; transform: translateY(-2px); }
+    &:hover { background: s.$primary-hover; transform: translateY(-2px); }
   }
 }

--- a/src/pages/PublicProfile/PublicProfile.scss
+++ b/src/pages/PublicProfile/PublicProfile.scss
@@ -208,7 +208,7 @@
     flex-direction: column;
     overflow: hidden;
     background: #fff;
-    border: 1px solid #ece2d6;
+    border: 1px solid s.$surface-warm-border;
     border-radius: 14px;
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
     text-decoration: none;

--- a/src/pages/Settings/Settings.scss
+++ b/src/pages/Settings/Settings.scss
@@ -111,7 +111,7 @@
   /* ── Content pane ── */
   .settings-pane {
     background: s.$white;
-    border: 1px solid #ece2d6;
+    border: 1px solid s.$surface-warm-border;
     border-radius: 18px;
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
     padding: 1.75rem;
@@ -155,7 +155,7 @@
         position: static;
         gap: 0;
         background: s.$white;
-        border: 1px solid #ece2d6;
+        border: 1px solid s.$surface-warm-border;
         border-radius: 16px;
         box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
         overflow: hidden;

--- a/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
+++ b/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
@@ -84,7 +84,7 @@
       font-size: 0.95rem;
       text-decoration: none;
       transition: background 0.12s ease;
-      &:hover { background: #e74e1d; }
+      &:hover { background: s.$primary-hover; }
       &:focus-visible { @include s.outline(); }
     }
   }

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -187,7 +187,7 @@ $danger: #d23f31;
       background: s.$primary;
       border-color: s.$primary;
       color: s.$white;
-      &:hover { background: #e74e1d; border-color: #e74e1d; }
+      &:hover { background: s.$primary-hover; border-color: s.$primary-hover; }
       &.is-saved {
         background: s.$secondary;
         border-color: s.$secondary;
@@ -648,7 +648,7 @@ $danger: #d23f31;
         font-weight: 700;
         font-size: 0.9rem;
         cursor: pointer;
-        &:hover { background: #e74e1d; }
+        &:hover { background: s.$primary-hover; }
       }
     }
   }


### PR DESCRIPTION
## Design-consistency sweep — cheap unifications + backlog

Structured pass over the shared SCSS token system (`src/helpers.scss`) vs. hardcoded drift. This PR
applies the **two pixel-identical cheap wins** the [2026-06-13 audit](../blob/development/docs/DESIGN_CONSISTENCY_AUDIT_2026-06-13.md)
recommended but never landed (that audit was findings-only), and **files the systemic work** to
`docs/BACKLOG.md`. Polish only — no redesign.

### Token system inventory
`src/helpers.scss` is the single `@use`'d source of truth: brand `$primary`/`$secondary`, a text +
gray ramp, semantic status/alert colors, one `$border-radius: 10px`, one `$card-box-shadow`, layout
vars. **Gaps:** no type scale (~367 raw `font-size:` literals), no radius scale beyond the single
token, ad-hoc shadows (~31 inline vs ~2 token uses), no shared breakpoints (~77 ad-hoc media queries).

### Applied (value-identical repoints — rendering unchanged)
| Token | Value | Was hardcoded |
|---|---|---|
| `$primary-hover` | `#e74e1d` | 5 spots (Home, RecipeNotFound, SingleRecipe ×2) + a Footer-local var |
| `$surface-warm-border` | `#ece2d6` | 11 spots / 8 files (Account, Settings, PublicProfile, Drafts, SavedRecipes, UserRatings, UserRecipeThumbnail, AddToCollection) |

Every edit just moves an existing hex into a token of the **same value**, so the resolved CSS is
byte-identical — pixel-identical by construction. `grep` confirms zero `#e74e1d` / `#ece2d6` remain
outside their token definitions.

### Filed to BACKLOG.md (systemic — needs design sign-off / touches many files)
- **Token scales:** type, radius (F4), elevation/shadow (F5), breakpoints — promote + sweep
- **Near-duplicate brand shades:** collapse `#f4501e`→`$primary-hover`, `#ff8a5c`/`#ff8a65`→one `$primary-tint`
- **One danger-red token** (F6): `$error-red` vs local `$danger #d23f31` vs `#d64545`
- **Name the admin "cool" sub-palette** + wire the token-less files into `helpers.scss` (F1/F2)
- **Component reuse:** `.btn` variant system (bespoke pills everywhere), `RecipeCard`/`RecipeThumbnail`
  merge, `RecipeFormInput`↔`FormInput`, one icon per concept, shared react-modal style config
- **State patterns:** codify skeleton-vs-spinner loading
- **Toast copy:** consistent terminal punctuation + dedupe repeated strings (continues track 4-qa)

### Verification
- `npm run build` — ✅ zero Sass deprecation warnings (only the pre-existing chunk-size note)
- `npx tsc --noEmit` — ✅
- `npm test` (Vitest) — ✅ 516 passed, 2 skipped, 71 files
- Headless render check (Home, Recipes) — clean, no console errors

Rendering was confirmed locally via the headless driver (Home + Recipes, no console errors). Because
the repoints are value-identical, a before/after screenshot diff is empty by construction, so none is
attached.
