### PR TITLE
style(tokens): breakpoint scale + below/above/between mixins

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -398,8 +398,13 @@ The triage date stamped on items is the date they were filed here, not when they
       ~40 other `box-shadow`s are nearly all unique and need a re-authored scale (`$shadow-card`/`-hover`/
       `-glow-primary`), e.g. the avatar-glow `rgba(255,87,34,0.18)` repeated in Account + PublicProfile
       (audit F5) — a re-author, not a pixel-identical repoint.
-    - **Breakpoint tokens/mixin** — no shared breakpoints; ~77 ad-hoc media queries repeat 725px (navbar
-      flip), 768px, 600px, 560px, 640px… Add a `$bp-*` set or a `respond-to()` mixin and converge.
+    - `[x]` **Breakpoint tokens/mixin** — DONE 2026-06-25 (PR `style/breakpoint-tokens`). Added an 8-tier
+      `$bp-xs..4xl` scale + `$bp-nav`/`$bp-nav-up` and `below()`/`above()`/`between()` mixins; migrated all 69
+      width queries. The recurring content breakpoints converged to tiers (7 approved small shifts ≤30px:
+      350→375, 420/460/480→450, 550→560, 650→640, 880→900); tuned one-offs (recipe page 700/720/820,
+      isolated 500/520, Home 850/851 boundary pair) and the DesktopNav 860/1000/1080/1240 cascade pass
+      literal px to the mixins and keep their exact values. **Remaining (design call):** converge those
+      deliberately-bespoke one-offs into the scale if/when their layouts are retuned.
   *(surfaced 2026-06-25 in the design-consistency sweep; cheap wins + radius/recurring-shadow scales applied,
   type scale + full elevation re-author deferred.)*
 - `[ ]` **Collapse near-duplicate brand shades to one value** — now that `$primary-hover` exists, the

--- a/src/Components/Footer/Footer.scss
+++ b/src/Components/Footer/Footer.scss
@@ -38,7 +38,7 @@ $inner-max: s.$max-width;
     // stretching across the full half.
     grid-template-columns: 1.6fr 1.4fr;
     gap: 3rem;
-    @media (max-width: 768px) {
+    @include s.below(s.$bp-2xl) {
       grid-template-columns: 1fr;
       gap: 2rem;
     }
@@ -86,11 +86,11 @@ $inner-max: s.$max-width;
   // fixed band — moderate, even gaps at every screen size — pinned to the right.
   width: min(520px, 100%);
   margin-left: auto;
-  @media (max-width: 768px) {
+  @include s.below(s.$bp-2xl) {
     width: 100%;
     margin-left: 0;
   }
-  @media (max-width: 560px) {
+  @include s.below(s.$bp-md) {
     grid-template-columns: repeat(2, 1fr);
     justify-content: normal;
     gap: 1.5rem;

--- a/src/Components/Navbar/Navbar.scss
+++ b/src/Components/Navbar/Navbar.scss
@@ -21,7 +21,7 @@
   width: 100%;
 
   // Desktop: fixed so the bar stays put and can solidify + condense on scroll.
-  @media screen and (min-width: 726px) {
+  @include s.above(s.$bp-nav-up) {
     position: fixed;
     transition: background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
       height 0.2s ease;
@@ -46,7 +46,7 @@
       color: s.$white;
     }
 
-    @media screen and (max-width: 725px) {
+    @include s.below(s.$bp-nav) {
       .hamburger {
         position: absolute;
         z-index: 11;
@@ -211,7 +211,7 @@
     }
   }
 
-  @media screen and (max-width: 725px) {
+  @include s.below(s.$bp-nav) {
     .nav-logo {
       font-size: 1.875rem;
     }
@@ -223,7 +223,7 @@
   // Tight desktop band just above the mobile breakpoint: the bar packs logo +
   // search + links + CTAs into little space, so shrink the logo/BETA to give
   // the search room.
-  @media screen and (min-width: 726px) and (max-width: 860px) {
+  @include s.between(s.$bp-nav-up, 860px) {
     .nav-logo {
       font-size: 1.6rem;
     }

--- a/src/Components/Navbar/desktop/DesktopNav.scss
+++ b/src/Components/Navbar/desktop/DesktopNav.scss
@@ -31,7 +31,7 @@
   align-items: center;
   gap: 1.25rem;
 
-  @media screen and (max-width: 725px) {
+  @include s.below(s.$bp-nav) {
     display: none;
   }
 }
@@ -96,7 +96,7 @@
 // links go full-white (Quiet mutes them, which hurts here), and a soft shadow
 // handles high-contrast spots. Scoped to desktop so the mobile bar is
 // untouched; only the Home hero is ever non-solid.
-@media screen and (min-width: 726px) {
+@include s.above(s.$bp-nav-up) {
   .nav:not(.nav--solid) {
     background: linear-gradient(
       180deg,
@@ -519,7 +519,7 @@
 // avatar). Shrink the search, then collapse link labels to icons, so it never
 // overflows or wraps between the mobile breakpoint (725px) and ~1240px.
 // =============================================================================
-@media screen and (max-width: 1240px) {
+@include s.below(1240px) {
   .dnav {
     gap: 1rem;
   }
@@ -527,7 +527,7 @@
     flex-basis: 420px;
   }
 }
-@media screen and (max-width: 1080px) {
+@include s.below(1080px) {
   .dnav {
     gap: 0.8rem;
   }
@@ -538,7 +538,7 @@
     flex-basis: 300px;
   }
 }
-@media screen and (max-width: 1000px) {
+@include s.below(1000px) {
   // search now fills the remaining space (not a fixed centered width) so it
   // doesn't collapse to a sliver as the bar narrows
   .dnav__search {
@@ -561,7 +561,7 @@
     padding-right: 0.6rem;
   }
 }
-@media screen and (max-width: 860px) {
+@include s.below(860px) {
   .dnav {
     gap: 0.5rem;
   }

--- a/src/Components/Navbar/menu/NavMenu.scss
+++ b/src/Components/Navbar/menu/NavMenu.scss
@@ -26,7 +26,7 @@
   pointer-events: none;
 
   // mobile only — desktop keeps the inline nav links
-  @media screen and (min-width: 726px) {
+  @include s.above(s.$bp-nav-up) {
     display: none;
   }
 

--- a/src/Components/RecipeThumbnail/RecipeThumbnail.scss
+++ b/src/Components/RecipeThumbnail/RecipeThumbnail.scss
@@ -71,7 +71,7 @@
     }
   }
 
-  @media screen and (max-width: 725px) {
+  @include s.below(s.$bp-nav) {
     width: 400px;
     max-width: 400px;
 
@@ -86,7 +86,7 @@
       font-weight: 600;
     }
   }
-  @media screen and (max-width: 550px) {
+  @include s.below(s.$bp-md) {
     width: 325px;
     max-width: 325px;
 
@@ -97,7 +97,7 @@
       }
     }
   }
-  @media screen and (max-width: 375px) {
+  @include s.below(s.$bp-xs) {
     max-width: 250px;
 
     .img-container {

--- a/src/Components/ReleaseNotes/ReleaseNotes.scss
+++ b/src/Components/ReleaseNotes/ReleaseNotes.scss
@@ -104,7 +104,7 @@
     color: s.$secondary;
   }
 
-  @media screen and (max-width: 600px) {
+  @include s.below(s.$bp-lg) {
     max-width: 95%;
     width: 95%;
     max-height: 95%;

--- a/src/Components/SearchRecipesInput/SearchRecipesInput.scss
+++ b/src/Components/SearchRecipesInput/SearchRecipesInput.scss
@@ -46,7 +46,7 @@
       padding: 0 1.25rem;
       border-radius: s.$border-radius;
     }
-    @media screen and (max-width: 500px) {
+    @include s.below(500px) {
       input {
         padding-right: 6.25rem;
       }
@@ -182,7 +182,7 @@
         white-space: nowrap;
       }
 
-      @media screen and (max-width: 600px) {
+      @include s.below(s.$bp-lg) {
         &__tags {
           display: none;
         }

--- a/src/helpers.scss
+++ b/src/helpers.scss
@@ -88,6 +88,36 @@ $shadow-chip: 0 2px 6px rgba(0, 0, 0, 0.18);  // tight drop shadow on price / fl
 
 $font-family: 'Montserrat', sans-serif;
 
+// Responsive breakpoints. Canonical "down" (max-width) tiers, anchored on the
+// values already used most across the app. Queries reach them through the
+// below()/above()/between() mixins so the breakpoint list lives in one place.
+// Tuned one-offs (the recipe page's 700/720/820, isolated 500/520/850, and the
+// DesktopNav 860/1000/1080/1240 cascade) pass a literal px to the mixins and
+// keep their exact values; convergence of those is a separate design call
+// (see docs/BACKLOG.md).
+$bp-xs: 375px;
+$bp-sm: 450px;
+$bp-md: 560px;
+$bp-lg: 600px;
+$bp-xl: 640px;
+$bp-2xl: 768px;
+$bp-3xl: 900px;
+$bp-4xl: 1100px;
+// Navbar flip — a complementary max/min pair kept distinct from the content
+// scale (the nav reflows on its own breakpoint, not a content one).
+$bp-nav: 725px;
+$bp-nav-up: 726px;
+
+@mixin below($bp) {
+  @media screen and (max-width: $bp) { @content; }
+}
+@mixin above($bp) {
+  @media screen and (min-width: $bp) { @content; }
+}
+@mixin between($min, $max) {
+  @media screen and (min-width: $min) and (max-width: $max) { @content; }
+}
+
 @mixin outline() {
   outline-color: #4d90fe;
   // outline-offset: -2px;

--- a/src/index.scss
+++ b/src/index.scss
@@ -130,7 +130,7 @@ a {
     border-color: s.$tertiary-text;
   }
 
-  @media screen and (max-width: 375px) {
+  @include s.below(s.$bp-xs) {
     font-size: 1.25rem;
   }
 }

--- a/src/pages/404/404.scss
+++ b/src/pages/404/404.scss
@@ -33,7 +33,7 @@
       stroke-width: 1.5;
     }
 
-    @media screen and (max-width: 650px) {
+    @include s.below(s.$bp-xl) {
       span.number {
         font-size: 10rem;
       }
@@ -42,7 +42,7 @@
         height: 160px;
       }
     }
-    @media screen and (max-width: 550px) {
+    @include s.below(s.$bp-md) {
       span.number {
         font-size: 8.75rem;
       }
@@ -51,7 +51,7 @@
         height: 140px;
       }
     }
-    @media screen and (max-width: 450px) {
+    @include s.below(s.$bp-sm) {
       span.number {
         font-size: 7.5rem;
       }
@@ -87,7 +87,7 @@
       font-weight: 700;
       margin-top: 2rem;
     }
-    @media screen and (max-width: 450px) {
+    @include s.below(s.$bp-sm) {
       h1 {
         font-size: 1.5rem;
       }

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -448,7 +448,7 @@
   }
 
   // ---- Responsive ----
-  @media (max-width: 768px) {
+  @include s.below(s.$bp-2xl) {
     .about-steps-grid {
       grid-template-columns: 1fr;
       gap: 2.25rem;
@@ -462,7 +462,7 @@
     }
   }
 
-  @media (max-width: 480px) {
+  @include s.below(s.$bp-sm) {
     padding-top: calc(#{s.$nav-height} + 1rem);
 
     .about-features-grid {

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -31,7 +31,7 @@
     box-shadow: s.$shadow-soft;
     margin-bottom: 1.75rem;
 
-    @media (max-width: 880px) {
+    @include s.below(s.$bp-3xl) {
       grid-template-columns: 1fr;
       gap: 1.25rem;
     }
@@ -104,7 +104,7 @@
     align-items: stretch;
     gap: 0.75rem;
 
-    @media (max-width: 880px) {
+    @include s.below(s.$bp-3xl) {
       border-top: 1px solid #f0e8dd;
       padding-top: 1.25rem;
     }
@@ -252,7 +252,7 @@
     gap: 1.5rem;
     align-items: start;
 
-    @media (max-width: 900px) {
+    @include s.below(s.$bp-3xl) {
       grid-template-columns: 1fr;
       gap: 1.25rem;
     }
@@ -274,7 +274,7 @@
 
     // Collapse to a fixed four-up tab bar — all four destinations fit, no
     // horizontal scroll.
-    @media (max-width: 900px) {
+    @include s.below(s.$bp-3xl) {
       display: grid;
       grid-template-columns: repeat(4, 1fr);
       gap: 0.25rem;
@@ -330,7 +330,7 @@
 
     // Tab-bar cell (≤900px): icon over label, centered; count rides as a corner
     // badge so each cell stays two tidy lines.
-    @media (max-width: 900px) {
+    @include s.below(s.$bp-3xl) {
       flex-direction: column;
       gap: 0.3rem;
       justify-content: center;
@@ -365,7 +365,7 @@
   // segmented control becomes an icon-over-label tab bar. Mobile-first rebuild
   // approved against the "Option B" mock. Placed last so it overrides the ≤880px
   // rules where they overlap.
-  @media (max-width: 600px) {
+  @include s.below(s.$bp-lg) {
     .acct-head {
       grid-template-columns: 1fr;
       justify-items: center;

--- a/src/pages/Account/Drafts/Drafts.scss
+++ b/src/pages/Account/Drafts/Drafts.scss
@@ -15,7 +15,7 @@
     gap: 1.25rem;
     margin: 0;
 
-    @media screen and (max-width: 420px) {
+    @include s.below(s.$bp-sm) {
       grid-template-columns: 1fr;
     }
   }

--- a/src/pages/Account/SavedRecipes/SavedRecipes.scss
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.scss
@@ -354,7 +354,7 @@
     gap: 1.5rem;
     margin: 1.5rem 0;
 
-    @media screen and (max-width: 420px) {
+    @include s.below(s.$bp-sm) {
       grid-template-columns: 1fr;
     }
   }

--- a/src/pages/Account/UserRatings/UserRatings.scss
+++ b/src/pages/Account/UserRatings/UserRatings.scss
@@ -121,7 +121,7 @@
     }
   }
 
-  @media (max-width: 460px) {
+  @include s.below(s.$bp-sm) {
     .single-review {
       padding: 0.85rem 0.9rem;
       gap: 0.75rem;

--- a/src/pages/Account/UserRecipes/UserRecipes.scss
+++ b/src/pages/Account/UserRecipes/UserRecipes.scss
@@ -12,7 +12,7 @@
     margin: 0 0 2rem;
     gap: 1.25rem;
 
-    @media screen and (max-width: 420px) {
+    @include s.below(s.$bp-sm) {
       grid-template-columns: 1fr;
     }
   }

--- a/src/pages/AddRecipe/AddRecipe.scss
+++ b/src/pages/AddRecipe/AddRecipe.scss
@@ -135,7 +135,7 @@
     margin-bottom: 0.5rem;
   }
 
-  @media screen and (max-width: 600px) {
+  @include s.below(s.$bp-lg) {
     .container {
       padding: 40px 0 32px;
 

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.scss
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.scss
@@ -141,7 +141,7 @@
     }
   }
 
-  @media screen and (max-width: 600px) {
+  @include s.below(s.$bp-lg) {
     .summary-inner {
       padding: 0.7rem 1rem;
       gap: 1rem;

--- a/src/pages/AddRecipe/DraftResumeBanner.scss
+++ b/src/pages/AddRecipe/DraftResumeBanner.scss
@@ -17,7 +17,7 @@
   border-radius: s.$border-radius;
   padding: 0.75rem 1.25rem;
 
-  @media screen and (max-width: 560px) {
+  @include s.below(s.$bp-md) {
     flex-direction: column;
     align-items: stretch;
     gap: 0.85rem;
@@ -46,7 +46,7 @@
       // On phones a single ellipsed line cuts the title off almost immediately
       // (the "Pick up where you left off on …" prefix eats the width). Let it
       // wrap to a tidy two lines instead so the recipe name is actually visible.
-      @media screen and (max-width: 560px) {
+      @include s.below(s.$bp-md) {
         white-space: normal;
         display: -webkit-box;
         -webkit-line-clamp: 2;
@@ -55,7 +55,7 @@
     }
 
     // Keep the text clear of the corner dismiss button when stacked.
-    @media screen and (max-width: 560px) {
+    @include s.below(s.$bp-md) {
       padding-right: 1.75rem;
     }
   }
@@ -66,7 +66,7 @@
     gap: 1rem;
     flex-shrink: 0;
 
-    @media screen and (max-width: 560px) {
+    @include s.below(s.$bp-md) {
       width: 100%;
       gap: 0.85rem;
     }
@@ -88,7 +88,7 @@
       }
 
       // Comfortable full-width tap target on phones.
-      @media screen and (max-width: 560px) {
+      @include s.below(s.$bp-md) {
         flex: 1;
         padding: 0.6rem 0.9rem;
       }
@@ -122,7 +122,7 @@
       }
 
       // Tuck into the top-right corner so the stacked layout reads cleanly.
-      @media screen and (max-width: 560px) {
+      @include s.below(s.$bp-md) {
         position: absolute;
         top: 0.5rem;
         right: 0.5rem;

--- a/src/pages/Admin/AdminLayout.scss
+++ b/src/pages/Admin/AdminLayout.scss
@@ -72,7 +72,7 @@
   }
 }
 
-@media (max-width: 640px) {
+@include s.below(s.$bp-xl) {
   .admin-layout {
     flex-direction: column;
 

--- a/src/pages/Admin/BugReports/BugReports.scss
+++ b/src/pages/Admin/BugReports/BugReports.scss
@@ -333,7 +333,7 @@
   }
 }
 
-@media (max-width: 640px) {
+@include s.below(s.$bp-xl) {
   .admin-bug-reports .bug-report-card {
     flex-direction: column;
 

--- a/src/pages/Admin/Reports/Reports.scss
+++ b/src/pages/Admin/Reports/Reports.scss
@@ -331,7 +331,7 @@
   }
 }
 
-@media (max-width: 640px) {
+@include s.below(s.$bp-xl) {
   .admin-reports .report-card {
     flex-direction: column;
 

--- a/src/pages/Admin/Users/Users.scss
+++ b/src/pages/Admin/Users/Users.scss
@@ -208,7 +208,7 @@
   }
 }
 
-@media (max-width: 640px) {
+@include s.below(s.$bp-xl) {
   .admin-users .user-card {
     flex-direction: column;
 

--- a/src/pages/Home/Home.scss
+++ b/src/pages/Home/Home.scss
@@ -38,7 +38,7 @@
     }
     // On narrow screens let the title use the full width and drop "See all"
     // beside the description instead of reserving a tall right-hand column.
-    @media (max-width: 560px) {
+    @include s.below(s.$bp-md) {
       grid-template-areas:
         "title title"
         "desc  see";
@@ -51,8 +51,8 @@
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: 1.25rem;
-    @media (max-width: 1100px) { grid-template-columns: repeat(2, 1fr); }
-    @media (max-width: 520px) { grid-template-columns: 1fr; }
+    @include s.below(s.$bp-4xl) { grid-template-columns: repeat(2, 1fr); }
+    @include s.below(520px) { grid-template-columns: 1fr; }
   }
   .home-recipe-card {
     display: block;
@@ -93,8 +93,8 @@
     grid-template-columns: repeat(3, 1fr);
     gap: 1.5rem;
     // Mid-range: three columns get tight — pull the gap in before collapsing.
-    @media (max-width: 1100px) { gap: 1rem; }
-    @media (max-width: 850px) { grid-template-columns: 1fr; gap: 1.5rem; }
+    @include s.below(s.$bp-4xl) { gap: 1rem; }
+    @include s.below(850px) { grid-template-columns: 1fr; gap: 1.5rem; }
   }
   .home-meal-col {
     background: s.$white;
@@ -144,7 +144,7 @@
     // Mid-range (3 narrow columns): tighten padding and shrink rows so recipe
     // titles keep enough width to breathe. Must come after the base nested
     // rules above — same specificity, so source order decides.
-    @media (min-width: 851px) and (max-width: 1100px) {
+    @include s.between(851px, s.$bp-4xl) {
       padding: 0.85rem;
       .meal-col-head h3 { font-size: 1rem; }
       a { gap: 0.6rem; padding: 0.3rem; img { width: 44px; height: 44px; } }

--- a/src/pages/PublicProfile/PublicProfile.scss
+++ b/src/pages/PublicProfile/PublicProfile.scss
@@ -329,7 +329,7 @@
     }
   }
 
-  @media (max-width: 480px) {
+  @include s.below(s.$bp-sm) {
     .pp-avatar {
       width: 92px;
       height: 92px;

--- a/src/pages/Recipes/Recipes.scss
+++ b/src/pages/Recipes/Recipes.scss
@@ -73,7 +73,7 @@
     gap: 0.6rem;
 
     // Mobile: search takes its own row; Filters + Sort sit beneath it.
-    @media (max-width: 640px) {
+    @include s.below(s.$bp-xl) {
       flex-wrap: wrap;
       .search-recipes-form {
         flex: 1 1 100%;

--- a/src/pages/Settings/Settings.scss
+++ b/src/pages/Settings/Settings.scss
@@ -136,7 +136,7 @@
 /* ── Mobile master-detail (≤880px) ─────────────────────────────────────────────
    Root (/settings) shows the section list and hides the pane; a section path
    hides the list and shows just that pane with a back link. Desktop is unaffected. */
-@media (max-width: 880px) {
+@include s.below(s.$bp-3xl) {
   .settings-page {
     .settings-shell {
       display: block;

--- a/src/pages/Settings/components/controls.scss
+++ b/src/pages/Settings/components/controls.scss
@@ -343,7 +343,7 @@
 // On mobile the sticky bar can sit below the fold of a long form, so a user can
 // miss it and lose edits. Pin it to the bottom of the viewport instead so it's
 // always visible while there are unsaved changes.
-@media (max-width: 880px) {
+@include s.below(s.$bp-3xl) {
   .sr-savebar.show {
     position: fixed;
     left: 0.9rem;

--- a/src/pages/Settings/sections/sections.scss
+++ b/src/pages/Settings/sections/sections.scss
@@ -12,7 +12,7 @@
     grid-template-columns: 1fr 1fr;
     gap: 1rem 1.25rem;
 
-    @media (max-width: 600px) {
+    @include s.below(s.$bp-lg) {
       grid-template-columns: 1fr;
     }
   }
@@ -128,7 +128,7 @@
     max-width: 46ch;
   }
 
-  @media (max-width: 600px) {
+  @include s.below(s.$bp-lg) {
     flex-direction: column;
     align-items: flex-start;
   }

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
@@ -10,7 +10,7 @@
     text-align: center;
     margin-bottom: 3rem;
 
-    @media screen and (max-width: 450px) {
+    @include s.below(s.$bp-sm) {
       margin-bottom: 2rem;
     }
   }
@@ -97,7 +97,7 @@
         }
       }
 
-      @media screen and (max-width: 450px) {
+      @include s.below(s.$bp-sm) {
         flex-direction: column;
         justify-content: flex-start;
         align-items: center;

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
@@ -27,7 +27,7 @@
       font-weight: 500;
       color: s.$tertiary-text;
     }
-    @media screen and (max-width: 450px) {
+    @include s.below(s.$bp-sm) {
       position: relative;
       flex-wrap: wrap;
       gap: 0.25rem;
@@ -53,7 +53,7 @@
         font-size: 0.75rem;
       }
     }
-    @media screen and (max-width: 350px) {
+    @include s.below(s.$bp-xs) {
       .name-content {
         max-width: 200px;
       }

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
@@ -104,7 +104,7 @@
 
   // ── mobile: stack into a tidy card — heading, equal Edit/Delete row, evenly
   // spaced stats ──────────────────────────────────────────────────────────────
-  @media screen and (max-width: 600px) {
+  @include s.below(s.$bp-lg) {
     gap: 0.85rem;
     padding: 1rem 1.1rem;
     .who {

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -43,7 +43,7 @@ $danger: #d23f31;
     grid-template-columns: 400px 1fr;
     gap: 3.25rem;
     align-items: stretch;
-    @media screen and (max-width: 820px) {
+    @include s.below(820px) {
       grid-template-columns: 1fr;
       gap: 1.75rem;
     }
@@ -218,7 +218,7 @@ $danger: #d23f31;
     border-radius: $soft-radius;
     box-shadow: $soft-shadow;
     padding: 1.5rem 1.75rem;
-    @media screen and (max-width: 600px) { padding: 1.25rem 1rem; }
+    @include s.below(s.$bp-lg) { padding: 1.25rem 1rem; }
     > h2 { font-size: 1.35rem; font-weight: 700; margin-bottom: 1.1rem; }
   }
 
@@ -273,7 +273,7 @@ $danger: #d23f31;
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 0.25rem 1.75rem;
-      @media screen and (max-width: 640px) { grid-template-columns: 1fr; }
+      @include s.below(s.$bp-xl) { grid-template-columns: 1fr; }
 
       .ing {
         display: grid;
@@ -345,7 +345,7 @@ $danger: #d23f31;
       margin: 0;
       column-count: 2;
       column-gap: 2.75rem;
-      @media screen and (max-width: 720px) { column-count: 1; }
+      @include s.below(720px) { column-count: 1; }
 
       .step {
         display: grid;
@@ -438,7 +438,7 @@ $danger: #d23f31;
       grid-template-columns: 1fr 1fr;
       gap: 1.5rem 2.5rem;
       align-items: start;
-      @media screen and (max-width: 700px) { grid-template-columns: 1fr; }
+      @include s.below(700px) { grid-template-columns: 1fr; }
     }
     .nd-cal {
       font-size: 0.95rem;
@@ -673,11 +673,11 @@ $danger: #d23f31;
   // Pull the page in toward the screen edges on phones — the global .page is
   // 90% wide (≈19px gutter at 375px), which wastes room the cards need. Scoped
   // to ≤640px so tablets keep a comfortable margin.
-  @media screen and (max-width: 640px) {
+  @include s.below(s.$bp-xl) {
     width: calc(100% - 1.5rem); // 0.75rem (12px) gutter each side
   }
 
-  @media screen and (max-width: 600px) {
+  @include s.below(s.$bp-lg) {
     .hero-text h1 { font-size: 1.9rem; }
 
     // ── action bar: stack the meta over a full-width, equal 3-up button row ──


### PR DESCRIPTION
## What

Replaces 69 ad-hoc width media queries (28 distinct values, heavy near-duplicate drift) with an 8-tier breakpoint scale + mixins, the single source of truth for responsive breakpoints.

```scss
$bp-xs: 375  $bp-sm: 450  $bp-md: 560  $bp-lg: 600
$bp-xl: 640  $bp-2xl: 768  $bp-3xl: 900  $bp-4xl: 1100
$bp-nav: 725  $bp-nav-up: 726     // navbar flip pair (bespoke)

@mixin below($bp)  // @media screen and (max-width: $bp)
@mixin above($bp)  // @media screen and (min-width: $bp)
@mixin between($min,$max)
```

## ⚠️ NOT pixel-identical — by design (signed off)

Unlike the radius/white PRs, this **intentionally moves 7 breakpoints** to converge the drift. Every shift is ≤30px and was approved:

| from → to | Δ | where |
|---|---|---|
| 350 → 375 | +25 | RecipeReview |
| 420 → 450 | +30 | Drafts, SavedRecipes, UserRecipes |
| 460 → 450 | −10 | UserRatings |
| 480 → 450 | −30 | About, PublicProfile |
| 550 → 560 | +10 | 404, RecipeThumbnail |
| 650 → 640 | −10 | 404 |
| 880 → 900 | +20 | Account ×2, Settings, controls |

**Kept bespoke (exact px, via literal-arg mixins)** so their hand-tuned layouts don't move: the recipe page's `700/720/820`, the isolated `500/520`, the Home `850/851` boundary pair, and the DesktopNav `860/1000/1080/1240` progressive-collapse cascade.

The mixins emit `screen and (…)`, which scopes the formerly-bare queries to screen (more correct given the dedicated `PrintableRecipe` + `@media print`).

## Verification

Compiled the CSS bundle before/after and diffed the **`@media` condition multiset** — it reconciles exactly: 69 width queries before and after, and the only differences are the 7 shifts above + the `screen` normalization. Nothing else moved. (e.g. `$bp-sm` 450 = 450×5 + 420×3 + 460×1 + 480×2 = 11 ✓.)

## Gates
- `npx tsc --noEmit` → exit 0
- `npm run build` → clean (no Sass warnings / undefined-mixin errors)
- `npm test` → 516 passed / 2 skipped (71 files)

Remaining convergence of the deliberately-bespoke one-offs is filed in `docs/BACKLOG.md` (needs per-page layout retuning).