### PR TITLE
style(scss): one danger-red token — consolidate $danger/#d64545 onto $error-red

### DIFF
--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -76,7 +76,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **2-scss** | Design: pill `.btn` system | `[ ]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | — |
 | **2-scss** | Design: type scale (~520 `font-size:` literals) | `[ ]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | — |
 | **2-scss** | Design: elevation/shadow re-author (~52 literals) | `[ ]` | **`helpers.scss` + page `.scss`** ⚠ chokepoint | — |
-| **2-scss** | Design: one danger-red token | `[~]` | **`helpers.scss` + SingleRecipe/ReportControl/…** ⚠ chokepoint | `worktree-feat+danger-red-token` (2026-06-29) |
+| **2-scss** | Design: one danger-red token | `[P]` | **`helpers.scss` + SingleRecipe/ReportControl/…** ⚠ chokepoint | #208 |
 | **2-scss** | Design: name the `$admin-*` sub-palette | `[ ]` | **`helpers.scss` + Admin/moderation `.scss`** ⚠ chokepoint | — |
 | **2-scss** | A11y: `$primary-hover` AA-on-hover | `[ ]` | **`helpers.scss`** ⚠ chokepoint | — |
 | **blocked** | A11y: brand-orange contrast (AA) | `[blocked]` | `helpers.scss` `$primary-accessible` — **needs the brand-orange decision** | — |
@@ -287,3 +287,16 @@ narrates the *why*.
   currently unused. Convention written down at `docs/design/icon-system.md` (first piece of the design-system
   docs). Temp `/icon-audit` page built for owner glyph approval, then removed before the PR. **Fourth Design
   `2-iso` track to land.** Worktree + branch torn down.
+- _2026-06-29_ — **Design: one danger-red token** PR opened (#208, `[~]`→`[P]`) — **first `2-scss` lane to reach
+  PR**. Collapsed the three off-token "danger" reds onto the shared `s.$error-red` (`#c5303f`): dropped the dead
+  local `$danger #d23f31` (SingleRecipe, 1 use), and converted `#d64545` ×9 across ReportControl (×7, incl. its
+  `rgba(214,69,69, …)` tints → `rgba(s.$error-red, X)`), AdminRecipeControls (takedown border), and Reports
+  (takedown bg). **No `helpers.scss` edit** — the token already existed, so this `2-scss` track skips the usual
+  chokepoint (ran safely alongside the two in-flight `2-iso` worktrees; zero file overlap — they touch the `.tsx`,
+  this touches the `.scss`). Closes the BACKLOG 'One danger-red token' item (audit F6). Small **intentional**
+  visual shift: the moderation/error reds now match the brand danger. Verified by driving the running app — built
+  CSS has 0× old reds; all four changed files confirmed rendering `rgb(197,48,63)` live (report menu/link hover +
+  filled submit, review `.error`, admin takedown border + `/admin/reports` takedown bg). The auth/admin surfaces
+  were driven with a throwaway account (admin claim granted via firebase-admin), then deleted with a full Mongo
+  orphan-scan; the prod rating used to surface `.error` was removed, and the real reports queue was observed
+  read-only. Awaiting CI.

--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -76,7 +76,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **2-scss** | Design: pill `.btn` system | `[ ]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | — |
 | **2-scss** | Design: type scale (~520 `font-size:` literals) | `[ ]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | — |
 | **2-scss** | Design: elevation/shadow re-author (~52 literals) | `[ ]` | **`helpers.scss` + page `.scss`** ⚠ chokepoint | — |
-| **2-scss** | Design: one danger-red token | `[ ]` | **`helpers.scss` + SingleRecipe/ReportControl/…** ⚠ chokepoint | — |
+| **2-scss** | Design: one danger-red token | `[~]` | **`helpers.scss` + SingleRecipe/ReportControl/…** ⚠ chokepoint | `worktree-feat+danger-red-token` (2026-06-29) |
 | **2-scss** | Design: name the `$admin-*` sub-palette | `[ ]` | **`helpers.scss` + Admin/moderation `.scss`** ⚠ chokepoint | — |
 | **2-scss** | A11y: `$primary-hover` AA-on-hover | `[ ]` | **`helpers.scss`** ⚠ chokepoint | — |
 | **blocked** | A11y: brand-orange contrast (AA) | `[blocked]` | `helpers.scss` `$primary-accessible` — **needs the brand-orange decision** | — |

--- a/src/Components/AdminRecipeControls/AdminRecipeControls.scss
+++ b/src/Components/AdminRecipeControls/AdminRecipeControls.scss
@@ -84,7 +84,7 @@
     }
 
     &.takedown {
-      border-color: #d64545;
+      border-color: s.$error-red;
       color: #b91c1c;
     }
 

--- a/src/Components/ReportControl/ReportControl.scss
+++ b/src/Components/ReportControl/ReportControl.scss
@@ -15,15 +15,15 @@
   transition: color 0.15s, background 0.15s;
 
   &:hover {
-    color: #d64545;
-    background: rgba(214, 69, 69, 0.08);
+    color: s.$error-red;
+    background: rgba(s.$error-red, 0.08);
   }
 
   // Keyboard users get a clear ring (the hover tint isn't enough on its own).
   &:focus-visible {
-    outline: 2px solid rgba(214, 69, 69, 0.5);
+    outline: 2px solid rgba(s.$error-red, 0.5);
     outline-offset: 1px;
-    color: #d64545;
+    color: s.$error-red;
   }
 
   &.button {
@@ -32,7 +32,7 @@
     font-size: 0.85rem;
 
     &:hover {
-      border-color: #d64545;
+      border-color: s.$error-red;
     }
   }
 }
@@ -105,14 +105,14 @@
     }
 
     &:hover {
-      background: rgba(214, 69, 69, 0.08);
-      color: #d64545;
+      background: rgba(s.$error-red, 0.08);
+      color: s.$error-red;
     }
 
     &:focus-visible {
-      outline: 2px solid rgba(214, 69, 69, 0.5);
+      outline: 2px solid rgba(s.$error-red, 0.5);
       outline-offset: -2px;
-      color: #d64545;
+      color: s.$error-red;
     }
   }
 }
@@ -179,8 +179,8 @@
     }
 
     .report-submit-btn {
-      background: #d64545;
-      border: 1px solid #d64545;
+      background: s.$error-red;
+      border: 1px solid s.$error-red;
       color: #fff;
       display: inline-flex;
       align-items: center;

--- a/src/pages/Admin/Reports/Reports.scss
+++ b/src/pages/Admin/Reports/Reports.scss
@@ -304,7 +304,7 @@
         }
 
         &.takedown {
-          background: #d64545;
+          background: s.$error-red;
           color: s.$white;
         }
 

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -10,7 +10,6 @@
 $soft-border: s.$gray-200;
 $soft-radius: 16px;
 $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
-$danger: #d23f31;
 
 .single-recipe-page {
   max-width: 1080px;
@@ -635,7 +634,7 @@ $danger: #d23f31;
         margin-bottom: 0.6rem;
         span { color: s.$tertiary-text; font-weight: 600; }
       }
-      .error { color: $danger; font-size: 0.85rem; margin-bottom: 0.6rem; }
+      .error { color: s.$error-red; font-size: 0.85rem; margin-bottom: 0.6rem; }
       .review-text-area {
         width: 100%;
         min-height: 72px;


### PR DESCRIPTION
## Wave 2 · 2-scss — one danger-red token

Collapses the three off-token "danger" reds onto the shared `s.$error-red` (`#c5303f`) token (the AA-darkened brand danger from the a11y pass). Closes the BACKLOG **One danger-red token** item (audit F6).

### What changed
- `SingleRecipe.scss` — drop the dead local `$danger: #d23f31` var; repoint its one use to `s.$error-red`.
- `ReportControl.scss` — `#d64545` ×7 → `s.$error-red`; the `rgba(214,69,69, …)` tints → `rgba(s.$error-red, X)` (so the literal red leaves the file entirely, matching the token idiom used in Settings).
- `AdminRecipeControls.scss` — takedown button **border** `#d64545` → `s.$error-red` (the `#b91c1c` text is a separate token, intentionally untouched).
- `Reports.scss` — takedown button **background** `#d64545` → `s.$error-red`.

No `helpers.scss` change — the token already existed, so this is the lightest-touch `2-scss` lane (no chokepoint edit).

### Note
Small **intentional visual shift** on a few moderation/error surfaces: the slightly-different reds `#d23f31`/`#d64545` now match the brand danger `#c5303f`.

### Verification
Built + drove the running app. Shipped prod CSS has **0×** `#d64545`/`#d23f31`/`rgb(214,69,69)`; all danger surfaces resolve to `#c5303f`. Confirmed live (computed `rgb(197,48,63)`) on every changed file: report menu/link hover + filled submit button, review `.error` text, admin takedown border, and `/admin/reports` takedown background (driven with a throwaway admin account, since deleted; prod state restored).

https://claude.ai/code/session_01Rn2MgxgPgbrC4QHYGTkpVK