### PR TITLE
style(tokens): radius scale + recurring-shadow elevation tokens

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -382,17 +382,26 @@ The triage date stamped on items is the date they were filed here, not when they
   design-consistency sweep (2026-06-25) applied the two pixel-identical cheap wins from the
   [2026-06-13 audit](./DESIGN_CONSISTENCY_AUDIT_2026-06-13.md): `$primary-hover` (`#e74e1d`, was hardcoded
   in 5 spots + a Footer local var) and `$surface-warm-border` (`#ece2d6`, 11 spots across 8 files). The
-  systemic scales remain un-tokenized and need design sign-off because they touch many files / pixels:
-    - **Type scale** — ~367 raw `font-size:` literals, no scale token. Define a small ramp (e.g.
-      `$fs-sm`/`$fs-base`/`$fs-lg`/…) and migrate the common sizes.
-    - **Radius scale** — only `$border-radius: 10px` exists; cards use 10/12/14/16/20px + `999px` pills
-      ad-hoc (audit F4). Define `$radius-sm/md/lg/pill` and map each surface.
-    - **Elevation/shadow scale** — `$card-box-shadow` is used ~twice vs ~31 inline `box-shadow`s, several
-      near-duplicates; the avatar-glow `rgba(255,87,34,0.18)` is repeated verbatim in Account + PublicProfile
-      (audit F5). Define `$shadow-card`/`$shadow-card-hover`/`$shadow-glow-primary`.
+  remaining systemic scales need design sign-off because they touch many files / pixels:
+    - **Type scale** — ~520 raw `font-size:` literals across ~50 distinct values (0.8/0.82/0.84/0.85/0.875…
+      all coexist). A real scale *normalizes* those to a handful of steps, so it is **not** a pixel-identical
+      repoint — it is a deliberate normalization pass needing design sign-off. Define a small ramp (e.g.
+      `$fs-sm`/`$fs-base`/`$fs-lg`/…) and snap each size to its nearest step.
+    - `[x]` **Radius scale** — DONE 2026-06-25 (PR `style/radius-scale-tokens`). `$radius-xs..4xl` +
+      `$radius-pill`/`$radius-circle` now in `helpers.scss`; `$border-radius` aliases `$radius-lg`. ~200
+      value-identical repoints across 32 `s`-importing files (compiled CSS byte-identical). **Remaining:**
+      off-scale one-offs (5/7/9/11/13/18px) need ±1px normalization (design call), and the token-less admin
+      files (`Admin/*`, `AdminRecipeControls`, `SavedFilterBar`) keep raw radii pending the import-wiring item
+      below.
+    - **Elevation/shadow scale** — partly done 2026-06-25: the two shadows that recur verbatim are now
+      `$shadow-soft` (warm card resting, ×8) and `$shadow-chip` (price/floating chips, ×3). **Remaining:** the
+      ~40 other `box-shadow`s are nearly all unique and need a re-authored scale (`$shadow-card`/`-hover`/
+      `-glow-primary`), e.g. the avatar-glow `rgba(255,87,34,0.18)` repeated in Account + PublicProfile
+      (audit F5) — a re-author, not a pixel-identical repoint.
     - **Breakpoint tokens/mixin** — no shared breakpoints; ~77 ad-hoc media queries repeat 725px (navbar
       flip), 768px, 600px, 560px, 640px… Add a `$bp-*` set or a `respond-to()` mixin and converge.
-  *(surfaced 2026-06-25 in the design-consistency sweep; cheap wins applied, scales deferred.)*
+  *(surfaced 2026-06-25 in the design-consistency sweep; cheap wins + radius/recurring-shadow scales applied,
+  type scale + full elevation re-author deferred.)*
 - `[ ]` **Collapse near-duplicate brand shades to one value** — now that `$primary-hover` exists, the
   Drafts primary-button hover `#f4501e` (`Drafts.scss:138`) should point at it, and the avatar/XP gradient
   stops `#ff8a5c` (`Account.scss:163,186`) vs `#ff8a65` (`RecipePlaceholder.scss:13`) should collapse to a

--- a/src/Components/AddToCollection/AddToCollection.scss
+++ b/src/Components/AddToCollection/AddToCollection.scss
@@ -55,7 +55,7 @@
   width: 230px;
   background: #fff;
   border: 1px solid s.$surface-warm-border;
-  border-radius: 14px;
+  border-radius: s.$radius-2xl;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
   padding: 0.6rem;
   text-align: left;

--- a/src/Components/BugReport/BugReportModal.scss
+++ b/src/Components/BugReport/BugReportModal.scss
@@ -7,7 +7,7 @@
   color: s.$tertiary-text;
   font-size: 0.8rem;
   padding: 0.15rem 0.35rem;
-  border-radius: 4px;
+  border-radius: s.$radius-xs;
   transition: color 0.15s, background 0.15s;
 
   &:hover {
@@ -40,7 +40,7 @@
     margin: -0.75rem 0 1.25rem;
     padding: 0.5rem 0.7rem;
     background: #f1f5f9;
-    border-radius: 6px;
+    border-radius: s.$radius-sm;
     color: #374151;
     font-size: 0.85rem;
 
@@ -65,7 +65,7 @@
       font-size: 0.9rem;
       padding: 0.55rem 0.65rem;
       border: 1px solid #d8dbe0;
-      border-radius: 6px;
+      border-radius: s.$radius-sm;
       font-family: inherit;
       resize: vertical;
 
@@ -84,7 +84,7 @@
 
     button {
       cursor: pointer;
-      border-radius: 6px;
+      border-radius: s.$radius-sm;
       padding: 0.55rem 1rem;
       font-size: 0.9rem;
       font-weight: 600;

--- a/src/Components/EmptyState/EmptyState.scss
+++ b/src/Components/EmptyState/EmptyState.scss
@@ -23,7 +23,7 @@
     width: 72px;
     height: 72px;
     margin-bottom: 1.25rem;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     background: rgba(255, 87, 34, 0.09);
     color: s.$primary;
     font-size: 1.85rem;
@@ -50,7 +50,7 @@
     margin-top: 1.5rem;
     padding: 0.7rem 1.5rem;
     border: none;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     background: s.$primary;
     color: #fff;
     font-family: inherit;

--- a/src/Components/Form/FormStyles.scss
+++ b/src/Components/Form/FormStyles.scss
@@ -31,7 +31,7 @@
     flex-direction: column;
     text-align: center;
     padding: 2.5rem 2rem;
-    border-radius: 20px;
+    border-radius: s.$radius-4xl;
     border: 1px solid rgba(255, 255, 255, 0.7);
     background: rgba(255, 255, 255, 0.92);
     backdrop-filter: blur(18px);
@@ -47,7 +47,7 @@
     justify-content: center;
     width: 52px;
     height: 52px;
-    border-radius: 16px;
+    border-radius: s.$radius-3xl;
     font-size: 2.3rem;
     font-weight: 300;
     font-style: italic;

--- a/src/Components/Navbar/desktop/DesktopNav.scss
+++ b/src/Components/Navbar/desktop/DesktopNav.scss
@@ -192,7 +192,7 @@
 .dnav__actions-loading {
   width: 45px;
   height: 45px;
-  border-radius: 50%;
+  border-radius: s.$radius-circle;
 }
 
 .dnav__icon-link {
@@ -201,7 +201,7 @@
   justify-content: center;
   height: 42px;
   width: 42px;
-  border-radius: 50%;
+  border-radius: s.$radius-circle;
   flex-shrink: 0;
   color: var(--dnav-text);
   font-size: 1.35rem;
@@ -273,7 +273,7 @@
     flex-shrink: 0;
     height: 42px;
     width: 42px;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     object-fit: cover;
     overflow: hidden;
   }
@@ -403,7 +403,7 @@
   flex-shrink: 0;
   height: 42px;
   width: 42px;
-  border-radius: 50%;
+  border-radius: s.$radius-circle;
   object-fit: cover;
   overflow: hidden;
 }
@@ -480,7 +480,7 @@
   .search-recipes-form .search-recipes-input-label input {
     background: s.$gray-200;
     border: 1px solid s.$gray-400;
-    border-radius: 8px;
+    border-radius: s.$radius-md;
     &:focus {
       background: s.$white;
       border-color: s.$gray-600;

--- a/src/Components/Navbar/menu/NavMenu.scss
+++ b/src/Components/Navbar/menu/NavMenu.scss
@@ -153,7 +153,7 @@
     flex-shrink: 0;
     height: 48px;
     width: 48px;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     object-fit: cover;
     overflow: hidden;
   }

--- a/src/Components/RecipeCard/RecipeCard.scss
+++ b/src/Components/RecipeCard/RecipeCard.scss
@@ -3,7 +3,7 @@
 .recipe-card {
   position: relative;
   background: s.$white;
-  border-radius: 14px;
+  border-radius: s.$radius-2xl;
   overflow: hidden;
   box-shadow: rgba(0, 0, 0, 0.06) 0px 6px 18px;
   display: flex;
@@ -57,8 +57,8 @@
     font-weight: 800;
     font-size: 0.74rem;
     padding: 0.28rem 0.6rem;
-    border-radius: 999px;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+    border-radius: s.$radius-pill;
+    box-shadow: s.$shadow-chip;
   }
 
   // Unified save control — floated over the image (sibling of the link).
@@ -74,7 +74,7 @@
     width: 2rem;
     height: 2rem;
     border: none;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     background: rgba(255, 255, 255, 0.92);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
     color: s.$secondary-text;

--- a/src/Components/ReportControl/ReportControl.scss
+++ b/src/Components/ReportControl/ReportControl.scss
@@ -11,7 +11,7 @@
   font-size: 0.8rem;
   line-height: 1.2;
   padding: 0.15rem 0.35rem;
-  border-radius: 4px;
+  border-radius: s.$radius-xs;
   transition: color 0.15s, background 0.15s;
 
   &:hover {
@@ -50,7 +50,7 @@
     border: none;
     cursor: pointer;
     color: s.$tertiary-text;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     width: 1.9rem;
     height: 1.9rem;
     font-size: 1.05rem;
@@ -78,7 +78,7 @@
     padding: 0.3rem;
     background: #fff;
     border: 1px solid #e5e7eb;
-    border-radius: 8px;
+    border-radius: s.$radius-md;
     box-shadow: 0 6px 20px rgba(17, 24, 39, 0.12);
   }
 
@@ -90,7 +90,7 @@
     padding: 0.5rem 0.6rem;
     background: none;
     border: none;
-    border-radius: 6px;
+    border-radius: s.$radius-sm;
     cursor: pointer;
     font-family: inherit;
     font-size: 0.85rem;
@@ -146,7 +146,7 @@
       font-size: 0.9rem;
       padding: 0.55rem 0.65rem;
       border: 1px solid #d8dbe0;
-      border-radius: 6px;
+      border-radius: s.$radius-sm;
       font-family: inherit;
       resize: vertical;
 
@@ -165,7 +165,7 @@
 
     button {
       cursor: pointer;
-      border-radius: 6px;
+      border-radius: s.$radius-sm;
       padding: 0.55rem 1rem;
       font-size: 0.9rem;
       font-weight: 600;

--- a/src/Components/SearchRecipesInput/SearchRecipesInput.scss
+++ b/src/Components/SearchRecipesInput/SearchRecipesInput.scss
@@ -94,7 +94,7 @@
       border: none;
       outline: none;
       background: transparent;
-      border-radius: 8px;
+      border-radius: s.$radius-md;
       cursor: pointer;
       text-align: start;
       transition: background 0.1s ease;
@@ -109,7 +109,7 @@
         flex-shrink: 0;
         width: 56px;
         height: 56px;
-        border-radius: 8px;
+        border-radius: s.$radius-md;
         overflow: hidden;
         background: s.$gray-200;
         &-skeleton {
@@ -178,7 +178,7 @@
         color: s.$secondary-text;
         background: s.$primary-background;
         padding: 0.15rem 0.45rem;
-        border-radius: 999px;
+        border-radius: s.$radius-pill;
         white-space: nowrap;
       }
 
@@ -204,7 +204,7 @@
         flex-shrink: 0;
         width: 56px;
         height: 56px;
-        border-radius: 8px;
+        border-radius: s.$radius-md;
       }
       &__body {
         display: flex;

--- a/src/helpers.scss
+++ b/src/helpers.scss
@@ -57,11 +57,34 @@ $recipe-body-max-width: 800px;
 
 $home-hero-height: calc(500px - #{$page-top-padding} - #{$page-top-margin});
 
-$border-radius: 10px;
+// Corner-radius scale. Steps are the radii already in use across the app, so
+// every repoint is value-identical. Off-scale one-offs (5/7/9/11/13/18px) and
+// the token-less admin files keep raw values pending normalization / import
+// wiring (see docs/BACKLOG.md).
+$radius-xs: 4px;
+$radius-sm: 6px;
+$radius-md: 8px;
+$radius-lg: 10px;
+$radius-xl: 12px;
+$radius-2xl: 14px;
+$radius-3xl: 16px;
+$radius-4xl: 20px;
+$radius-pill: 999px;
+$radius-circle: 50%;
+
+// Canonical default radius (cards/controls). Alias of $radius-lg; retained for
+// the existing s.$border-radius references.
+$border-radius: $radius-lg;
 
 $max-width: 1400px;
 
 $card-box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+
+// Elevation — only the shadows that recur verbatim are tokenized so repoints
+// stay value-identical; bespoke one-off shadows remain raw pending an
+// elevation-scale re-author (see docs/BACKLOG.md).
+$shadow-soft: 0 4px 14px rgba(0, 0, 0, 0.05); // soft resting shadow on warm account/settings cards
+$shadow-chip: 0 2px 6px rgba(0, 0, 0, 0.18);  // tight drop shadow on price / floating chips
 
 $font-family: 'Montserrat', sans-serif;
 

--- a/src/pages/404/404.scss
+++ b/src/pages/404/404.scss
@@ -82,7 +82,7 @@
       background: s.$primary;
       color: s.$white;
       padding: 0.75rem 2rem;
-      border-radius: 10px;
+      border-radius: s.$radius-lg;
       font-size: 1.5rem;
       font-weight: 700;
       margin-top: 2rem;

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -54,7 +54,7 @@
     align-items: center;
     gap: 0.45rem;
     padding: 0.65rem 1.35rem;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     font-size: 0.9375rem;
     font-weight: 600;
     text-decoration: none;
@@ -186,7 +186,7 @@
     font-weight: 700;
     font-size: 0.8125rem;
     padding: 0.3rem 0.65rem;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
   }
 
   .about-card-body {
@@ -267,7 +267,7 @@
     flex-direction: column;
     padding: 0.5rem 0.65rem;
     background-color: s.$gray-50;
-    border-radius: 8px;
+    border-radius: s.$radius-md;
   }
 
   .about-macro-value {
@@ -329,7 +329,7 @@
     justify-content: center;
     width: 2.5rem;
     height: 2.5rem;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     background-color: s.$white;
     box-shadow: s.$card-box-shadow;
     color: s.$primary;

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -26,9 +26,9 @@
     align-items: center;
     background: #fff;
     border: 1px solid s.$surface-warm-border;
-    border-radius: 20px;
+    border-radius: s.$radius-4xl;
     padding: 1.5rem;
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
+    box-shadow: s.$shadow-soft;
     margin-bottom: 1.75rem;
 
     @media (max-width: 880px) {
@@ -47,7 +47,7 @@
   .acct-avatar {
     width: 80px;
     height: 80px;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     object-fit: cover;
     flex-shrink: 0;
     box-shadow: 0 8px 22px rgba(255, 87, 34, 0.18);
@@ -124,7 +124,7 @@
       rgba(s.$primary, 0.09)
     );
     border: 1px solid rgba(s.$primary, 0.22);
-    border-radius: 14px;
+    border-radius: s.$radius-2xl;
     padding: 0.85rem 1rem;
     transition: border-color 0.12s ease, box-shadow 0.12s ease;
 
@@ -149,7 +149,7 @@
     color: s.$secondary-text;
     background: #fff;
     border: 1px solid rgba(s.$primary-text, 0.08);
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     padding: 0.3rem 0.75rem 0.3rem 0.3rem;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
     white-space: nowrap;
@@ -162,7 +162,7 @@
     color: #fff;
     background: linear-gradient(135deg, s.$primary, #ff8a5c);
     padding: 0.18rem 0.5rem;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
   }
   .acct-rewards-cta {
     font-weight: 800;
@@ -178,13 +178,13 @@
     .acct-xpbar-track {
       height: 6px;
       background: rgba(s.$primary-text, 0.1);
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       overflow: hidden;
     }
     .acct-xpbar-fill {
       height: 100%;
       background: linear-gradient(90deg, #ff8a5c, s.$primary);
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
     }
     .acct-xpbar-label {
       display: block;
@@ -220,7 +220,7 @@
     color: s.$secondary-text;
     background: #fff;
     border: 1px solid #e3d9ca;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     padding: 0.5rem 1.1rem;
     &:hover {
       border-color: s.$primary;
@@ -231,7 +231,7 @@
     width: 38px;
     height: 38px;
     padding: 0;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     color: s.$secondary-text;
     background: #fff;
     border: 1px solid #e3d9ca;
@@ -265,9 +265,9 @@
     gap: 0.3rem;
     background: #fff;
     border: 1px solid s.$surface-warm-border;
-    border-radius: 16px;
+    border-radius: s.$radius-3xl;
     padding: 0.6rem;
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
+    box-shadow: s.$shadow-soft;
     // Keep the rail in view while scrolling a long sub-page.
     position: sticky;
     top: calc(#{s.$nav-height} + 1rem);
@@ -320,7 +320,7 @@
       font-weight: 800;
       color: s.$secondary-text;
       background: s.$gray-200;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       padding: 0.1rem 0.5rem;
     }
     &.active .acct-seg-count {
@@ -416,7 +416,7 @@
       width: 42px;
       height: 42px;
       padding: 0;
-      border-radius: 50%;
+      border-radius: s.$radius-circle;
       span {
         display: none;
       }

--- a/src/pages/Account/Drafts/Drafts.scss
+++ b/src/pages/Account/Drafts/Drafts.scss
@@ -34,8 +34,8 @@
     height: 100%;
     background: s.$white;
     border: 1px solid s.$surface-warm-border;
-    border-radius: 16px;
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
+    border-radius: s.$radius-3xl;
+    box-shadow: s.$shadow-soft;
     padding: 1.15rem 1.25rem;
     transition: transform 0.14s ease, box-shadow 0.14s ease;
 
@@ -126,7 +126,7 @@
         font-size: 0.9rem;
         font-weight: 700;
         padding: 0.55rem 1rem;
-        border-radius: 10px;
+        border-radius: s.$radius-lg;
         border: none;
         background: s.$primary;
         color: #fff;
@@ -151,7 +151,7 @@
         font-size: 0.82rem;
         font-weight: 700;
         padding: 0.5rem 0.85rem;
-        border-radius: 10px;
+        border-radius: s.$radius-lg;
         background: none;
         border: 1px solid #ecd9d9;
         color: s.$secondary-text;

--- a/src/pages/Account/SavedRecipes/SavedRecipes.scss
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.scss
@@ -23,7 +23,7 @@
     height: 158px;
     overflow: hidden;
     border: 1px solid s.$surface-warm-border;
-    border-radius: 12px;
+    border-radius: s.$radius-xl;
     background: #fff;
     cursor: pointer;
     text-align: left;
@@ -129,7 +129,7 @@
         font-size: 0.85rem;
         padding: 0.45rem 0.6rem;
         border: 1px solid s.$gray-400;
-        border-radius: 8px;
+        border-radius: s.$radius-md;
         color: s.$primary-text;
         &:focus {
           outline: none;
@@ -147,7 +147,7 @@
         font-family: inherit;
         font-weight: 800;
         font-size: 0.82rem;
-        border-radius: 8px;
+        border-radius: s.$radius-md;
         padding: 0.4rem 0.7rem;
         cursor: pointer;
         &:disabled {
@@ -190,7 +190,7 @@
       font-size: 0.9rem;
       padding: 0 2.6rem;
       border: 1px solid s.$gray-400;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       background: #fff;
       &:focus {
         outline: none;
@@ -208,7 +208,7 @@
       width: 22px;
       height: 22px;
       border: none;
-      border-radius: 50%;
+      border-radius: s.$radius-circle;
       background: s.$gray-200;
       color: s.$secondary-text;
       cursor: pointer;
@@ -235,7 +235,7 @@
       color: s.$primary-text;
       background: #fff;
       border: 1px solid s.$gray-400;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       cursor: pointer;
       white-space: nowrap;
       .chev {
@@ -259,7 +259,7 @@
       margin: 0;
       background: #fff;
       border: 1px solid s.$gray-300;
-      border-radius: 12px;
+      border-radius: s.$radius-xl;
       box-shadow: 0 12px 30px rgba(0, 0, 0, 0.14);
       padding: 0.4rem;
       button {
@@ -273,7 +273,7 @@
         font-weight: 600;
         color: s.$primary-text;
         padding: 0.45rem 0.6rem;
-        border-radius: 8px;
+        border-radius: s.$radius-md;
         cursor: pointer;
         &:hover {
           background: s.$gray-200;
@@ -313,7 +313,7 @@
     font-family: inherit;
     font-size: 0.82rem;
     padding: 0.35rem 0.6rem;
-    border-radius: 8px;
+    border-radius: s.$radius-md;
     border: 1px solid s.$gray-400;
     background: #fff;
     color: s.$secondary-text;
@@ -337,7 +337,7 @@
       font-size: 1rem;
       padding: 0.4rem 0.6rem;
       border: 1px solid s.$gray-400;
-      border-radius: 8px;
+      border-radius: s.$radius-md;
       &:focus {
         outline: none;
         border-color: s.$primary;

--- a/src/pages/Account/UserRatings/UserRatings.scss
+++ b/src/pages/Account/UserRatings/UserRatings.scss
@@ -15,8 +15,8 @@
     margin: 0 0 2rem;
     background: #fff;
     border: 1px solid s.$surface-warm-border;
-    border-radius: 16px;
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
+    border-radius: s.$radius-3xl;
+    box-shadow: s.$shadow-soft;
     overflow: hidden;
   }
 
@@ -49,7 +49,7 @@
     .sr-thumb {
       width: 52px;
       height: 52px;
-      border-radius: 50%;
+      border-radius: s.$radius-circle;
       overflow: hidden;
       flex-shrink: 0;
       border: 2px solid #fff;

--- a/src/pages/Account/UserRecipes/UserRecipeThumbnail.scss
+++ b/src/pages/Account/UserRecipes/UserRecipeThumbnail.scss
@@ -12,7 +12,7 @@
   background: #fff;
   border: 1px solid s.$surface-warm-border;
   border-radius: 18px;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
+  box-shadow: s.$shadow-soft;
   text-decoration: none;
   color: s.$primary-text;
   transition: box-shadow 0.18s ease, transform 0.18s ease;
@@ -40,7 +40,7 @@
     .thumb {
       width: 64px;
       height: 64px;
-      border-radius: 12px;
+      border-radius: s.$radius-xl;
       overflow: hidden;
       // react-loading-skeleton fills its parent; give it a target box.
       .img,

--- a/src/pages/Account/components/AchievementsModal.scss
+++ b/src/pages/Account/components/AchievementsModal.scss
@@ -31,7 +31,7 @@
     font-weight: 700;
     color: s.$tertiary-text;
     background: #efe6da;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     padding: 0.2rem 0.65rem;
   }
   .am-close {
@@ -41,7 +41,7 @@
     justify-content: center;
     width: 34px;
     height: 34px;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     border: 1px solid #e3d9ca;
     background: #fff;
     color: s.$secondary-text;
@@ -67,7 +67,7 @@
     align-items: center;
     gap: 0.85rem;
     padding: 0.7rem 0.75rem;
-    border-radius: 12px;
+    border-radius: s.$radius-xl;
 
     &.locked {
       opacity: 0.55;

--- a/src/pages/AddRecipe/ImagePicker/ImagePicker.scss
+++ b/src/pages/AddRecipe/ImagePicker/ImagePicker.scss
@@ -29,7 +29,7 @@
     background: rgba(255, 255, 255, 0.829);
     height: 28px;
     width: 28px;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     color: black;
     border: 0;
     cursor: pointer;

--- a/src/pages/AddRecipe/Ingredients/IngredientList/IngredientList.scss
+++ b/src/pages/AddRecipe/Ingredients/IngredientList/IngredientList.scss
@@ -55,7 +55,7 @@
       height: 46px;
       width: 46px;
       background: s.$white;
-      border-radius: 50%;
+      border-radius: s.$radius-circle;
       .img {
         height: 38px;
         width: 38px;

--- a/src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem.scss
+++ b/src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem.scss
@@ -56,7 +56,7 @@
     color: s.$white;
     font-weight: 700;
     font-size: 1rem;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
   }
 
   .content {

--- a/src/pages/Help/Help.scss
+++ b/src/pages/Help/Help.scss
@@ -64,7 +64,7 @@
       gap: 0.4rem;
       padding: 0.9rem 0.5rem;
       border: 1.5px solid s.$gray-300;
-      border-radius: 14px;
+      border-radius: s.$radius-2xl;
       background: s.$white;
       color: s.$secondary-text;
       font-weight: 600;

--- a/src/pages/Home/Home.scss
+++ b/src/pages/Home/Home.scss
@@ -57,7 +57,7 @@
   .home-recipe-card {
     display: block;
     background: s.$white;
-    border-radius: 14px;
+    border-radius: s.$radius-2xl;
     overflow: hidden;
     text-decoration: none;
     color: s.$primary-text;
@@ -71,7 +71,7 @@
         position: absolute; bottom: 0.6rem; right: 0.6rem;
         background: rgba(255, 255, 255, 0.95); color: s.$primary;
         font-weight: 800; font-size: 0.78rem; padding: 0.28rem 0.6rem;
-        border-radius: 999px; box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+        border-radius: s.$radius-pill; box-shadow: s.$shadow-chip;
       }
     }
     .body { padding: 0.85rem 1rem 1rem; }
@@ -99,7 +99,7 @@
   .home-meal-col {
     background: s.$white;
     border: 1px solid #efe6db;
-    border-radius: 16px;
+    border-radius: s.$radius-3xl;
     padding: 1.25rem;
     box-shadow: rgba(0, 0, 0, 0.04) 0px 4px 14px;
 
@@ -121,11 +121,11 @@
       align-items: center;
       text-decoration: none;
       color: s.$primary-text;
-      border-radius: 10px;
+      border-radius: s.$radius-lg;
       padding: 0.4rem;
       transition: background 0.12s ease;
       &:hover { background: #fbf7f2; }
-      img { width: 56px; height: 56px; border-radius: 10px; object-fit: cover; flex-shrink: 0; }
+      img { width: 56px; height: 56px; border-radius: s.$radius-lg; object-fit: cover; flex-shrink: 0; }
     }
     .info { display: flex; flex-direction: column; gap: 0.2rem; min-width: 0; }
     .title { font-weight: 600; font-size: 0.92rem; text-transform: capitalize; line-height: 1.25; }
@@ -166,7 +166,7 @@
     background: s.$primary;
     color: s.$white;
     padding: 0.95rem 2rem;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     font-weight: 700;
     font-size: 1rem;
     text-decoration: none;

--- a/src/pages/Home/HomeCookSuggestion.scss
+++ b/src/pages/Home/HomeCookSuggestion.scss
@@ -6,7 +6,7 @@
   position: relative;
   width: min(360px, 90vw);
   background: #fff;
-  border-radius: 16px;
+  border-radius: s.$radius-3xl;
   overflow: hidden;
   text-align: left;
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
@@ -19,7 +19,7 @@
     z-index: 2;
     width: 30px;
     height: 30px;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     border: none;
     background: rgba(255, 255, 255, 0.92);
     color: s.$primary-text;
@@ -56,8 +56,8 @@
       font-weight: 800;
       font-size: 0.78rem;
       padding: 0.28rem 0.6rem;
-      border-radius: 999px;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+      border-radius: s.$radius-pill;
+      box-shadow: s.$shadow-chip;
     }
     .reroll-veil {
       position: absolute;
@@ -68,7 +68,7 @@
       .spinner {
         width: 30px;
         height: 30px;
-        border-radius: 50%;
+        border-radius: s.$radius-circle;
         border: 3px solid rgba(0, 0, 0, 0.15);
         border-top-color: s.$primary;
         animation: cook-spin 0.7s linear infinite;
@@ -115,7 +115,7 @@
     gap: 0.35rem;
     flex: 1;
     border: none;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     font-size: 0.9rem;
     font-weight: 600;
     padding: 0.6rem 1rem;
@@ -138,7 +138,7 @@
 .cook-modal-state {
   width: min(360px, 90vw);
   background: #fff;
-  border-radius: 16px;
+  border-radius: s.$radius-3xl;
   overflow: hidden;
   .body { padding: 0.9rem 1rem 1rem; }
   &.cook-modal-msg {
@@ -149,7 +149,7 @@
     .ghost {
       background: #f0f1f3;
       border: none;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       padding: 0.5rem 1.1rem;
       font-weight: 600;
       cursor: pointer;

--- a/src/pages/Home/HomeHero/HomeHero.scss
+++ b/src/pages/Home/HomeHero/HomeHero.scss
@@ -60,7 +60,7 @@
     gap: 0.5rem;
     padding: 0.7rem 1.4rem;
     border: none;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     background: s.$primary;
     color: s.$white;
     font-size: 1rem;

--- a/src/pages/PublicProfile/PublicProfile.scss
+++ b/src/pages/PublicProfile/PublicProfile.scss
@@ -37,7 +37,7 @@
     text-decoration: none;
     color: #fff;
     background: s.$primary;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     padding: 0.6rem 1.5rem;
     transition: filter 0.12s ease;
     &:hover {
@@ -55,7 +55,7 @@
   .pp-avatar {
     width: 116px;
     height: 116px;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     object-fit: cover;
     flex-shrink: 0;
     box-shadow: 0 8px 22px rgba(255, 87, 34, 0.18);
@@ -85,7 +85,7 @@
   .pp-share {
     width: 30px;
     height: 30px;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -164,7 +164,7 @@
       font-weight: 800;
       color: s.$primary;
       background: rgba(s.$primary, 0.1);
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       padding: 0.12rem 0.55rem;
     }
   }
@@ -186,7 +186,7 @@
     color: s.$secondary-text;
     background: #fdf3ec;
     border: 1px solid #f0e1d4;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     padding: 0.32rem 0.7rem;
     svg {
       color: s.$primary;
@@ -209,8 +209,8 @@
     overflow: hidden;
     background: #fff;
     border: 1px solid s.$surface-warm-border;
-    border-radius: 14px;
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
+    border-radius: s.$radius-2xl;
+    box-shadow: s.$shadow-soft;
     text-decoration: none;
     color: s.$primary-text;
     transition: transform 0.16s ease, box-shadow 0.16s ease;
@@ -260,7 +260,7 @@
       align-items: center;
       gap: 0.25rem;
       padding: 0.18rem 0.45rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       background: rgba(0, 0, 0, 0.55);
       backdrop-filter: blur(2px);
       color: #fff;

--- a/src/pages/Recipes/Recipes.scss
+++ b/src/pages/Recipes/Recipes.scss
@@ -41,7 +41,7 @@
         box-sizing: border-box;
         height: 44px;
         border: 1px solid s.$gray-400;
-        border-radius: 999px;
+        border-radius: s.$radius-pill;
         background: s.$white;
         font-size: 0.95rem;
         padding: 0.1rem 6.5rem 0.1rem 2.85rem;
@@ -61,7 +61,7 @@
         height: 36px;
         font-size: 0.9rem;
         padding: 0 1.15rem;
-        border-radius: 999px;
+        border-radius: s.$radius-pill;
       }
     }
   }
@@ -98,7 +98,7 @@
     padding: 0 1.1rem;
     box-sizing: border-box;
     min-height: 44px; // compact, matches the search pill (G06 sizing)
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     cursor: pointer;
     white-space: nowrap;
     flex-shrink: 0;
@@ -117,7 +117,7 @@
       padding: 0 0.35rem;
       background: s.$primary;
       color: s.$white;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       font-size: 0.72rem;
     }
   }
@@ -139,7 +139,7 @@
       color: s.$primary-text;
       background: s.$white;
       border: 1px solid s.$gray-400;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       cursor: pointer;
       white-space: nowrap;
       .chev {
@@ -163,7 +163,7 @@
       list-style: none;
       background: s.$white;
       border: 1px solid s.$gray-300;
-      border-radius: 12px;
+      border-radius: s.$radius-xl;
       box-shadow: 0 12px 30px rgba(0, 0, 0, 0.14);
       padding: 0.4rem;
       button {
@@ -177,7 +177,7 @@
         font-weight: 600;
         color: s.$primary-text;
         padding: 0.45rem 0.6rem;
-        border-radius: 8px;
+        border-radius: s.$radius-md;
         cursor: pointer;
         &:hover {
           background: s.$gray-200;
@@ -204,7 +204,7 @@
       font-weight: 700;
       font-size: 0.78rem;
       padding: 0.35rem 0.75rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       cursor: pointer;
       text-transform: capitalize;
     }
@@ -240,7 +240,7 @@
       background: s.$white;
       color: s.$primary-text;
       border: 1.5px solid s.$gray-400;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       font-family: inherit;
       font-weight: 700;
       font-size: 0.95rem;
@@ -284,7 +284,7 @@
       justify-content: center;
       width: 5rem;
       height: 5rem;
-      border-radius: 50%;
+      border-radius: s.$radius-circle;
       background: s.$primary-background;
       color: s.$primary;
       margin-bottom: 1.25rem;
@@ -321,7 +321,7 @@
       font-weight: 700;
       font-size: 0.95rem;
       padding: 0.7rem 1.6rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
       &--primary {
         background: s.$primary;
@@ -421,7 +421,7 @@
       color: s.$secondary-text;
       font-weight: 700;
       padding: 0.75rem 1.25rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       cursor: pointer;
     }
     &__apply {
@@ -431,7 +431,7 @@
       color: s.$white;
       font-weight: 700;
       padding: 0.75rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       cursor: pointer;
     }
   }
@@ -440,7 +440,7 @@
     display: inline-flex;
     align-items: center;
     padding: 0.4rem 0.85rem;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     border: 1px solid s.$gray-400;
     background: s.$white;
     color: s.$secondary-text;

--- a/src/pages/Settings/Settings.scss
+++ b/src/pages/Settings/Settings.scss
@@ -113,7 +113,7 @@
     background: s.$white;
     border: 1px solid s.$surface-warm-border;
     border-radius: 18px;
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
+    box-shadow: s.$shadow-soft;
     padding: 1.75rem;
 
     .settings-panehead {
@@ -156,8 +156,8 @@
         gap: 0;
         background: s.$white;
         border: 1px solid s.$surface-warm-border;
-        border-radius: 16px;
-        box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05);
+        border-radius: s.$radius-3xl;
+        box-shadow: s.$shadow-soft;
         overflow: hidden;
       }
       .settings-navitem {

--- a/src/pages/Settings/components/controls.scss
+++ b/src/pages/Settings/components/controls.scss
@@ -11,7 +11,7 @@
     flex-shrink: 0;
     height: 84px;
     width: 84px;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     overflow: hidden;
     display: flex;
     align-items: center;
@@ -145,7 +145,7 @@
   position: relative;
   width: 44px;
   height: 26px;
-  border-radius: 999px;
+  border-radius: s.$radius-pill;
   border: none;
   background: s.$gray-400;
   cursor: pointer;
@@ -158,7 +158,7 @@
     left: 3px;
     height: 20px;
     width: 20px;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     background: s.$white;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
     transition: transform 0.15s ease;
@@ -216,7 +216,7 @@
   font-weight: 600;
   white-space: nowrap;
   padding: 0.6rem 1.2rem;
-  border-radius: 10px;
+  border-radius: s.$radius-lg;
   cursor: pointer;
   transition: opacity 0.12s ease;
   &:hover {
@@ -236,7 +236,7 @@
   font-size: 0.85rem;
   font-weight: 600;
   padding: 0.45rem 0.95rem;
-  border-radius: 10px;
+  border-radius: s.$radius-lg;
   cursor: pointer;
   transition: all 0.12s ease;
   &:hover {
@@ -258,7 +258,7 @@
   color: s.$secondary-text;
   cursor: pointer;
   padding: 0.45rem 0.5rem;
-  border-radius: 8px;
+  border-radius: s.$radius-md;
   &:hover {
     color: s.$primary-text;
   }
@@ -272,7 +272,7 @@
   font-size: 0.85rem;
   font-weight: 600;
   padding: 0.5rem 1rem;
-  border-radius: 10px;
+  border-radius: s.$radius-lg;
   cursor: pointer;
   transition: all 0.12s ease;
   &:hover {
@@ -299,7 +299,7 @@
   justify-content: space-between;
   gap: 1rem;
   background: s.$primary-text;
-  border-radius: 14px;
+  border-radius: s.$radius-2xl;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
   // Collapsed by default so the hidden bar reserves no space under the form
   // (opacity alone left ~3.5rem of dead padding at the bottom of every section).

--- a/src/pages/Settings/sections/sections.scss
+++ b/src/pages/Settings/sections/sections.scss
@@ -110,7 +110,7 @@
   padding: 1.1rem 1.25rem;
   border: 1px solid rgba(s.$error-red, 0.4);
   background: rgba(s.$error-red, 0.04);
-  border-radius: 14px;
+  border-radius: s.$radius-2xl;
 
   .sr-row-text {
     display: flex;
@@ -155,7 +155,7 @@
 .sr-modal {
   width: min(440px, 100%);
   background: s.$white;
-  border-radius: 16px;
+  border-radius: s.$radius-3xl;
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.24);
   padding: 1.5rem;
   display: flex;
@@ -182,7 +182,7 @@
       height: 32px;
       width: 32px;
       border: none;
-      border-radius: 8px;
+      border-radius: s.$radius-md;
       background: s.$gray-200;
       color: s.$secondary-text;
       cursor: pointer;

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
@@ -14,7 +14,7 @@
   box-sizing: border-box;
   background: linear-gradient(135deg, rgba(s.$secondary, 0.13), rgba(s.$primary, 0.09));
   border: 1.5px solid rgba(s.$primary, 0.22);
-  border-radius: 16px;
+  border-radius: s.$radius-3xl;
   box-shadow: rgba(48, 56, 65, 0.06) 0px 8px 22px;
   .who {
     display: flex;
@@ -62,7 +62,7 @@
     gap: 0.4rem;
     border: 1.5px solid s.$gray-300;
     padding: 0.5rem 0.95rem;
-    border-radius: 10px;
+    border-radius: s.$radius-lg;
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 700;

--- a/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
+++ b/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
@@ -20,7 +20,7 @@
     padding: 2.75rem 2rem;
     background: s.$white;
     border: 1.5px solid s.$gray-200;
-    border-radius: 20px;
+    border-radius: s.$radius-4xl;
     box-shadow: rgba(48, 56, 65, 0.06) 0px 10px 30px;
   }
 
@@ -31,7 +31,7 @@
     width: 76px;
     height: 76px;
     margin-bottom: 1.4rem;
-    border-radius: 50%;
+    border-radius: s.$radius-circle;
     background: linear-gradient(135deg, rgba(s.$secondary, 0.14), rgba(s.$primary, 0.12));
     color: s.$primary;
     svg { width: 38px; height: 38px; }
@@ -77,7 +77,7 @@
       align-items: center;
       justify-content: center;
       padding: 0.75rem 1.6rem;
-      border-radius: 10px;
+      border-radius: s.$radius-lg;
       background: s.$primary;
       color: s.$white;
       font-weight: 700;

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -104,7 +104,7 @@ $danger: #d23f31;
       .avatar {
         width: 28px;
         height: 28px;
-        border-radius: 50%;
+        border-radius: s.$radius-circle;
         background: s.$secondary;
         color: s.$white;
         display: inline-flex;
@@ -172,7 +172,7 @@ $danger: #d23f31;
       font-weight: 700;
       font-size: 0.95rem;
       padding: 0.7rem 1.25rem;
-      border-radius: 10px;
+      border-radius: s.$radius-lg;
       cursor: pointer;
       height: auto !important;
       border: 1.5px solid s.$gray-300;
@@ -201,7 +201,7 @@ $danger: #d23f31;
       align-items: center;
       justify-content: center;
       background: rgba(255, 255, 255, 0.6);
-      border-radius: 10px;
+      border-radius: s.$radius-lg;
     }
   }
 
@@ -236,13 +236,13 @@ $danger: #d23f31;
       align-items: center;
       gap: 0.15rem;
       background: s.$primary-background;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       padding: 0.2rem;
       font-weight: 700;
       .step-btn {
         width: 26px;
         height: 26px;
-        border-radius: 50%;
+        border-radius: s.$radius-circle;
         border: none;
         background: s.$white;
         cursor: pointer;
@@ -281,7 +281,7 @@ $danger: #d23f31;
         align-items: center;
         gap: 0.65rem;
         padding: 0.5rem 0.4rem;
-        border-radius: 10px;
+        border-radius: s.$radius-lg;
         cursor: pointer;
         font-size: 0.94rem;
         &:hover { background: s.$primary-background; }
@@ -357,7 +357,7 @@ $danger: #d23f31;
         .num {
           width: 34px;
           height: 34px;
-          border-radius: 50%;
+          border-radius: s.$radius-circle;
           background: s.$primary;
           color: s.$white;
           display: flex;
@@ -385,7 +385,7 @@ $danger: #d23f31;
       background: rgba(s.$secondary, 0.12);
       color: s.$secondary;
       padding: 0.35rem 0.85rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       font-size: 0.85rem;
       font-weight: 600;
       text-decoration: none;
@@ -407,7 +407,7 @@ $danger: #d23f31;
       width: auto;
       height: auto;
       padding: 0.75rem 1.5rem;
-      border-radius: 10px;
+      border-radius: s.$radius-lg;
       font-weight: 700;
       font-size: 0.95rem;
       background: rgba(s.$secondary, 0.12);
@@ -458,8 +458,8 @@ $danger: #d23f31;
         margin-bottom: 0.3rem;
         span:last-child { color: s.$secondary; }
       }
-      .nd-track { height: 8px; background: s.$primary-background; border-radius: 999px; overflow: hidden; }
-      .nd-fill { height: 100%; border-radius: 999px; background: linear-gradient(90deg, s.$secondary, #2fd0d8); }
+      .nd-track { height: 8px; background: s.$primary-background; border-radius: s.$radius-pill; overflow: hidden; }
+      .nd-fill { height: 100%; border-radius: s.$radius-pill; background: linear-gradient(90deg, s.$secondary, #2fd0d8); }
     }
     .nd-facts {
       width: 100%;
@@ -555,7 +555,7 @@ $danger: #d23f31;
             letter-spacing: 0;
             color: s.$primary;
             border: 1.5px solid rgba(s.$primary, 0.4);
-            border-radius: 999px;
+            border-radius: s.$radius-pill;
             padding: 0.4rem 0.95rem;
             transition: background 0.12s ease;
           }
@@ -589,7 +589,7 @@ $danger: #d23f31;
       padding: 1rem 1.25rem;
       background: s.$white;
       border: 1px solid $soft-border;
-      border-radius: 12px;
+      border-radius: s.$radius-xl;
       margin-bottom: 1rem;
       .body .text { color: s.$secondary-text; line-height: 1.6; font-size: 0.92rem; }
       // hide the empty options bar on others' reviews (the beta like/dislike was
@@ -629,7 +629,7 @@ $danger: #d23f31;
         min-height: 72px;
         resize: vertical;
         border: 1.5px solid s.$gray-300;
-        border-radius: 10px;
+        border-radius: s.$radius-lg;
         padding: 0.65rem 0.8rem;
         font-family: inherit;
         font-size: 0.9rem;
@@ -642,7 +642,7 @@ $danger: #d23f31;
         background: s.$primary;
         color: s.$white;
         border: none;
-        border-radius: 10px;
+        border-radius: s.$radius-lg;
         padding: 0.6rem 1.25rem;
         font-family: inherit;
         font-weight: 700;
@@ -699,7 +699,7 @@ $danger: #d23f31;
       gap: 0;
       background: s.$gray-50;
       border: 1px solid s.$gray-200;
-      border-radius: 12px;
+      border-radius: s.$radius-xl;
       padding: 0.7rem 0.35rem;
       .m-item {
         flex: 1;


### PR DESCRIPTION
## What

Promotes the corner-radius values **already in use** across the app into a named scale, and the two box-shadows that recur verbatim into elevation tokens. Continues the design-consistency token sweep (follows #180).

### Added to `src/helpers.scss`
- **Radius scale:** `$radius-xs (4) / -sm (6) / -md (8) / -lg (10) / -xl (12) / -2xl (14) / -3xl (16) / -4xl (20)`, plus `$radius-pill (999px)` and `$radius-circle (50%)`. `$border-radius` now aliases `$radius-lg` (its existing references are untouched).
- **Elevation:** `$shadow-soft` (the soft resting shadow on warm account/settings cards, used ×8) and `$shadow-chip` (the tight price/floating-chip drop shadow, used ×3). Named to avoid collision with the existing heavier `$card-box-shadow`.

### Repointed
~200 value-identical `border-radius` repoints + 11 shadow repoints across **32 files that already `@use` helpers as `s`**.

## Polish only — provably no visual change
Every step in the scale equals a radius/shadow already present in the source, so this is exact-match repointing, not normalization. Verified by compiling the full CSS bundle on `development` vs. this branch:

```
before: 200311 bytes   after: 200311 bytes   →  diff = IDENTICAL (byte-for-byte)
```

Byte-identical compiled CSS is conclusive that rendering is unchanged, so no screenshot diff is needed.

## Deliberately left out (filed/updated in `docs/BACKLOG.md`)
- **Off-scale radii** (`5/7/9/11/13/18px`) — would need ±1px normalization (a design call), not value-identical.
- **Token-less admin files** (`Admin/*`, `AdminRecipeControls`, `SavedFilterBar`, `AppErrorFallback`) — `@use` nothing, so repointing them belongs to the existing "wire token-less files into helpers" backlog item.
- **Type scale** (~520 font-sizes, ~50 distinct values) and the **full elevation re-author** (~40 mostly-unique shadows) — both normalize values, so they need design sign-off, not a blind repoint.

## Gates
- `npx tsc --noEmit` → exit 0
- `npm run build` → clean (no Sass warnings; only the pre-existing chunk-size note)
- `npm test` → 516 passed / 2 skipped (71 files)