### PR TITLE
security(sweep): Wave 1 — harden review/recipe/report write paths + findings

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -331,6 +331,70 @@ The triage date stamped on items is the date they were filed here, not when they
   uses a literal `#a52f0a` hover with a comment, *not* `$primary-hover`). *(surfaced 2026-06-25 while merging
   the brand-contrast PR #184 over the design-tokens track.)*
 
+## Security
+
+*(Filed by the Security sweep, 2026-06-26 — Wave 1 of [`sweeps/ROADMAP.md`](sweeps/ROADMAP.md). The
+sweep's cheap, unambiguous hardening shipped in the sweep PR; these are the structural / debatable tail.
+The headline IDOR/authz, CORS, secrets-in-git, and XSS checks all came back clean — see the sweep PR's
+findings table.)*
+
+- `[ ]` **[action] Revoke the live OpenAI key sitting in cleartext in the local `.env`** *(highest-priority
+  follow-up)* — `.env:9` carries a full-access `VITE_OPEN_AI_API_KEY = sk-…`. Verified **dead** (zero
+  references in `src/`, so Vite does NOT bundle it) and **never committed** (`.env` is gitignored; `git log
+  -S` for the key is clean), so it is not an active leak — but it's a live, full-access credential in
+  plaintext on disk. **Rotate/revoke it and delete the line.** OpenAI is server-side only now
+  (`OPENAI_API_KEY` in `server/.env`). While there, drop the now-dead `SPOONACULAR_API_KEY` from
+  `server/.env` (the v2 parser is key-free — the proxy holds the key). These are local gitignored files, so
+  this is an operator action, not a code change / PR. *(surfaced 2026-06-26 in the security sweep.)*
+- `[ ]` **Public recipe reads return the full Mongo doc, leaking internal fields** — `GET /getRecipe`'s
+  public path (`server/routes/recipes.js:411-437`) returns the entire recipe document with no projection,
+  so internal curation/moderation stamps (`moderatedBy`/`moderatedAt`/`featuredBy`/`featuredAt`/
+  `publishUpdatedBy`/`publishUpdatedAt`/`status` — admin Firebase uids + moderation metadata) leak to
+  anonymous clients on any recipe that was ever featured/unhidden. `publicProfile.js:74` & `:157` share the
+  full-doc pattern (only `RECIPE_VISIBLE`/active recipes, so no moderation-state leak, but they still expose
+  the author uid + other internal fields the card never reads). Fix: a shared public-recipe projection /
+  output whitelist (verify the FE doesn't read the stamped fields first). Low (PII = internal admin uids,
+  not user-facing). *(surfaced 2026-06-26 in the security sweep.)*
+- `[ ]` **Recipe numeric/array fields aren't range- or type-validated server-side** —
+  `validateRecipeBounds` (`server/util/recipeLimits.js`, used by add/editRecipe) bounds title/description
+  length, ingredient/instruction counts, and instruction-content length, but NOT the numeric fields
+  (`servings`/`prepTime`/`cookTime`/`totalTime`/`servingPrice` accept negative/huge/non-numeric), per-element
+  ingredient size, or the shape/size of `nutritionData`/`cuisine`/`mealTypes`/`nutritionLabels` (copied
+  through, bounded only by the global JSON body-size limit). Add numeric type+range clamps and per-element
+  caps. Low. *(surfaced 2026-06-26 in the security sweep.)*
+- `[ ]` **Admin review takedown matches on the stale denormalized `username`** —
+  `PATCH /admin/reviews/moderation` (`server/routes/reviews.js:318-353`) matches `{ username, recipeId }`,
+  but ratings are keyed by the stable `userId` (username is a set-once display field). If an author renames
+  their handle after posting, the admin match can hit the wrong doc or 404, and the audit `targetId`
+  (`${username}:${recipeId}`) inherits the ambiguity. Resolve `username → userId` (as
+  `getSingleUserReviews:267` already does) and match on `userId`. Admin-only ⇒ a moderation-reliability bug,
+  not an exploit. Low. *(surfaced 2026-06-26 in the security sweep.)*
+- `[ ]` **`POST /reports` has no per-user rate limiter (report-spam breadth)** —
+  `server/routes/reports.js:69` enforces one-open-report-per-(reporter,target) but nothing caps *breadth*:
+  one account can open a report against every recipe/user and re-file after each resolve/dismiss to bloat the
+  moderation queue. Only the coarse global per-IP 1000/15min backstop applies. Add a `makeUserLimiter`-style
+  per-uid limiter (mirrors how content writes are bounded in `middleware/writeLimiter.js`). Low-med.
+  *(surfaced 2026-06-26 in the security sweep.)*
+- `[ ]` **Two authed writes lack the per-user write limiter (consistency)** — `POST /updatePrivacy`
+  (`server/routes/auth.js:310`) and `POST /acknowledgeAchievements` (`server/routes/gamification.js:31`) are
+  authed writes with no `profileWriteLimiter`, unlike their sibling profile writes. Both are cheap +
+  idempotent so impact is minimal; add the limiter for consistency. Low. *(surfaced 2026-06-26 in the
+  security sweep.)*
+- `[ ]` **`POST /recipes/:id/save` counter update is read-then-write (TOCTOU)** —
+  `server/routes/recipes.js:760-773` reads `alreadySaved` then `$push`+`$inc`, so two concurrent saves from
+  one user can both pass the guard and double-count `numTimesSaved`. Single-user, low impact. (The sibling
+  `madeRecipe` counter-inflation — same shape but exploitable by *intentional* repeat POSTs — was fixed in
+  the sweep PR by deduping off the atomic `$addToSet` result; `save` still has the narrow concurrent window.)
+  Fix: array-condition update (`$ne` filter) / unique-element write. Low. *(surfaced 2026-06-26 in the
+  security sweep.)*
+- `[ ]` **`firebase-admin` pulls transitive moderate CVEs (needs a breaking major bump)** — `cd server &&
+  npm audit --omit=dev` = **8 moderate, 0 high/critical**, all transitive under `firebase-admin` →
+  `@google-cloud/{firestore,storage}` → `gaxios`/`google-gax`/`teeny-request`/`retry-request`/`uuid`. The
+  `uuid <11.1.1` advisory only triggers when the caller passes a `buf` arg, which firebase-admin doesn't —
+  no runtime exploit path here. Fix requires `firebase-admin@14.x` (**breaking major**). Schedule it; not
+  urgent. (Root/frontend `npm audit` shows 1 high = `undici`, but it's **dev-only/transitive** — `npm audit
+  --omit=dev` at root = 0; the deployed bundle is clean.) Low. *(surfaced 2026-06-26 in the security sweep.)*
+
 ## Features
 
 - `[ ]` **Press `/` to focus search** — global keyboard shortcut to bring up search. No handler exists today.

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -117,6 +117,15 @@ a feature flag. Do these together:
   rotate them** — Prepify intends to migrate off Edamam entirely (see BACKLOG → Tech debt), so rotating
   a soon-to-be-retired key isn't worth it. The old `VITE_OPEN_AI_API_KEY` was never wired to a live
   call (removed in PR #151). Firebase web key is public-by-design + referrer-locked. **(blocker → waived)**
+- `[ ]` **Revoke the live OpenAI `sk-` key still on disk in the local `.env`** — **reopened by the Security
+  sweep (2026-06-26).** PR #151 removed `VITE_OPEN_AI_API_KEY` from the committed `.env.example` (the two
+  `[x]` items above), but the **actual gitignored `.env` still carries a live, full-access
+  `VITE_OPEN_AI_API_KEY = sk-…`** (`.env:9`). It is **dead** (zero `src/` callers → Vite does not bundle it)
+  and **never committed** (`git log -S` clean), so it is not an active leak — but unlike the waived Edamam
+  keys, this is a current, full-access credential sitting in plaintext, so the "never wired → don't rotate"
+  reasoning doesn't apply. **Rotate/revoke it and delete the line.** While there, drop the now-dead
+  `SPOONACULAR_API_KEY` from `server/.env` (the v2 parser is key-free). Operator action on local files — no
+  PR. See BACKLOG → Security. **(launch-gating hygiene)**
 - `[x]` **Lock down Edamam / Firebase usage server-side** — **done (2026-06-25).** Firebase **web API key
   is HTTP-referrer-restricted** — verified live that `prepifymeals.com`, `www.prepifymeals.com`, and
   `localhost:3000` are allowed while an empty referer is blocked (so prod + local dev work; a lifted key

--- a/docs/sweeps/README.md
+++ b/docs/sweeps/README.md
@@ -35,7 +35,7 @@ PR (method §7).
 | Sweep | Last run | PR | Cheap wins shipped | Open follow-ups |
 |---|---|---|---|---|
 | **Performance** | _not yet run_ | — | — | — |
-| **Security** | _not yet run_ | — | — | — |
+| **Security** | 2026-06-26 | #197 | `madeRecipe` counter-inflation dedup; `reports` username→uid oracle closed; `addRating` per-user limiter; review-route type guards | 8 → [BACKLOG → Security](../BACKLOG.md#security): **revoke live OpenAI key on disk** (+ `RELEASE_PLAN.md` §B), public `getRecipe` full-doc leak, recipe numeric validation, admin-takedown stale-username match, reports breadth limiter, two authed writes missing limiter, `save` TOCTOU, `firebase-admin` major bump (8 moderate transitive CVEs) |
 | **Accessibility** | 2026-06-25 | #179 (+#181, #184 contrast follow-ups) | ingredient-checklist role (recipe page 89→97); grey / teal / beta-tag / error-red contrast | 5 → [BACKLOG → Accessibility](../BACKLOG.md#accessibility): autocomplete listbox + keyboard nav, servings target-size, `$primary-hover` AA-on-hover, brand orange (reverted to vivid — owner call), account-heading route-map |
 | **Design consistency** | 2026-06-25 | #180 (+#183, #185, #186, #192) | `$primary-hover` + `$surface-warm-border` tokens; radius scale, breakpoint tokens, admin import-wiring, decorative tint | ~10 → [BACKLOG → UX / visual polish](../BACKLOG.md#ux--visual-polish) + [Tech debt](../BACKLOG.md#tech-debt--process--infra): pill `.btn` system, delete `RecipeThumbnail`, icon-per-concept, modal style config, loading-state pattern, toast punctuation; type scale, elevation re-author, danger-red token, `$admin-*` palette, `RecipeFormInput` dup |
 | **Code quality & tests** | _not yet run_ | — | — | — |

--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -61,7 +61,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 |---|---|---|---|---|
 | — | Accessibility sweep (initial) | `[x]` | — | #179 (+#181/#184) |
 | — | Design-consistency sweep (initial) | `[x]` | — | #180 (+#183/#185/#186/#192) |
-| **1** | **Security sweep** | `[~]` | `server/` (routes, middleware, `app.js` CORS), Firebase rules, `.env.example`, `src/api/http-common.ts` | `worktree-feat+security-sweep` (2026-06-26) |
+| **1** | **Security sweep** | `[P]` | `server/` (routes, middleware, `app.js` CORS), Firebase rules, `.env.example`, `src/api/http-common.ts` | #197 |
 | **1** | **Performance sweep** | `[ ]` | measure → backlog; cheap wins = `<img>` dims/`loading` in a few components | — |
 | **1** | **Code-quality & tests sweep** | `[ ]` | `src/test/`, `server/` tests, `cypress/`, types, **dead-code delete (`RecipeThumbnail`)**, error handling | — |
 | **2-iso** | A11y: autocomplete listbox + keyboard nav | `[ ]` | `SearchRecipesInput.tsx` | — |
@@ -149,3 +149,11 @@ narrates the *why*.
 - _2026-06-26_ — Roadmap created. Wave 1 (Security / Performance / Code-quality) defined and open; the two
   completed sweeps' tails organized into Wave 2 (`2-iso` parallel + `2-scss` serialized) and a `[blocked]`
   brand-orange lane; Wave 3 = pre-1.0 re-sweep. Nothing in Wave 1 started yet.
+- _2026-06-26_ — **Security sweep** run (PR #197). Highest-value authz/IDOR check + CORS, secrets-in-git, and
+  XSS all came back **clean**. Cheap hardening shipped: `madeRecipe` global-counter inflation (single account
+  could re-POST to inflate `numTimesMade`) deduped off the atomic `$addToSet`; `POST /reports` username→uid
+  oracle closed (stopped echoing `reportedUid`); `addRating` got the missing per-user limiter; type guards
+  on 4 review read/delete routes. 8 structural follow-ups filed → [BACKLOG → Security](../BACKLOG.md#security)
+  (headline: **revoke the live OpenAI key on disk** — also `RELEASE_PLAN.md` §B; public `getRecipe` full-doc
+  leak; recipe numeric validation; `firebase-admin` major bump for 8 moderate transitive CVEs). Server suite
+  697/697; authenticated headless smoke confirmed no regressions.

--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -61,7 +61,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 |---|---|---|---|---|
 | — | Accessibility sweep (initial) | `[x]` | — | #179 (+#181/#184) |
 | — | Design-consistency sweep (initial) | `[x]` | — | #180 (+#183/#185/#186/#192) |
-| **1** | **Security sweep** | `[ ]` | `server/` (routes, middleware, `app.js` CORS), Firebase rules, `.env.example`, `src/api/http-common.ts` | — |
+| **1** | **Security sweep** | `[~]` | `server/` (routes, middleware, `app.js` CORS), Firebase rules, `.env.example`, `src/api/http-common.ts` | `worktree-feat+security-sweep` (2026-06-26) |
 | **1** | **Performance sweep** | `[ ]` | measure → backlog; cheap wins = `<img>` dims/`loading` in a few components | — |
 | **1** | **Code-quality & tests sweep** | `[ ]` | `src/test/`, `server/` tests, `cypress/`, types, **dead-code delete (`RecipeThumbnail`)**, error handling | — |
 | **2-iso** | A11y: autocomplete listbox + keyboard nav | `[ ]` | `SearchRecipesInput.tsx` | — |

--- a/docs/sweeps/security.md
+++ b/docs/sweeps/security.md
@@ -1,6 +1,9 @@
 # Security sweep
 
-> **Status:** _Not yet run._ *(See the [run log](README.md#run-log).)*
+> **Status:** Run 2026-06-26 — **PR #197**. Authz/IDOR, CORS, secrets-in-git, and XSS all clean. Cheap
+> hardening shipped (`madeRecipe` counter-inflation, `reports` username→uid oracle, `addRating` limiter,
+> review-route type guards); 8 follow-ups filed → [BACKLOG → Security](../BACKLOG.md#security) (headline:
+> revoke the live OpenAI key on disk). *(See the [run log](README.md#run-log).)*
 
 Full-coverage security audit of the Prepify client + API: secrets, authentication/authorization (incl.
 IDOR), input validation, rate limiting, CORS, Firebase rules, dependency CVEs, and data exposure /

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -570,6 +570,44 @@ describe('POST /recipes/:id/save', () => {
   })
 })
 
+// ─── POST /madeRecipe ─────────────────────────────────────────────────────────
+
+describe('POST /madeRecipe', () => {
+  beforeEach(async () => {
+    const db = getDB()
+    await db.collection('recipes').insertOne({ ...BASE_RECIPE, numTimesMade: 0 })
+  })
+
+  it('records the recipe and increments numTimesMade on first call', async () => {
+    const res = await request(server)
+      .post(`/api/madeRecipe?recipeId=${RECIPE_ID}`)
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ made: true })
+
+    const db = getDB()
+    const recipe = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.numTimesMade).toBe(1)
+    const userData = await db.collection('userRecipeData').findOne({ _id: TEST_UID })
+    expect(userData.madeRecipes).toEqual([{ recipeId: RECIPE_ID }])
+  })
+
+  it('does not inflate numTimesMade when the same user re-marks it made', async () => {
+    // Three calls from the same user — madeRecipes is a set, so the global
+    // counter must only count the first (guards against counter inflation).
+    for (let i = 0; i < 3; i++) {
+      await request(server).post(`/api/madeRecipe?recipeId=${RECIPE_ID}`).set(AUTH_HEADER)
+    }
+
+    const db = getDB()
+    const recipe = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.numTimesMade).toBe(1)
+    const userData = await db.collection('userRecipeData').findOne({ _id: TEST_UID })
+    expect(userData.madeRecipes).toHaveLength(1)
+  })
+})
+
 // ─── DELETE /recipes/:id/save ─────────────────────────────────────────────────
 
 describe('DELETE /recipes/:id/save', () => {

--- a/server/__tests__/reports.test.js
+++ b/server/__tests__/reports.test.js
@@ -69,7 +69,11 @@ describe('POST /api/reports', () => {
       .set(AUTH_HEADER)
       .send({ targetType: 'review', recipeId: 'recipe-001', reportedUsername: 'baduser', reason: 'offensive' })
     expect(res.status).toBe(201)
-    expect(res.body.reportedUid).toBe('bad-uid')
+    // reportedUid is stamped on the stored doc but never echoed to the reporter
+    // (echoing it leaked any handle's Firebase uid — see the route comment).
+    expect(res.body.reportedUid).toBeUndefined()
+    const stored = await getDB().collection('reports').findOne({ reporterUid: TEST_UID })
+    expect(stored.reportedUid).toBe('bad-uid')
   })
 
   it('leaves reportedUid null when the reported handle has no account', async () => {
@@ -78,7 +82,8 @@ describe('POST /api/reports', () => {
       .set(AUTH_HEADER)
       .send({ targetType: 'review', recipeId: 'recipe-001', reportedUsername: 'ghost', reason: 'offensive' })
     expect(res.status).toBe(201)
-    expect(res.body.reportedUid).toBeNull()
+    const stored = await getDB().collection('reports').findOne({ reporterUid: TEST_UID })
+    expect(stored.reportedUid).toBeNull()
   })
 
   it('does not stamp reportedUid on a recipe report', async () => {
@@ -87,7 +92,8 @@ describe('POST /api/reports', () => {
       .set(AUTH_HEADER)
       .send(validRecipeReport)
     expect(res.status).toBe(201)
-    expect(res.body.reportedUid).toBeUndefined()
+    const stored = await getDB().collection('reports').findOne({ reporterUid: TEST_UID })
+    expect(stored.reportedUid).toBeUndefined()
   })
 
   it('creates a user report carrying reportedUsername and no recipeId', async () => {
@@ -110,7 +116,9 @@ describe('POST /api/reports', () => {
       .set(AUTH_HEADER)
       .send({ targetType: 'user', reportedUsername: 'baduser', reason: 'offensive' })
     expect(res.status).toBe(201)
-    expect(res.body.reportedUid).toBe('bad-uid')
+    expect(res.body.reportedUid).toBeUndefined()
+    const stored = await getDB().collection('reports').findOne({ reporterUid: TEST_UID })
+    expect(stored.reportedUid).toBe('bad-uid')
   })
 
   it('requires reportedUsername for a user report', async () => {

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -830,15 +830,25 @@ router.post('/madeRecipe', verifyToken, requireActive, asyncHandler(async (req, 
     return res.status(400).json({ error: 'recipeId is required' })
   }
   const uid = req.uid
-  await db.collection('recipes').updateOne(
-    recipeIdQuery(recipeId),
-    { $inc: { numTimesMade: 1 } }
-  )
-  await db.collection('userRecipeData').updateOne(
+  // Record the made-recipe first and only bump the global counter when this is
+  // the user's FIRST time marking it made. madeRecipes is a $addToSet, so a
+  // repeat call is idempotent there — but the unconditional $inc let a single
+  // account inflate numTimesMade arbitrarily by re-POSTing the same id. Mirror
+  // the dedup the save route gets from its alreadySaved guard, off the atomic
+  // write result (a fresh user doc shows as an upsert; a new set member as a
+  // modifiedCount of 1) so there's no read-then-write race.
+  const addResult = await db.collection('userRecipeData').updateOne(
     { _id: uid },
     { $addToSet: { madeRecipes: { recipeId } } },
     { upsert: true }
   )
+  const newlyMade = addResult.upsertedCount > 0 || addResult.modifiedCount > 0
+  if (newlyMade) {
+    await db.collection('recipes').updateOne(
+      recipeIdQuery(recipeId),
+      { $inc: { numTimesMade: 1 } }
+    )
+  }
   res.json({ made: true })
 }))
 

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -139,7 +139,13 @@ router.post('/reports', verifyToken, requireActive, asyncHandler(async (req, res
     createdAt: new Date(),
   }
   await db.collection('reports').insertOne(doc)
-  res.status(201).json(doc)
+  // Don't echo the reported account's internal Firebase uid back to the
+  // reporter — returning the raw doc turned this into a username→uid oracle
+  // (file a 'user' report against any handle, read reportedUid off the 201).
+  // The client never reads this body (it only toasts on success), so strip the
+  // internal id; the rest of the doc stays for shape-compatibility.
+  const { reportedUid: _omitReportedUid, ...safeDoc } = doc
+  res.status(201).json(safeDoc)
 }))
 
 // GET /reports — admin queue. Filters by status/targetType, paginates, and

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -19,7 +19,7 @@ const router = Router()
 const MAX_PER_PAGE = 50
 
 // POST /addRating
-router.post('/addRating', verifyToken, requireActive, asyncHandler(async (req, res) => {
+router.post('/addRating', verifyToken, requireActive, reviewWriteLimiter, asyncHandler(async (req, res) => {
   const { recipeId, rating } = req.query
   const db = getDB()
   // Identity is the stable uid (D1); the username is denormalized onto the
@@ -111,7 +111,7 @@ router.post('/newReview', verifyToken, requireActive, reviewWriteLimiter, asyncH
 router.get('/checkIfReviewed', verifyToken, asyncHandler(async (req, res) => {
   const db = getDB()
   const { recipeId } = req.query
-  if (!recipeId) {
+  if (!recipeId || typeof recipeId !== 'string') {
     return res.status(400).json({ error: 'recipeId is required' })
   }
 
@@ -158,7 +158,7 @@ router.delete('/deleteReview', verifyToken, asyncHandler(async (req, res) => {
   const db = getDB()
   const { recipeId } = req.query
   const userId = req.uid
-  if (!recipeId) {
+  if (!recipeId || typeof recipeId !== 'string') {
     return res.status(400).json({ error: 'recipeId is required' })
   }
 
@@ -194,7 +194,7 @@ router.delete('/removeRating', verifyToken, asyncHandler(async (req, res) => {
   const db = getDB()
   const { recipeId } = req.query
   const userId = req.uid
-  if (!recipeId) {
+  if (!recipeId || typeof recipeId !== 'string') {
     return res.status(400).json({ error: 'recipeId is required' })
   }
 
@@ -230,7 +230,7 @@ router.delete('/removeRating', verifyToken, asyncHandler(async (req, res) => {
 router.get('/getReviews', optionalAuth, asyncHandler(async (req, res) => {
   const db = getDB()
   const { recipeId, page = 0, reviewsPerPage = 5, filter } = req.query
-  if (!recipeId) return res.status(400).json({ error: 'recipeId is required' })
+  if (!recipeId || typeof recipeId !== 'string') return res.status(400).json({ error: 'recipeId is required' })
 
   const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
   const skip = (parseInt(page) || 0) * limit


### PR DESCRIPTION
## Security sweep — Wave 1 of [`docs/sweeps/ROADMAP.md`](../blob/development/docs/sweeps/ROADMAP.md)

Structured security pass over the Prepify client + API per [`docs/sweeps/security.md`](../blob/development/docs/sweeps/security.md): secrets, authN/authZ + IDOR, input validation, rate limits, CORS, Firebase rules, dependency CVEs, data exposure / XSS. **Read-and-report first** — cheap, unambiguous hardening shipped here; the structural/debatable tail is filed to the backlog. No existing control was weakened.

### Fixed in this PR (cheap, unambiguous hardening)

| Sev | Area | File | Finding | Resolution |
|---|---|---|---|---|
| **med** | Integrity / abuse | `server/routes/recipes.js:833` | `POST /madeRecipe` unconditionally `$inc`'d `numTimesMade` while `madeRecipes` is a `$addToSet` — so one account could inflate the **global** made-counter arbitrarily by re-POSTing the same id. | Bump the counter **only on the user's first** made, deduped off the atomic `$addToSet` result (`upsertedCount`/`modifiedCount`) — no read-then-write race. |
| **med** | Data exposure (uid oracle) | `server/routes/reports.js:142` | `POST /reports` returned the raw doc, echoing the reported account's internal Firebase `reportedUid` to the reporter — a **username→uid oracle** (report any handle, read the uid off the 201). | Strip `reportedUid` from the response (still persisted for moderation). Client only toasts on success, so no shape break. |
| **low** | Rate limiting | `server/routes/reviews.js:22` | `POST /addRating` was the one review-write surface with **no** per-user limiter (its siblings `newReview`/`editReview` had it). | Mount the shared `reviewWriteLimiter` (same 30/min/user bucket). |
| **low** | Input validation | `server/routes/reviews.js` (×4) | `checkIfReviewed`/`deleteReview`/`removeRating`/`getReviews` guarded `!recipeId` but not its **type**. | Add `typeof recipeId !== 'string'` guards to match the write siblings (defense-in-depth; `query parser: 'simple'` already neutralizes operator injection app-wide). |

### Verified clean (no action)

Authz/IDOR across every mutating route (all scope by server-side `req.uid`, not request-body ids) · CORS prod-lock (`FRONTEND_URLS` + netlify-preview regex + non-prod-only `localhost:3000–3010`) · secrets-in-git (nothing committed; `.env`/`server/.env` gitignored, `git log -S` clean) · NoSQL operator injection (neutralized app-wide by `app.set('query parser', 'simple')`) · XSS (no exposed `dangerouslySetInnerHTML`) · Firebase Storage rules (auth + 5 MB + `image/*`, `profilePhotos/{uid}` ownership) · stack-trace-safe error backstop.

### Filed to [`docs/BACKLOG.md` → Security](../blob/development/docs/BACKLOG.md) (structural / debatable tail)

8 items — headlines: **[action] revoke the live OpenAI `sk-` key on disk** in local `.env` (dead + never committed, but a live full-access credential in plaintext — operator action, also flagged in `RELEASE_PLAN.md` §B) · public `GET /getRecipe` returns the full Mongo doc (leaks internal moderation/curation stamps to anon) · recipe numeric fields aren't range/type-validated server-side · admin review takedown matches on stale denormalized `username` · `POST /reports` has no per-user breadth limiter · two authed writes missing the per-user limiter (consistency) · `save` counter TOCTOU · `firebase-admin` major bump (8 moderate **transitive** CVEs, no runtime exploit path).

### Launch-gating

`RELEASE_PLAN.md` §B reopened for the live OpenAI key (corrects stale `[x]` claims from PR #151). Owner has confirmed it'll be rotated down the line.

### Verification

- `cd server && npm test` → **697/697 pass** (incl. 2 new `POST /madeRecipe` dedup tests + 4 repointed `reports` assertions).
- Authenticated **headless smoke test** (Firebase custom-token bridge) against the dev backend: madeRecipe first-call +1 / repeat stays flat ✅; addRating + newReview 200 ✅; reports 201 with no `reportedUid` ✅; addRating burst → 28×200 then 7×429 `RATE_LIMITED` ✅; recipe page renders logged-in with **0 console errors** ✅. Temp artifacts + the `VITE_CYPRESS` flag reverted; dev DB scrubbed.

### Trackers

Run-log ledger, ROADMAP Board (`[~]`→`[P]`) + Status-log, and the `security.md` `> Status:` banner updated in this PR.

https://claude.ai/code/session_01EDb6rjjnkrYCQNuX2wMqXc
