### PR TITLE
style(tokens): collapse decorative orange tint to $primary-tint

### DIFF
--- a/src/Components/RecipePlaceholder/RecipePlaceholder.scss
+++ b/src/Components/RecipePlaceholder/RecipePlaceholder.scss
@@ -1,3 +1,5 @@
+@use '../../helpers.scss' as s;
+
 .recipe-placeholder {
   display: flex;
   align-items: center;
@@ -10,7 +12,7 @@
   aspect-ratio: 4 / 3;
   // Soft tint of the brand orange so it reads as "no photo" not "broken".
   background: linear-gradient(135deg, #fff3ee, #ffe1d4);
-  color: #ff8a65;
+  color: s.$primary-tint;
 
   &__icon {
     width: 36%;

--- a/src/helpers.scss
+++ b/src/helpers.scss
@@ -1,5 +1,9 @@
 $primary: #ff5722; // Also located in TrendingRecipes.js
 $primary-hover: #e74e1d; // darkened orange for primary-button/link hover
+// Light decorative tint of the brand orange — gradient stops + the "no photo"
+// placeholder. Purely decorative (never text/contrast), so it's outside the
+// accessible-orange story below.
+$primary-tint: #ff8a5c;
 $secondary: #00adb5;
 // Accessible (WCAG AA) variants of the brand colors, for the cases where the
 // brand color is small text on a light surface OR a fill behind white text —

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -160,7 +160,7 @@
     font-size: 0.72rem;
     font-weight: 800;
     color: #fff;
-    background: linear-gradient(135deg, s.$primary, #ff8a5c);
+    background: linear-gradient(135deg, s.$primary, s.$primary-tint);
     padding: 0.18rem 0.5rem;
     border-radius: s.$radius-pill;
   }
@@ -183,7 +183,7 @@
     }
     .acct-xpbar-fill {
       height: 100%;
-      background: linear-gradient(90deg, #ff8a5c, s.$primary);
+      background: linear-gradient(90deg, s.$primary-tint, s.$primary);
       border-radius: s.$radius-pill;
     }
     .acct-xpbar-label {


### PR DESCRIPTION
## What

Collapses the two near-duplicate **decorative** brand-orange tints into one token:

- `#ff8a5c` — avatar / XP gradient stops (`Account.scss` ×2)
- `#ff8a65` — the "no photo" `RecipePlaceholder` icon color

Both are the same light tint of `$primary` at values 9/255 apart. Promotes `$primary-tint: #ff8a5c` and repoints all three uses (RecipePlaceholder also gains the `@use helpers as s` import it lacked).

## Scope — deliberately isolated from the brand-orange work

This is the **only** slice of the "collapse brand shades" backlog item that's independent of the in-flight a11y / brand-orange recolor. These tints are purely decorative (gradient stops + a placeholder glyph — never text on a surface), so they carry no contrast implications. The hover/accessible-orange shades (`#f4501e`, `#a52f0a`, `$primary-hover`) are **left untouched** — they belong to the brand-orange recolor.

## Verification

Compiled CSS before/after — the **only** change is the placeholder color:

```
< color:#ff8a65   →   > color:#ff8a5c
```

Account's gradients are byte-identical. The single `#ff8a65`→`#ff8a5c` shift is 9/255 in the blue channel — imperceptible.

## Gates
- `npx tsc --noEmit` → 0
- `npm run build` → clean
- `npm test` → 516 passed / 2 skipped