### PR TITLE
feat(ingredients): migrate to @jclind/ingredient-parser v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ npx cypress open       # Open Cypress test runner
 - `FIREBASE_SERVICE_ACCOUNT` - JSON string of Firebase service account
 - `FRONTEND_URLS` - Comma-separated CORS origins
 - `PORT` - Default 4000
-- `SPOONACULAR_API_KEY` - Spoonacular API key used by `POST /api/ingredients/parse` (server/routes/ingredients.js)
+- `INGREDIENT_PARSER_PROXY_URL` - Optional. Overrides the base URL of the hosted ingredient-enrichment proxy used by `@jclind/ingredient-parser` v2 (server/routes/ingredients.js). Unset = the package's default hosted proxy. NOTE: as of `@jclind/ingredient-parser` v2 the parser is key-free on the client — the proxy holds the Spoonacular key — so `SPOONACULAR_API_KEY` is **no longer used by this server** (it was needed only by the v1 in-process library call).
 - `EDAMAM_APP_ID` / `EDAMAM_APP_KEY` - Edamam nutrition API credentials, used server-side only by the `POST /api/nutrition/details` proxy (server/routes/nutrition.js). Moved off the client (formerly `VITE_EDAMAM_APP_ID/KEY`) so the keys aren't shipped in the browser bundle.
 
 ## Key Patterns
@@ -91,7 +91,7 @@ npx cypress open       # Open Cypress test runner
 ### Recipe Data Flow
 1. User creates recipe → image uploaded to Firebase Storage → data posted to main server
 2. Nutrition data calculated via Edamam API, proxied through the server (`src/api/recipes.ts`: `getRecipeNutrition` → `POST /api/nutrition/details` in server/routes/nutrition.js)
-3. Ingredient parsing uses `@jclind/ingredient-parser` library locally
+3. Ingredient parsing/enrichment uses `@jclind/ingredient-parser` **v2**: the client parses locally and synchronously via `parseIngredientString` (legacy flat shape), while enrichment (image + estimated price) goes through `POST /api/ingredients/parse` (server/routes/ingredients.js), which calls the package's `ingredientParser` → hosted proxy (key-free; the proxy holds the Spoonacular key). The server maps the v2 result (`price.cents`/`image`) back onto Prepify's stable persisted shape (`totalPriceUSACents`/`imagePath`), so saved recipe documents and downstream consumers are decoupled from the package's type surface (the app owns `ParsedIngredient`/`IngredientData` in `src/types.ts`)
 4. Serving price calculated via `src/util/calculateServingPrice.ts`
 
 ### Testing

--- a/cypress/e2e/addRecipe.cy.ts
+++ b/cypress/e2e/addRecipe.cy.ts
@@ -321,22 +321,14 @@ describe('Add Recipe', () => {
     // distinguishable (the shared fixture would otherwise label them all "flour").
     cy.intercept('POST', PARSE_URL, req => {
       const name = String(req.body.ingredientString || '').trim()
+      // The server returns only the enrichment block; the row's parsed name comes
+      // from the client's own local parse of the typed string.
       req.reply({
-        parsedIngredient: {
-          quantity: null,
-          unit: null,
-          ingredient: name,
-          originalIngredientString: name,
-          comment: '',
-        },
         ingredientData: {
-          _id: `srv-${name}`,
           name,
-          amount: 1,
           imagePath: 'https://img.spoonacular.com/ingredients_100x100/flour.png',
           totalPriceUSACents: 42,
         },
-        id: `srv-${name}`,
       })
     }).as('parseIngredient')
 

--- a/cypress/fixtures/ingredient-parse-result.json
+++ b/cypress/fixtures/ingredient-parse-result.json
@@ -1,28 +1,9 @@
 {
-  "parsedIngredient": {
-    "quantity": 2,
-    "unit": "cup",
-    "unitPlural": "cups",
-    "symbol": "c",
-    "ingredient": "flour",
-    "minQty": 2,
-    "maxQty": 2,
-    "originalIngredientString": "2 cups flour",
-    "comment": ""
-  },
   "ingredientData": {
-    "_id": "fixture-ingredient-1",
-    "originalName": "all-purpose flour",
-    "name": "flour",
-    "amount": 1,
-    "possibleUnits": ["cup", "g", "oz", "tablespoon", "teaspoon"],
-    "consistency": "solid",
-    "shoppingListUnits": ["ounces", "pounds"],
-    "aisle": "Baking",
-    "image": "flour.png",
-    "ingredientId": 20081,
+    "name": "all-purpose flour",
+    "category": "Baking",
     "imagePath": "https://img.spoonacular.com/ingredients_100x100/flour.png",
+    "possibleUnits": ["cup", "g", "oz", "tablespoon", "teaspoon"],
     "totalPriceUSACents": 42
-  },
-  "id": "fixture-id-1"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@formspree/react": "^3.0.0",
         "@hello-pangea/dnd": "^18.0.1",
-        "@jclind/ingredient-parser": "^1.3.4",
+        "@jclind/ingredient-parser": "2.0.0",
         "@sentry/react": "^10.57.0",
         "@tanstack/react-query": "^5.100.10",
         "@types/node": "^25.6.2",
@@ -1738,21 +1738,13 @@
       }
     },
     "node_modules/@jclind/ingredient-parser": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@jclind/ingredient-parser/-/ingredient-parser-1.3.4.tgz",
-      "integrity": "sha512-2v+lKkHomo+Vw5BbnGZnpnxWnzxjf5U27NGErJzDaj6TBjaXR9riqU6BtcW8cqka3ot6cfzpa81OQyODfiiFgA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jclind/ingredient-parser/-/ingredient-parser-2.0.0.tgz",
+      "integrity": "sha512-apAMM/5J2B1kbE+sbo9zE7xOwwxYk2TPun1ncM4UTYqJyIXluh4HPDSvSVq8aBdGjBEeljpqW0h2sytdUVl7LQ==",
       "license": "ISC",
-      "dependencies": {
-        "@jclind/ingredient-unit-converter": "^1.1.0",
-        "axios": "^1.16.0",
-        "recipe-ingredient-parser-v3": "^1.5.0"
+      "engines": {
+        "node": ">=18"
       }
-    },
-    "node_modules/@jclind/ingredient-unit-converter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@jclind/ingredient-unit-converter/-/ingredient-unit-converter-1.1.1.tgz",
-      "integrity": "sha512-C5+DAeA3n/ZzozQwYh5Qz7e5uUNj0Zn5td9FAaWDJeoR40QdSOlRVaey8q/CHnI17zZcjyJhdEhjpfCAl6+LYg==",
-      "license": "ISC"
     },
     "node_modules/@jest/diff-sequences": {
       "version": "30.4.0",
@@ -7955,21 +7947,6 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/recipe-ingredient-parser-v3": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/recipe-ingredient-parser-v3/-/recipe-ingredient-parser-v3-1.5.0.tgz",
-      "integrity": "sha512-E5OlcB3itv3kXJRxKI2K61EZxANftXBuq+LVNXuZPXYqJ7JrXags0fY1LlJ1S+TTcliJMd6VxkgJF+QtSM7hwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^10.5.1"
-      }
-    },
-    "node_modules/recipe-ingredient-parser-v3/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@formspree/react": "^3.0.0",
     "@hello-pangea/dnd": "^18.0.1",
-    "@jclind/ingredient-parser": "^1.3.4",
+    "@jclind/ingredient-parser": "2.0.0",
     "@sentry/react": "^10.57.0",
     "@tanstack/react-query": "^5.100.10",
     "@types/node": "^25.6.2",

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,6 +1,12 @@
 MONGO_URI=mongodb+srv://<user>:<password>@cluster0.xxxxx.mongodb.net/prepify?retryWrites=true&w=majority
 PORT=4000
-SPOONACULAR_API_KEY=<your-spoonacular-api-key>
+
+# Ingredient enrichment (@jclind/ingredient-parser v2). As of v2 the parser is
+# "key-free on the client": POST /api/ingredients/parse calls a hosted proxy that
+# holds the Spoonacular key, so this server no longer needs SPOONACULAR_API_KEY —
+# it is intentionally not set here. Optionally override the proxy base URL (e.g.
+# to self-host the cache/proxy); unset = the package's default hosted proxy.
+# INGREDIENT_PARSER_PROXY_URL=https://ingredient-parser-service-production-2635.up.railway.app
 
 # Edamam nutrition API credentials, used server-side only by the
 # POST /api/nutrition/details proxy (routes/nutrition.js). These moved off the

--- a/server/__tests__/ingredients.test.js
+++ b/server/__tests__/ingredients.test.js
@@ -7,19 +7,20 @@
  *
  * Mock strategy
  * ─────────────
- * @jclind/ingredient-parser is mocked inline so tests never make real HTTP
- * calls to the Spoonacular API. The jest.mock() call is hoisted by Jest above
+ * @jclind/ingredient-parser v2 is mocked inline so tests never make real HTTP
+ * calls to the enrichment proxy. The jest.mock() call is hoisted by Jest above
  * all require() statements, so the route module picks up the mock when it is
  * first loaded through require('../app').
  *
  * firebase-admin is automatically mocked via server/__mocks__/firebase-admin.js.
  *
- * SPOONACULAR_API_KEY note
- * ────────────────────────
- * dotenv is loaded only in index.js, which tests never import. Therefore
- * process.env.SPOONACULAR_API_KEY is undefined at test time. Because
- * ingredientParser is mocked this has no effect on test correctness, but the
- * args-forwarding test documents this as current behaviour.
+ * v2 contract
+ * ───────────
+ * ingredientParser(input, options) resolves to { parsed, data }. `data` is the
+ * vendor-neutral IngredientData (or null on a clean miss); it carries `image`
+ * (full CDN URL) and `price: { cents, ... } | null`. The route projects that
+ * onto Prepify's stable shape ({ imagePath, totalPriceUSACents, ... }) and
+ * rewrites the CDN host. No Spoonacular API key is passed — the proxy holds it.
  */
 
 jest.mock('@jclind/ingredient-parser', () => ({
@@ -32,20 +33,24 @@ const { ingredientParser } = require('@jclind/ingredient-parser')
 
 const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
 
-// Minimal valid IngredientResponse shape (mirrors the package's TypeScript types)
-const PARSED_RESULT = {
-  parsedIngredient: {
-    quantity: 2,
-    unit: 'cup',
-    unitPlural: 'cups',
-    symbol: null,
-    ingredient: 'flour',
-    originalIngredientString: '2 cups flour',
-    minQty: 2,
-    maxQty: 2,
+// A representative v2 ingredientParser result (mirrors the real runtime shape).
+const V2_RESULT = {
+  parsed: {
+    quantity: { value: 2, min: 2, max: 2, isRange: false, isApproximate: false },
+    unit: { name: 'cup', plural: 'cups', symbol: 'c', type: 'volume', system: 'us' },
+    ingredient: { name: 'flour', descriptors: [], preparation: [] },
     comment: null,
+    original: '2 cups flour',
   },
-  ingredientData: { name: 'flour', id: 1234 },
+  data: {
+    name: 'all-purpose flour',
+    category: 'Baking',
+    image: 'https://spoonacular.com/cdn/ingredients_100x100/flour.png',
+    possibleUnits: ['g', 'oz', 'cup'],
+    nutrition: null,
+    // v2 prices are gram-estimated floats; the route rounds to whole cents.
+    price: { cents: 32.6, basis: 'gram', grams: 250, perGramCents: 0.13, confidence: 'low' },
+  },
 }
 
 // ─── POST /api/ingredients/parse ─────────────────────────────────────────────
@@ -53,7 +58,7 @@ const PARSED_RESULT = {
 describe('POST /api/ingredients/parse', () => {
   beforeEach(() => {
     ingredientParser.mockReset()
-    ingredientParser.mockResolvedValue(PARSED_RESULT)
+    ingredientParser.mockResolvedValue(V2_RESULT)
   })
 
   // ── Auth ─────────────────────────────────────────────────────────────────────
@@ -98,135 +103,135 @@ describe('POST /api/ingredients/parse', () => {
     expect(ingredientParser).not.toHaveBeenCalled()
   })
 
-  // ── Happy path ───────────────────────────────────────────────────────────────
+  // ── Happy path / mapping ──────────────────────────────────────────────────────
 
-  it('returns 200 with the full parser result for a valid ingredientString', async () => {
+  it('returns 200 with the v2 result mapped onto Prepify\'s stable shape', async () => {
     const res = await request(app)
       .post('/api/ingredients/parse')
       .set(AUTH_HEADER)
       .send({ ingredientString: '2 cups flour' })
     expect(res.status).toBe(200)
-    expect(res.body).toEqual(PARSED_RESULT)
+    expect(res.body).toEqual({
+      ingredientData: {
+        name: 'all-purpose flour',
+        category: 'Baking',
+        imagePath: 'https://img.spoonacular.com/ingredients_100x100/flour.png',
+        possibleUnits: ['g', 'oz', 'cup'],
+        totalPriceUSACents: 33,
+      },
+    })
   })
 
-  it('response body contains parsedIngredient with the expected shape', async () => {
+  it('rounds the v2 float price to whole cents (32.6 → 33)', async () => {
     const res = await request(app)
       .post('/api/ingredients/parse')
       .set(AUTH_HEADER)
       .send({ ingredientString: '2 cups flour' })
-    const { parsedIngredient } = res.body
-    expect(parsedIngredient).toHaveProperty('ingredient', 'flour')
-    expect(parsedIngredient).toHaveProperty('quantity', 2)
-    expect(parsedIngredient).toHaveProperty('unit', 'cup')
-    expect(parsedIngredient).toHaveProperty('originalIngredientString', '2 cups flour')
-    expect(parsedIngredient).toHaveProperty('minQty')
-    expect(parsedIngredient).toHaveProperty('maxQty')
+    expect(res.body.ingredientData.totalPriceUSACents).toBe(33)
   })
 
-  it('forwards options from the request body to ingredientParser', async () => {
-    const options = { servings: 4 }
+  it('calls ingredientParser with no API key (v2 is key-free; proxy holds it)', async () => {
     await request(app)
       .post('/api/ingredients/parse')
       .set(AUTH_HEADER)
-      .send({ ingredientString: '2 cups flour', options })
-    // SPOONACULAR_API_KEY is process.env.SPOONACULAR_API_KEY (undefined in test
-    // env — dotenv is not loaded when tests import app.js directly).
-    expect(ingredientParser).toHaveBeenCalledWith(
-      '2 cups flour',
-      process.env.SPOONACULAR_API_KEY,
-      options
+      .send({ ingredientString: '2 cups flour' })
+    expect(ingredientParser).toHaveBeenCalledWith('2 cups flour', {
+      imageSize: '100x100',
+    })
+  })
+
+  it('ignores client-supplied options so a caller cannot redirect the proxy', async () => {
+    await request(app)
+      .post('/api/ingredients/parse')
+      .set(AUTH_HEADER)
+      .send({
+        ingredientString: '2 cups flour',
+        options: { serverUrl: 'https://evil.example.com' },
+      })
+    // The route forwards only its own server-controlled options — never the
+    // client's. serverUrl from the body must not reach the parser.
+    expect(ingredientParser).toHaveBeenCalledWith('2 cups flour', {
+      imageSize: '100x100',
+    })
+  })
+
+  // ── CDN host rewrite ──────────────────────────────────────────────────────────
+
+  it('rewrites spoonacular.com/cdn → img.spoonacular.com on the image URL', async () => {
+    const res = await request(app)
+      .post('/api/ingredients/parse')
+      .set(AUTH_HEADER)
+      .send({ ingredientString: '2 cups flour' })
+    expect(res.body.ingredientData.imagePath).toBe(
+      'https://img.spoonacular.com/ingredients_100x100/flour.png'
     )
   })
 
-  // ── Error handling ────────────────────────────────────────────────────────────
+  it('preserves the configurable image-size segment (e.g., 250x250)', async () => {
+    ingredientParser.mockResolvedValue({
+      ...V2_RESULT,
+      data: {
+        ...V2_RESULT.data,
+        image: 'https://spoonacular.com/cdn/ingredients_250x250/garlic.png',
+      },
+    })
+    const res = await request(app)
+      .post('/api/ingredients/parse')
+      .set(AUTH_HEADER)
+      .send({ ingredientString: '2 cloves garlic' })
+    expect(res.body.ingredientData.imagePath).toBe(
+      'https://img.spoonacular.com/ingredients_250x250/garlic.png'
+    )
+  })
+
+  // ── Partial enrichment (found, but no price/image) ──────────────────────────────
+
+  it('omits totalPriceUSACents when the ingredient has no price', async () => {
+    ingredientParser.mockResolvedValue({
+      ...V2_RESULT,
+      data: { ...V2_RESULT.data, price: null },
+    })
+    const res = await request(app)
+      .post('/api/ingredients/parse')
+      .set(AUTH_HEADER)
+      .send({ ingredientString: 'pinch of salt' })
+    expect(res.status).toBe(200)
+    expect(res.body.ingredientData).not.toHaveProperty('totalPriceUSACents')
+    expect(res.body.ingredientData.name).toBe('all-purpose flour')
+  })
+
+  it('omits imagePath when the ingredient has no image', async () => {
+    ingredientParser.mockResolvedValue({
+      ...V2_RESULT,
+      data: { ...V2_RESULT.data, image: null },
+    })
+    const res = await request(app)
+      .post('/api/ingredients/parse')
+      .set(AUTH_HEADER)
+      .send({ ingredientString: '2 cups flour' })
+    expect(res.body.ingredientData).not.toHaveProperty('imagePath')
+  })
+
+  // ── Clean miss / error handling ────────────────────────────────────────────────
+
+  it('returns 200 with ingredientData: null on a clean lookup miss (data: null)', async () => {
+    ingredientParser.mockResolvedValue({ parsed: V2_RESULT.parsed, data: null })
+    const res = await request(app)
+      .post('/api/ingredients/parse')
+      .set(AUTH_HEADER)
+      .send({ ingredientString: 'zzqxnonexistent' })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ingredientData: null })
+  })
 
   it('returns a generic 500 (not the raw error) when ingredientParser throws', async () => {
-    ingredientParser.mockRejectedValue(new Error('parser exploded'))
+    ingredientParser.mockRejectedValue(new Error('proxy exploded'))
     const res = await request(app)
       .post('/api/ingredients/parse')
       .set(AUTH_HEADER)
       .send({ ingredientString: '2 cups flour' })
     expect(res.status).toBe(500)
-    // Body is generic; the real message ('parser exploded') is logged, not echoed.
+    // Body is generic; the real message ('proxy exploded') is logged, not echoed.
     expect(res.body).toHaveProperty('error', 'Internal server error')
-  })
-
-  // ── Spoonacular CDN URL rewrite ──────────────────────────────────────────────
-
-  describe('Spoonacular CDN URL rewrite', () => {
-    it('rewrites spoonacular.com/cdn → img.spoonacular.com on the returned imagePath', async () => {
-      ingredientParser.mockResolvedValue({
-        ...PARSED_RESULT,
-        ingredientData: {
-          ...PARSED_RESULT.ingredientData,
-          imagePath: 'https://spoonacular.com/cdn/ingredients_100x100/flour.png',
-        },
-      })
-
-      const res = await request(app)
-        .post('/api/ingredients/parse')
-        .set(AUTH_HEADER)
-        .send({ ingredientString: '2 cups flour' })
-
-      expect(res.status).toBe(200)
-      expect(res.body.ingredientData.imagePath).toBe(
-        'https://img.spoonacular.com/ingredients_100x100/flour.png'
-      )
-    })
-
-    it('preserves the configurable image-size segment (e.g., 250x250)', async () => {
-      ingredientParser.mockResolvedValue({
-        ...PARSED_RESULT,
-        ingredientData: {
-          ...PARSED_RESULT.ingredientData,
-          imagePath: 'https://spoonacular.com/cdn/ingredients_250x250/garlic.png',
-        },
-      })
-
-      const res = await request(app)
-        .post('/api/ingredients/parse')
-        .set(AUTH_HEADER)
-        .send({ ingredientString: '2 cloves garlic' })
-
-      expect(res.body.ingredientData.imagePath).toBe(
-        'https://img.spoonacular.com/ingredients_250x250/garlic.png'
-      )
-    })
-
-    it('does not touch the response when ingredientData is null (soft-fail / error branch)', async () => {
-      ingredientParser.mockResolvedValue({
-        parsedIngredient: PARSED_RESULT.parsedIngredient,
-        ingredientData: null,
-        error: { message: 'Ingredient not formatted correctly' },
-      })
-
-      const res = await request(app)
-        .post('/api/ingredients/parse')
-        .set(AUTH_HEADER)
-        .send({ ingredientString: 'asdf' })
-
-      expect(res.status).toBe(200)
-      expect(res.body.ingredientData).toBeNull()
-      expect(res.body.error).toEqual({ message: 'Ingredient not formatted correctly' })
-    })
-
-    it('leaves an already-new-format URL untouched (idempotent)', async () => {
-      ingredientParser.mockResolvedValue({
-        ...PARSED_RESULT,
-        ingredientData: {
-          ...PARSED_RESULT.ingredientData,
-          imagePath: 'https://img.spoonacular.com/ingredients_100x100/flour.png',
-        },
-      })
-
-      const res = await request(app)
-        .post('/api/ingredients/parse')
-        .set(AUTH_HEADER)
-        .send({ ingredientString: '2 cups flour' })
-
-      expect(res.body.ingredientData.imagePath).toBe(
-        'https://img.spoonacular.com/ingredients_100x100/flour.png'
-      )
-    })
   })
 })

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,7 +8,7 @@
       "name": "prepify-server",
       "version": "1.0.0",
       "dependencies": {
-        "@jclind/ingredient-parser": "^1.3.4",
+        "@jclind/ingredient-parser": "2.0.0",
         "@sentry/node": "^10.57.0",
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
@@ -936,21 +936,13 @@
       }
     },
     "node_modules/@jclind/ingredient-parser": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@jclind/ingredient-parser/-/ingredient-parser-1.3.4.tgz",
-      "integrity": "sha512-2v+lKkHomo+Vw5BbnGZnpnxWnzxjf5U27NGErJzDaj6TBjaXR9riqU6BtcW8cqka3ot6cfzpa81OQyODfiiFgA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jclind/ingredient-parser/-/ingredient-parser-2.0.0.tgz",
+      "integrity": "sha512-apAMM/5J2B1kbE+sbo9zE7xOwwxYk2TPun1ncM4UTYqJyIXluh4HPDSvSVq8aBdGjBEeljpqW0h2sytdUVl7LQ==",
       "license": "ISC",
-      "dependencies": {
-        "@jclind/ingredient-unit-converter": "^1.1.0",
-        "axios": "^1.16.0",
-        "recipe-ingredient-parser-v3": "^1.5.0"
+      "engines": {
+        "node": ">=18"
       }
-    },
-    "node_modules/@jclind/ingredient-unit-converter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@jclind/ingredient-unit-converter/-/ingredient-unit-converter-1.1.1.tgz",
-      "integrity": "sha512-C5+DAeA3n/ZzozQwYh5Qz7e5uUNj0Zn5td9FAaWDJeoR40QdSOlRVaey8q/CHnI17zZcjyJhdEhjpfCAl6+LYg==",
-      "license": "ISC"
     },
     "node_modules/@jest/console": {
       "version": "30.4.1",
@@ -2531,18 +2523,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
     },
     "node_modules/b4a": {
       "version": "1.8.1",
@@ -3213,6 +3195,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -3374,6 +3357,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -3570,6 +3554,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4010,6 +3995,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -4047,6 +4033,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4475,6 +4462,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6949,15 +6937,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -7086,21 +7065,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/recipe-ingredient-parser-v3": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/recipe-ingredient-parser-v3/-/recipe-ingredient-parser-v3-1.5.0.tgz",
-      "integrity": "sha512-E5OlcB3itv3kXJRxKI2K61EZxANftXBuq+LVNXuZPXYqJ7JrXags0fY1LlJ1S+TTcliJMd6VxkgJF+QtSM7hwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^10.5.1"
-      }
-    },
-    "node_modules/recipe-ingredient-parser-v3/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
     "test": "jest --runInBand"
   },
   "dependencies": {
-    "@jclind/ingredient-parser": "^1.3.4",
+    "@jclind/ingredient-parser": "2.0.0",
     "@sentry/node": "^10.57.0",
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",

--- a/server/routes/ingredients.js
+++ b/server/routes/ingredients.js
@@ -6,56 +6,84 @@ const { GENERIC_500_MESSAGE } = require('../util/respondServerError')
 
 const router = Router()
 
-// Every call spends paid Spoonacular quota, so this route gets its own tight
-// per-user limit — an independent bucket from the content-write limiters (see
-// middleware/writeLimiter), keyed by req.uid (set by verifyToken, which runs
-// first), not IP, so shared NATs don't collide. 30/min comfortably covers the
-// add-recipe flow — one parse per ingredient added, max 50 per recipe.
-// Skipped under Jest along with the global limiter (see app.js).
+// Every call can spend paid Spoonacular quota (via the parser's proxy), so this
+// route gets its own tight per-user limit — an independent bucket from the
+// content-write limiters (see middleware/writeLimiter), keyed by req.uid (set by
+// verifyToken, which runs first), not IP, so shared NATs don't collide. 30/min
+// comfortably covers the add-recipe flow — one parse per ingredient added, max
+// 50 per recipe. Skipped under Jest along with the global limiter (see app.js).
 const parseLimiter = makeUserLimiter({
   message: 'Too many ingredient lookups — wait a minute and try again.',
 })
 
+// Spoonacular migrated CDNs: the old spoonacular.com/cdn host now 301-redirects;
+// img.spoonacular.com serves the image directly. The parser's buildImageUrl
+// still constructs the old host (node_modules/@jclind/ingredient-parser/dist/
+// cjs/enrich/spoonacular.js), so rewrite to the live host here, at the funnel,
+// before the response leaves the server.
+function rewriteImageHost(url) {
+  if (typeof url !== 'string') return url
+  return url.replace(
+    'https://spoonacular.com/cdn/ingredients_',
+    'https://img.spoonacular.com/ingredients_'
+  )
+}
+
+// Project the v2 `IngredientData` onto Prepify's stable, persisted shape. Keeping
+// the field names the app reads (`totalPriceUSACents`, `imagePath`) means every
+// downstream consumer and every already-saved recipe document stays valid — the
+// v2 renames (`price.cents`, `image`) are absorbed entirely at this boundary.
+// Price/image are omitted when absent so the UI shows its soft-fail state ('—' /
+// basket icon) instead of a misleading "$0.00" / broken thumbnail. Cents are
+// rounded to whole cents to match v1's integer-cent convention (v2 prices are
+// gram-estimated floats).
+function mapIngredientData(data) {
+  if (!data) return null
+  const out = { name: data.name }
+  if (data.image) out.imagePath = rewriteImageHost(data.image)
+  if (data.price && typeof data.price.cents === 'number') {
+    out.totalPriceUSACents = Math.round(data.price.cents)
+  }
+  if (Array.isArray(data.possibleUnits)) out.possibleUnits = data.possibleUnits
+  if (data.category) out.category = data.category
+  return out
+}
+
 router.post('/parse', verifyToken, parseLimiter, async (req, res) => {
-  const { ingredientString, options } = req.body
+  const { ingredientString } = req.body
   if (!ingredientString || typeof ingredientString !== 'string') {
     return res.status(400).json({ error: 'ingredientString must be a non-empty string' })
   }
   try {
-    const result = await ingredientParser(
-      ingredientString,
-      process.env.SPOONACULAR_API_KEY,
-      options
-    )
-    // Spoonacular migrated CDN: spoonacular.com/cdn → img.spoonacular.com.
-    // The @jclind/ingredient-parser package still constructs the old URL
-    // (node_modules/@jclind/ingredient-parser/dist/src/funcs/ingredientParser.js:47).
-    // Rewrite here, at the funnel, before the response leaves the server.
-    if (result && result.ingredientData && typeof result.ingredientData.imagePath === 'string') {
-      result.ingredientData.imagePath = result.ingredientData.imagePath.replace(
-        'https://spoonacular.com/cdn/ingredients_',
-        'https://img.spoonacular.com/ingredients_'
-      )
-    }
-    // Phase A: structured warn when enrichment didn't fully succeed.
-    // Soft-fail by design — we still return 200 with the parsed-only payload —
-    // but log so we can see in prod which ingredient strings are missing enrichment.
-    if (result && (result.error || !result.ingredientData)) {
+    // v2 is key-free on the client: the parser calls the hosted proxy (which
+    // holds the Spoonacular key), so no API key is passed here. The proxy URL is
+    // fixed server-side — optionally overridable via INGREDIENT_PARSER_PROXY_URL,
+    // otherwise the package default. We deliberately do NOT forward any
+    // client-supplied options, so a caller can't redirect the proxy target.
+    const { data } = await ingredientParser(ingredientString, {
+      imageSize: '100x100',
+      ...(process.env.INGREDIENT_PARSER_PROXY_URL
+        ? { serverUrl: process.env.INGREDIENT_PARSER_PROXY_URL }
+        : {}),
+    })
+
+    const ingredientData = mapIngredientData(data)
+
+    // Soft-fail by design: a clean lookup miss (no Spoonacular match) returns 200
+    // with `ingredientData: null`. Log it so we can see which strings miss in
+    // prod and decide whether to seed the proxy cache.
+    if (!ingredientData) {
       console.warn(
-        '[ingredients/parse] enrichment incomplete',
-        JSON.stringify({
-          ingredientString,
-          parsedName: result.parsedIngredient && result.parsedIngredient.ingredient,
-          hasIngredientData: Boolean(result.ingredientData),
-          error: result.error || null,
-        })
+        '[ingredients/parse] enrichment miss',
+        JSON.stringify({ ingredientString })
       )
     }
-    return res.json(result)
+    return res.json({ ingredientData })
   } catch (err) {
-    // Phase A: full error with stack so we can debug network / Spoonacular failures in prod.
+    // A throw here is an EnrichError (proxy/network failure) — distinct from a
+    // clean miss. Full error with stack so we can debug proxy outages in prod.
     console.error(
-      '[ingredients/parse] parser threw',
+      '[ingredients/parse] enrichment threw',
       JSON.stringify({ ingredientString, message: err && err.message }),
       err && err.stack
     )

--- a/src/api/ingredientParserApi.ts
+++ b/src/api/ingredientParserApi.ts
@@ -1,5 +1,15 @@
-import { ParsedIngredient, IngredientData, IngredientResponse } from '@jclind/ingredient-parser'
+import { IngredientData, ParsedIngredient } from 'types'
 import { http } from 'src/api/http-common'
+
+// The shape POST /api/ingredients/parse returns. The server enriches via
+// @jclind/ingredient-parser v2 (proxy-backed, key-free) and projects the v2
+// result onto Prepify's stable IngredientData shape, soft-failing to
+// `ingredientData: null` on a lookup miss. `error` is only present when the
+// server surfaces an enrichment problem.
+interface ParseEnrichResponse {
+  ingredientData: IngredientData | null
+  error?: { message: string }
+}
 
 export interface EnrichmentResult {
   source: 'cache' | 'spoonacular'
@@ -10,11 +20,11 @@ export interface EnrichmentResult {
 export async function fetchIngredientEnrichment(
   parsedIngredient: ParsedIngredient
 ): Promise<EnrichmentResult> {
-  const response = await http.post<IngredientResponse>('/api/ingredients/parse', {
+  const response = await http.post<ParseEnrichResponse>('/api/ingredients/parse', {
     ingredientString: parsedIngredient.originalIngredientString,
   })
   const result = response.data
-  if ('error' in result) {
+  if (result.error) {
     return { source: 'spoonacular', data: result.ingredientData, error: result.error }
   }
   return { source: 'spoonacular', data: result.ingredientData }

--- a/src/api/ingredientParserApi.ts
+++ b/src/api/ingredientParserApi.ts
@@ -4,17 +4,14 @@ import { http } from 'src/api/http-common'
 // The shape POST /api/ingredients/parse returns. The server enriches via
 // @jclind/ingredient-parser v2 (proxy-backed, key-free) and projects the v2
 // result onto Prepify's stable IngredientData shape, soft-failing to
-// `ingredientData: null` on a lookup miss. `error` is only present when the
-// server surfaces an enrichment problem.
+// `ingredientData: null` on a lookup miss. A transport/proxy failure surfaces as
+// a 5xx (axios rejection) — not a field on this body — so there is no `error` key.
 interface ParseEnrichResponse {
   ingredientData: IngredientData | null
-  error?: { message: string }
 }
 
 export interface EnrichmentResult {
-  source: 'cache' | 'spoonacular'
   data: IngredientData | null
-  error?: { message: string }
 }
 
 export async function fetchIngredientEnrichment(
@@ -23,9 +20,5 @@ export async function fetchIngredientEnrichment(
   const response = await http.post<ParseEnrichResponse>('/api/ingredients/parse', {
     ingredientString: parsedIngredient.originalIngredientString,
   })
-  const result = response.data
-  if (result.error) {
-    return { source: 'spoonacular', data: result.ingredientData, error: result.error }
-  }
-  return { source: 'spoonacular', data: result.ingredientData }
+  return { data: response.data.ingredientData }
 }

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -486,9 +486,12 @@ class RecipeAPIClass {
     try {
       const enrichment = await fetchIngredientEnrichment(parsedIngredient)
 
-      if (enrichment.error || !enrichment.data) {
+      // A clean lookup miss returns `data: null` (the server soft-fails to that;
+      // a real proxy/network failure throws and is caught below). Surface it as
+      // the row's error state so the UI shows its Retry affordance.
+      if (!enrichment.data) {
         return {
-          error: enrichment.error ?? { message: 'No ingredient data returned' },
+          error: { message: 'No ingredient data returned' },
           parsedIngredient,
           ingredientData: null,
           id: uuidv4(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,54 @@
-import { IngredientData, ParsedIngredient } from '@jclind/ingredient-parser'
+// Prepify-owned ingredient types. These deliberately do NOT import from
+// @jclind/ingredient-parser: v2 restructured its output (nested quantity/unit
+// objects, `price`/`image` renames) and these names are the app's stable,
+// persisted contract. The server projects the v2 result back onto this shape at
+// the /api/ingredients/parse boundary (server/routes/ingredients.js), so both
+// freshly-enriched ingredients and every already-saved recipe document stay
+// valid. The flat ParsedIngredient below matches the package's `parseIngredient
+// String` legacy adapter, which the add-recipe flow still calls locally.
+export type ParsedIngredient = {
+  quantity: number | null
+  unit: string | null
+  unitPlural: string | null
+  symbol: string | null
+  ingredient: string | null
+  originalIngredientString: string
+  minQty: number | null
+  maxQty: number | null
+  comment: string | null
+}
+
+export interface IngredientData {
+  // Fields the app reads/persists today.
+  name: string
+  imagePath?: string
+  totalPriceUSACents?: number
+  possibleUnits?: string[]
+  category?: string
+  // Tolerated extras: older recipe documents persisted the full v1 enrichment
+  // blob. These stay optional so historical reads keep type-checking; new
+  // enrichments only populate the fields above.
+  _id?: string
+  ingredientId?: number
+  originalName?: string
+  amount?: number
+  consistency?: string
+  shoppingListUnits?: string[]
+  aisle?: string
+  image?: string
+  nutrition?: unknown
+  estimatedPrices?: {
+    estimatedGramPrice?: number
+    estimatedSingleUnitPrice?: number
+  }
+  meta?: unknown
+  categoryPath?: unknown
+  unit?: string
+  unitShort?: string
+  unitLong?: string
+  original?: unknown
+  id?: number
+}
 
 export type RecipeType = {
   _id: string

--- a/src/util/updateIngredients.ts
+++ b/src/util/updateIngredients.ts
@@ -1,5 +1,4 @@
-import { IngredientData, ParsedIngredient } from '@jclind/ingredient-parser'
-import { IngredientsType } from 'types'
+import { IngredientData, ParsedIngredient, IngredientsType } from 'types'
 // import { evalNum } from './validateIngredientQuantityStr'
 
 // const mixedToDecimal = (str: string): number => {


### PR DESCRIPTION
## Summary

Migrates ingredient enrichment from `@jclind/ingredient-parser` **v1.3.4 → v2.0.0**. v2 is **key-free on the client**: `POST /api/ingredients/parse` now calls the package's hosted proxy (which holds the Spoonacular key) instead of the in-process v1 library, so the server no longer needs `SPOONACULAR_API_KEY`.

The v2 output was restructured (nested `parsed`, renamed `price.cents` / `image`). To keep persisted recipe documents and every downstream consumer stable, the server **projects the v2 result onto Prepify's existing shape at the route boundary** (`totalPriceUSACents` / `imagePath`), and the app now **owns** `ParsedIngredient` / `IngredientData` in `src/types.ts` (decoupled from the package's type surface).

## Changes

**Server**
- `server/routes/ingredients.js` — call `ingredientParser()` and map `{parsed, data}` onto the stable shape via `mapIngredientData`. Price `price.cents` → `Math.round()` whole cents (v1 parity); price/image omitted when absent so the UI shows its soft-fail state (`—` / basket icon) rather than `$0.00` / a broken thumbnail. Retargets the Spoonacular CDN host rewrite (v2's `buildImageUrl` still emits the old `spoonacular.com/cdn` host). Optional `INGREDIENT_PARSER_PROXY_URL` override; **client-supplied `options` are no longer forwarded** so a caller can't redirect the proxy target.
- Pin `"@jclind/ingredient-parser": "2.0.0"` (root + server) — the `latest` dist-tag is still 1.3.4.

**Client**
- `src/types.ts` — app-owned `ParsedIngredient` (exact match to the package's legacy `parseIngredientString` adapter) + `IngredientData` (fields the app reads, plus tolerated optional extras so historical recipe docs still type-check).
- `src/api/ingredientParserApi.ts`, `src/util/updateIngredients.ts` — consume the app-owned types and the `{ ingredientData }` response.
- Dropped vestigial `error` / `source` plumbing from the enrichment result (the route only ever returns `{ ingredientData }` or a generic 500; a miss is `data: null`). No behavior change.

**Tests / fixtures / docs**
- Rewrote `server/__tests__/ingredients.test.js` to the v2 mapping (price round, CDN rewrite, omit-when-absent, clean-miss, ignores client options).
- Updated the Cypress fixture + inline intercept to the new response shape.
- `CLAUDE.md` + `server/.env.example` document the key-free proxy path and that `SPOONACULAR_API_KEY` is no longer used by this server.

## Testing

- `tsc --noEmit`: clean
- Frontend (Vitest): **516 passed / 2 skipped**
- Backend (Jest): **695 passed** (ingredient route: 14)
- **Live end-to-end smoke test** against the real stack (client + API → hosted proxy → Spoonacular): created an account, added ingredients (`2 cups flour`, `3 large eggs`, `pinch of salt`), confirmed each row enriches with a real (loaded) thumbnail + price, the subtotal computes, a non-existent ingredient soft-fails to a Retry affordance, and the recipe saves. Test data was deleted afterward.

## Notes

- Verified against the **installed v2 type defs**: `EnricherOptions` really has `serverUrl?` / `imageSize?`, and `buildImageUrl` hardcodes the old CDN host — so the override and rewrite are both real, not silent no-ops.
- No consumer reads a now-missing v1 field (swept all `ingredientData.*` reads — only `imagePath` / `totalPriceUSACents` / `name`).