### PR TITLE
style(tokens): wire token-less files into helpers (radius + white)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -411,12 +411,19 @@ The triage date stamped on items is the date they were filed here, not when they
 - `[ ]` **One danger-red token** — three reds mean the same thing: `$error-red #dc3545` (token), local
   `$danger #d23f31` (`SingleRecipe.scss`), and `#d64545` (`ReportControl`/`Reports`). Consolidate onto the
   token. *(audit F6; surfaced 2026-06-25 in the design-consistency sweep.)*
-- `[ ]` **Name the admin/“cool” sub-palette and wire the token-less files into `helpers.scss`** — Admin +
+- `[~]` **Name the admin/“cool” sub-palette and wire the token-less files into `helpers.scss`** — Admin +
   moderation surfaces hardcode a Tailwind-ish slate/blue palette (`#3b82f6`/`#2563eb` action blue exists
-  nowhere in the brand) and several files (`Admin/*`, `ReportControl`, `SavedFilterBar`,
-  `AdminRecipeControls`, `AccountStatusBanner`, `Layout`) `@use` nothing at all (audit F1/F2). Define a
-  documented `$admin-*` token group and migrate the literals so the warm/cool split is a decision, not 200+
-  loose hexes. *(surfaced 2026-06-25 in the design-consistency sweep; the bulk of the remaining token work.)*
+  nowhere in the brand) and several files `@use` nothing at all (audit F1/F2).
+    - `[x]` **Import-wiring + value-identical repoints** — DONE 2026-06-25 (PR `style/admin-token-wiring`).
+      Added `@use helpers as s` to the 10 token-less files that had a value-identical win and repointed their
+      radii (radius scale) and `#fff`/`#ffffff` → `$white` (compiled CSS byte-identical). The bespoke admin
+      palette in those files was deliberately left raw.
+    - **Remaining (the brand decision):** define a documented `$admin-*` token group for the slate/blue/
+      green/amber/red ramps and migrate the literals so the warm/cool split is a decision, not 200+ loose
+      hexes. Five files stay fully token-less because they hold *only* bespoke-palette values
+      (`RecipePlaceholder`, `ClassifierNote`, `AccountStatusBanner`, `DefaultAvatar`,
+      `AddRecipe/ListComponents/Item`) — they get wired when the `$admin-*` group lands.
+  *(surfaced 2026-06-25 in the design-consistency sweep; import-wiring applied, palette naming deferred.)*
 - `[ ]` **`RecipeFormInput` duplicates the shared `FormInput`** — AddRecipe ships its own ~85%-identical
   input/textarea (`RecipeFormInput`/`RecipeFormTextArea`) instead of the shared `Components/Form/FormInput`,
   and Settings/BugReport use raw `<input>`/`<textarea>`/`<select>`. Converge on one input primitive.

--- a/src/Components/AdminRecipeControls/AdminRecipeControls.scss
+++ b/src/Components/AdminRecipeControls/AdminRecipeControls.scss
@@ -1,3 +1,5 @@
+@use '../../helpers.scss' as s;
+
 .admin-recipe-controls {
   display: flex;
   align-items: center;
@@ -6,7 +8,7 @@
   margin: 1rem 0;
   padding: 0.6rem 0.8rem;
   border: 1px dashed #c7b3e6;
-  border-radius: 8px;
+  border-radius: s.$radius-md;
   background: #faf7ff;
 
   .arc-label {
@@ -17,7 +19,7 @@
     color: #6b21a8;
     background: #ede4fb;
     padding: 0.15rem 0.45rem;
-    border-radius: 4px;
+    border-radius: s.$radius-xs;
   }
 
   .arc-pill {
@@ -26,7 +28,7 @@
     text-transform: uppercase;
     letter-spacing: 0.03em;
     padding: 0.15rem 0.45rem;
-    border-radius: 4px;
+    border-radius: s.$radius-xs;
 
     &.hidden {
       background: #fee2e2;
@@ -58,12 +60,12 @@
 
   .arc-btn {
     cursor: pointer;
-    border-radius: 6px;
+    border-radius: s.$radius-sm;
     padding: 0.4rem 0.85rem;
     font-size: 0.82rem;
     font-weight: 600;
     border: 1px solid #d1d5db;
-    background: #fff;
+    background: s.$white;
     color: #374151;
     transition: all 0.15s;
 
@@ -91,7 +93,7 @@
     &.approve {
       border-color: #15803d;
       background: #16a34a;
-      color: #fff;
+      color: s.$white;
 
       &:hover:not(:disabled) {
         background: #15803d;

--- a/src/Components/AppErrorFallback/AppErrorFallback.scss
+++ b/src/Components/AppErrorFallback/AppErrorFallback.scss
@@ -1,10 +1,12 @@
+@use '../../helpers.scss' as s;
+
 .app-error-fallback {
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 2rem;
-  background: #fff;
+  background: s.$white;
 
   .app-error-content {
     max-width: 480px;
@@ -33,16 +35,16 @@
         align-items: center;
         justify-content: center;
         padding: 0.65rem 1.25rem;
-        border-radius: 8px;
+        border-radius: s.$radius-md;
         border: none;
         cursor: pointer;
         font-weight: 600;
         text-decoration: none;
         background: #1f2430;
-        color: #fff;
+        color: s.$white;
 
         &.secondary {
-          background: #fff;
+          background: s.$white;
           color: #1f2430;
           border: 1px solid #d1d5db;
         }

--- a/src/Components/SavedFilters/SavedFilterBar.scss
+++ b/src/Components/SavedFilters/SavedFilterBar.scss
@@ -1,3 +1,5 @@
+@use '../../helpers.scss' as s;
+
 .saved-filter-bar {
   display: flex;
   align-items: center;
@@ -15,8 +17,8 @@
     display: inline-flex;
     align-items: center;
     border: 1px solid #d8dbe0;
-    background: #fff;
-    border-radius: 999px;
+    background: s.$white;
+    border-radius: s.$radius-pill;
     overflow: hidden;
 
     .preset-apply {
@@ -49,10 +51,10 @@
 
   .preset-save {
     border: 1px dashed #cbd2da;
-    background: #fff;
+    background: s.$white;
     color: #6b7280;
     padding: 0.3rem 0.7rem;
-    border-radius: 999px;
+    border-radius: s.$radius-pill;
     font-size: 0.8rem;
     cursor: pointer;
 

--- a/src/pages/Admin/AdminLayout.scss
+++ b/src/pages/Admin/AdminLayout.scss
@@ -1,3 +1,5 @@
+@use '../../helpers.scss' as s;
+
 .admin-layout {
   display: flex;
   min-height: 100vh;
@@ -21,7 +23,7 @@
       font-size: 1.15rem;
 
       a {
-        color: #fff;
+        color: s.$white;
         text-decoration: none;
       }
 
@@ -31,9 +33,9 @@
         text-transform: uppercase;
         letter-spacing: 0.05em;
         background: #3b82f6;
-        color: #fff;
+        color: s.$white;
         padding: 0.15rem 0.4rem;
-        border-radius: 4px;
+        border-radius: s.$radius-xs;
       }
     }
 
@@ -46,18 +48,18 @@
         color: #b9bec9;
         text-decoration: none;
         padding: 0.5rem 0.75rem;
-        border-radius: 6px;
+        border-radius: s.$radius-sm;
         font-size: 0.95rem;
         transition: background 0.15s, color 0.15s;
 
         &:hover {
           background: rgba(255, 255, 255, 0.06);
-          color: #fff;
+          color: s.$white;
         }
 
         &.active {
           background: #3b82f6;
-          color: #fff;
+          color: s.$white;
         }
       }
     }

--- a/src/pages/Admin/Analytics/Analytics.scss
+++ b/src/pages/Admin/Analytics/Analytics.scss
@@ -1,3 +1,5 @@
+@use '../../../helpers.scss' as s;
+
 .admin-analytics {
   max-width: 960px;
 
@@ -37,10 +39,10 @@
 
     .range {
       border: 1px solid #d8dbe0;
-      background: #fff;
+      background: s.$white;
       color: #4b5563;
       padding: 0.35rem 0.75rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       font-size: 0.82rem;
       cursor: pointer;
       transition: all 0.15s;
@@ -52,7 +54,7 @@
       &.active {
         background: #1f2430;
         border-color: #1f2430;
-        color: #fff;
+        color: s.$white;
       }
     }
   }
@@ -85,9 +87,9 @@
       display: flex;
       flex-direction: column;
       gap: 0.2rem;
-      background: #fff;
+      background: s.$white;
       border: 1px solid #e5e7eb;
-      border-radius: 10px;
+      border-radius: s.$radius-lg;
       padding: 1rem 1.1rem;
 
       .stat-value {
@@ -128,9 +130,9 @@
     margin-bottom: 1.75rem;
 
     .trend-card {
-      background: #fff;
+      background: s.$white;
       border: 1px solid #e5e7eb;
-      border-radius: 10px;
+      border-radius: s.$radius-lg;
       padding: 1rem 1.1rem;
 
       h2 {
@@ -191,9 +193,9 @@
   }
 
   .recent-actions {
-    background: #fff;
+    background: s.$white;
     border: 1px solid #e5e7eb;
-    border-radius: 10px;
+    border-radius: s.$radius-lg;
     padding: 1rem 1.25rem;
 
     h2 {
@@ -224,7 +226,7 @@
       .dot {
         width: 9px;
         height: 9px;
-        border-radius: 50%;
+        border-radius: s.$radius-circle;
         margin-top: 0.35rem;
         flex-shrink: 0;
         background: #9ca3af;

--- a/src/pages/Admin/Audit/Audit.scss
+++ b/src/pages/Admin/Audit/Audit.scss
@@ -1,3 +1,5 @@
+@use '../../../helpers.scss' as s;
+
 .admin-audit {
   max-width: 820px;
 
@@ -18,7 +20,7 @@
       color: #4b5563;
       background: #f3f4f6;
       padding: 0.2rem 0.55rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
     }
   }
 
@@ -31,10 +33,10 @@
 
     .action-select {
       border: 1px solid #d8dbe0;
-      background: #fff;
+      background: s.$white;
       color: #374151;
       padding: 0.4rem 0.7rem;
-      border-radius: 8px;
+      border-radius: s.$radius-md;
       font-size: 0.85rem;
       cursor: pointer;
     }
@@ -46,10 +48,10 @@
 
       .tab {
         border: 1px solid #d8dbe0;
-        background: #fff;
+        background: s.$white;
         color: #4b5563;
         padding: 0.35rem 0.8rem;
-        border-radius: 999px;
+        border-radius: s.$radius-pill;
         font-size: 0.82rem;
         cursor: pointer;
         transition: all 0.15s;
@@ -61,7 +63,7 @@
         &.active {
           background: #1f2430;
           border-color: #1f2430;
-          color: #fff;
+          color: s.$white;
         }
       }
     }
@@ -93,7 +95,7 @@
     .dot {
       width: 9px;
       height: 9px;
-      border-radius: 50%;
+      border-radius: s.$radius-circle;
       margin-top: 0.4rem;
       flex-shrink: 0;
       background: #9ca3af;
@@ -157,10 +159,10 @@
 
     button {
       border: 1px solid #d8dbe0;
-      background: #fff;
+      background: s.$white;
       color: #374151;
       padding: 0.4rem 0.9rem;
-      border-radius: 8px;
+      border-radius: s.$radius-md;
       cursor: pointer;
 
       &:disabled {

--- a/src/pages/Admin/BugReports/BugReports.scss
+++ b/src/pages/Admin/BugReports/BugReports.scss
@@ -1,3 +1,5 @@
+@use '../../../helpers.scss' as s;
+
 .admin-bug-reports {
   max-width: 820px;
 
@@ -18,7 +20,7 @@
       color: #b45309;
       background: #fef3c7;
       padding: 0.2rem 0.55rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
     }
   }
 
@@ -31,10 +33,10 @@
 
     .tab {
       border: 1px solid #d8dbe0;
-      background: #fff;
+      background: s.$white;
       color: #4b5563;
       padding: 0.4rem 0.9rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       font-size: 0.85rem;
       cursor: pointer;
       transition: all 0.15s;
@@ -46,17 +48,17 @@
       &.active {
         background: #1f2430;
         border-color: #1f2430;
-        color: #fff;
+        color: s.$white;
       }
     }
 
     .category-select {
       margin-left: auto;
       border: 1px solid #d8dbe0;
-      background: #fff;
+      background: s.$white;
       color: #374151;
       padding: 0.4rem 0.7rem;
-      border-radius: 8px;
+      border-radius: s.$radius-md;
       font-size: 0.85rem;
       cursor: pointer;
     }
@@ -81,7 +83,7 @@
     padding: 0.6rem 0.9rem;
     background: #f9fafb;
     border: 1px solid #e5e7eb;
-    border-radius: 8px;
+    border-radius: s.$radius-md;
 
     .bulk-select-all {
       display: flex;
@@ -98,7 +100,7 @@
 
       .action {
         cursor: pointer;
-        border-radius: 6px;
+        border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
         font-size: 0.82rem;
         font-weight: 600;
@@ -113,11 +115,11 @@
         &.resolve {
           background: #16a34a;
           border-color: #16a34a;
-          color: #fff;
+          color: s.$white;
         }
 
         &.dismiss {
-          background: #fff;
+          background: s.$white;
           border-color: #d1d5db;
           color: #6b7280;
         }
@@ -143,9 +145,9 @@
   }
 
   .bug-report-card {
-    background: #fff;
+    background: s.$white;
     border: 1px solid #e5e7eb;
-    border-radius: 10px;
+    border-radius: s.$radius-lg;
     padding: 1.1rem 1.25rem;
     display: flex;
     justify-content: space-between;
@@ -168,7 +170,7 @@
         text-transform: uppercase;
         letter-spacing: 0.03em;
         padding: 0.15rem 0.45rem;
-        border-radius: 4px;
+        border-radius: s.$radius-xs;
       }
 
       .category-pill {
@@ -227,7 +229,7 @@
         color: #4b5563;
         background: #f3f4f6;
         padding: 0.1rem 0.4rem;
-        border-radius: 4px;
+        border-radius: s.$radius-xs;
         max-width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -258,7 +260,7 @@
 
       .action {
         cursor: pointer;
-        border-radius: 6px;
+        border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
         font-size: 0.82rem;
         font-weight: 600;
@@ -271,13 +273,13 @@
         }
 
         &.resolve {
-          background: #fff;
+          background: s.$white;
           border-color: #16a34a;
           color: #16a34a;
         }
 
         &.dismiss {
-          background: #fff;
+          background: s.$white;
           border-color: #d1d5db;
           color: #6b7280;
         }
@@ -311,9 +313,9 @@
       .page-btn {
         cursor: pointer;
         border: 1px solid #d8dbe0;
-        background: #fff;
+        background: s.$white;
         color: #374151;
-        border-radius: 6px;
+        border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
         font-size: 0.82rem;
         font-weight: 600;

--- a/src/pages/Admin/Reports/Reports.scss
+++ b/src/pages/Admin/Reports/Reports.scss
@@ -1,3 +1,5 @@
+@use '../../../helpers.scss' as s;
+
 .admin-reports {
   max-width: 820px;
 
@@ -18,7 +20,7 @@
       color: #b45309;
       background: #fef3c7;
       padding: 0.2rem 0.55rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
     }
   }
 
@@ -29,10 +31,10 @@
 
     .tab {
       border: 1px solid #d8dbe0;
-      background: #fff;
+      background: s.$white;
       color: #4b5563;
       padding: 0.4rem 0.9rem;
-      border-radius: 999px;
+      border-radius: s.$radius-pill;
       font-size: 0.85rem;
       cursor: pointer;
       transition: all 0.15s;
@@ -44,7 +46,7 @@
       &.active {
         background: #1f2430;
         border-color: #1f2430;
-        color: #fff;
+        color: s.$white;
       }
     }
   }
@@ -68,7 +70,7 @@
     padding: 0.6rem 0.9rem;
     background: #f9fafb;
     border: 1px solid #e5e7eb;
-    border-radius: 8px;
+    border-radius: s.$radius-md;
 
     .bulk-select-all {
       display: flex;
@@ -85,7 +87,7 @@
 
       .action {
         cursor: pointer;
-        border-radius: 6px;
+        border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
         font-size: 0.82rem;
         font-weight: 600;
@@ -100,11 +102,11 @@
         &.resolve {
           background: #16a34a;
           border-color: #16a34a;
-          color: #fff;
+          color: s.$white;
         }
 
         &.dismiss {
-          background: #fff;
+          background: s.$white;
           border-color: #d1d5db;
           color: #6b7280;
         }
@@ -130,9 +132,9 @@
   }
 
   .report-card {
-    background: #fff;
+    background: s.$white;
     border: 1px solid #e5e7eb;
-    border-radius: 10px;
+    border-radius: s.$radius-lg;
     padding: 1.1rem 1.25rem;
     display: flex;
     justify-content: space-between;
@@ -158,7 +160,7 @@
         text-transform: uppercase;
         letter-spacing: 0.03em;
         padding: 0.15rem 0.45rem;
-        border-radius: 4px;
+        border-radius: s.$radius-xs;
       }
 
       .type-pill {
@@ -219,7 +221,7 @@
         width: 56px;
         height: 56px;
         object-fit: cover;
-        border-radius: 6px;
+        border-radius: s.$radius-sm;
         flex-shrink: 0;
       }
 
@@ -260,7 +262,7 @@
       background: #fee2e2;
       color: #991b1b;
       padding: 0.1rem 0.35rem;
-      border-radius: 4px;
+      border-radius: s.$radius-xs;
     }
 
     .preview-missing {
@@ -289,7 +291,7 @@
 
       .action {
         cursor: pointer;
-        border-radius: 6px;
+        border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
         font-size: 0.82rem;
         font-weight: 600;
@@ -303,24 +305,24 @@
 
         &.takedown {
           background: #d64545;
-          color: #fff;
+          color: s.$white;
         }
 
         &.restore,
         &.approve {
           background: #16a34a;
           border-color: #16a34a;
-          color: #fff;
+          color: s.$white;
         }
 
         &.resolve {
-          background: #fff;
+          background: s.$white;
           border-color: #16a34a;
           color: #16a34a;
         }
 
         &.dismiss {
-          background: #fff;
+          background: s.$white;
           border-color: #d1d5db;
           color: #6b7280;
         }

--- a/src/pages/Admin/Users/Users.scss
+++ b/src/pages/Admin/Users/Users.scss
@@ -1,3 +1,5 @@
+@use '../../../helpers.scss' as s;
+
 .admin-users {
   max-width: 820px;
 
@@ -18,16 +20,16 @@
     input {
       flex: 1;
       border: 1px solid #d8dbe0;
-      border-radius: 8px;
+      border-radius: s.$radius-md;
       padding: 0.55rem 0.8rem;
       font-size: 0.9rem;
     }
 
     .clear-btn {
       border: 1px solid #d8dbe0;
-      background: #fff;
+      background: s.$white;
       color: #4b5563;
-      border-radius: 8px;
+      border-radius: s.$radius-md;
       padding: 0.55rem 1.1rem;
       font-size: 0.9rem;
       font-weight: 600;
@@ -54,9 +56,9 @@
 
     button {
       border: 1px solid #d8dbe0;
-      background: #fff;
+      background: s.$white;
       color: #374151;
-      border-radius: 8px;
+      border-radius: s.$radius-md;
       padding: 0.45rem 1rem;
       font-size: 0.85rem;
       font-weight: 600;
@@ -97,9 +99,9 @@
   }
 
   .user-card {
-    background: #fff;
+    background: s.$white;
     border: 1px solid #e5e7eb;
-    border-radius: 10px;
+    border-radius: s.$radius-lg;
     padding: 1.1rem 1.25rem;
     display: flex;
     justify-content: space-between;
@@ -133,7 +135,7 @@
       text-transform: uppercase;
       letter-spacing: 0.03em;
       padding: 0.15rem 0.45rem;
-      border-radius: 4px;
+      border-radius: s.$radius-xs;
       background: #dcfce7;
       color: #166534;
 
@@ -182,20 +184,20 @@
       select,
       .reason-input {
         border: 1px solid #d8dbe0;
-        border-radius: 6px;
+        border-radius: s.$radius-sm;
         padding: 0.35rem 0.5rem;
         font-size: 0.82rem;
       }
 
       .apply-btn {
         cursor: pointer;
-        border-radius: 6px;
+        border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
         font-size: 0.82rem;
         font-weight: 600;
         border: 1px solid #1f2430;
         background: #1f2430;
-        color: #fff;
+        color: s.$white;
 
         &:disabled {
           opacity: 0.5;

--- a/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.scss
+++ b/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.scss
@@ -1,3 +1,5 @@
+@use '../../../helpers.scss' as s;
+
 // Dedicated print-only layout for a recipe. Hidden on screen; react-to-print
 // clones this subtree into an isolated iframe and prints it, so the styles here
 // are fully decoupled from the on-screen SingleRecipe design.
@@ -13,7 +15,7 @@
 .printable-recipe {
   box-sizing: border-box;
   color: #000;
-  background: #fff;
+  background: s.$white;
   font-family: Georgia, 'Times New Roman', serif;
   line-height: 1.45;
   font-size: 12pt;


### PR DESCRIPTION
## What

Extends the radius scale (PR #183) into the admin/moderation surfaces that previously `@use`'d nothing. Adds `@use 'helpers' as s` to the **10 token-less SCSS files that had a value-identical win**, and repoints:
- on-scale `border-radius` → the radius scale (`$radius-xs..4xl`, `$radius-pill`, `$radius-circle`)
- `#fff` / `#ffffff` → `$white`

Files touched: `Admin/{AdminLayout,Analytics,Audit,BugReports,Reports,Users}`, `AdminRecipeControls`, `AppErrorFallback`, `SavedFilterBar`, `PrintableRecipe`.

## Polish only — provably no visual change
Compiled the full CSS bundle on `development` vs. this branch:

```
before: 200311 bytes   after: 200311 bytes   →  diff = IDENTICAL (byte-for-byte)
```

`$white` serializes to `rgb(255,255,255)`, but Vite's CSS minifier canonicalizes that back to `#fff`, so the output is byte-identical — not just value-identical.

## Deliberately left raw (the deferred brand decision)
The bespoke admin palette — Tailwind-ish slate (`#9ca3af`/`#374151`/`#6b7280`…), action blue (`#3b82f6`/`#2563eb`, which exists nowhere in the brand), and the admin green/amber/red ramps — has **no matching brand token**, so naming it (`$admin-*`) is a design call and stays in `docs/BACKLOG.md`. The 5 files that hold *only* palette values (`RecipePlaceholder`, `ClassifierNote`, `AccountStatusBanner`, `DefaultAvatar`, `AddRecipe/ListComponents/Item`) remain token-less until that group lands.

### Watch-out handled
Every `white` keyword in these files was `white-space: nowrap`, **not** a color — none were touched. Longer hex like `#fff3ee` (a warm tint) was excluded from the `#fff`→`$white` repoint via lookahead.

## Gates
- `npx tsc --noEmit` → exit 0
- `npm run build` → clean (no Sass warnings)
- `npm test` → 516 passed / 2 skipped (71 files)