### PR TITLE
Design: toast punctuation + string dedupe (Wave 2 2-iso)

### DIFF
--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -71,7 +71,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **2-iso** | Design: one icon per concept | `[x]` | new `src/Components/icons` + import swaps | #205 |
 | **2-iso** | Design: single icon family (Lucide) | `[x]` | `src/Components/icons` glyph remap (no call-site churn) + temp audit page + docs | #206 |
 | **2-iso** | Design: `RecipeFormInput` → shared `FormInput` | `[x]` | `AddRecipe/*`, `Components/Form/*` | #204 |
-| **2-iso** | Design: toast punctuation + string dedupe | `[ ]` | ~10 toast call sites (TSX strings) | — |
+| **2-iso** | Design: toast punctuation + string dedupe | `[~]` | ~10 toast call sites (TSX strings) | `worktree-feat+toast-punctuation-string-dedupe` (2026-06-29) |
 | **2-iso** | Design: codify loading-state pattern | `[ ]` | convention + `TailSpin`/skeleton outliers | — |
 | **2-scss** | Design: pill `.btn` system | `[ ]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | — |
 | **2-scss** | Design: type scale (~520 `font-size:` literals) | `[ ]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | — |

--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -71,7 +71,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **2-iso** | Design: one icon per concept | `[x]` | new `src/Components/icons` + import swaps | #205 |
 | **2-iso** | Design: single icon family (Lucide) | `[x]` | `src/Components/icons` glyph remap (no call-site churn) + temp audit page + docs | #206 |
 | **2-iso** | Design: `RecipeFormInput` → shared `FormInput` | `[x]` | `AddRecipe/*`, `Components/Form/*` | #204 |
-| **2-iso** | Design: toast punctuation + string dedupe | `[~]` | ~10 toast call sites (TSX strings) | `worktree-feat+toast-punctuation-string-dedupe` (2026-06-29) |
+| **2-iso** | Design: toast punctuation + string dedupe | `[P]` | ~10 toast call sites (TSX strings) | #207 |
 | **2-iso** | Design: codify loading-state pattern | `[ ]` | convention + `TailSpin`/skeleton outliers | — |
 | **2-scss** | Design: pill `.btn` system | `[ ]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | — |
 | **2-scss** | Design: type scale (~520 `font-size:` literals) | `[ ]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | — |
@@ -258,6 +258,18 @@ narrates the *why*.
   GitGuardian). Closes the Design-consistency `RecipeFormInput` dup follow-up; filed one new UX-polish item
   (make the create-recipe **dropdown** inputs visually uniform with the unified text fields). Worktree + branch
   torn down. **Second Design `2-iso` track to land.**
+- _2026-06-29_ — **Design: toast punctuation + string dedupe** PR opened (#207, `[~]`→`[P]`). Codified one toast
+  copy convention (errors → terminal period; success → period except genuine milestones keep `!`; no raw
+  `Error: …` dumps) and extracted the cross-file duplicate strings into a new `src/util/toastMessages.ts` (12
+  constants + `reportsBulkUpdated`/`reportUpdated` helpers) — same single-source pattern as `modalStyles`/
+  `accountTabs`. The roadmap's "~10 sites" estimate was low: ~90 `toast` calls across 25 files, but most already
+  conformed — actual edits ~25 sites (8 period-less errors fixed, 6 routine success `!`→`.`, 8 cross-file dups
+  deduped incl. the identical Reports/BugReports mutation block). `tsc` clean, frontend suite 543/2-skip green,
+  build passing; 3 test assertions + TEST_PLAN updated to the new copy. Verified live (headless): PublicProfile
+  Share renders `Profile link copied.` / `Could not copy link.` (both branches), zero console errors —
+  auth-gated toasts covered by tsc+tests, not driven (no dev creds). High-effort multi-agent code review: no
+  correctness bugs; two reuse nits (coincidentally-identical admin toggle string; generic sentence shared with
+  `authErrors`' inline default) considered and intentionally left inline. **Third Design `2-iso` track to reach PR.**
 - _2026-06-29_ — **Design: one icon per concept merged** (PR #205 → `development`, `[~]`→`[P]`→`[x]`). All five CI
   checks green against the merge HEAD (Backend/Supertest, E2E/Cypress, Frontend/Vitest, Fallow advisory,
   GitGuardian). Collapsed react-icons drift into a single re-export module `src/Components/icons` (94 semantic

--- a/src/Components/AddToCollection/AddToCollectionPopover.tsx
+++ b/src/Components/AddToCollection/AddToCollectionPopover.tsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast'
 import CollectionsAPI from 'src/api/collections'
 import RecipeAPI from 'src/api/recipes'
 import { RecipeCollection } from 'types'
+import { COLLECTION_CREATE_ERROR } from 'src/util/toastMessages'
 
 type Props = {
   recipeId: string
@@ -53,7 +54,7 @@ const AddToCollectionPopover: FC<Props> = ({
       onMutated()
     } catch {
       setSelected(prev) // roll back on failure
-      toast.error('Could not update collections')
+      toast.error('Could not update collections.')
     } finally {
       setBusy(false)
     }
@@ -74,7 +75,7 @@ const AddToCollectionPopover: FC<Props> = ({
     try {
       created = await CollectionsAPI.create(name)
     } catch (err: any) {
-      toast.error(err?.response?.data?.error ?? 'Could not create collection')
+      toast.error(err?.response?.data?.error ?? COLLECTION_CREATE_ERROR)
       setBusy(false)
       return
     }
@@ -90,7 +91,7 @@ const AddToCollectionPopover: FC<Props> = ({
       await CollectionsAPI.setRecipeCollections(recipeId, [...next])
       setSelected(next)
     } catch {
-      toast.error('Collection created, but the recipe couldn’t be added to it')
+      toast.error('Collection created, but the recipe couldn’t be added to it.')
     } finally {
       onMutated()
       setBusy(false)

--- a/src/Components/AdminRecipeControls/AdminRecipeControls.tsx
+++ b/src/Components/AdminRecipeControls/AdminRecipeControls.tsx
@@ -7,6 +7,7 @@ import AdminAPI from 'src/api/admin'
 import ReportAPI from 'src/api/reports'
 import ClassifierNote from 'src/Components/ClassifierNote/ClassifierNote'
 import { formatClassifier } from 'src/util/formatClassifier'
+import { RECIPE_APPROVED, RECIPE_APPROVE_ERROR } from 'src/util/toastMessages'
 import './AdminRecipeControls.scss'
 
 interface AdminRecipeControlsProps {
@@ -72,10 +73,10 @@ const AdminRecipeControls: FC<AdminRecipeControlsProps> = ({ recipe }) => {
   const approveMutation = useMutation({
     mutationFn: () => AdminAPI.approveRecipe(recipe._id),
     onSuccess: () => {
-      toast.success('Recipe approved and published.')
+      toast.success(RECIPE_APPROVED)
       invalidate()
     },
-    onError: () => toast.error('Could not approve the recipe.'),
+    onError: () => toast.error(RECIPE_APPROVE_ERROR),
   })
 
   if (!isAdmin) return null

--- a/src/pages/Account/Account.tsx
+++ b/src/pages/Account/Account.tsx
@@ -78,7 +78,7 @@ const Account: FC = () => {
       .map(id => byId.get(id)?.name)
       .filter((n): n is string => !!n)
     if (names.length === 1) {
-      toast.success(`🏅 Achievement unlocked: ${names[0]}`)
+      toast.success(`🏅 Achievement unlocked: ${names[0]}!`)
     } else if (names.length > 1) {
       toast.success(`🏅 ${names.length} achievements unlocked!`)
     }

--- a/src/pages/Account/SavedRecipes/SavedRecipes.tsx
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.tsx
@@ -12,6 +12,7 @@ import CollectionsAPI from 'src/api/collections'
 import AuthAPI from 'src/api/auth'
 import { RecipeType } from 'types'
 import { useDelayedLoading } from 'src/pages/Account/useDelayedLoading'
+import { COLLECTION_CREATE_ERROR } from 'src/util/toastMessages'
 import { useDebounce } from 'src/hooks/useDebounce'
 import { invalidateSavedCaches } from 'src/util/invalidateSavedCaches'
 import CollectionCard from './CollectionCard'
@@ -141,7 +142,7 @@ const SavedRecipes: FC = () => {
       await queryClient.invalidateQueries({ queryKey: ['collections'] })
       selectCollection(created.id)
     } catch (err: any) {
-      toast.error(err?.response?.data?.error ?? 'Could not create collection')
+      toast.error(err?.response?.data?.error ?? COLLECTION_CREATE_ERROR)
     } finally {
       setCreating(false)
     }
@@ -155,7 +156,7 @@ const SavedRecipes: FC = () => {
       setRenaming(false)
       queryClient.invalidateQueries({ queryKey: ['collections'] })
     } catch (err: any) {
-      toast.error(err?.response?.data?.error ?? 'Could not rename collection')
+      toast.error(err?.response?.data?.error ?? 'Could not rename collection.')
     }
   }
 
@@ -169,7 +170,7 @@ const SavedRecipes: FC = () => {
       await queryClient.invalidateQueries({ queryKey: ['collections'] })
       selectCollection(null)
     } catch (err: any) {
-      toast.error(err?.response?.data?.error ?? 'Could not delete collection')
+      toast.error(err?.response?.data?.error ?? 'Could not delete collection.')
     }
   }
 

--- a/src/pages/Account/components/ProfileControls.tsx
+++ b/src/pages/Account/components/ProfileControls.tsx
@@ -2,6 +2,10 @@ import { EditIcon, SettingsIcon, ShareIcon } from 'src/Components/icons'
 import React, { FC } from 'react'
 import { useNavigate } from 'react-router-dom'
 import toast from 'react-hot-toast'
+import {
+  PROFILE_LINK_COPIED,
+  PROFILE_LINK_COPY_ERROR,
+} from 'src/util/toastMessages'
 
 // ProfileControls — the header action cluster: a subtle Edit button plus icon
 // buttons for Settings and Share. Edit + Settings both route to the existing
@@ -21,9 +25,9 @@ const ProfileControls: FC<ProfileControlsProps> = ({ username }) => {
       : window.location.href
     try {
       await navigator.clipboard.writeText(url)
-      toast.success('Profile link copied to clipboard')
+      toast.success(PROFILE_LINK_COPIED)
     } catch {
-      toast.error('Could not copy link')
+      toast.error(PROFILE_LINK_COPY_ERROR)
     }
   }
 

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -48,6 +48,10 @@ import DraftResumeBanner from 'src/pages/AddRecipe/DraftResumeBanner'
 
 type TimeVal = { hours: number; minutes: number } | null
 
+// Same auth-expiry message on both the update and publish paths below.
+const SESSION_EXPIRED =
+  'Your session has expired — please sign in again and retry.'
+
 // Shown when a recipe saves but is held by automated moderation for an admin to
 // review before it appears publicly. Longer-lived than a normal toast (and not
 // styled as an error — nothing went wrong) so the owner doesn't miss it.
@@ -348,7 +352,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
         setLoadingProgress
       )
       if (result.status === 'auth-error') {
-        toast.error('Your session has expired — please sign in again and retry.')
+        toast.error(SESSION_EXPIRED)
       } else if (result.status === 'success') {
         // Write the server's updated recipe straight into the cache rather than
         // invalidating: invalidation would refetch GET /getRecipe (which bumps
@@ -358,11 +362,11 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
         queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
         // A medium-confidence moderation hold saves the edit but withholds it from
         // public reads until an admin clears it; tell the owner instead of the
-        // usual "updated!" so a silently-hidden recipe isn't a surprise.
+        // usual "updated" so a silently-hidden recipe isn't a surprise.
         if (result.recipe.status === 'pending_review') {
           notifyPendingReview()
         } else {
-          toast.success('Recipe updated!')
+          toast.success('Recipe updated.')
         }
         navigate(`/recipes/${initialRecipe._id}`)
       } else {
@@ -372,7 +376,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
       const recipeData: RecipeFormType = { ...formData, recipeImage: recipeImage! }
       const result = await RecipeAPI.addRecipe(recipeData, setLoadingProgress)
       if (result.status === 'auth-error') {
-        toast.error('Your session has expired — please sign in again and retry.')
+        toast.error(SESSION_EXPIRED)
       } else if (result.status === 'success') {
         // Recipe is saved — remove the now-redundant draft (and stop autosave
         // from recreating it on unmount) before navigating away.
@@ -381,7 +385,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
         if (result.pendingReview) {
           notifyPendingReview()
         } else {
-          toast.success('Recipe published!')
+          toast.success('Recipe published.')
         }
         navigate(`/recipes/${result.id}`)
       } else {

--- a/src/pages/AddRecipe/ImagePicker/ImagePicker.tsx
+++ b/src/pages/AddRecipe/ImagePicker/ImagePicker.tsx
@@ -1,6 +1,7 @@
 import { CloseIcon } from 'src/Components/icons'
 import React, { useState, useRef } from 'react'
 import toast from 'react-hot-toast'
+import { IMAGE_TOO_LARGE } from 'src/util/toastMessages'
 import './ImagePicker.scss'
 
 const MAX_IMAGE_SIZE = 5000 * 1024 // 5MB
@@ -45,7 +46,7 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
         return
       }
       if (file.size > MAX_IMAGE_SIZE) {
-        toast.error('Image cannot be more than 5MB in size.')
+        toast.error(IMAGE_TOO_LARGE)
         resetInput()
         return
       }

--- a/src/pages/Admin/BugReports/BugReports.tsx
+++ b/src/pages/Admin/BugReports/BugReports.tsx
@@ -9,6 +9,12 @@ import toast from 'react-hot-toast'
 import { AdminBugReportType, BugReportStatus, BugReportCategory } from 'types'
 import BugReportAPI from 'src/api/bugReports'
 import SavedFilterBar from 'src/Components/SavedFilters/SavedFilterBar'
+import {
+  REPORTS_BULK_UPDATE_ERROR,
+  REPORT_UPDATE_ERROR,
+  reportsBulkUpdated,
+  reportUpdated,
+} from 'src/util/toastMessages'
 import './BugReports.scss'
 
 type StatusFilter = BugReportStatus | 'all'
@@ -101,21 +107,21 @@ const BugReports: FC = () => {
     mutationFn: ({ status }: { status: 'resolved' | 'dismissed' }) =>
       BugReportAPI.bulkResolve(Array.from(selected), status),
     onSuccess: (res, vars) => {
-      toast.success(`${res.updated} report${res.updated === 1 ? '' : 's'} ${vars.status}.`)
+      toast.success(reportsBulkUpdated(res.updated, vars.status))
       setSelected(new Set())
       invalidate()
     },
-    onError: () => toast.error('Could not update the selected reports.'),
+    onError: () => toast.error(REPORTS_BULK_UPDATE_ERROR),
   })
 
   const resolveMutation = useMutation({
     mutationFn: ({ id, status }: { id: string; status: 'resolved' | 'dismissed' }) =>
       BugReportAPI.resolveBugReport(id, status),
     onSuccess: (_d, vars) => {
-      toast.success(`Report ${vars.status}.`)
+      toast.success(reportUpdated(vars.status))
       invalidate()
     },
-    onError: () => toast.error('Could not update the report.'),
+    onError: () => toast.error(REPORT_UPDATE_ERROR),
   })
 
   const busy = resolveMutation.isPending || bulkMutation.isPending

--- a/src/pages/Admin/Reports/Reports.tsx
+++ b/src/pages/Admin/Reports/Reports.tsx
@@ -8,6 +8,14 @@ import AdminAPI from 'src/api/admin'
 import SavedFilterBar from 'src/Components/SavedFilters/SavedFilterBar'
 import ClassifierNote from 'src/Components/ClassifierNote/ClassifierNote'
 import { formatClassifier } from 'src/util/formatClassifier'
+import {
+  RECIPE_APPROVED,
+  RECIPE_APPROVE_ERROR,
+  REPORTS_BULK_UPDATE_ERROR,
+  REPORT_UPDATE_ERROR,
+  reportsBulkUpdated,
+  reportUpdated,
+} from 'src/util/toastMessages'
 import './Reports.scss'
 
 type StatusFilter = ReportStatus | 'all'
@@ -83,11 +91,11 @@ const Reports: FC = () => {
         status
       ),
     onSuccess: (res, vars) => {
-      toast.success(`${res.updated} report${res.updated === 1 ? '' : 's'} ${vars.status}.`)
+      toast.success(reportsBulkUpdated(res.updated, vars.status))
       setSelected(new Set())
       invalidate()
     },
-    onError: () => toast.error('Could not update the selected reports.'),
+    onError: () => toast.error(REPORTS_BULK_UPDATE_ERROR),
   })
 
   // Resolve / dismiss a report (does not itself change the content).
@@ -95,10 +103,10 @@ const Reports: FC = () => {
     mutationFn: ({ id, status }: { id: string; status: 'resolved' | 'dismissed' }) =>
       ReportAPI.resolveReport(id, status),
     onSuccess: (_d, vars) => {
-      toast.success(`Report ${vars.status}.`)
+      toast.success(reportUpdated(vars.status))
       invalidate()
     },
-    onError: () => toast.error('Could not update the report.'),
+    onError: () => toast.error(REPORT_UPDATE_ERROR),
   })
 
   // Take the reported content down, then close the report as resolved.
@@ -155,10 +163,10 @@ const Reports: FC = () => {
     mutationFn: (report: AdminReportType) =>
       AdminAPI.approveRecipe(report.recipeId as string),
     onSuccess: () => {
-      toast.success('Recipe approved and published.')
+      toast.success(RECIPE_APPROVED)
       invalidate()
     },
-    onError: () => toast.error('Could not approve the recipe.'),
+    onError: () => toast.error(RECIPE_APPROVE_ERROR),
   })
 
   // Whether the reported target is currently hidden (from the queue's snapshot).

--- a/src/pages/PublicProfile/PublicProfile.tsx
+++ b/src/pages/PublicProfile/PublicProfile.tsx
@@ -14,6 +14,10 @@ import DefaultAvatar from 'src/Components/DefaultAvatar/DefaultAvatar'
 import { formatRating } from 'src/util/formatRating'
 import { formatCompactCount } from 'src/util/formatCompactCount'
 import { formatPrice } from 'src/util/formatPrice'
+import {
+  PROFILE_LINK_COPIED,
+  PROFILE_LINK_COPY_ERROR,
+} from 'src/util/toastMessages'
 import { SITE_URL, DEFAULT_OG_IMAGE } from 'src/util/seo'
 import { RecipeType } from 'types'
 
@@ -96,9 +100,9 @@ const PublicProfile: FC = () => {
     }
     try {
       await navigator.clipboard.writeText(url)
-      toast.success('Profile link copied')
+      toast.success(PROFILE_LINK_COPIED)
     } catch {
-      toast.error('Could not copy link')
+      toast.error(PROFILE_LINK_COPY_ERROR)
     }
   }
 

--- a/src/pages/Settings/sections/AccountSection.tsx
+++ b/src/pages/Settings/sections/AccountSection.tsx
@@ -3,6 +3,7 @@ import React, { FC, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useAuth } from 'src/context/AuthContext'
 import { TextField, SettingRow } from '../components/controls'
+import { EMAIL_IN_USE, PASSWORD_INCORRECT } from 'src/util/toastMessages'
 import './sections.scss'
 
 type PassErrors = { currPass: string; newPass: string; confirmPass: string }
@@ -48,9 +49,9 @@ const AccountSection: FC = () => {
           err.code === 'auth/wrong-password' ||
           err.code === 'auth/invalid-credential'
         ) {
-          toast.error('Password incorrect, please try again.')
+          toast.error(PASSWORD_INCORRECT)
         } else if (err.code === 'auth/email-already-in-use') {
-          toast.error('Email already in use.')
+          toast.error(EMAIL_IN_USE)
         } else {
           toast.error(err.message || 'Could not update email.')
         }
@@ -107,7 +108,7 @@ const AccountSection: FC = () => {
       .then(() => {
         setPassLoading(false)
         clearPasswords()
-        toast.success('Password successfully changed!')
+        toast.success('Password successfully changed.')
       })
       .catch(err => {
         setPassLoading(false)

--- a/src/pages/Settings/sections/DangerSection.tsx
+++ b/src/pages/Settings/sections/DangerSection.tsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast'
 import { useAuth } from 'src/context/AuthContext'
 import AuthAPI from 'src/api/auth'
 import { TextField } from '../components/controls'
+import { PASSWORD_INCORRECT } from 'src/util/toastMessages'
 import './sections.scss'
 
 const CONFIRM_WORD = 'DELETE'
@@ -76,7 +77,7 @@ const DangerSection: FC = () => {
           err.code === 'auth/wrong-password' ||
           err.code === 'auth/invalid-credential'
         ) {
-          toast.error('Password incorrect, please try again.')
+          toast.error(PASSWORD_INCORRECT)
         } else if (err.code === 'auth/popup-closed-by-user') {
           toast.error('Reauthentication was cancelled.')
         } else {

--- a/src/pages/Settings/sections/PrivacySection.tsx
+++ b/src/pages/Settings/sections/PrivacySection.tsx
@@ -54,7 +54,7 @@ const PrivacySection: FC = () => {
         // Keep the shared profile query in sync for the next visit.
         queryClient.invalidateQueries({ queryKey: ['profile', uid] })
         setSaving(false)
-        toast.success('Privacy settings saved!')
+        toast.success('Privacy settings saved.')
       })
       .catch(err => {
         setSaving(false)

--- a/src/pages/Settings/sections/ProfileSection.tsx
+++ b/src/pages/Settings/sections/ProfileSection.tsx
@@ -4,6 +4,11 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from 'src/context/AuthContext'
 import AuthAPI from 'src/api/auth'
 import { getApiErrorMessage } from 'src/util/getApiErrorMessage'
+import {
+  EMAIL_IN_USE,
+  GENERIC_ERROR,
+  IMAGE_TOO_LARGE,
+} from 'src/util/toastMessages'
 import { AvatarField, TextField, TextArea, SaveBar } from '../components/controls'
 import { useSettingsDirty } from '../SettingsDirtyContext'
 import './sections.scss'
@@ -110,7 +115,7 @@ const ProfileSection: FC = () => {
     const file = event.target.files?.[0]
     if (file && /\.(jpe?g|png)$/i.test(file.name)) {
       if (file.size > MAX_FILE_SIZE) {
-        toast.error('Image cannot be more than 5MB in size.')
+        toast.error(IMAGE_TOO_LARGE)
         return
       }
       setImgFile(file)
@@ -211,16 +216,16 @@ const ProfileSection: FC = () => {
         setSaving(false)
         setImgFile(null)
         setAvatarRemoved(false)
-        toast.success('Profile updated!')
+        toast.success('Profile updated.')
       })
       .catch(err => {
         setSaving(false)
         if (err.code === 'auth/email-already-in-use') {
-          toast.error('Email already in use.')
+          toast.error(EMAIL_IN_USE)
         } else {
           // Prefer the server's reason (e.g. a 422 moderation block on the
           // username, bio, or location) over axios's generic "Request failed…".
-          toast.error(getApiErrorMessage(err, 'Something went wrong.'))
+          toast.error(getApiErrorMessage(err, GENERIC_ERROR))
         }
       })
   }

--- a/src/pages/SingleRecipe/Buttons/MadeRecipeBtn.tsx
+++ b/src/pages/SingleRecipe/Buttons/MadeRecipeBtn.tsx
@@ -3,6 +3,7 @@ import toast from 'react-hot-toast'
 import { TailSpin } from 'react-loader-spinner'
 import AuthAPI from 'src/api/auth'
 import RecipeAPI from 'src/api/recipes'
+import { GENERIC_ERROR } from 'src/util/toastMessages'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 const canMakeAgain = (lastDateMade: number | null): boolean => {
@@ -47,12 +48,12 @@ const MadeRecipeBtn: FC<MadeRecipeBtnProps> = ({ recipeId }) => {
             })
           )
           setLoading(false)
-          toast.success('Recipe marked as read, share your feedback below!', {
+          toast.success('Recipe marked as read, share your feedback below.', {
             duration: 3000,
           })
         })
-        .catch((error: unknown) => {
-          toast.error(`Error: ${String(error)}`)
+        .catch(() => {
+          toast.error(GENERIC_ERROR)
           setLoading(false)
         })
     } else if (lastDateMade) {
@@ -60,7 +61,7 @@ const MadeRecipeBtn: FC<MadeRecipeBtnProps> = ({ recipeId }) => {
         `Recipe can only be marked as read once an hour. Try again in ${60 - Math.ceil((new Date().getTime() - lastDateMade) / (1000 * 60))} minutes.`
       )
     } else {
-      toast.error('Something went wrong, try refreshing.', { duration: 10000 })
+      toast.error('Something went wrong. Try refreshing.', { duration: 10000 })
     }
   }
 

--- a/src/test/AddRecipe.test.tsx
+++ b/src/test/AddRecipe.test.tsx
@@ -304,7 +304,7 @@ describe('AddRecipe form', () => {
     await waitFor(() =>
       expect(navigateFn).toHaveBeenCalledWith('/recipes/new-1')
     )
-    expect(toastSuccess).toHaveBeenCalledWith('Recipe published!')
+    expect(toastSuccess).toHaveBeenCalledWith('Recipe published.')
   })
 
   it('shows a pending-review notice (not "published") when the recipe is held for review', async () => {
@@ -319,7 +319,7 @@ describe('AddRecipe form', () => {
     // Still navigates to the (owner-visible) recipe, but the notice replaces the
     // usual success toast so the owner knows it isn't public yet.
     await waitFor(() => expect(navigateFn).toHaveBeenCalledWith('/recipes/new-1'))
-    expect(toastSuccess).not.toHaveBeenCalledWith('Recipe published!')
+    expect(toastSuccess).not.toHaveBeenCalledWith('Recipe published.')
     expect(toastBase).toHaveBeenCalledWith(
       expect.stringMatching(/pending review/i),
       expect.anything()

--- a/src/test/TEST_PLAN.md
+++ b/src/test/TEST_PLAN.md
@@ -170,7 +170,7 @@ independently.
 
 - **On a successful submission, navigates to the new recipe and confirms with a toast**
   `navigate('/recipes/<newId>')` must run after a successful API call, and a
-  `toast.success('Recipe published!')` must fire (it persists across the route change).
+  `toast.success('Recipe published.')` must fire (it persists across the route change).
 
 - **On API failure (`addRecipe` returns `null`), fires `toast.error('Failed to create recipe. Please try again.')`**
   Flow-level outcomes route through `react-hot-toast`, not inline state. This is the

--- a/src/test/toastSystem.test.tsx
+++ b/src/test/toastSystem.test.tsx
@@ -42,8 +42,8 @@ afterEach(() => {
 describe('toast system (react-hot-toast contract)', () => {
   it('renders a success toast with its message', async () => {
     renderToaster()
-    fire(() => toast.success('Profile updated!'))
-    expect(await screen.findByText('Profile updated!')).toBeInTheDocument()
+    fire(() => toast.success('Profile updated.'))
+    expect(await screen.findByText('Profile updated.')).toBeInTheDocument()
   })
 
   it('renders an error toast with its message', async () => {
@@ -62,9 +62,9 @@ describe('toast system (react-hot-toast contract)', () => {
 
   it('renders a neutral (blank) toast with its message', async () => {
     renderToaster()
-    fire(() => toast('Recipe marked as read, share your feedback below!'))
+    fire(() => toast('Recipe marked as read, share your feedback below.'))
     expect(
-      await screen.findByText('Recipe marked as read, share your feedback below!')
+      await screen.findByText('Recipe marked as read, share your feedback below.')
     ).toBeInTheDocument()
   })
 

--- a/src/util/toastMessages.ts
+++ b/src/util/toastMessages.ts
@@ -1,0 +1,40 @@
+/**
+ * Single source of truth for toast strings that were duplicated across files.
+ * Keeping the repeats here stops them drifting apart again (the same rationale
+ * behind src/util/modalStyles and the shared accountTabs map). One-off toast
+ * strings stay inline at their call site — only cross-file repeats live here.
+ *
+ * Copy convention (see docs/sweeps — toast-punctuation track):
+ *  - Errors: sentence case, end with a period; "Could not <verb> <object>.",
+ *    append "Please try again." when the action is worth retrying.
+ *  - Success: end with a period; reserve "!" for genuine milestones
+ *    (Welcome to Prepify, achievement unlocks) — not routine confirmations.
+ */
+
+/** Generic fallback when there's nothing more specific to say. */
+export const GENERIC_ERROR = 'Something went wrong. Please try again.'
+
+// Account / auth — shared across the Settings sections.
+export const EMAIL_IN_USE = 'Email already in use.'
+export const PASSWORD_INCORRECT = 'Password incorrect, please try again.'
+
+// Image upload — ProfileSection avatar + AddRecipe ImagePicker.
+export const IMAGE_TOO_LARGE = 'Image cannot be more than 5MB in size.'
+
+// Profile-link copy — PublicProfile + Account ProfileControls.
+export const PROFILE_LINK_COPIED = 'Profile link copied.'
+export const PROFILE_LINK_COPY_ERROR = 'Could not copy link.'
+
+// Collections — AddToCollectionPopover + SavedRecipes.
+export const COLLECTION_CREATE_ERROR = 'Could not create collection.'
+
+// Recipe moderation — AdminRecipeControls + the Reports approve path.
+export const RECIPE_APPROVED = 'Recipe approved and published.'
+export const RECIPE_APPROVE_ERROR = 'Could not approve the recipe.'
+
+// Admin report queue — identical mutation block in Reports + BugReports.
+export const REPORTS_BULK_UPDATE_ERROR = 'Could not update the selected reports.'
+export const REPORT_UPDATE_ERROR = 'Could not update the report.'
+export const reportsBulkUpdated = (updated: number, status: string) =>
+  `${updated} report${updated === 1 ? '' : 's'} ${status}.`
+export const reportUpdated = (status: string) => `Report ${status}.`


### PR DESCRIPTION
## Wave 2 `2-iso` — Design: toast punctuation + string dedupe

Normalizes toast copy to a single convention and extracts the cross-file
duplicate strings into one source of truth. Surfaced from the design-consistency
sweep ([ROADMAP](docs/sweeps/ROADMAP.md) Wave 2 `2-iso`).

### Convention
- **Errors** — sentence case, terminal period; `Could not <verb> <object>.`,
  append `Please try again.` when retryable. Dropped the raw `Error: ${error}`
  dump in `MadeRecipeBtn` for a human message.
- **Success** — terminal period by default; `!` reserved for genuine milestones
  (Welcome to Prepify, achievement unlocks).
- **Dynamic/server text** still flows through `getApiErrorMessage(err, fallback)`;
  only the fallback literals were normalized.

### Changes
- **New `src/util/toastMessages.ts`** — 12 constants + 2 template helpers
  (`reportsBulkUpdated`/`reportUpdated`), each genuinely shared across ≥2 files.
  Same single-source-of-truth pattern as `modalStyles` / `accountTabs`.
- Fixed **8 period-less errors** (collections ×4, profile-link copy ×2,
  "update collections", "couldn't be added").
- Demoted **6 routine success exclamations** to periods (Profile updated,
  Privacy settings saved, Password changed, Recipe published/updated,
  "marked as read…"). Milestones keep `!`.
- Deduped: email-in-use, password-incorrect, 5MB-image, collection-create,
  recipe-approve ×2, and the identical `Reports`/`BugReports` mutation block.
- One in-file repeat (`SESSION_EXPIRED`, AddRecipe ×2) kept as a local const so
  the shared module stays "cross-file only".

### Verification
- `tsc --noEmit` clean; frontend suite **543 pass / 2 skip (74 files)**; build passing.
- Updated 3 test assertions (`AddRecipe.test`, `toastSystem.test`) + `TEST_PLAN`
  reference to the new copy.
- **Driven live** (headless): PublicProfile Share renders `Profile link copied.`
  (success) and `Could not copy link.` (error) — both deduped/period-normalized
  strings, zero console errors. Auth-gated toasts not driven live (no dev creds);
  covered by tsc + tests.
- High-effort multi-agent code review: no correctness bugs; two reuse nits
  considered and intentionally left inline (coincidentally-identical admin
  toggle string; a generic sentence shared with `authErrors`' inline default).

https://claude.ai/code/session_01EDb6rjjnkrYCQNuX2wMqXc
