### PR TITLE
ci(e2e): fix failing Cypress job — run Express server against ephemeral Mongo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,9 @@
 #   VITE_FIREBASE_APP_ID
 #   VITE_FIREBASE_MEASUREMENT_ID
 #   FIREBASE_SERVICE_ACCOUNT   (base64-encoded service account JSON for backend tests)
-#   MONGO_URI                  (MongoDB connection string for E2E Express server)
 #   CYPRESS_API_URL            (Railway backend URL, e.g. https://prepify.up.railway.app)
+# The E2E Express server runs against an ephemeral Mongo service container (see the
+# e2e job), so no MONGO_URI secret is needed — the Cypress specs mock the API anyway.
 
 name: Tests
 
@@ -59,6 +60,21 @@ jobs:
   e2e:
     name: E2e (Cypress)
     runs-on: ubuntu-latest
+    # The Cypress specs fully intercept the API with fixtures (cy.intercept), so
+    # the Express server only needs to boot and serve /health for the wait-on
+    # gate — it never reads real data. Run it against an ephemeral, throwaway
+    # Mongo so E2E doesn't depend on (and never touches) the prod database or a
+    # rotating MONGO_URI secret. GitHub waits for the healthcheck before steps run.
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -79,7 +95,7 @@ jobs:
         working-directory: server
         env:
           PORT: 4000
-          MONGO_URI: ${{ secrets.MONGO_URI }}
+          MONGO_URI: mongodb://localhost:27017/prepify
           FRONTEND_URLS: http://localhost:3000
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
       - name: Check Express server startup

--- a/server/db.js
+++ b/server/db.js
@@ -7,7 +7,17 @@ async function connectDB(uri) {
   const mongoUri = uri || process.env.MONGO_URI
   const options = uri
     ? { serverSelectionTimeoutMS: 5000 }
-    : { tls: true, serverSelectionTimeoutMS: 5000, socketTimeoutMS: 45000, maxPoolSize: 10 }
+    : { serverSelectionTimeoutMS: 5000, socketTimeoutMS: 45000, maxPoolSize: 10 }
+
+  // Force TLS for the remote (Atlas/prod) MONGO_URI connection, but never for a
+  // localhost host. A plain mongodb://localhost — local dev or the CI E2E mongo
+  // service container — has no TLS endpoint, so forcing it fails the handshake.
+  // The explicit-`uri` arg path (server unit tests / in-memory Mongo) is already
+  // TLS-free. Remote prod URIs (any non-localhost host) keep TLS exactly as before.
+  const isLocalHost = /^mongodb:\/\/(localhost|127\.0\.0\.1)([:/]|$)/.test(mongoUri || '')
+  if (!uri && !isLocalHost) {
+    options.tls = true
+  }
 
   client = new MongoClient(mongoUri, options)
   await client.connect()


### PR DESCRIPTION
## Problem

The **E2e (Cypress)** check has been failing on `development` (pre-existing — it failed on the docs-only PR #194 too). The failure is **not** a Cypress spec/assertion; it's at the **Check Express server startup** step:

```
Express server failed to start
Failed to connect to MongoDB: bad auth : authentication failed
```

`server/index.js` does `process.exit(1)` when `connectDB()` rejects, so when the `MONGO_URI` secret's credentials went bad/rotated, the server died before booting and Cypress never ran.

## Why the server doesn't need the prod DB here

Every E2E spec **fully intercepts the API with `cy.intercept` + fixtures** (`cypress/e2e/*.cy.ts`, `cypress/fixtures/`). The Express server's only role in CI is to come up and answer `/health` (a DB-free `res.json({ status: 'ok' })`) for the `wait-on` gate. It never reads real data — so coupling E2E to a live prod Mongo (with a rotating credential) was both fragile and undesirable.

## Fix

- **Ephemeral Mongo service container** in the `e2e` job (`mongo:7`, healthchecked) and point `MONGO_URI` at `mongodb://localhost:27017/prepify` instead of `secrets.MONGO_URI`. CI now boots reliably and **never touches the prod database** (aligns with the dev/prod env-separation direction).
- **`server/db.js`**: the env-var connection path hardcoded `tls: true`, which fails a plain `mongodb://localhost` handshake. Scope forced TLS to **non-localhost** hosts, so remote/prod URIs keep TLS *exactly as before* while local CI/dev Mongo connects cleanly. The explicit-`uri` arg path (server unit tests / in-memory Mongo) is untouched.

This is a root-cause fix, not a retry/skip mask — no test was weakened.

## Notes
- The `MONGO_URI` GitHub secret is no longer consumed by any job; updated the workflow's "Required GitHub secrets" header comment accordingly.
- Backend (Supertest) job unaffected: it uses `connectDB(mongod.getUri())` (the `uri`-arg path), which this change leaves byte-for-byte identical.