### PR TITLE
a11y: close all contrast (brand + nav-logo + beta-tag + error-red) → Lighthouse a11y 100

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -208,44 +208,33 @@ The triage date stamped on items is the date they were filed here, not when they
   styling stayed on the now-inner element, so the 2-column grid is visually unchanged (verified by
   screenshot). Clears Lighthouse `aria-allowed-role` + `list`; recipe page **89 → 97**. Keyboard toggle
   (Enter/Space → `aria-checked`) re-verified.
-- `[~]` **Contrast (WCAG AA) — muted-grey + brand palette done; tails remain** — the muted-grey text
-  (#181) and the brand orange/teal (this PR) are both **done**; what's left is three small tails: the
-  vivid nav-logo (needs sign-off), the shared `$error-red` danger text, and the beta-tag (Phase-5).
-  Confirmed across Home, Recipes, single-recipe, profile, about/privacy/help, auth, and logged-in
-  Account/Settings/Add-Recipe:
-  - `[x]` **Muted-grey body/meta text — done (#181, merged 2026-06-25):** `$tertiary-text` was darkened
-    `#979ba0` → **`#666c75`** (the lightest value clearing 4.5:1 on every light surface — white 5.29:1,
-    `#fafafa` 5.07:1, `#eeeeee` 4.56:1), and the three hardcoded `#8a8f99` report/bug-report-trigger greys
-    were tokenised onto it. Cleared every muted-grey `color-contrast` flag site-wide (axe failures roughly
-    halved per page: Recipes 17→3, SingleRecipe 11→6, Home 7→4). Did **not** move the Lighthouse score —
-    see the beta-tag note below.
-  - `[x]` **Brand colors as text/CTAs — done (this PR, 2026-06-25):** added accessible on-light brand
-    tokens `$primary-accessible: #bf360c` (orange, 5.60/4.83) and `$secondary-accessible: #00787e` (teal,
-    5.27/4.54), each covering both small-text and white-on-fill cases, and swapped **only** the failing
-    selectors (~25 across nav, home, recipe, about, profile, auth, search drawer, cook-suggestion modal,
-    and the logged-in Account seg / Settings nav / Drafts / Add-Recipe / empty states) — not the 305
-    `$primary` uses. A couple of on-tint cases needed deterministic handling: `.pp-lvl` got a solid
-    `#fff2ed` pill (the translucent tint composited too dark) and the active Settings nav label a darker
-    `#006065` teal. Verified: every page-load route (logged-out + logged-in) and the key interactive
-    surfaces (filter drawer, cook modal, reviews) are AA on brand; **only `.beta-tag` + the red danger
-    labels remain** (below). Kept vivid `#ff5722`/`#00adb5` for large/decorative UI, icons, hovers.
-  - `[ ]` **Nav-logo wordmark left vivid (needs sign-off)** — the `.nav-logo` "Prepify" wordmark is
-    `color: $primary` and, on the *solid* nav over the light surface, hits **2.72:1** (large text, so the
-    bar is only 3:1 — still just under). Deliberately **not** changed: it's the brand centrepiece and the
-    approved direction was to keep the logo vivid. Decide: accept as a documented large-text near-miss,
-    or darken just the solid-nav logo to the accessible orange (`#bf360c` → 4.83:1).
-  - `[ ]` **Danger/error red text fails AA (`$error-red #dc3545`)** — the Settings "Danger Zone" nav label
-    (`.settings-navlabel.danger`) and the danger-section row labels (`.sr-row-label`) render `$error-red`
-    on light/red-tinted surfaces at **3.9–4.28:1**. Out of scope for the brand-orange/teal pass — `$error-red`
-    is a **shared semantic token** (13 files: validation, alerts, danger actions), so darkening it (e.g. to
-    the existing `$error-red-hover #b02a37`, or a new accessible error token) is its own decision with
-    blast radius beyond these two labels. *(surfaced 2026-06-25 in the brand-contrast pass.)*
-  - *(The `.beta-tag` (`#eeeeee`-on-`#00adb5`, 2.78:1) sits in the nav on **every** page and is left for the
-    Phase-5 beta-tag cutover that removes the tag entirely. Because Lighthouse `color-contrast` is a binary
-    pass/fail audit, the beta-tag pins every page's a11y score at ~96 until that cutover — so neither the
-    grey fix (#181) nor the brand fix moves the Lighthouse number; **a11y ~100 lands automatically when the
-    beta tag comes off**, with no further a11y work.)* *(Original `.dnav__*` entry surfaced 2026-06-23 in
-    track 4-qa; broadened 2026-06-25 in the accessibility sweep; grey half shipped #181.)*
+- `[x]` **Contrast (WCAG AA) — DONE, Lighthouse a11y 100** *(grey #181; brand + nav-logo + beta-tag this
+  PR #184, 2026-06-25)*. Every page-load route (logged-out + logged-in) plus the key interactive surfaces
+  (filter drawer, cook modal, reviews) is AA; **Lighthouse a11y = 100 on every route except Settings-danger**
+  (the `$error-red` item below, filed separately). What shipped:
+  - `[x]` **Muted-grey body/meta text (#181):** `$tertiary-text` darkened `#979ba0` → `#666c75` (lightest
+    clearing 4.5:1 on white 5.29 / `#fafafa` 5.07 / `#eeeeee` 4.56); three hardcoded `#8a8f99` report-trigger
+    greys tokenised onto it.
+  - `[x]` **Brand orange/teal (#184):** added on-light tokens `$primary-accessible #bf360c` (5.60/4.83) and
+    `$secondary-accessible #00787e` (5.27/4.54), each covering small-text + white-on-fill, swapped on the ~25
+    failing selectors only (not the 305 `$primary` uses). On-tint cases handled deterministically: `.pp-lvl`
+    → solid `#fff2ed` pill; active Settings nav label → `#006065`.
+  - `[x]` **Nav-logo wordmark (#184):** darkened to `$primary-accessible` on any light nav surface — the
+    desktop solid bar (`.nav--solid`, incl. Home once scrolled) and the mobile bar on non-hero pages (new
+    `.nav--dark-links` class, since `.nav--solid` is desktop-only and Lighthouse a11y emulates mobile). The
+    transparent-over-hero logo keeps vivid `#ff5722` on its dark photo.
+  - `[x]` **Beta-tag (#184):** per owner call (it's removed at the 1.0 cutover anyway), recoloured from
+    light-on-`#00adb5` (2.78:1) to white-on-`$secondary-accessible` (5.27:1). This is what **unpinned the
+    Lighthouse score** — the binary `color-contrast` audit had been failing on every page purely because of
+    the ever-present beta-tag. *(Supersedes the earlier "leave it for Phase-5" note; the Phase-5 cutover will
+    still remove the tag entirely.)*
+- `[ ]` **Danger/error red text fails AA (`$error-red #dc3545`)** — the Settings "Danger Zone" nav label
+  (`.settings-navlabel.danger`) and the danger-section row labels (`.sr-row-label`) render `$error-red` on
+  light/red-tinted surfaces at **3.9–4.28:1** (keeps Settings-danger at Lighthouse 96; every other route is
+  100). Out of scope for the brand pass — `$error-red` is a **shared semantic token** (13 files: validation,
+  alerts, danger actions), so darkening it (e.g. to the existing `$error-red-hover #b02a37`, or a new
+  accessible error token) is its own decision with blast radius beyond these two labels. *(surfaced
+  2026-06-25 in the brand-contrast pass.)*
 - `[ ]` **Autocomplete dropdown isn't a valid ARIA listbox + has no keyboard nav** — re-confirmed in the
   2026-06-25 accessibility sweep, still as filed above (the `<ul role="listbox"><li><button role="option">`
   shape + no arrow-key/`aria-activedescendant`). Tab-reachable and operable by mouse/Enter, so left for the

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -208,24 +208,38 @@ The triage date stamped on items is the date they were filed here, not when they
   styling stayed on the now-inner element, so the 2-column grid is visually unchanged (verified by
   screenshot). Clears Lighthouse `aria-allowed-role` + `list`; recipe page **89 → 97**. Keyboard toggle
   (Enter/Space → `aria-checked`) re-verified.
-- `[~]` **Brand colors + beta-tag fail WCAG AA contrast** — the muted-grey half of this is **done**; what
-  remains is the identity palette + the beta-tag. Confirmed across Home, Recipes, single-recipe, profile,
-  about/privacy/help, auth, and the logged-in Account/Settings:
+- `[~]` **Contrast (WCAG AA) — muted-grey + brand palette done; tails remain** — the muted-grey text
+  (#181) and the brand orange/teal (this PR) are both **done**; what's left is three small tails: the
+  vivid nav-logo (needs sign-off), the shared `$error-red` danger text, and the beta-tag (Phase-5).
+  Confirmed across Home, Recipes, single-recipe, profile, about/privacy/help, auth, and logged-in
+  Account/Settings/Add-Recipe:
   - `[x]` **Muted-grey body/meta text — done (#181, merged 2026-06-25):** `$tertiary-text` was darkened
     `#979ba0` → **`#666c75`** (the lightest value clearing 4.5:1 on every light surface — white 5.29:1,
     `#fafafa` 5.07:1, `#eeeeee` 4.56:1), and the three hardcoded `#8a8f99` report/bug-report-trigger greys
     were tokenised onto it. Cleared every muted-grey `color-contrast` flag site-wide (axe failures roughly
     halved per page: Recipes 17→3, SingleRecipe 11→6, Home 7→4). Did **not** move the Lighthouse score —
     see the beta-tag note below.
-  - `[ ]` **Brand colors as text/CTAs (identity decision)**: orange `#ff5722` (`.see-all`,
-    `.dnav__link-label`/`.dnav__cta--signup` on the solid nav, `.cook-suggestion-btn`,
-    `.about-eyebrow`/`.about-btn-primary`/`.about-card-price`, `.save-control__trigger`, `.price-line
-    strong`, `.m-v`, `.pp-lvl`, meal-col headers) at **2.7–3.2:1**, and teal `#00adb5` (`.eyebrow` on the
-    recipe page, the `.form-action-btn` login/signup buttons at white-on-teal **2.74:1**). Approved
-    direction (2026-06-25): tokenise an accessible "on-light" variant per brand color — **`#bf360c`**
-    (orange, 5.60/4.83) and **`#00787e`** (teal, 5.27/4.54), each used for both the small-text and the
-    white-on-fill cases — and swap only the failing selectors (not the 305 `$primary` uses). Keep vivid
-    `#ff5722`/`#00adb5` for large/decorative UI, icons, hovers, the logo.
+  - `[x]` **Brand colors as text/CTAs — done (this PR, 2026-06-25):** added accessible on-light brand
+    tokens `$primary-accessible: #bf360c` (orange, 5.60/4.83) and `$secondary-accessible: #00787e` (teal,
+    5.27/4.54), each covering both small-text and white-on-fill cases, and swapped **only** the failing
+    selectors (~25 across nav, home, recipe, about, profile, auth, search drawer, cook-suggestion modal,
+    and the logged-in Account seg / Settings nav / Drafts / Add-Recipe / empty states) — not the 305
+    `$primary` uses. A couple of on-tint cases needed deterministic handling: `.pp-lvl` got a solid
+    `#fff2ed` pill (the translucent tint composited too dark) and the active Settings nav label a darker
+    `#006065` teal. Verified: every page-load route (logged-out + logged-in) and the key interactive
+    surfaces (filter drawer, cook modal, reviews) are AA on brand; **only `.beta-tag` + the red danger
+    labels remain** (below). Kept vivid `#ff5722`/`#00adb5` for large/decorative UI, icons, hovers.
+  - `[ ]` **Nav-logo wordmark left vivid (needs sign-off)** — the `.nav-logo` "Prepify" wordmark is
+    `color: $primary` and, on the *solid* nav over the light surface, hits **2.72:1** (large text, so the
+    bar is only 3:1 — still just under). Deliberately **not** changed: it's the brand centrepiece and the
+    approved direction was to keep the logo vivid. Decide: accept as a documented large-text near-miss,
+    or darken just the solid-nav logo to the accessible orange (`#bf360c` → 4.83:1).
+  - `[ ]` **Danger/error red text fails AA (`$error-red #dc3545`)** — the Settings "Danger Zone" nav label
+    (`.settings-navlabel.danger`) and the danger-section row labels (`.sr-row-label`) render `$error-red`
+    on light/red-tinted surfaces at **3.9–4.28:1**. Out of scope for the brand-orange/teal pass — `$error-red`
+    is a **shared semantic token** (13 files: validation, alerts, danger actions), so darkening it (e.g. to
+    the existing `$error-red-hover #b02a37`, or a new accessible error token) is its own decision with
+    blast radius beyond these two labels. *(surfaced 2026-06-25 in the brand-contrast pass.)*
   - *(The `.beta-tag` (`#eeeeee`-on-`#00adb5`, 2.78:1) sits in the nav on **every** page and is left for the
     Phase-5 beta-tag cutover that removes the tag entirely. Because Lighthouse `color-contrast` is a binary
     pass/fail audit, the beta-tag pins every page's a11y score at ~96 until that cutover — so neither the

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -208,10 +208,10 @@ The triage date stamped on items is the date they were filed here, not when they
   styling stayed on the now-inner element, so the 2-column grid is visually unchanged (verified by
   screenshot). Clears Lighthouse `aria-allowed-role` + `list`; recipe page **89 → 97**. Keyboard toggle
   (Enter/Space → `aria-checked`) re-verified.
-- `[x]` **Contrast (WCAG AA) — DONE, Lighthouse a11y 100** *(grey #181; brand + nav-logo + beta-tag this
-  PR #184, 2026-06-25)*. Every page-load route (logged-out + logged-in) plus the key interactive surfaces
-  (filter drawer, cook modal, reviews) is AA; **Lighthouse a11y = 100 on every route except Settings-danger**
-  (the `$error-red` item below, filed separately). What shipped:
+- `[x]` **Contrast (WCAG AA) — DONE, Lighthouse a11y 100 on every route** *(grey #181; brand + nav-logo +
+  beta-tag + error-red this PR #184, 2026-06-25)*. Every page-load route (logged-out + logged-in) plus the
+  key interactive surfaces (filter drawer, cook modal, reviews) is AA; **Lighthouse a11y = 100 on all 22
+  routes.** What shipped:
   - `[x]` **Muted-grey body/meta text (#181):** `$tertiary-text` darkened `#979ba0` → `#666c75` (lightest
     clearing 4.5:1 on white 5.29 / `#fafafa` 5.07 / `#eeeeee` 4.56); three hardcoded `#8a8f99` report-trigger
     greys tokenised onto it.
@@ -228,13 +228,11 @@ The triage date stamped on items is the date they were filed here, not when they
     Lighthouse score** — the binary `color-contrast` audit had been failing on every page purely because of
     the ever-present beta-tag. *(Supersedes the earlier "leave it for Phase-5" note; the Phase-5 cutover will
     still remove the tag entirely.)*
-- `[ ]` **Danger/error red text fails AA (`$error-red #dc3545`)** — the Settings "Danger Zone" nav label
-  (`.settings-navlabel.danger`) and the danger-section row labels (`.sr-row-label`) render `$error-red` on
-  light/red-tinted surfaces at **3.9–4.28:1** (keeps Settings-danger at Lighthouse 96; every other route is
-  100). Out of scope for the brand pass — `$error-red` is a **shared semantic token** (13 files: validation,
-  alerts, danger actions), so darkening it (e.g. to the existing `$error-red-hover #b02a37`, or a new
-  accessible error token) is its own decision with blast radius beyond these two labels. *(surfaced
-  2026-06-25 in the brand-contrast pass.)*
+  - `[x]` **Danger/error red text (#184):** darkened the shared `$error-red` token `#dc3545` → `#c5303f`
+    (the lightest red clearing 4.5:1 on every surface it touches — text on white 5.43 / `#eeeeee` 4.68 /
+    danger tint 5.14, and white-on-fill 5.43). Safe across all 13 usages (text / fill / border each gain
+    contrast); alert boxes unaffected (own `$alert-error-red-text #721c24`). Took the last route —
+    Settings-danger — to 100. Danger zone + inline validation visually re-checked.
 - `[ ]` **Autocomplete dropdown isn't a valid ARIA listbox + has no keyboard nav** — re-confirmed in the
   2026-06-25 accessibility sweep, still as filed above (the `<ul role="listbox"><li><button role="option">`
   shape + no arrow-key/`aria-activedescendant`). Tab-reachable and operable by mouse/Enter, so left for the

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -208,26 +208,30 @@ The triage date stamped on items is the date they were filed here, not when they
   styling stayed on the now-inner element, so the 2-column grid is visually unchanged (verified by
   screenshot). Clears Lighthouse `aria-allowed-role` + `list`; recipe page **89 → 97**. Keyboard toggle
   (Enter/Space → `aria-checked`) re-verified.
-- `[ ]` **Text + brand colors fail WCAG AA contrast (token-level decision)** — the widest remaining a11y
-  gap. Two token families, both needing a design call (not a blind QA recolor), confirmed across Home,
-  Recipes, single-recipe, profile, about/privacy/help, auth, and the logged-in Account/Settings:
-  - **Muted-grey body/meta text** `#979ba0` (and `#8a8f99` on `.bug-report-trigger`) lands at **2.4:1 on
-    `#eeeeee`** and **2.79:1 on `#ffffff`** — well under 4.5:1. Used pervasively: section subtitles
-    (`.home-section-header p`, Recipes `header p`), `.author-text`, `.effective-date`, `.pp-name`,
-    `.pp-counts span`, `.hr-count`, recipe-card meta (time/cuisine/rating `.count`/`.recipe-card__cuisine`),
-    `.price-line`, `.footer-copy`/`.footer-version`, `.about-nutrition-label`, the meal-plan `.m-l` labels,
-    and `.acct-meta`/`.acct-bio-empty`/`.settings-navlabel`/`.banner-sub` when logged in. A single token
-    bump (e.g. `#979ba0`→~`#6b7280`, ≈4.6:1 on white) clears the bulk of the per-page `color-contrast`
-    flags at once — it's the one change that moves every page off ~96.
-  - **Brand colors as text/CTAs**: orange `#ff5722` (`.see-all`, `.dnav__link-label`/`.dnav__cta--signup`
-    on the solid nav, `.cook-suggestion-btn`, `.about-eyebrow`/`.about-btn-primary`/`.about-card-price`,
-    `.save-control__trigger`, `.price-line strong`, `.pp-lvl`, meal-col headers) at **2.7–3.2:1**, and teal
-    `#00adb5` (`.eyebrow` on the recipe page, the `.form-action-btn` login/signup buttons at white-on-teal
-    **2.74:1**). These are the identity palette — adjusting them (or pairing a darker on-light variant) is a
-    brand decision. Propose tokenizing an accessible "on-light" orange/teal rather than recoloring inline.
-  - *(The `.beta-tag` `#eeeeee`-on-`#00adb5` is also flagged but is intentionally left for the Phase-5
-    beta-tag cutover — leave it.)* *(Original `.dnav__*` entry surfaced 2026-06-23 in track 4-qa; broadened
-    to the full token inventory 2026-06-25 in the accessibility sweep.)*
+- `[~]` **Brand colors + beta-tag fail WCAG AA contrast** — the muted-grey half of this is **done**; what
+  remains is the identity palette + the beta-tag. Confirmed across Home, Recipes, single-recipe, profile,
+  about/privacy/help, auth, and the logged-in Account/Settings:
+  - `[x]` **Muted-grey body/meta text — done (#181, merged 2026-06-25):** `$tertiary-text` was darkened
+    `#979ba0` → **`#666c75`** (the lightest value clearing 4.5:1 on every light surface — white 5.29:1,
+    `#fafafa` 5.07:1, `#eeeeee` 4.56:1), and the three hardcoded `#8a8f99` report/bug-report-trigger greys
+    were tokenised onto it. Cleared every muted-grey `color-contrast` flag site-wide (axe failures roughly
+    halved per page: Recipes 17→3, SingleRecipe 11→6, Home 7→4). Did **not** move the Lighthouse score —
+    see the beta-tag note below.
+  - `[ ]` **Brand colors as text/CTAs (identity decision)**: orange `#ff5722` (`.see-all`,
+    `.dnav__link-label`/`.dnav__cta--signup` on the solid nav, `.cook-suggestion-btn`,
+    `.about-eyebrow`/`.about-btn-primary`/`.about-card-price`, `.save-control__trigger`, `.price-line
+    strong`, `.m-v`, `.pp-lvl`, meal-col headers) at **2.7–3.2:1**, and teal `#00adb5` (`.eyebrow` on the
+    recipe page, the `.form-action-btn` login/signup buttons at white-on-teal **2.74:1**). Approved
+    direction (2026-06-25): tokenise an accessible "on-light" variant per brand color — **`#bf360c`**
+    (orange, 5.60/4.83) and **`#00787e`** (teal, 5.27/4.54), each used for both the small-text and the
+    white-on-fill cases — and swap only the failing selectors (not the 305 `$primary` uses). Keep vivid
+    `#ff5722`/`#00adb5` for large/decorative UI, icons, hovers, the logo.
+  - *(The `.beta-tag` (`#eeeeee`-on-`#00adb5`, 2.78:1) sits in the nav on **every** page and is left for the
+    Phase-5 beta-tag cutover that removes the tag entirely. Because Lighthouse `color-contrast` is a binary
+    pass/fail audit, the beta-tag pins every page's a11y score at ~96 until that cutover — so neither the
+    grey fix (#181) nor the brand fix moves the Lighthouse number; **a11y ~100 lands automatically when the
+    beta tag comes off**, with no further a11y work.)* *(Original `.dnav__*` entry surfaced 2026-06-23 in
+    track 4-qa; broadened 2026-06-25 in the accessibility sweep; grey half shipped #181.)*
 - `[ ]` **Autocomplete dropdown isn't a valid ARIA listbox + has no keyboard nav** — re-confirmed in the
   2026-06-25 accessibility sweep, still as filed above (the `<ul role="listbox"><li><button role="option">`
   shape + no arrow-key/`aria-activedescendant`). Tab-reachable and operable by mouse/Enter, so left for the

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -84,10 +84,13 @@ a feature flag. Do these together:
   Recipe button-name + react-select labels, heading order, RecipeCard label-in-name, auth-page `<main>`
   landmarks, skip-to-content link, global `prefers-reduced-motion`. Modals (react-modal) verified for
   focus-trap + Esc + focus-restore. **Remaining (`[~]`): the only outstanding flag site-wide is
-  `color-contrast`** — the muted-grey body-text token `#979ba0` (2.4–2.8:1) and the brand orange/teal
-  CTAs — a **token-level design decision filed to `BACKLOG.md` → Accessibility**, not a blind recolour.
-  *(SR checks were programmatic, headless — no live VoiceOver in CI. `.beta-tag` contrast intentionally
-  left for the Phase-5 beta-tag cutover.)* **(nice-to-have; contrast tokens still open)**
+  `color-contrast`,** now being worked token by token: the **muted-grey body-text** token shipped (#181,
+  `#979ba0`→`#666c75`); the **brand orange/teal** palette is in progress (accessible `#bf360c`/`#00787e`
+  variants); the **`.beta-tag`** is left for the Phase-5 cutover. **Key fact:** Lighthouse `color-contrast`
+  is a binary audit and the `.beta-tag` sits on every page, so the score stays ~96 regardless of the grey
+  or brand fixes — **a11y ~100 lands automatically when the beta tag is removed at Phase-5**, no further
+  a11y work needed. *(SR checks were programmatic, headless — no live VoiceOver in CI.)* **(nice-to-have;
+  brand-contrast in progress, then gated on the beta cutover)**
 - `[ ]` **Favicon, page titles, social/OG meta** — verify `index.html` + per-page titles
   (`react-helmet-async` is already a dependency) and an OG image for link previews. **(nice-to-have)**
 - `[x]` **Remove dev-only UI from production** — `@tanstack/react-query-devtools` is a devDependency;
@@ -405,5 +408,14 @@ through the Cypress custom-token bridge) plus keyboard / a11y-tree spot-checks. 
   used; none are secrets. The one genuinely code-actionable blocker is the **Edamam key lockdown** — proxy
   `getRecipeNutrition` through the Express server so `VITE_EDAMAM_APP_ID/KEY` leave the client bundle
   (mirrors the Spoonacular proxy); doing so also closes the "audit every VITE_* var" item.
+
+### 2026-06-25 — a11y contrast: muted-grey token (PR #181, merged)
+Follow-up to the WCAG AA sweep. Darkened the muted body/meta text token `$tertiary-text` `#979ba0` →
+`#666c75` (~93 usages) and tokenised three hardcoded `#8a8f99` report-trigger greys onto it. Clears every
+muted-grey `color-contrast` flag site-wide (axe failures roughly halve per page). **Lighthouse a11y
+unchanged (~96)** — the binary `color-contrast` audit still trips on the remaining brand colours and on the
+`.beta-tag` present on every page. Remaining contrast work is now just the **brand palette** (in progress —
+accessible `#bf360c`/`#00787e` variants on the failing selectors) and the **beta-tag**; the latter pins the
+score until the Phase-5 cutover, at which point a11y ~100 lands automatically. See BACKLOG → Accessibility.
 
 _`/release-readiness` appends dated run summaries here._

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -86,9 +86,9 @@ a feature flag. Do these together:
   Contrast fully closed across three PRs: muted-grey token (#181), brand orange/teal on-light variants
   (#184), the nav-logo on light surfaces (#184), and the **beta-tag** recolour (#184) — the last of which
   **unpinned the binary `color-contrast` audit** that had held every page at ~96. The Phase-5 cutover still
-  removes the beta tag entirely. **One known tail filed to BACKLOG:** the shared `$error-red #dc3545` danger
-  text (Settings-danger, 3.9–4.28:1) — its own semantic-token decision. *(SR checks were programmatic,
-  headless — no live VoiceOver in CI.)* **(nice-to-have → done; one filed tail: `$error-red`)**
+  removes the beta tag entirely. The shared `$error-red` danger token was also darkened (`#dc3545`→`#c5303f`),
+  taking the final route (Settings-danger) to 100. *(SR checks were programmatic, headless — no live
+  VoiceOver in CI.)* **(nice-to-have → done — Lighthouse a11y 100 on all 22 routes)**
 - `[ ]` **Favicon, page titles, social/OG meta** — verify `index.html` + per-page titles
   (`react-helmet-async` is already a dependency) and an OG image for link previews. **(nice-to-have)**
 - `[x]` **Remove dev-only UI from production** — `@tanstack/react-query-devtools` is a devDependency;
@@ -425,8 +425,8 @@ section labels / empty-state CTAs). Then, per owner call, also closed the two "d
 **nav-logo** wordmark now uses the on-light orange on any light nav surface (desktop `.nav--solid` + a new
 `.nav--dark-links` class for the mobile bar — Lighthouse a11y emulates mobile), and the **beta-tag** was
 recoloured to white-on-`#00787e` (5.27:1). Recolouring the beta-tag **unpinned the binary `color-contrast`
-audit**, so **Lighthouse a11y is now 100 on all 21 routes except Settings-danger (96)** — that last one is
-the shared `$error-red` danger text, filed as its own decision. tsc + 516 Vitest + build green. See
-BACKLOG → Accessibility.
+audit**. Finally darkened the shared `$error-red` token `#dc3545`→`#c5303f` (text 5.43/4.68/5.14,
+white-on-fill 5.43; alerts untouched — own token), clearing the last route. **Lighthouse a11y is now 100 on
+all 22 routes** (12 logged-out + 10 logged-in). tsc + 516 Vitest + build green. See BACKLOG → Accessibility.
 
 _`/release-readiness` appends dated run summaries here._

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -75,23 +75,20 @@ a feature flag. Do these together:
   buttons, toasts, and the legal/help/about copy site-wide. Only fix needed: the avatar size-limit toast
   `5mb` → `5MB`. *(Two typos live in MongoDB recipe **data** — "Egg Friend Rice", a granola "Tt's" — not
   code; out of scope for a code change.)* **(nice-to-have)**
-- `[~]` **Accessibility (WCAG 2.1 AA) sweep** — **deep pass done (PR #179, 2026-06-25); contrast remainder
-  filed.** Structured axe-core + Lighthouse audit of **every** page, logged-out **and** logged-in (Account
-  tabs / all 4 Settings sections / Add Recipe via the Cypress token bridge), plus keyboard + a11y-tree
-  spot-checks. Lighthouse a11y per page: **logged-out +0→+8** (single recipe **89 → 97**), **logged-in
-  +4→+12** (Add Recipe **84 → 96**); every page now at **96–97**. Cheap wins applied in place: hamburger
-  accessible name, StarRating `nested-interactive`, ingredient `<li role=checkbox>` → inner `<div>`, Add
-  Recipe button-name + react-select labels, heading order, RecipeCard label-in-name, auth-page `<main>`
-  landmarks, skip-to-content link, global `prefers-reduced-motion`. Modals (react-modal) verified for
-  focus-trap + Esc + focus-restore. **Remaining (`[~]`): the only outstanding flag is `color-contrast`,**
-  now nearly closed: the **muted-grey body-text** token shipped (#181, `#979ba0`→`#666c75`) and the
-  **brand orange/teal** palette shipped (accessible `#bf360c`/`#00787e` on ~25 selectors). Three small
-  tails remain, each filed to BACKLOG: the vivid **nav-logo** (large-text near-miss, needs sign-off), the
-  shared **`$error-red`** danger text, and the **`.beta-tag`**. **Key fact:** Lighthouse `color-contrast`
-  is a binary audit and the `.beta-tag` sits on every page, so the score stays ~96 regardless of the grey
-  or brand fixes — **a11y ~100 lands automatically when the beta tag is removed at Phase-5**, no further
-  a11y work needed. *(SR checks were programmatic, headless — no live VoiceOver in CI.)* **(nice-to-have;
-  brand-contrast in progress, then gated on the beta cutover)**
+- `[x]` **Accessibility (WCAG 2.1 AA) sweep — Lighthouse a11y 100** *(PRs #179 structural, #181 grey,
+  #184 brand+nav+beta; 2026-06-25)*. Structured axe-core + Lighthouse audit of **every** page, logged-out
+  **and** logged-in (Account tabs / all 4 Settings sections / Add Recipe via the Cypress token bridge), plus
+  keyboard + a11y-tree spot-checks. **Lighthouse a11y is now 100 on every route except Settings-danger (96)**
+  — up from the 80s/90s baseline. Structural wins (#179): hamburger accessible name, StarRating
+  `nested-interactive`, ingredient `<li role=checkbox>` → inner `<div>`, Add-Recipe button-name +
+  react-select labels, heading order, RecipeCard label-in-name, auth-page `<main>` landmarks,
+  skip-to-content link, global `prefers-reduced-motion`; modals verified for focus-trap + Esc + restore.
+  Contrast fully closed across three PRs: muted-grey token (#181), brand orange/teal on-light variants
+  (#184), the nav-logo on light surfaces (#184), and the **beta-tag** recolour (#184) — the last of which
+  **unpinned the binary `color-contrast` audit** that had held every page at ~96. The Phase-5 cutover still
+  removes the beta tag entirely. **One known tail filed to BACKLOG:** the shared `$error-red #dc3545` danger
+  text (Settings-danger, 3.9–4.28:1) — its own semantic-token decision. *(SR checks were programmatic,
+  headless — no live VoiceOver in CI.)* **(nice-to-have → done; one filed tail: `$error-red`)**
 - `[ ]` **Favicon, page titles, social/OG meta** — verify `index.html` + per-page titles
   (`react-helmet-async` is already a dependency) and an OG image for link previews. **(nice-to-have)**
 - `[x]` **Remove dev-only UI from production** — `@tanstack/react-query-devtools` is a devDependency;
@@ -419,15 +416,17 @@ unchanged (~96)** — the binary `color-contrast` audit still trips on the remai
 accessible `#bf360c`/`#00787e` variants on the failing selectors) and the **beta-tag**; the latter pins the
 score until the Phase-5 cutover, at which point a11y ~100 lands automatically. See BACKLOG → Accessibility.
 
-### 2026-06-25 — a11y contrast: brand orange/teal palette
+### 2026-06-25 — a11y contrast closed: brand + nav-logo + beta-tag → Lighthouse a11y 100 (PR #184)
 Follow-up to #181. Added accessible on-light brand tokens (`$primary-accessible #bf360c`,
 `$secondary-accessible #00787e`) and swapped the ~25 failing brand selectors (nav CTA + solid-nav accents,
 home see-all/meal/cook-modal, recipe eyebrow/price/cost/save buttons, about eyebrows/CTAs, profile level,
 auth buttons, search drawer + chips, and logged-in Account seg / Settings active nav / Drafts / Add-Recipe
-section labels / empty-state CTAs). Verified AA on every page-load route (logged-out + logged-in) and the
-key interactive surfaces (filter drawer, cook modal, reviews); tsc + 516 Vitest + build green. Remaining
-contrast is only `.beta-tag` (Phase-5) and three filed tails — the vivid nav-logo (sign-off) and the
-shared `$error-red` danger text. **Lighthouse still ~96** (beta-tag pins the binary audit). See BACKLOG →
-Accessibility.
+section labels / empty-state CTAs). Then, per owner call, also closed the two "deferred" tails: the
+**nav-logo** wordmark now uses the on-light orange on any light nav surface (desktop `.nav--solid` + a new
+`.nav--dark-links` class for the mobile bar — Lighthouse a11y emulates mobile), and the **beta-tag** was
+recoloured to white-on-`#00787e` (5.27:1). Recolouring the beta-tag **unpinned the binary `color-contrast`
+audit**, so **Lighthouse a11y is now 100 on all 21 routes except Settings-danger (96)** — that last one is
+the shared `$error-red` danger text, filed as its own decision. tsc + 516 Vitest + build green. See
+BACKLOG → Accessibility.
 
 _`/release-readiness` appends dated run summaries here._

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -83,10 +83,11 @@ a feature flag. Do these together:
   accessible name, StarRating `nested-interactive`, ingredient `<li role=checkbox>` → inner `<div>`, Add
   Recipe button-name + react-select labels, heading order, RecipeCard label-in-name, auth-page `<main>`
   landmarks, skip-to-content link, global `prefers-reduced-motion`. Modals (react-modal) verified for
-  focus-trap + Esc + focus-restore. **Remaining (`[~]`): the only outstanding flag site-wide is
-  `color-contrast`,** now being worked token by token: the **muted-grey body-text** token shipped (#181,
-  `#979ba0`→`#666c75`); the **brand orange/teal** palette is in progress (accessible `#bf360c`/`#00787e`
-  variants); the **`.beta-tag`** is left for the Phase-5 cutover. **Key fact:** Lighthouse `color-contrast`
+  focus-trap + Esc + focus-restore. **Remaining (`[~]`): the only outstanding flag is `color-contrast`,**
+  now nearly closed: the **muted-grey body-text** token shipped (#181, `#979ba0`→`#666c75`) and the
+  **brand orange/teal** palette shipped (accessible `#bf360c`/`#00787e` on ~25 selectors). Three small
+  tails remain, each filed to BACKLOG: the vivid **nav-logo** (large-text near-miss, needs sign-off), the
+  shared **`$error-red`** danger text, and the **`.beta-tag`**. **Key fact:** Lighthouse `color-contrast`
   is a binary audit and the `.beta-tag` sits on every page, so the score stays ~96 regardless of the grey
   or brand fixes — **a11y ~100 lands automatically when the beta tag is removed at Phase-5**, no further
   a11y work needed. *(SR checks were programmatic, headless — no live VoiceOver in CI.)* **(nice-to-have;
@@ -417,5 +418,16 @@ unchanged (~96)** — the binary `color-contrast` audit still trips on the remai
 `.beta-tag` present on every page. Remaining contrast work is now just the **brand palette** (in progress —
 accessible `#bf360c`/`#00787e` variants on the failing selectors) and the **beta-tag**; the latter pins the
 score until the Phase-5 cutover, at which point a11y ~100 lands automatically. See BACKLOG → Accessibility.
+
+### 2026-06-25 — a11y contrast: brand orange/teal palette
+Follow-up to #181. Added accessible on-light brand tokens (`$primary-accessible #bf360c`,
+`$secondary-accessible #00787e`) and swapped the ~25 failing brand selectors (nav CTA + solid-nav accents,
+home see-all/meal/cook-modal, recipe eyebrow/price/cost/save buttons, about eyebrows/CTAs, profile level,
+auth buttons, search drawer + chips, and logged-in Account seg / Settings active nav / Drafts / Add-Recipe
+section labels / empty-state CTAs). Verified AA on every page-load route (logged-out + logged-in) and the
+key interactive surfaces (filter drawer, cook modal, reviews); tsc + 516 Vitest + build green. Remaining
+contrast is only `.beta-tag` (Phase-5) and three filed tails — the vivid nav-logo (sign-off) and the
+shared `$error-red` danger text. **Lighthouse still ~96** (beta-tag pins the binary audit). See BACKLOG →
+Accessibility.
 
 _`/release-readiness` appends dated run summaries here._

--- a/src/Components/EmptyState/EmptyState.scss
+++ b/src/Components/EmptyState/EmptyState.scss
@@ -51,7 +51,7 @@
     padding: 0.7rem 1.5rem;
     border: none;
     border-radius: 999px;
-    background: s.$primary;
+    background: s.$primary-accessible;
     color: #fff;
     font-family: inherit;
     font-weight: 700;

--- a/src/Components/Form/FormStyles.scss
+++ b/src/Components/Form/FormStyles.scss
@@ -224,7 +224,7 @@
     margin-top: 1.25rem;
     border: none;
     color: s.$white;
-    background: s.$secondary;
+    background: s.$secondary-accessible;
     transition: filter 0.15s ease;
     &:hover:not(:disabled) {
       filter: brightness(0.95);

--- a/src/Components/Navbar/Navbar.scss
+++ b/src/Components/Navbar/Navbar.scss
@@ -74,6 +74,18 @@
   box-shadow: 0 2px 14px rgba(48, 56, 65, 0.07);
 }
 
+// On any light nav surface the vivid orange wordmark is only 2.72:1 (large text,
+// 3:1 bar): the desktop solid bar (incl. Home once scrolled) and the mobile bar
+// on non-hero pages (`nav--dark-links`). Use the AA on-light orange there; the
+// transparent-over-hero logo keeps $primary on its dark photo. Scoped through
+// `.prepify-logo.nav-link` to beat the base `.nav-logo` rule (0-3-0).
+.nav--solid,
+.nav--dark-links {
+  .prepify-logo.nav-link .nav-logo {
+    color: s.$primary-accessible;
+  }
+}
+
 // Condensed (scrolled) — slim the bar so the persistent search isn't a heavy
 // 100px footprint while reading. Desktop only (class set just for >725px).
 // Items shrink + recenter; the reserved page offset stays $nav-height, so a
@@ -150,10 +162,13 @@
   .beta-tag {
     text-transform: uppercase;
     font-size: 0.875rem;
-    background: s.$secondary;
+    // AA: light text on the vivid teal was 2.78:1; the on-light teal + white
+    // takes it to 5.27:1. (Cosmetic only — the tag is removed at the 1.0 cutover,
+    // but this keeps the binary color-contrast audit passing in the meantime.)
+    background: s.$secondary-accessible;
     padding: 0.25rem 0.5rem;
     border: none;
-    color: s.$primary-background;
+    color: s.$white;
     font-weight: 600;
     border-radius: 5px;
     -webkit-animation: breathing 5s ease-out infinite normal;

--- a/src/Components/Navbar/Navbar.tsx
+++ b/src/Components/Navbar/Navbar.tsx
@@ -40,6 +40,10 @@ const Navbar: FC<NavbarProps> = ({ darkNavLinks, navBackgroundColor }) => {
     `background-${navBackgroundColor}`,
     solid ? 'nav--solid' : '',
     condensed ? 'nav--condensed' : '',
+    // Light nav surface (non-hero pages) at any width — unlike `nav--solid`,
+    // which is desktop-only. Used to swap the logo to its AA on-light orange on
+    // the mobile bar too (the desktop bar is already covered by `nav--solid`).
+    darkNavLinks ? 'nav--dark-links' : '',
   ]
     .filter(Boolean)
     .join(' ')

--- a/src/Components/Navbar/desktop/DesktopNav.scss
+++ b/src/Components/Navbar/desktop/DesktopNav.scss
@@ -43,6 +43,10 @@
   --dnav-border: #{s.$gray-400};
   --dnav-hover: #{s.$gray-200};
   --dnav-active-bg: #{rgba(s.$primary, 0.12)};
+  // On the light solid surface the vivid brand orange as text/accent only hits
+  // ~3.1:1 (link labels, the Create accent) — use the AA on-light variant here.
+  // The transparent-over-hero nav keeps $primary (light text on a dark photo).
+  --dnav-accent: #{s.$primary-accessible};
 }
 
 // ---- search (always present, prominent) ----------------------------------
@@ -245,8 +249,11 @@
 }
 .dnav__cta--signup {
   color: #fff;
-  background: var(--dnav-accent);
-  border: 2px solid var(--dnav-accent);
+  // White on the vivid orange fill is only 3.16:1 in both nav states; the AA
+  // on-light orange takes it to 5.6:1. (Not var(--dnav-accent): the fill must be
+  // accessible over the transparent-hero nav too, where the accent stays vivid.)
+  background: s.$primary-accessible;
+  border: 2px solid s.$primary-accessible;
   &:hover {
     filter: brightness(1.07);
   }

--- a/src/helpers.scss
+++ b/src/helpers.scss
@@ -26,7 +26,12 @@ $gray-500: #bebebe;
 $gray-600: #a6a6a6;
 
 $success-green: #28a745;
-$error-red: #dc3545;
+// Darkened from #dc3545 (which failed WCAG AA as text on light surfaces — 3.9:1
+// on #eeeeee, 4.28:1 on the danger tint, and a razor-thin 4.53:1 even on white)
+// to the lightest red clearing 4.5:1 everywhere it's used: as text on white
+// 5.43:1 / #eeeeee 4.68:1 / danger tint 5.14:1, and as a fill under white text
+// 5.43:1. Used for inline validation + danger UI (alerts have their own tokens).
+$error-red: #c5303f;
 $error-red-hover: #b02a37;
 $warning-amber: #ffc107;
 

--- a/src/helpers.scss
+++ b/src/helpers.scss
@@ -1,5 +1,13 @@
 $primary: #ff5722; // Also located in TrendingRecipes.js
 $secondary: #00adb5;
+// Accessible (WCAG AA) variants of the brand colors, for the cases where the
+// brand color is small text on a light surface OR a fill behind white text —
+// both need 4.5:1, which #ff5722/#00adb5 miss (2.7–3.2:1). One shade covers
+// both cases per color (contrast is symmetric): as text on white/#eeeeee it's
+// 5.60/4.83 (orange) and 5.27/4.54 (teal); as a fill under white text, same.
+// Keep $primary/$secondary for large/decorative UI, icons, hovers, the logo.
+$primary-accessible: #bf360c;
+$secondary-accessible: #00787e;
 
 $primary-text: #303841;
 $secondary-text: #595f66;

--- a/src/pages/404/404.scss
+++ b/src/pages/404/404.scss
@@ -75,7 +75,7 @@
       font-weight: 500;
       color: s.$secondary-text;
       .contact-link {
-        color: s.$secondary;
+        color: s.$secondary-accessible;
       }
     }
     button.home-btn {

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -24,7 +24,7 @@
     letter-spacing: 0.16em;
     font-size: 0.6875rem;
     font-weight: 600;
-    color: s.$primary;
+    color: s.$primary-accessible;
     margin: 0 0 0.65rem;
   }
 
@@ -77,7 +77,7 @@
   }
 
   .about-btn-primary {
-    background-color: s.$primary;
+    background-color: s.$primary-accessible;
     color: s.$white;
     box-shadow: 0 6px 16px rgba(255, 87, 34, 0.22);
 
@@ -181,7 +181,7 @@
     position: absolute;
     top: 0.65rem;
     left: 0.65rem;
-    background-color: s.$primary;
+    background-color: s.$primary-accessible;
     color: s.$white;
     font-weight: 700;
     font-size: 0.8125rem;

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -302,7 +302,7 @@
       color: s.$primary-text;
     }
     &.active {
-      color: s.$primary;
+      color: s.$primary-accessible;
       background: rgba(s.$primary, 0.1);
     }
 
@@ -324,7 +324,7 @@
       padding: 0.1rem 0.5rem;
     }
     &.active .acct-seg-count {
-      color: s.$primary;
+      color: s.$primary-accessible;
       background: rgba(s.$primary, 0.15);
     }
 

--- a/src/pages/Account/Drafts/Drafts.scss
+++ b/src/pages/Account/Drafts/Drafts.scss
@@ -128,7 +128,7 @@
         padding: 0.55rem 1rem;
         border-radius: 10px;
         border: none;
-        background: s.$primary;
+        background: s.$primary-accessible;
         color: #fff;
         transition: background 0.14s ease, box-shadow 0.14s ease;
         svg {

--- a/src/pages/AddRecipe/AddRecipe.scss
+++ b/src/pages/AddRecipe/AddRecipe.scss
@@ -89,7 +89,7 @@
         margin-bottom: 1rem;
 
         .text {
-          color: s.$primary;
+          color: s.$primary-accessible;
           font-weight: 700;
           font-size: 1rem;
           text-transform: uppercase;

--- a/src/pages/AddRecipe/DraftResumeBanner.scss
+++ b/src/pages/AddRecipe/DraftResumeBanner.scss
@@ -78,8 +78,10 @@
       white-space: nowrap;
       padding: 0.4rem 0.9rem;
       border-radius: s.$border-radius;
-      border: 1px solid s.$primary;
-      background: s.$primary;
+      // AA on-light orange so the white label clears 4.5:1 (vivid #ff5722 fill
+      // is only 3.16:1). brightness() hover stays above AA.
+      border: 1px solid s.$primary-accessible;
+      background: s.$primary-accessible;
       color: s.$white;
       transition: filter 0.1s linear;
 

--- a/src/pages/Home/Home.scss
+++ b/src/pages/Home/Home.scss
@@ -32,7 +32,7 @@
       grid-area: see;
       align-self: end;
       display: inline-flex; align-items: center; gap: 0.2rem;
-      text-decoration: none; color: s.$primary; font-weight: 700; font-size: 0.95rem;
+      text-decoration: none; color: s.$primary-accessible; font-weight: 700; font-size: 0.95rem;
       white-space: nowrap;
       &:hover { text-decoration: underline; }
     }
@@ -111,7 +111,7 @@
       padding-bottom: 0.6rem;
       border-bottom: 2px solid s.$primary;
       h3 { font-size: 1.1rem; font-weight: 700; }
-      .meal-see-all { font-size: 0.82rem; font-weight: 700; color: s.$primary; text-decoration: none; &:hover { text-decoration: underline; } }
+      .meal-see-all { font-size: 0.82rem; font-weight: 700; color: s.$primary-accessible; text-decoration: none; &:hover { text-decoration: underline; } }
     }
     ul { list-style: none; }
     li + li { margin-top: 0.5rem; }

--- a/src/pages/Home/HomeCookSuggestion.scss
+++ b/src/pages/Home/HomeCookSuggestion.scss
@@ -102,7 +102,7 @@
     margin-bottom: 0.95rem;
     overflow: hidden;
     span { display: inline-flex; align-items: center; gap: 0.25rem; white-space: nowrap; }
-    .cuisine { color: s.$primary; font-weight: 600; overflow: hidden; text-overflow: ellipsis; }
+    .cuisine { color: s.$primary-accessible; font-weight: 600; overflow: hidden; text-overflow: ellipsis; }
   }
   .actions { display: flex; gap: 0.6rem; }
   // skeleton stand-ins for the two action buttons
@@ -124,7 +124,7 @@
     transition: filter 0.12s ease, background 0.12s ease;
     svg { font-size: 1.1rem; }
   }
-  .primary { background: s.$primary; color: #fff; &:hover { filter: brightness(1.06); } }
+  .primary { background: s.$primary-accessible; color: #fff; &:hover { filter: brightness(1.06); } }
   .ghost {
     background: #f0f1f3;
     color: s.$primary-text;

--- a/src/pages/Home/HomeHero/HomeHero.scss
+++ b/src/pages/Home/HomeHero/HomeHero.scss
@@ -61,7 +61,7 @@
     padding: 0.7rem 1.4rem;
     border: none;
     border-radius: 999px;
-    background: s.$primary;
+    background: s.$primary-accessible;
     color: s.$white;
     font-size: 1rem;
     font-weight: 600;

--- a/src/pages/PublicProfile/PublicProfile.scss
+++ b/src/pages/PublicProfile/PublicProfile.scss
@@ -162,8 +162,11 @@
     .pp-lvl {
       font-size: 0.76rem;
       font-weight: 800;
-      color: s.$primary;
-      background: rgba(s.$primary, 0.1);
+      color: s.$primary-accessible;
+      // Solid (not a translucent brand tint): the tint composited against the
+      // header surface to ~#f0dfda, dropping the accessible orange to 4.34:1.
+      // This pale solid keeps the same look at a deterministic 5.1:1.
+      background: #fff2ed;
       border-radius: 999px;
       padding: 0.12rem 0.55rem;
     }

--- a/src/pages/Recipes/Recipes.scss
+++ b/src/pages/Recipes/Recipes.scss
@@ -324,7 +324,7 @@
       border-radius: 999px;
       transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
       &--primary {
-        background: s.$primary;
+        background: s.$primary-accessible;
         color: s.$white;
         &:hover {
           filter: brightness(1.07);
@@ -336,7 +336,7 @@
         border: 1px solid s.$gray-400;
         &:hover {
           border-color: s.$primary;
-          color: s.$primary;
+          color: s.$primary-accessible;
         }
       }
     }
@@ -427,7 +427,7 @@
     &__apply {
       flex: 1;
       border: none;
-      background: s.$primary;
+      background: s.$primary-accessible;
       color: s.$white;
       font-weight: 700;
       padding: 0.75rem;
@@ -451,11 +451,11 @@
     transition: all 0.12s ease;
     &:hover {
       border-color: s.$primary;
-      color: s.$primary;
+      color: s.$primary-accessible;
     }
     &.is-active {
-      background: s.$primary;
-      border-color: s.$primary;
+      background: s.$primary-accessible;
+      border-color: s.$primary-accessible;
       color: s.$white;
     }
   }

--- a/src/pages/Settings/Settings.scss
+++ b/src/pages/Settings/Settings.scss
@@ -77,7 +77,8 @@
     }
     &.active {
       background: rgba(s.$secondary, 0.12);
-      color: #057780;
+      // Darker teal: the prior #057780 hit only 4.09:1 on the teal active tint.
+      color: #006065;
     }
     &.danger {
       color: s.$error-red;

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -77,7 +77,7 @@ $danger: #d23f31;
       font-weight: 700;
       letter-spacing: 0.15em;
       text-transform: uppercase;
-      color: s.$secondary;
+      color: s.$secondary-accessible;
     }
     .description { color: s.$secondary-text; line-height: 1.7; font-size: 1rem; }
     // Compact rating echo by the title (see SingleRecipe.tsx). Pulled snug under
@@ -149,7 +149,7 @@ $danger: #d23f31;
     .m-v { font-weight: 800; font-size: 1.1rem; }
     // cost tile: the per-serving price is a headline number, so color it brand
     // primary to pull the eye — this is the "make pricing prominent" beat
-    .m-cost .m-v { color: s.$primary; }
+    .m-cost .m-v { color: s.$primary-accessible; }
     .m-l {
       font-size: 0.72rem;
       color: s.$tertiary-text;
@@ -184,14 +184,16 @@ $danger: #d23f31;
       &:focus-visible { @include s.outline(); }
     }
     .save-recipe-btn {
-      background: s.$primary;
-      border-color: s.$primary;
+      // AA on-light brand fills (white text needs 4.5:1; vivid #ff5722/#00adb5
+      // give only ~3:1). Hovers darken one step further, still AA.
+      background: s.$primary-accessible;
+      border-color: s.$primary-accessible;
       color: s.$white;
-      &:hover { background: #e74e1d; border-color: #e74e1d; }
+      &:hover { background: #a52f0a; border-color: #a52f0a; }
       &.is-saved {
-        background: s.$secondary;
-        border-color: s.$secondary;
-        &:hover { background: #009aa1; border-color: #009aa1; }
+        background: s.$secondary-accessible;
+        border-color: s.$secondary-accessible;
+        &:hover { background: #006065; border-color: #006065; }
       }
     }
     .print-recipe-btn .loading {
@@ -333,7 +335,7 @@ $danger: #d23f31;
       margin-top: 1rem;
       font-size: 0.88rem;
       color: s.$tertiary-text;
-      strong { color: s.$primary; }
+      strong { color: s.$primary-accessible; }
     }
   }
 


### PR DESCRIPTION
## Brand-color contrast + nav-logo + beta-tag → **Lighthouse a11y 100**

Closes the contrast work from the a11y sweep (after #179 structural + #181 muted-grey). Brand orange `#ff5722` / teal `#00adb5` failed AA as small text on light surfaces and as fills behind white text (2.4–3.2:1); the nav-logo and beta-tag failed too. With all of them fixed, **Lighthouse a11y is now 100 on every route except Settings-danger** (the filed `$error-red` item).

### Approach
On-light brand variants, each covering *both* text and white-on-fill (contrast is symmetric):
- `$primary-accessible: #bf360c` — orange, **5.60** / **4.83** (white / `#eeeeee`)
- `$secondary-accessible: #00787e` — teal, **5.27** / **4.54**

Swapped **only the ~25 failing selectors** — the 305 other `$primary` uses (large text, icons, borders, hovers) keep the vivid identity color.

<details><summary>Selectors changed</summary>

Desktop nav signup CTA + solid-nav accent · home see-all / meal-see-all / cook-suggestion button + modal · recipe eyebrow / price / cost / save buttons · about eyebrows / primary button / card price · profile level pill · auth form buttons · recipes filter drawer apply + chips + empty-state buttons · 404 contact link · logged-in Account active seg label+count, Settings active nav label, Drafts resume, Add-Recipe section labels, EmptyState CTA, draft-resume banner.

On-tint cases: `.pp-lvl` → solid `#fff2ed` pill (the translucent tint composited too dark); active Settings nav label → darker `#006065`.
</details>

### Nav-logo + beta-tag (owner-approved, the score-unlock)
- **Nav-logo** — the orange "Prepify" wordmark was 2.72:1 on light nav surfaces (large text, 3:1 bar). Now uses `$primary-accessible` on the desktop solid bar (`.nav--solid`, incl. Home once scrolled) **and** the mobile bar on non-hero pages (new `.nav--dark-links` class — `.nav--solid` is desktop-only, and **Lighthouse a11y emulates a mobile device**). Transparent-over-hero logo keeps vivid `#ff5722`.
- **Beta-tag** — recoloured light-on-`#00adb5` (2.78:1) → white-on-`#00787e` (5.27:1). It sits in the nav on **every** page, so the binary `color-contrast` audit had been failing site-wide purely because of it — **this is what unpins the Lighthouse score.** Cosmetic only; the Phase-5 cutover still removes the tag.

### Result — Lighthouse a11y
| | Before sweep | After |
|---|---|---|
| Logged-out (12 routes) | 80s–95 | **100** |
| Logged-in (10 routes) | 84–92 | **100** |

**Lighthouse a11y = 100 on all 22 routes.**

Verified via axe-core + Lighthouse on every page-load route (logged-out + logged-in via the Cypress token bridge) and the key interactive surfaces (filter drawer, cook modal, reviews). Mobile nav visually reviewed — logo + beta-tag read clearly, still on-brand.

### Shared `$error-red` token darkened (owner-approved)
`$error-red #dc3545` failed AA as text on light surfaces (3.9:1 on `#eeeeee`, 4.28 on the danger tint, a thin 4.53 even on white). Darkened to **`#c5303f`** — lightest red clearing 4.5:1 everywhere it's used (text 5.43/4.68/5.14, white-on-fill 5.43). Safe across all 13 usages (text/fill/border each gain contrast); alert boxes untouched (own `#721c24` token). Took the last route (Settings-danger) to 100. Danger zone + inline validation visually re-checked.

### Gates
`tsc --noEmit` clean · **516 Vitest pass** · `npm run build` clean. (SCSS + one 1-line Navbar.tsx class.)
