### PR TITLE
fix(ui): keep card actions & section heads inside their container on narrow widths

### DIFF
--- a/src/pages/404/404.scss
+++ b/src/pages/404/404.scss
@@ -60,6 +60,17 @@
         height: 120px;
       }
     }
+    // Smallest phones (≤375px): the two italic digits + donut overrun a ~320px
+    // viewport at 7.5rem — step down once more so the glyph stays inside.
+    @include s.below(s.$bp-xs) {
+      span.number {
+        font-size: 6rem;
+      }
+      .zero {
+        width: 100px;
+        height: 100px;
+      }
+    }
   }
   .content {
     display: flex;

--- a/src/pages/Account/Drafts/Drafts.scss
+++ b/src/pages/Account/Drafts/Drafts.scss
@@ -109,13 +109,21 @@
     // their button rows aligned across the grid row.
     .actions {
       display: flex;
+      // Wrap so Delete drops to its own row instead of spilling past the card's
+      // right edge when a narrow grid track (~320px, the 2-up layout) leaves the
+      // two buttons no room side by side.
+      flex-wrap: wrap;
       align-items: stretch;
       gap: 0.5rem;
       margin-top: auto;
       padding-top: 0.15rem;
 
       .resume {
-        flex: 1;
+        flex: 1 1 auto;
+        // min-width:0 lets the button shrink below its nowrap label's intrinsic
+        // width (that intrinsic min is what forced the overflow); with flex-wrap
+        // it shares the row when it fits and drops Delete below when it doesn't.
+        min-width: 0;
         display: inline-flex;
         align-items: center;
         justify-content: center;

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -230,8 +230,12 @@ $danger: #d23f31;
   .ingredients-card {
     .sec-head {
       display: flex;
+      // Wrap the (fixed-width) servings pill below the heading on very narrow
+      // screens instead of letting it spill past the section's right edge.
+      flex-wrap: wrap;
       justify-content: space-between;
       align-items: center;
+      gap: 0.5rem 1rem;
       margin-bottom: 1.1rem;
       h2 { margin-bottom: 0; }
     }


### PR DESCRIPTION
## What

Three responsive **overflow** bugs found in a headless viewport sweep (320–1100px). Each is the same class: a flex row whose children can't shrink below their combined content width, so something spills past its container's edge.

| # | Where | Trigger | Fix |
|---|---|---|---|
| 1 | **Drafts** card actions | ~738px viewport (the 2-up grid yields ~320px cards) — "Delete" escaped the card's right edge | `flex-wrap` on `.actions` + `min-width: 0` / `flex: 1 1 auto` on `.resume`, so Delete drops to its own row |
| 2 | **Recipe** ingredients `.sec-head` | ≤~320px — the fixed-width servings pill overran the heading | `flex-wrap` so the pill wraps below the title |
| 3 | **404** glyph | ≤~320px — the two italic digits + donut overran the viewport at 7.5rem | add a ≤375px step (6rem / 100px donut) |

#1 is the bug @jclind spotted on the Drafts page. Root cause: `.resume` was `flex: 1` + `white-space: nowrap` with no `min-width: 0`, so it floored at its label's intrinsic width (~182px) while `.del` (`flex-shrink: 0`, ~97px) couldn't shrink either — together they exceeded the card's inner width once cards hit ~320px.

## How it was found & verified

Built two headless tools under `.claude/skills/run-prepify/` (gitignored deps):
- **`overflow.mjs`** — loads a page at a width sweep and reports any element whose edge escapes its container/viewport. Ran across all public pages; flagged #2 and #3.
- **`cardshot.mjs`** — renders the real `.draft-card` markup with the compiled CSS **and the real Montserrat font** (the bug only reproduces with the actual font metrics), measuring the `.del` escape. Quantified: 7px escape at 320px cards, 27px at 300px → 0 after the fix.

**Swept clean (no change needed):** SavedRecipes (rows already `flex-wrap`), UserRatings (`.sr-title` has `min-width:0`+ellipsis), UserRecipeThumbnail (shrinkable-title grid). Drafts was the lone offender among the account cards.

## Scope

Polish/bug-fix only — each change alters layout **only** at the narrow widths where content was already overflowing; wider layouts are untouched.

## Gates
- `npx tsc --noEmit` → 0
- `npm run build` → clean
- `npm test` → 516 passed / 2 skipped