### PR TITLE
Design (2-scss): canonical pill .btn system

### DIFF
--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -299,6 +299,19 @@ Chunky design efforts that are bigger than a single checkbox. Tag each as **(blo
     usages (Home hero, `src/Components/Navbar/menu/`).
   - Gates nothing for 1.0 — tracked here so it isn't lost.
 
+- `[ ]` **Ratings & Reviews area overhaul** — **(blocker)**
+  - **Now:** the ratings/reviews experience on the single-recipe page is functional but rough
+    ("scuffed") — the rating summary/breakdown, the "your review" vs the public list, and the
+    add/edit/delete review affordances need a visual + interaction pass to match the current design
+    vocabulary. (The pill `.btn` sweep, 2026-06-29, restyled the buttons in this area onto the shared
+    system but did **not** touch the layout/UX — that's this item.)
+  - **Goal:** _(dedicated session)_ redesign the ratings + reviews UI end-to-end — summary/breakdown,
+    your-review card, add/edit/delete flow, and empty/loading states.
+  - **Touches:** `src/pages/SingleRecipe/DataSections/RatingsAndReviews/*` (+ `.scss` — `RatingsAndReviews`,
+    `Ratings`, `Reviews/` incl. `AddReview`, `RecipeReview`, `ReviewsList`, `EditingReviewOptions`,
+    `ConfirmDeleteReviewModal`), and likely `server/routes/reviews.js` if the data shape changes.
+  - **Why a blocker:** owner wants this looking right before dropping beta (filed 2026-06-29).
+
 - `[x]` **Homepage redesign** — **(design shipped)**
   - **Shipped:** the redesign landed earlier (`e1539c3`) — Home is now `HomeHero → Trending → Browse by
     meal → View all recipes`, fully responsive with empty/loading states. The "sparse Home" wording here

--- a/docs/design/button-system.md
+++ b/docs/design/button-system.md
@@ -16,8 +16,12 @@ one set of tokens. This doc is the convention; the code that implements it is th
    About, Home, EmptyState, PublicProfile, Account) already started; the older
    form/settings/recipe-detail surfaces move onto it.
 3. **Color comes from a variant modifier, never inline.** Pick one of the five
-   variants below. The hover treatment is an explicit color/border change (never
-   `filter: brightness()` or bare `opacity`), the danger color is the single
+   variants below. Each variant's hover is an explicit color/border change, not
+   `filter: brightness()` or bare `opacity`. (A few KEEP-BESPOKE buttons sit on
+   the base *without* a variant — the teal auth submit, the brand-orange
+   suggestion CTA — and do use a `filter: brightness()` hover; the base `.btn`
+   transition animates `filter`, so they ease like the rest.) The danger color is
+   the single
    `$error-red` token (see [one-danger-red-token, #208]), and the focus ring stays
    on the global `button:focus-visible` rule in `index.scss` (the `s.outline()`
    mixin) — variants never re-declare focus.

--- a/docs/design/button-system.md
+++ b/docs/design/button-system.md
@@ -1,0 +1,73 @@
+# Button system
+
+Prepify uses **one pill `.btn` system** — a base reset class plus BEM-style
+modifiers — so every action button shares one shape, one hover convention, and
+one set of tokens. This doc is the convention; the code that implements it is the
+`.btn` block in `src/index.scss`.
+
+## The rules
+
+1. **One base class: `.btn`.** It provides the reset (no native chrome), the
+   layout (inline-flex, centered, icon gap), the default size, the **pill** shape
+   (`$radius-pill`), the transition, and the disabled treatment. Every button in
+   the app composes `.btn` with one color variant and (optionally) a size.
+2. **Pill shape, app-wide.** Action buttons are pill-shaped (`border-radius:
+   $radius-pill`). This finishes the migration the redesigned surfaces (Recipes,
+   About, Home, EmptyState, PublicProfile, Account) already started; the older
+   form/settings/recipe-detail surfaces move onto it.
+3. **Color comes from a variant modifier, never inline.** Pick one of the five
+   variants below. The hover treatment is an explicit color/border change (never
+   `filter: brightness()` or bare `opacity`), the danger color is the single
+   `$error-red` token (see [one-danger-red-token, #208]), and the focus ring stays
+   on the global `button:focus-visible` rule in `index.scss` (the `s.outline()`
+   mixin) — variants never re-declare focus.
+
+## The anatomy
+
+```scss
+.btn { /* base: reset + inline-flex layout + md size + pill + transition + :disabled */ }
+
+/* sizes (default = md, baked into .btn) */
+.btn--sm     /* compact / inline / dense rows */
+.btn--lg     /* hero CTAs */
+.btn--block  /* width: 100% — the responsive mobile pattern */
+
+/* color variants */
+.btn--primary       /* orange fill, white text — the main CTA            */
+.btn--outline       /* white fill, gray border, dark text                */
+.btn--ghost         /* no fill/border, muted text — tertiary/text actions */
+.btn--danger        /* outline red that inverts to a red fill on hover    */
+.btn--danger-solid  /* solid red fill — destructive confirm              */
+
+/* shape override */
+.btn--icon   /* padding:0, fixed square, $radius-circle — icon-only buttons */
+```
+
+| Variant | Resting | Hover |
+|---|---|---|
+| `--primary` | `$primary` fill / white text | `$primary-hover` fill |
+| `--outline` | white / `$gray-400` border / `$primary-text` | border → `$primary-text` |
+| `--ghost` | transparent / `$secondary-text` | text → `$primary-text` |
+| `--danger` | white / `$error-red` border + text | `$error-red` fill / white text |
+| `--danger-solid` | `$error-red` fill / white text | `$error-red-hover` fill |
+
+`--icon` composes with a color variant for its hover treatment (e.g. a circular
+ghost icon button is `.btn .btn--icon .btn--ghost`).
+
+## Out of scope (deliberately not `.btn`)
+
+- **Selection controls** — filter chips, segmented navs, and the settings toggle
+  switch are *selection state*, not actions. They keep their own classes (a future
+  chip/toggle component), even though several are also pill-shaped.
+- **Admin-surface button colors** — Admin / BugReports / Reports /
+  AdminRecipeControls render on a hardcoded slate palette (`#1f2430`, `#d8dbe0`,
+  `#374151`, `#16a34a`). Those belong to the separate `$admin-*` sub-palette
+  `2-scss` track; this track does not recolor them.
+
+## Migration note
+
+The pre-system page classes (`.sr-btn-primary`, `.about-btn-primary`,
+`.recipes-empty__btn`, `.form-action-btn`, `.submit-review-btn`, …) are replaced
+by `.btn .btn--*` at the call site, deleting the duplicated rule blocks. Where a
+class carries layout beyond the button itself, only the button-look declarations
+move to the variant.

--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -73,7 +73,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **2-iso** | Design: `RecipeFormInput` → shared `FormInput` | `[x]` | `AddRecipe/*`, `Components/Form/*` | #204 |
 | **2-iso** | Design: toast punctuation + string dedupe | `[x]` | ~10 toast call sites (TSX strings) | #207 |
 | **2-iso** | Design: codify loading-state pattern | `[ ]` | convention + `TailSpin`/skeleton outliers | — |
-| **2-scss** | Design: pill `.btn` system | `[~]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | `worktree-feat+pill-btn-system` (2026-06-29) |
+| **2-scss** | Design: pill `.btn` system | `[P]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | #210 |
 | **2-scss** | Design: type scale (~520 `font-size:` literals) | `[ ]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | — |
 | **2-scss** | Design: elevation/shadow re-author (~52 literals) | `[ ]` | **`helpers.scss` + page `.scss`** ⚠ chokepoint | — |
 | **2-scss** | Design: one danger-red token | `[x]` | **`helpers.scss` + SingleRecipe/ReportControl/…** ⚠ chokepoint | #208 |
@@ -338,3 +338,20 @@ narrates the *why*.
   single `2-scss` lane runs safely alongside it (same precedent as #208 vs. the `2-iso` trio). This track collapses
   the ad-hoc button styles onto one shared pill `.btn` system (`index.scss` + page `.scss`). Worktree on free ports
   3001/4001.
+- _2026-06-29_ — **Design: pill `.btn` system** PR opened (#210, `[~]`→`[P]`) — **second `2-scss` lane to reach
+  PR.** Collapsed ~70 ad-hoc button styles across ~35 files onto one pill `.btn` base + BEM modifiers (5 colour
+  variants, 3 sizes, `--icon`) defined in `index.scss` and documented at `docs/design/button-system.md` (second
+  design-system doc after `icon-system.md`). Owner sign-off: **pill everywhere** (finishes the migration the
+  redesigned pages started) + **non-admin scope** (admin button *colours* stay for the `$admin-*` lane). Kept
+  bespoke on the base (no colour variant): AA-tuned brand fills (`$primary-accessible`/`#a52f0a`/`#006065` — the
+  generic `--primary` hover fails white-on-fill AA), the teal auth-submit, stateful toggles, and the non-token
+  green/slate; nav CTAs go pill but stay off the variants (theme-variable `--dnav-*`). Out of scope: selection
+  chips/segmented-navs/toggle-switches + the shared `SortDropdown` (also on the out-of-scope Recipes page). Built
+  with one pilot surface (SingleRecipe action bar) verified live first, then a 5-agent parallel sweep + the
+  nuanced surfaces (auth-teal, themed nav, AddRecipe) by hand. `tsc`/build/**543 Vitest** green; high-effort
+  4-angle code review found 3 real regressions, all fixed (SavedRecipes clear-button grey fill dropped by
+  `--ghost`; two `&:hover` overrides lost to the variant's `:hover:not(:disabled)`; a Settings leading-icon
+  additive margin). Verified live (headless) across home/recipes/recipe-detail/about/login/signup/404/profile;
+  the auth-gated surfaces (Settings/SavedRecipes/AddRecipe/review edit-delete) are covered by tsc/build/tests/
+  review, not driven (no dev creds). Net −81 lines. Ran safely alongside the in-flight `2-iso` loading-state
+  worktree (zero file overlap). Awaiting CI.

--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -73,7 +73,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **2-iso** | Design: `RecipeFormInput` → shared `FormInput` | `[x]` | `AddRecipe/*`, `Components/Form/*` | #204 |
 | **2-iso** | Design: toast punctuation + string dedupe | `[x]` | ~10 toast call sites (TSX strings) | #207 |
 | **2-iso** | Design: codify loading-state pattern | `[ ]` | convention + `TailSpin`/skeleton outliers | — |
-| **2-scss** | Design: pill `.btn` system | `[ ]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | — |
+| **2-scss** | Design: pill `.btn` system | `[~]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | `worktree-feat+pill-btn-system` (2026-06-29) |
 | **2-scss** | Design: type scale (~520 `font-size:` literals) | `[ ]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | — |
 | **2-scss** | Design: elevation/shadow re-author (~52 literals) | `[ ]` | **`helpers.scss` + page `.scss`** ⚠ chokepoint | — |
 | **2-scss** | Design: one danger-red token | `[x]` | **`helpers.scss` + SingleRecipe/ReportControl/…** ⚠ chokepoint | #208 |
@@ -331,3 +331,10 @@ narrates the *why*.
   append-only) and CI re-ran clean on the merge commit. Closes the BACKLOG 'One danger-red token' item (audit
   F6). Worktree + branch torn down. Remaining Wave 2 = the loading-state pattern (`2-iso`, in flight) + the rest
   of the serialized `2-scss` lane (pill `.btn`, type scale, elevation, `$admin-*`, `$primary-hover`).
+- _2026-06-29_ — **Design: pill `.btn` system** claimed (`worktree-feat+pill-btn-system`, `[ ]`→`[~]`) — **second
+  `2-scss` lane to open.** Checked the lane is clear first: the only other in-flight worktree is the `2-iso`
+  loading-state pattern (`worktree-feat+loading-state-pattern`, `[~]` but not yet merged so the Board still shows
+  `[ ]`), which touches `.tsx` + `_exports.module.scss` — no `2-scss` chokepoint contention, so per rule 1 a
+  single `2-scss` lane runs safely alongside it (same precedent as #208 vs. the `2-iso` trio). This track collapses
+  the ad-hoc button styles onto one shared pill `.btn` system (`index.scss` + page `.scss`). Worktree on free ports
+  3001/4001.

--- a/src/Components/AddToCollection/AddToCollection.scss
+++ b/src/Components/AddToCollection/AddToCollection.scss
@@ -157,21 +157,16 @@
       }
     }
 
+    // `.btn .btn--primary .btn--sm` ($primary fill/hover from the variant);
+    // keeps its fixed square width (no-shrink in the input row) and the larger
+    // icon glyph, with padding zeroed so the 34px box isn't blown out.
     .create-btn {
       flex-shrink: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
       width: 34px;
-      background: s.$primary;
-      color: #fff;
-      border: none;
-      border-radius: 9px;
+      padding: 0;
       font-size: 1rem;
-      cursor: pointer;
       &:disabled {
         opacity: 0.5;
-        cursor: default;
       }
     }
   }

--- a/src/Components/AddToCollection/AddToCollectionPopover.tsx
+++ b/src/Components/AddToCollection/AddToCollectionPopover.tsx
@@ -155,7 +155,7 @@ const AddToCollectionPopover: FC<Props> = ({
         />
         <button
           type='submit'
-          className='create-btn'
+          className='create-btn btn btn--primary btn--sm'
           disabled={!newName.trim() || busy}
           aria-label='Create collection'
         >

--- a/src/Components/AppErrorFallback/AppErrorFallback.scss
+++ b/src/Components/AppErrorFallback/AppErrorFallback.scss
@@ -30,15 +30,11 @@
       justify-content: center;
       flex-wrap: wrap;
 
+      // Rides the global `.btn` base (layout/reset/pill). KEEP BESPOKE: the dark
+      // slate (#1f2430) fill + white/border `.secondary` aren't a token variant,
+      // so the colours stay local; only the radius is dropped to inherit pill.
       .btn {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
         padding: 0.65rem 1.25rem;
-        border-radius: s.$radius-md;
-        border: none;
-        cursor: pointer;
-        font-weight: 600;
         text-decoration: none;
         background: #1f2430;
         color: s.$white;

--- a/src/Components/BugReport/BugReportModal.scss
+++ b/src/Components/BugReport/BugReportModal.scss
@@ -1,14 +1,12 @@
 @use '../../helpers.scss' as s;
 
+// Adopts the `.btn` base for layout/reset/pill, but keeps its bespoke tertiary
+// text + blue (#2563eb) hover — these aren't the `--ghost` palette, so no colour
+// variant is applied (base only, like the KEEP-BESPOKE buttons).
 .bug-report-trigger {
-  background: none;
-  border: none;
-  cursor: pointer;
   color: s.$tertiary-text;
   font-size: 0.8rem;
   padding: 0.15rem 0.35rem;
-  border-radius: s.$radius-xs;
-  transition: color 0.15s, background 0.15s;
 
   &:hover {
     color: #2563eb;
@@ -82,32 +80,29 @@
     gap: 0.6rem;
     margin-top: 0.5rem;
 
+    // Both buttons ride the `.btn` base; only the modal's tighter padding /
+    // font-size and the spinner anchor are local.
     button {
-      cursor: pointer;
-      border-radius: s.$radius-sm;
       padding: 0.55rem 1rem;
       font-size: 0.9rem;
-      font-weight: 600;
       position: relative;
     }
 
+    // Bespoke grey secondary (not the white `--outline` palette) — base only.
     .bug-report-cancel-btn {
       background: #f1f2f4;
       border: 1px solid #d8dbe0;
       color: #374151;
     }
 
+    // KEEP BESPOKE: non-token green fill on the `.btn` base, no colour variant.
     .bug-report-submit-btn {
       background: #16a34a;
       border: 1px solid #16a34a;
       color: #fff;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
 
       &:disabled {
         opacity: 0.7;
-        cursor: default;
       }
     }
 

--- a/src/Components/BugReport/BugReportModal.scss
+++ b/src/Components/BugReport/BugReportModal.scss
@@ -2,8 +2,11 @@
 
 // Adopts the `.btn` base for layout/reset/pill, but keeps its bespoke tertiary
 // text + blue (#2563eb) hover — these aren't the `--ghost` palette, so no colour
-// variant is applied (base only, like the KEEP-BESPOKE buttons).
-.bug-report-trigger {
+// variant is applied (base only, like the KEEP-BESPOKE buttons). Selector is
+// `.bug-report-trigger.btn` (0,2,0) so its compact padding reliably outranks the
+// base `.btn` (0,1,0) regardless of stylesheet order (the element always carries
+// both classes — `bug-report-trigger btn ${variant}`).
+.bug-report-trigger.btn {
   color: s.$tertiary-text;
   font-size: 0.8rem;
   padding: 0.15rem 0.35rem;

--- a/src/Components/BugReport/BugReportModal.tsx
+++ b/src/Components/BugReport/BugReportModal.tsx
@@ -82,7 +82,7 @@ const BugReportModal: FC<BugReportModalProps> = ({ variant = 'link' }) => {
     <>
       <button
         type='button'
-        className={`bug-report-trigger ${variant}`}
+        className={`bug-report-trigger btn ${variant}`}
         onClick={() => setIsOpen(true)}
       >
         Report a bug
@@ -145,7 +145,7 @@ const BugReportModal: FC<BugReportModalProps> = ({ variant = 'link' }) => {
         <div className='bug-report-modal-actions'>
           <button
             type='button'
-            className='bug-report-cancel-btn'
+            className='bug-report-cancel-btn btn'
             onClick={close}
             disabled={submitting}
           >
@@ -153,7 +153,7 @@ const BugReportModal: FC<BugReportModalProps> = ({ variant = 'link' }) => {
           </button>
           <button
             type='button'
-            className='bug-report-submit-btn'
+            className='bug-report-submit-btn btn'
             onClick={handleSubmit}
             disabled={submitting}
           >

--- a/src/Components/Form/FormStyles.scss
+++ b/src/Components/Form/FormStyles.scss
@@ -208,30 +208,25 @@
     color: s.$error-red;
   }
 
+  // Auth-page button sizing: full-width, 48px tall (pill comes from the base
+  // `.btn`). Applies to both the submit CTA and the Google button.
   .btn {
     height: 48px;
     width: 100%;
-    border-radius: s.$border-radius;
     font-weight: 700;
     font-size: 1rem;
-    cursor: pointer;
   }
 
+  // Submit CTA — intentionally the brand TEAL ($secondary-accessible), matching
+  // the auth pages' teal brand mark (not the orange `.btn--primary`). On the
+  // `.btn` base; only the teal fill + spacing are local.
   .form-action-btn {
-    display: flex;
-    justify-content: center;
-    align-items: center;
     margin-top: 1.25rem;
-    border: none;
     color: s.$white;
     background: s.$secondary-accessible;
-    transition: filter 0.15s ease;
+    border-color: s.$secondary-accessible;
     &:hover:not(:disabled) {
       filter: brightness(0.95);
-    }
-    &:disabled {
-      opacity: 0.65;
-      cursor: default;
     }
   }
 
@@ -253,15 +248,13 @@
     }
   }
 
+  // Social button — white with a thin grey border (a bespoke look on the `.btn`
+  // base; not the generic `--outline`, whose hover shifts the border).
   .google-btn {
     border: 1.5px solid s.$gray-300;
     background: s.$white;
     color: s.$primary-text;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     gap: 0.6rem;
-    transition: background 0.15s ease;
     &:hover {
       background: s.$gray-50;
     }

--- a/src/Components/Navbar/desktop/DesktopNav.scss
+++ b/src/Components/Navbar/desktop/DesktopNav.scss
@@ -166,7 +166,10 @@
 // Create — promoted action. In the Quiet skin this is an outlined accent button
 // (override below) rather than a filled one, to keep the bar restrained.
 .dnav__create {
-  border-radius: s.$border-radius;
+  // Pill shape to match the app-wide `.btn` system. Kept off the `.btn` variant
+  // classes because the nav CTAs are theme-variable (colours flip via --dnav-*
+  // custom props as the bar goes transparent→solid over the hero).
+  border-radius: s.$radius-pill;
   .dnav__link-icon {
     display: block;
   }
@@ -227,7 +230,8 @@
   align-items: center;
   justify-content: center;
   padding: 0.5rem 1.1rem;
-  border-radius: s.$border-radius;
+  // Pill shape; themed colours kept off the `.btn` variants (see .dnav__create).
+  border-radius: s.$radius-pill;
   font-size: 1rem;
   font-weight: 700;
   text-decoration: none;

--- a/src/Components/ReleaseNotes/ReleaseNotes.scss
+++ b/src/Components/ReleaseNotes/ReleaseNotes.scss
@@ -8,6 +8,8 @@
   overflow-y: auto;
   max-width: 900px;
 
+  // `.btn .btn--icon`; only its absolute placement + icon size are local.
+  // (Focus ring is global on `button`.)
   .close-modal {
     top: 1rem;
     right: 1rem;
@@ -15,9 +17,6 @@
     .icon {
       height: 30px;
       width: 30px;
-    }
-    &:focus-visible {
-      @include s.outline();
     }
   }
   .release-notes-content-container {
@@ -90,14 +89,13 @@
     }
   }
 
+  // `.btn .btn--ghost` (secondary-text comes from the variant); keeps the
+  // underlined text-link treatment + left alignment + spacing.
   .all-release-notes-btn {
-    font-weight: 600;
     font-size: 1rem;
     text-decoration: underline;
     text-align: left;
-    margin: 0;
-    color: s.$secondary-text;
-    margin-top: 1rem;
+    margin: 1rem 0 0;
   }
 
   .link {

--- a/src/Components/ReleaseNotes/ReleaseNotes.tsx
+++ b/src/Components/ReleaseNotes/ReleaseNotes.tsx
@@ -70,7 +70,7 @@ const ReleaseNotes: FC<ReleaseNotesProps> = ({
       style={panelModalStyles}
       className='release-notes-modal'
     >
-      <button className='close-modal btn' onClick={closeModal}>
+      <button className='close-modal btn btn--icon' onClick={closeModal}>
         <CloseIcon className='icon' />
       </button>
       <div className='release-notes-content-container'>
@@ -136,7 +136,7 @@ const ReleaseNotes: FC<ReleaseNotesProps> = ({
         </div>
         <a
           href='https://github.com/jclind/prepify/releases'
-          className='all-release-notes-btn btn'
+          className='all-release-notes-btn btn btn--ghost'
         >
           View All Release Notes
         </a>

--- a/src/Components/SearchRecipesInput/SearchRecipesInput.scss
+++ b/src/Components/SearchRecipesInput/SearchRecipesInput.scss
@@ -32,19 +32,14 @@
       font-weight: 500;
       background: s.$white;
     }
+    // `.btn .btn--primary` ($primary fill/hover from the variant); only its
+    // in-input placement, larger type, inset height + padding are local.
     .search-recipes-btn {
       position: absolute;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      font-weight: 600;
-      color: s.$white;
       right: 5px;
       font-size: 1.1rem;
-      background: s.$primary;
       height: 80%;
       padding: 0 1.25rem;
-      border-radius: s.$border-radius;
     }
     @include s.below(500px) {
       input {

--- a/src/Components/SearchRecipesInput/SearchRecipesInput.tsx
+++ b/src/Components/SearchRecipesInput/SearchRecipesInput.tsx
@@ -237,7 +237,7 @@ const SearchRecipesInput: FC<SearchRecipesInputProps> = ({
           onKeyDown={handleKeyDown}
         />
         {searchRecipeVal && (
-          <div className='search-recipes-btn btn' onClick={handleSubmit}>
+          <div className='search-recipes-btn btn btn--primary' onClick={handleSubmit}>
             Search
           </div>
         )}

--- a/src/index.scss
+++ b/src/index.scss
@@ -116,7 +116,8 @@ a {
   border-radius: s.$radius-pill;
   cursor: pointer;
   transition: background-color 0.15s ease, border-color 0.15s ease,
-    color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+    color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease,
+    filter 0.15s ease;
 
   svg {
     font-size: 1.1em;
@@ -200,6 +201,13 @@ a {
 }
 
 .load-more-btn {
+  // Self-contained, deferred from the `.btn` system: supplies its own reset
+  // (background / cursor / colour / weight) that the old no-op `.btn` base used
+  // to provide, so it renders correctly WITHOUT a `btn` class on the element.
+  background: none;
+  color: s.$primary-text;
+  font-weight: 600;
+  cursor: pointer;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/index.scss
+++ b/src/index.scss
@@ -93,25 +93,110 @@ a {
   }
 }
 
+// ── Button system ──────────────────────────────────────────────────────────
+// One pill `.btn` base + BEM modifiers. See docs/design/button-system.md.
+// Base = reset + inline-flex layout + default (md) size + pill shape. Compose
+// with a colour variant (`.btn--primary` etc.) and, optionally, a size
+// (`.btn--sm`/`.btn--lg`/`.btn--block`). The :focus-visible ring is provided
+// globally by the `button` rule above — variants never re-declare focus.
 .btn {
-  background: none;
-  outline: none;
-  border: none;
-  cursor: pointer;
-  font-size: 1.5rem;
-  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  white-space: nowrap;
+  line-height: 1;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.6rem 1.3rem;
   color: s.$primary-text;
-}
-.action-btn {
-  padding: 0.75rem 1.5rem;
-  border: 2px solid s.$primary-text;
-  border-radius: s.$border-radius;
-  transition: all 0.1s linear;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: s.$radius-pill;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+    color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
 
-  &:hover {
-    border: 2px solid s.$primary;
-    background: s.$primary;
+  svg {
+    font-size: 1.1em;
   }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+}
+
+// Sizes (default = md, baked into `.btn`)
+.btn--sm {
+  padding: 0.45rem 0.95rem;
+  font-size: 0.85rem;
+}
+.btn--lg {
+  padding: 0.7rem 1.6rem;
+  font-size: 1rem;
+}
+.btn--block {
+  width: 100%;
+}
+
+// Colour variants
+.btn--primary {
+  background: s.$primary;
+  border-color: s.$primary;
+  color: s.$white;
+
+  &:hover:not(:disabled) {
+    background: s.$primary-hover;
+    border-color: s.$primary-hover;
+  }
+}
+.btn--outline {
+  background: s.$white;
+  border-color: s.$gray-400;
+  color: s.$primary-text;
+
+  &:hover:not(:disabled) {
+    border-color: s.$primary-text;
+  }
+}
+.btn--ghost {
+  background: none;
+  border-color: transparent;
+  color: s.$secondary-text;
+
+  &:hover:not(:disabled) {
+    color: s.$primary-text;
+  }
+}
+.btn--danger {
+  background: s.$white;
+  border-color: s.$error-red;
+  color: s.$error-red;
+
+  &:hover:not(:disabled) {
+    background: s.$error-red;
+    color: s.$white;
+  }
+}
+.btn--danger-solid {
+  background: s.$error-red;
+  border-color: s.$error-red;
+  color: s.$white;
+
+  &:hover:not(:disabled) {
+    background: s.$error-red-hover;
+    border-color: s.$error-red-hover;
+  }
+}
+
+// Icon-only — square, circular; composes with a colour variant for its hover.
+.btn--icon {
+  padding: 0;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: s.$radius-circle;
 }
 
 .load-more-btn {

--- a/src/pages/404/404.scss
+++ b/src/pages/404/404.scss
@@ -89,11 +89,10 @@
         color: s.$secondary-accessible;
       }
     }
+    // `.btn .btn--primary` — kept oversized on this hero 404: larger padding,
+    // 1.5rem type, heavier weight, and the top spacing are local.
     button.home-btn {
-      background: s.$primary;
-      color: s.$white;
       padding: 0.75rem 2rem;
-      border-radius: s.$radius-lg;
       font-size: 1.5rem;
       font-weight: 700;
       margin-top: 2rem;

--- a/src/pages/404/404.tsx
+++ b/src/pages/404/404.tsx
@@ -28,7 +28,7 @@ const NotFound: FC = () => {
           </Link>
           .
         </p>
-        <button className='home-btn btn' onClick={() => navigate('/')}>
+        <button className='home-btn btn btn--primary' onClick={() => navigate('/')}>
           Return Home
         </button>
       </div>

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -49,17 +49,13 @@
     justify-content: center;
   }
 
+  // `.btn` base supplies layout (inline-flex/centred/gap), pill shape, weight,
+  // and the transition; only the slightly larger CTA padding/size, the lift-on-
+  // hover, and the icon nudge are local.
   .about-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
     padding: 0.65rem 1.35rem;
-    border-radius: s.$radius-pill;
     font-size: 0.9375rem;
-    font-weight: 600;
     text-decoration: none;
-    transition: transform 0.18s ease, background-color 0.18s ease,
-      box-shadow 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 
     svg {
       font-size: 1.05em;
@@ -68,11 +64,6 @@
 
     &:hover {
       transform: translateY(-2px);
-    }
-
-    &:focus-visible {
-      outline: 2px solid s.$primary;
-      outline-offset: 2px;
     }
   }
 
@@ -472,7 +463,6 @@
 
     .about-btn {
       width: 100%;
-      justify-content: center;
     }
 
     .about-cta {

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -152,11 +152,11 @@ const About: FC = () => (
         getting into before you start cooking.
       </p>
       <div className='about-cta'>
-        <Link to='/recipes' className='about-btn about-btn-primary'>
+        <Link to='/recipes' className='about-btn about-btn-primary btn'>
           Browse recipes
           <ArrowRightIcon aria-hidden='true' />
         </Link>
-        <Link to='/signup' className='about-btn about-btn-ghost'>
+        <Link to='/signup' className='about-btn about-btn-ghost btn'>
           Create an account
         </Link>
       </div>
@@ -250,11 +250,11 @@ const About: FC = () => (
         Find your next meal. Price and nutrition included.
       </p>
       <div className='about-cta'>
-        <Link to='/recipes' className='about-btn about-btn-primary'>
+        <Link to='/recipes' className='about-btn about-btn-primary btn'>
           Browse recipes
           <ArrowRightIcon aria-hidden='true' />
         </Link>
-        <Link to='/signup' className='about-btn about-btn-ghost'>
+        <Link to='/signup' className='about-btn about-btn-ghost btn'>
           Create an account
         </Link>
       </div>

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -202,36 +202,32 @@
     justify-content: flex-end;
     gap: 0.5rem;
   }
+  // `.acct-btn` rides the shared `.btn` base; only the heavier 700 weight and a
+  // slightly smaller icon are local. (Layout/shape/reset come from `.btn`.)
   .acct-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.4rem;
-    font-family: inherit;
     font-weight: 700;
-    cursor: pointer;
-    transition: all 0.12s ease;
     svg {
       font-size: 1.05rem;
     }
   }
+  // Warm-palette outline pill on the `.btn` base — bespoke cream border + brand
+  // hover, so no colour variant. Tighter padding + smaller text than the base.
   .acct-edit {
     font-size: 0.86rem;
     color: s.$secondary-text;
     background: #fff;
     border: 1px solid #e3d9ca;
-    border-radius: s.$radius-pill;
     padding: 0.5rem 1.1rem;
     &:hover {
       border-color: s.$primary;
       color: s.$primary;
     }
   }
+  // `.btn--icon` gives the circular shape; the warm colours are bespoke (kept).
+  // A hair larger than the 2.25rem icon default.
   .acct-iconbtn {
     width: 38px;
     height: 38px;
-    padding: 0;
-    border-radius: s.$radius-circle;
     color: s.$secondary-text;
     background: #fff;
     border: 1px solid #e3d9ca;

--- a/src/pages/Account/Drafts/DraftCard.tsx
+++ b/src/pages/Account/Drafts/DraftCard.tsx
@@ -63,12 +63,12 @@ const DraftCard: FC<DraftCardProps> = ({ draft, onDelete }) => {
         )}
       </div>
       <div className='actions'>
-        <button type='button' className='resume' onClick={handleResume}>
+        <button type='button' className='btn resume' onClick={handleResume}>
           <EditIcon /> Continue editing
         </button>
         <button
           type='button'
-          className='del'
+          className='btn del'
           onClick={handleDelete}
           disabled={deleting}
           aria-label='Delete draft'

--- a/src/pages/Account/Drafts/Drafts.scss
+++ b/src/pages/Account/Drafts/Drafts.scss
@@ -118,27 +118,20 @@
       margin-top: auto;
       padding-top: 0.15rem;
 
+      // Bespoke filled CTA on the `.btn` base: the AA-tuned accessible-orange
+      // fill + warm hover/shadow don't map to `.btn--primary`, so no variant.
+      // Layout/shape/reset come from `.btn`.
       .resume {
         flex: 1 1 auto;
         // min-width:0 lets the button shrink below its nowrap label's intrinsic
         // width (that intrinsic min is what forced the overflow); with flex-wrap
         // it shares the row when it fits and drops Delete below when it doesn't.
         min-width: 0;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0.4rem;
-        white-space: nowrap;
-        cursor: pointer;
-        font-family: inherit;
         font-size: 0.9rem;
         font-weight: 700;
         padding: 0.55rem 1rem;
-        border-radius: s.$radius-lg;
-        border: none;
         background: s.$primary-accessible;
         color: #fff;
-        transition: background 0.14s ease, box-shadow 0.14s ease;
         svg {
           font-size: 1rem;
         }
@@ -148,22 +141,15 @@
         }
       }
 
+      // Soft warm-red outline on the `.btn` base — the muted #ecd9d9 border +
+      // tinted hover don't match `.btn--danger`'s fill, so kept bespoke.
       .del {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0.4rem;
         flex-shrink: 0;
-        cursor: pointer;
-        font-family: inherit;
         font-size: 0.82rem;
         font-weight: 700;
         padding: 0.5rem 0.85rem;
-        border-radius: s.$radius-lg;
-        background: none;
         border: 1px solid #ecd9d9;
         color: s.$secondary-text;
-        transition: color 0.14s ease, border-color 0.14s ease, background 0.14s ease;
         svg {
           font-size: 1rem;
         }
@@ -174,7 +160,6 @@
         }
         &:disabled {
           opacity: 0.5;
-          cursor: default;
         }
       }
     }

--- a/src/pages/Account/SavedRecipes/SavedRecipes.scss
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.scss
@@ -187,8 +187,9 @@
         border-color: s.$primary;
       }
     }
-    // `.btn .btn--icon .btn--ghost`; only the in-field position + the smaller
-    // 22px footprint (the icon default is 2.25rem) are local.
+    // `.btn .btn--icon` (no colour variant — it keeps its own grey-circle fill;
+    // `--ghost` would strip the background). Local: in-field position + the
+    // smaller 22px footprint (the icon default is 2.25rem).
     &__clear {
       position: absolute;
       right: 0.7rem;
@@ -196,6 +197,11 @@
       transform: translateY(-50%);
       width: 22px;
       height: 22px;
+      background: s.$gray-200;
+      color: s.$secondary-text;
+      &:hover {
+        background: s.$gray-300;
+      }
     }
   }
   // Custom sort control (mirrors the Recipes page) instead of a react-select box.

--- a/src/pages/Account/SavedRecipes/SavedRecipes.scss
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.scss
@@ -136,23 +136,13 @@
           border-color: s.$primary;
         }
       }
+      // `.btn .btn--primary`; only the heavier weight + compact size are local.
       .new-submit {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0.3rem;
-        border: none;
-        background: s.$primary;
-        color: #fff;
-        font-family: inherit;
         font-weight: 800;
         font-size: 0.82rem;
-        border-radius: s.$radius-md;
         padding: 0.4rem 0.7rem;
-        cursor: pointer;
         &:disabled {
           opacity: 0.5;
-          cursor: default;
         }
       }
     }
@@ -197,24 +187,15 @@
         border-color: s.$primary;
       }
     }
+    // `.btn .btn--icon .btn--ghost`; only the in-field position + the smaller
+    // 22px footprint (the icon default is 2.25rem) are local.
     &__clear {
       position: absolute;
       right: 0.7rem;
       top: 50%;
       transform: translateY(-50%);
-      display: flex;
-      align-items: center;
-      justify-content: center;
       width: 22px;
       height: 22px;
-      border: none;
-      border-radius: s.$radius-circle;
-      background: s.$gray-200;
-      color: s.$secondary-text;
-      cursor: pointer;
-      &:hover {
-        background: s.$gray-300;
-      }
     }
   }
   // Custom sort control (mirrors the Recipes page) instead of a react-select box.
@@ -305,22 +286,18 @@
     align-items: center;
     gap: 0.35rem;
   }
+  // `.btn .btn--outline` base; the compact size + secondary-text resting colour
+  // are local, and the `.ghost`/`.danger` modifiers stay as local tweaks.
   .btn-small {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.3rem;
-    font-family: inherit;
     font-size: 0.82rem;
     padding: 0.35rem 0.6rem;
-    border-radius: s.$radius-md;
-    border: 1px solid s.$gray-400;
-    background: #fff;
     color: s.$secondary-text;
-    cursor: pointer;
     &.ghost {
       border-color: transparent;
+      // keep the ghost borderless on hover too (the outline variant would
+      // otherwise draw a border in on :hover).
       &:hover {
+        border-color: transparent;
         background: s.$gray-50;
       }
     }

--- a/src/pages/Account/SavedRecipes/SavedRecipes.tsx
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.tsx
@@ -362,7 +362,7 @@ const SavedRecipes: FC = () => {
                 ))}
           </div>
           {isMoreRecipes && recipes.length > 0 ? (
-            <button className='load-more-btn btn' onClick={handleLoadMoreRecipes}>
+            <button className='load-more-btn' onClick={handleLoadMoreRecipes}>
               Load More Recipes
             </button>
           ) : null}

--- a/src/pages/Account/SavedRecipes/SavedRecipes.tsx
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.tsx
@@ -274,7 +274,7 @@ const SavedRecipes: FC = () => {
           {searchInput && (
             <button
               type='button'
-              className='btn btn--icon btn--ghost saved-search__clear'
+              className='btn btn--icon saved-search__clear'
               aria-label='Clear search'
               onClick={() => onSearchChange('')}
             >

--- a/src/pages/Account/SavedRecipes/SavedRecipes.tsx
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.tsx
@@ -239,7 +239,7 @@ const SavedRecipes: FC = () => {
             />
             <button
               type='submit'
-              className='new-submit'
+              className='btn btn--primary new-submit'
               disabled={creating || !newName.trim()}
             >
               <PlusIcon /> Create
@@ -274,7 +274,7 @@ const SavedRecipes: FC = () => {
           {searchInput && (
             <button
               type='button'
-              className='saved-search__clear'
+              className='btn btn--icon btn--ghost saved-search__clear'
               aria-label='Clear search'
               onClick={() => onSearchChange('')}
             >
@@ -307,10 +307,10 @@ const SavedRecipes: FC = () => {
               maxLength={50}
               onChange={e => setRenameValue(e.target.value)}
             />
-            <button type='submit' className='btn-small'>Save</button>
+            <button type='submit' className='btn btn--outline btn-small'>Save</button>
             <button
               type='button'
-              className='btn-small ghost'
+              className='btn btn--outline btn-small ghost'
               onClick={() => setRenaming(false)}
             >
               <CloseIcon />
@@ -322,7 +322,7 @@ const SavedRecipes: FC = () => {
             {activeCollection && (
               <div className='saved-collection-actions'>
                 <button
-                  className='btn-small ghost'
+                  className='btn btn--outline btn-small ghost'
                   onClick={() => {
                     setRenameValue(activeCollection.name)
                     setRenaming(true)
@@ -332,7 +332,7 @@ const SavedRecipes: FC = () => {
                   <EditIcon /> Rename
                 </button>
                 <button
-                  className='btn-small ghost danger'
+                  className='btn btn--outline btn-small ghost danger'
                   onClick={handleDelete}
                   aria-label='Delete collection'
                 >

--- a/src/pages/Account/UserRatings/UserRatings.tsx
+++ b/src/pages/Account/UserRatings/UserRatings.tsx
@@ -157,7 +157,7 @@ const Ratings: FC = () => {
           </div>
           {isMoreReviews && reviews.length > 0 ? (
             <button
-              className='load-more-btn btn'
+              className='load-more-btn'
               onClick={handleLoadMoreReviews}
             >
               Load More Reviews

--- a/src/pages/Account/UserRecipes/UserRecipes.tsx
+++ b/src/pages/Account/UserRecipes/UserRecipes.tsx
@@ -78,7 +78,7 @@ const UserRecipes: FC = () => {
           </div>
           {isMoreRecipes && recipes.length > 0 ? (
             <button
-              className='load-more-btn btn'
+              className='load-more-btn'
               onClick={handleLoadMoreRecipes}
             >
               Load More Recipes

--- a/src/pages/Account/components/ProfileControls.tsx
+++ b/src/pages/Account/components/ProfileControls.tsx
@@ -34,7 +34,7 @@ const ProfileControls: FC<ProfileControlsProps> = ({ username }) => {
   return (
     <div className='acct-controls'>
       <button
-        className='acct-btn acct-edit'
+        className='btn acct-btn acct-edit'
         onClick={() => navigate('/settings')}
         title='Edit profile'
       >
@@ -42,7 +42,7 @@ const ProfileControls: FC<ProfileControlsProps> = ({ username }) => {
         <span>Edit profile</span>
       </button>
       <button
-        className='acct-btn acct-iconbtn'
+        className='btn btn--icon acct-btn acct-iconbtn'
         onClick={() => navigate('/settings')}
         aria-label='Account settings'
         title='Settings'
@@ -50,7 +50,7 @@ const ProfileControls: FC<ProfileControlsProps> = ({ username }) => {
         <SettingsIcon />
       </button>
       <button
-        className='acct-btn acct-iconbtn'
+        className='btn btn--icon acct-btn acct-iconbtn'
         onClick={onShare}
         aria-label='Share profile'
         title='Share'

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.scss
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.scss
@@ -66,50 +66,35 @@
     gap: 0.75rem;
   }
 
+  // cancel = a quiet outline on the `.btn` base; only the fixed height + the
+  // muted transparent look are local.
   .cancel-btn {
     flex-shrink: 0;
     height: 46px;
     padding: 0 1.25rem;
-    border-radius: s.$border-radius;
     font-size: 1rem;
     font-weight: 600;
-    cursor: pointer;
-    outline: none;
     background: none;
     color: s.$secondary-text;
     border: 1px solid s.$tertiary-background;
-    transition: all 0.1s linear;
 
     &:hover {
       color: s.$primary-text;
       border-color: s.$tertiary-text;
     }
-    &:focus-visible {
-      @include s.outline();
-    }
     &:disabled {
-      opacity: 0.6;
       cursor: not-allowed;
     }
   }
 
+  // submit toggles .invalid/.valid (stateful) on the `.btn` base; the state
+  // colours are local.
   .submit-btn {
-    display: flex;
-    justify-content: center;
-    align-items: center;
     flex-shrink: 0;
     width: 170px;
     height: 46px;
-    border-radius: s.$border-radius;
     font-size: 1rem;
     font-weight: 600;
-    cursor: pointer;
-    outline: none;
-    transition: all 0.1s linear;
-
-    &:focus-visible {
-      @include s.outline();
-    }
   }
   .submit-btn.invalid {
     background: none;
@@ -131,7 +116,6 @@
     }
   }
   .submit-btn:disabled {
-    opacity: 0.6;
     cursor: not-allowed;
 
     &:hover {

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
@@ -84,7 +84,7 @@ const AddRecipeSummaryBar: FC<AddRecipeSummaryBarProps> = ({
           {onCancel && (
             <button
               type='button'
-              className='cancel-btn'
+              className='cancel-btn btn'
               disabled={loading}
               onClick={onCancel}
             >
@@ -92,7 +92,7 @@ const AddRecipeSummaryBar: FC<AddRecipeSummaryBarProps> = ({
             </button>
           )}
           <button
-            className={`submit-btn ${isValid ? 'valid' : 'invalid'}`}
+            className={`submit-btn btn ${isValid ? 'valid' : 'invalid'}`}
             disabled={loading}
             aria-busy={loading}
             onClick={onSubmit}

--- a/src/pages/AddRecipe/DraftResumeBanner.scss
+++ b/src/pages/AddRecipe/DraftResumeBanner.scss
@@ -71,13 +71,13 @@
       gap: 0.85rem;
     }
 
+    // AA-orange CTA on the `.btn` base — kept off the generic `.btn--primary`
+    // (whose hover fails white-on-fill AA); these fills are AA-tuned.
     .resume-btn {
-      cursor: pointer;
       font-size: 0.85rem;
       font-weight: 600;
       white-space: nowrap;
       padding: 0.4rem 0.9rem;
-      border-radius: s.$border-radius;
       // AA on-light orange so the white label clears 4.5:1 (vivid #ff5722 fill
       // is only 3.16:1). brightness() hover stays above AA.
       border: 1px solid s.$primary-accessible;

--- a/src/pages/AddRecipe/DraftResumeBanner.tsx
+++ b/src/pages/AddRecipe/DraftResumeBanner.tsx
@@ -39,7 +39,7 @@ const DraftResumeBanner: FC = () => {
       <div className='banner-actions'>
         <button
           type='button'
-          className='resume-btn'
+          className='resume-btn btn'
           onClick={() => navigate(`/add-recipe?draftId=${mostRecent._id}`)}
         >
           Resume

--- a/src/pages/Home/HomeCookSuggestion.scss
+++ b/src/pages/Home/HomeCookSuggestion.scss
@@ -12,6 +12,8 @@
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
   animation: cook-modal-pop 0.18s ease;
 
+  // `.btn .btn--icon` — square/circular icon button. Local: its absolute
+  // placement, the smaller 30px size, and the translucent-white chip look.
   .cook-modal-close {
     position: absolute;
     top: 0.55rem;
@@ -19,13 +21,8 @@
     z-index: 2;
     width: 30px;
     height: 30px;
-    border-radius: s.$radius-circle;
-    border: none;
     background: rgba(255, 255, 255, 0.92);
     color: s.$primary-text;
-    cursor: pointer;
-    display: grid;
-    place-items: center;
     font-size: 1.1rem;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     &:hover { background: #fff; }
@@ -107,19 +104,13 @@
   .actions { display: flex; gap: 0.6rem; }
   // skeleton stand-ins for the two action buttons
   .actions .sk-btn { flex: 1; line-height: 1; }
+  // Both sit on the `.btn` base; locally they flex to equal widths in the
+  // .actions row and keep the compact modal sizing + a filter/bg hover.
   .primary,
   .ghost {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.35rem;
     flex: 1;
-    border: none;
-    border-radius: s.$radius-pill;
     font-size: 0.9rem;
-    font-weight: 600;
     padding: 0.6rem 1rem;
-    cursor: pointer;
     text-decoration: none;
     transition: filter 0.12s ease, background 0.12s ease;
     svg { font-size: 1.1rem; }
@@ -148,11 +139,7 @@
     p { margin: 0 0 0.9rem; }
     .ghost {
       background: #f0f1f3;
-      border: none;
-      border-radius: s.$radius-pill;
       padding: 0.5rem 1.1rem;
-      font-weight: 600;
-      cursor: pointer;
       &:hover { background: #e4e6e9; }
     }
   }

--- a/src/pages/Home/HomeCookSuggestion.tsx
+++ b/src/pages/Home/HomeCookSuggestion.tsx
@@ -59,7 +59,7 @@ const HomeCookSuggestion: FC = () => {
 
   return (
     <div className='home-cook-suggestion'>
-      <button className='cook-suggestion-btn' type='button' onClick={open}>
+      <button className='cook-suggestion-btn btn' type='button' onClick={open}>
         <DiceIcon /> What should I cook?
       </button>
 
@@ -71,7 +71,7 @@ const HomeCookSuggestion: FC = () => {
         contentLabel='Recipe suggestion'
       >
         <div className='cook-modal-card'>
-          <button className='cook-modal-close' onClick={close} aria-label='Close' type='button'>
+          <button className='cook-modal-close btn btn--icon' onClick={close} aria-label='Close' type='button'>
             <CloseIcon />
           </button>
 
@@ -96,10 +96,10 @@ const HomeCookSuggestion: FC = () => {
                   {pick.cuisine && <span className='cuisine'>{pick.cuisine}</span>}
                 </div>
                 <div className='actions'>
-                  <Link to={`/recipes/${pick._id}`} className='primary' onClick={close}>
+                  <Link to={`/recipes/${pick._id}`} className='primary btn' onClick={close}>
                     View recipe
                   </Link>
-                  <button className='ghost' onClick={tryAnother} disabled={isPending} type='button'>
+                  <button className='ghost btn' onClick={tryAnother} disabled={isPending} type='button'>
                     <DiceIcon /> {isPending ? 'Finding…' : 'Try another'}
                   </button>
                 </div>
@@ -110,7 +110,7 @@ const HomeCookSuggestion: FC = () => {
           ) : isError ? (
             <div className='cook-modal-state cook-modal-msg'>
               <p>Couldn’t pick a recipe.</p>
-              <button className='ghost' onClick={() => mutate(undefined)} type='button'>
+              <button className='ghost btn' onClick={() => mutate(undefined)} type='button'>
                 Try again
               </button>
             </div>

--- a/src/pages/Home/HomeHero/HomeHero.scss
+++ b/src/pages/Home/HomeHero/HomeHero.scss
@@ -54,20 +54,16 @@
   display: flex;
   justify-content: center;
 
+  // Bespoke AA brand-orange CTA on the `.btn` base — keep its accessible fill,
+  // larger padding/size, drop shadow, and the lift + brightness hover. (The
+  // base handles layout/shape/weight; the filter needs its own transition.)
   .cook-suggestion-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
     padding: 0.7rem 1.4rem;
-    border: none;
-    border-radius: s.$radius-pill;
     background: s.$primary-accessible;
     color: s.$white;
     font-size: 1rem;
-    font-weight: 600;
-    cursor: pointer;
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
-    transition: transform 0.12s ease, filter 0.12s ease;
+    transition: filter 0.12s ease;
 
     svg {
       font-size: 1.25rem;

--- a/src/pages/Home/HomeHero/HomeHero.scss
+++ b/src/pages/Home/HomeHero/HomeHero.scss
@@ -56,14 +56,14 @@
 
   // Bespoke AA brand-orange CTA on the `.btn` base — keep its accessible fill,
   // larger padding/size, drop shadow, and the lift + brightness hover. (The
-  // base handles layout/shape/weight; the filter needs its own transition.)
+  // base transition now covers `transform` AND `filter`, so the lift and the
+  // brightness both ease — no local transition needed.)
   .cook-suggestion-btn {
     padding: 0.7rem 1.4rem;
     background: s.$primary-accessible;
     color: s.$white;
     font-size: 1rem;
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
-    transition: filter 0.12s ease;
 
     svg {
       font-size: 1.25rem;

--- a/src/pages/PublicProfile/PublicProfile.scss
+++ b/src/pages/PublicProfile/PublicProfile.scss
@@ -85,7 +85,7 @@
       font-size: 0.95rem;
     }
     // :not(:disabled) to outrank `.btn--ghost:hover:not(:disabled)` (0,3,0) so
-    // the brand-teal hover survives the ghost variant.
+    // the brand-orange hover survives the ghost variant.
     &:hover:not(:disabled) {
       color: s.$primary;
       background: rgba(s.$primary, 0.08);

--- a/src/pages/PublicProfile/PublicProfile.scss
+++ b/src/pages/PublicProfile/PublicProfile.scss
@@ -31,18 +31,11 @@
       margin-bottom: 1.5rem;
     }
   }
+  // `.btn .btn--primary` — only the heavier weight + roomier padding are local.
   .pp-browse-btn {
-    display: inline-block;
     font-weight: 700;
-    text-decoration: none;
-    color: #fff;
-    background: s.$primary;
-    border-radius: s.$radius-pill;
     padding: 0.6rem 1.5rem;
-    transition: filter 0.12s ease;
-    &:hover {
-      filter: brightness(1.05);
-    }
+    text-decoration: none;
   }
 
   // ── Header (centered identity) ───────────────────────────────────────────────
@@ -82,28 +75,18 @@
     letter-spacing: -0.01em;
   }
   // Non-intrusive share affordance sitting beside the handle.
+  // `.btn .btn--icon .btn--ghost` — local: the smaller 30px size, the quieter
+  // tertiary resting colour, and a brand-tinted hover (vs ghost's text-only).
   .pp-share {
     width: 30px;
     height: 30px;
-    border-radius: s.$radius-circle;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: transparent;
-    border: none;
     color: s.$tertiary-text;
-    cursor: pointer;
-    transition: color 0.15s ease, background 0.15s ease;
     svg {
       font-size: 0.95rem;
     }
     &:hover {
       color: s.$primary;
       background: rgba(s.$primary, 0.08);
-    }
-    &:focus-visible {
-      outline: 2px solid s.$primary;
-      outline-offset: 2px;
     }
   }
   .pp-name {

--- a/src/pages/PublicProfile/PublicProfile.scss
+++ b/src/pages/PublicProfile/PublicProfile.scss
@@ -84,7 +84,9 @@
     svg {
       font-size: 0.95rem;
     }
-    &:hover {
+    // :not(:disabled) to outrank `.btn--ghost:hover:not(:disabled)` (0,3,0) so
+    // the brand-teal hover survives the ghost variant.
+    &:hover:not(:disabled) {
       color: s.$primary;
       background: rgba(s.$primary, 0.08);
     }

--- a/src/pages/PublicProfile/PublicProfile.tsx
+++ b/src/pages/PublicProfile/PublicProfile.tsx
@@ -124,7 +124,7 @@ const PublicProfile: FC = () => {
         <div className='pp-notfound'>
           <h1>Profile not found</h1>
           <p>We couldn’t find a cook with the username “{username}”.</p>
-          <Link to='/recipes' className='pp-browse-btn'>
+          <Link to='/recipes' className='pp-browse-btn btn btn--primary'>
             Browse recipes
           </Link>
         </div>
@@ -191,7 +191,7 @@ const PublicProfile: FC = () => {
           <h1 className='pp-handle'>@{profile.username}</h1>
           <button
             type='button'
-            className='pp-share'
+            className='pp-share btn btn--icon btn--ghost'
             onClick={handleShare}
             aria-label='Share this profile'
             title='Share this profile'

--- a/src/pages/PublicProfile/PublicProfile.tsx
+++ b/src/pages/PublicProfile/PublicProfile.tsx
@@ -320,7 +320,7 @@ const PublicProfile: FC = () => {
               <div className='pp-more'>
                 <button
                   type='button'
-                  className='load-more-btn btn'
+                  className='load-more-btn'
                   onClick={() => setExtraPage(p => p + 1)}
                   disabled={isLoadingMore}
                 >

--- a/src/pages/Settings/components/controls.scss
+++ b/src/pages/Settings/components/controls.scss
@@ -206,83 +206,36 @@
   }
 }
 
-/* Buttons */
+/* Buttons — migrated onto the canonical `.btn` system (src/index.scss).
+   Each keeps `.btn .btn--*` at the call site; only intentionally-different
+   sizing (and the outline's deliberate teal hover + warm border) stays local. */
 .sr-btn-primary {
-  border: none;
-  background: s.$primary;
-  color: s.$white;
-  font-family: inherit;
+  // Compact size parity (base `.btn` is 0.95rem / .6rem 1.3rem).
   font-size: 0.88rem;
-  font-weight: 600;
-  white-space: nowrap;
   padding: 0.6rem 1.2rem;
-  border-radius: s.$radius-lg;
-  cursor: pointer;
-  transition: opacity 0.12s ease;
-  &:hover {
-    opacity: 0.88;
-  }
-  &:disabled {
-    opacity: 0.6;
-    cursor: default;
-  }
 }
 
 .sr-btn-outline {
-  border: 1px solid #d9d2c6;
-  background: s.$white;
-  color: s.$primary-text;
-  font-family: inherit;
+  // Warm border + teal hover are deliberate, not the `.btn--outline` defaults.
+  // `:not(:disabled)` matches the variant hover's specificity so the teal wins.
+  border-color: #d9d2c6;
   font-size: 0.85rem;
-  font-weight: 600;
   padding: 0.45rem 0.95rem;
-  border-radius: s.$radius-lg;
-  cursor: pointer;
-  transition: all 0.12s ease;
-  &:hover {
+  &:hover:not(:disabled) {
     border-color: s.$secondary;
     color: #057780;
-  }
-  &:disabled {
-    opacity: 0.6;
-    cursor: default;
   }
 }
 
 .sr-btn-text {
-  border: none;
-  background: none;
-  font-family: inherit;
   font-size: 0.85rem;
-  font-weight: 600;
-  color: s.$secondary-text;
-  cursor: pointer;
   padding: 0.45rem 0.5rem;
-  border-radius: s.$radius-md;
-  &:hover {
-    color: s.$primary-text;
-  }
 }
 
 .sr-btn-danger {
-  border: 1px solid s.$error-red;
-  background: s.$white;
-  color: s.$error-red;
-  font-family: inherit;
+  // Colour + hover come from `.btn--danger`; only the compact size is local.
   font-size: 0.85rem;
-  font-weight: 600;
   padding: 0.5rem 1rem;
-  border-radius: s.$radius-lg;
-  cursor: pointer;
-  transition: all 0.12s ease;
-  &:hover {
-    background: s.$error-red;
-    color: s.$white;
-  }
-  &:disabled {
-    opacity: 0.6;
-    cursor: default;
-  }
 }
 
 .sr-hint {

--- a/src/pages/Settings/components/controls.tsx
+++ b/src/pages/Settings/components/controls.tsx
@@ -40,11 +40,19 @@ export const AvatarField: FC<AvatarFieldProps> = ({
         )}
       </div>
       <div className='sr-avatar-actions'>
-        <button type='button' className='sr-btn-outline' onClick={onUpload}>
+        <button
+          type='button'
+          className='sr-btn-outline btn btn--outline'
+          onClick={onUpload}
+        >
           Upload photo
         </button>
         {imgUrl && (
-          <button type='button' className='sr-btn-text' onClick={onRemove}>
+          <button
+            type='button'
+            className='sr-btn-text btn btn--ghost'
+            onClick={onRemove}
+          >
             Remove
           </button>
         )}
@@ -209,12 +217,16 @@ export const SaveBar: FC<{
   <div className={`sr-savebar ${dirty ? 'show' : ''}`}>
     <span className='sr-savebar-msg'>You have unsaved changes</span>
     <div className='sr-savebar-actions'>
-      <button type='button' className='sr-btn-text' onClick={onReset}>
+      <button
+        type='button'
+        className='sr-btn-text btn btn--ghost'
+        onClick={onReset}
+      >
         Discard
       </button>
       <button
         type='button'
-        className='sr-btn-primary'
+        className='sr-btn-primary btn btn--primary'
         onClick={onSave}
         disabled={loading}
       >

--- a/src/pages/Settings/sections/AccountSection.tsx
+++ b/src/pages/Settings/sections/AccountSection.tsx
@@ -173,7 +173,7 @@ const AccountSection: FC = () => {
           )}
           <button
             type='button'
-            className='sr-btn-primary sr-self-start'
+            className='sr-btn-primary sr-self-start btn btn--primary'
             onClick={handleUpdateEmail}
             disabled={emailLoading}
           >
@@ -215,7 +215,7 @@ const AccountSection: FC = () => {
           </div>
           <button
             type='button'
-            className='sr-btn-outline'
+            className='sr-btn-outline btn btn--outline'
             onClick={handleChangePassword}
             disabled={passLoading}
           >

--- a/src/pages/Settings/sections/DangerSection.tsx
+++ b/src/pages/Settings/sections/DangerSection.tsx
@@ -100,7 +100,7 @@ const DangerSection: FC = () => {
         </div>
         <button
           type='button'
-          className='sr-btn-danger'
+          className='sr-btn-danger btn btn--danger'
           onClick={() => setModalOpen(true)}
         >
           <TrashIcon className='sr-btn-icon' />
@@ -126,7 +126,7 @@ const DangerSection: FC = () => {
               <h3 id='sr-delete-modal-title'>Delete your account?</h3>
               <button
                 type='button'
-                className='sr-modal-close'
+                className='sr-modal-close btn btn--icon'
                 aria-label='Close'
                 onClick={closeModal}
               >
@@ -155,7 +155,7 @@ const DangerSection: FC = () => {
             <div className='sr-modal-actions'>
               <button
                 type='button'
-                className='sr-btn-text'
+                className='sr-btn-text btn btn--ghost'
                 onClick={closeModal}
                 disabled={deleting}
               >
@@ -163,7 +163,7 @@ const DangerSection: FC = () => {
               </button>
               <button
                 type='button'
-                className='sr-btn-danger'
+                className='sr-btn-danger btn btn--danger'
                 onClick={handleDelete}
                 disabled={!canDelete || deleting}
               >
@@ -192,7 +192,7 @@ const SettingRowLikeExport: FC<{
     <div className='sr-row-control'>
       <button
         type='button'
-        className='sr-btn-outline'
+        className='sr-btn-outline btn btn--outline'
         onClick={onExport}
         disabled={exporting}
       >

--- a/src/pages/Settings/sections/sections.scss
+++ b/src/pages/Settings/sections/sections.scss
@@ -89,7 +89,8 @@
 }
 
 .sr-btn-icon {
-  margin-right: 0.4rem;
+  // Leading icon spacing now comes from the `.btn` base flex `gap`; a
+  // margin here would be additive. (vertical-align is moot under flex.)
   vertical-align: -2px;
 }
 

--- a/src/pages/Settings/sections/sections.scss
+++ b/src/pages/Settings/sections/sections.scss
@@ -174,18 +174,12 @@
       font-weight: 800;
       color: s.$primary-text;
     }
+    // Shape/size come from `.btn .btn--icon` (circular); only the grey fill +
+    // hover are local (the `--icon` variant carries no colour of its own).
     .sr-modal-close {
       flex-shrink: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      height: 32px;
-      width: 32px;
-      border: none;
-      border-radius: s.$radius-md;
       background: s.$gray-200;
       color: s.$secondary-text;
-      cursor: pointer;
       &:hover {
         background: s.$gray-300;
         color: s.$primary-text;

--- a/src/pages/SingleRecipe/Buttons/AddRatingBtn.tsx
+++ b/src/pages/SingleRecipe/Buttons/AddRatingBtn.tsx
@@ -17,7 +17,7 @@ const AddRatingBtn: FC<AddRatingBtnProps> = ({ currUserReview }) => {
   // hover is the button's own chrome. See docs/design/icon-system.md.
   return (
     <div className='add-rating'>
-      <button className='add-rating-btn btn' onClick={handleClick}>
+      <button className='add-rating-btn btn btn--outline' onClick={handleClick}>
         {currUserReview ? (
           <>
             <StarFilledIcon className='icon' />

--- a/src/pages/SingleRecipe/Buttons/MadeRecipeBtn.tsx
+++ b/src/pages/SingleRecipe/Buttons/MadeRecipeBtn.tsx
@@ -71,7 +71,7 @@ const MadeRecipeBtn: FC<MadeRecipeBtnProps> = ({ recipeId }) => {
     <div className='made-this-recipe'>
       <div className='content'>
         <button
-          className='made-recipe'
+          className='made-recipe btn'
           onClick={handleMadeRecipe}
           disabled={loading}
         >

--- a/src/pages/SingleRecipe/Buttons/PrintRecipeBtn.tsx
+++ b/src/pages/SingleRecipe/Buttons/PrintRecipeBtn.tsx
@@ -19,7 +19,7 @@ const PrintRecipeBtn: FC<PrintRecipeBtnProps> = ({ printedRef }) => {
   return (
     <div className='print-recipe'>
       <button
-        className='print-recipe-btn btn'
+        className='print-recipe-btn btn btn--outline'
         disabled={loading}
         onClick={() => handlePrint()}
       >

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Ratings/Ratings.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Ratings/Ratings.tsx
@@ -93,7 +93,7 @@ const Ratings: FC<RatingsProps> = ({
               {rating > 0 && (
                 <button
                   type='button'
-                  className='remove-rating'
+                  className='remove-rating btn btn--ghost'
                   onClick={handleRemoveRating}
                 >
                   Remove rating

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
@@ -168,29 +168,6 @@
         // NB: `.submit-review-btn` is migrated to `.btn .btn--primary` (markup in
         // AddReview.tsx; local spacing/weight in SingleRecipe.scss). It's dropped
         // from this rule so this deep selector no longer overrides its pill shape.
-        // `.leave-review-btn` below is legacy markup (no current call site).
-        .leave-review-btn {
-          font-size: 1rem;
-          background: s.$primary;
-          color: s.$primary-background;
-          padding: 0.5rem 1rem;
-          border-radius: s.$border-radius;
-          &:focus-visible {
-            @include s.outline();
-          }
-        }
-        .leave-review-btn {
-          position: absolute;
-          display: none;
-          right: 200%;
-          opacity: 0;
-        }
-        .leave-review-btn.visible {
-          position: relative;
-          display: flex;
-          right: 0;
-          opacity: 1;
-        }
         .review-open {
           position: absolute;
           right: 200%;

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
@@ -232,6 +232,13 @@
           padding-top: 2rem;
           margin: 0 auto;
           text-align: center;
+          // Readable CTA, not the muted `--ghost` grey: dark resting text + an
+          // underline on hover. This is the only "more reviews" control, so the
+          // variant's secondary-text grey reads too quiet as the resting state.
+          color: s.$primary-text;
+          &:hover:not(:disabled) {
+            text-decoration: underline;
+          }
         }
       }
     }

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
@@ -79,21 +79,13 @@
             @include s.outline();
           }
         }
+        // `.btn .btn--ghost` link-style: ghost supplies the colour + hover; only
+        // the compact link treatment (no padding, smaller, underlined) is local.
         .remove-rating {
-          background: none;
-          border: none;
           padding: 0;
           margin-left: 0.5rem;
           font-size: 0.8125rem;
-          color: s.$secondary-text;
           text-decoration: underline;
-          cursor: pointer;
-          &:hover {
-            color: s.$primary-text;
-          }
-          &:focus-visible {
-            @include s.outline();
-          }
         }
       }
 
@@ -173,8 +165,11 @@
           font-weight: 500;
           color: s.$secondary-text;
         }
-        .leave-review-btn,
-        .submit-review-btn {
+        // NB: `.submit-review-btn` is migrated to `.btn .btn--primary` (markup in
+        // AddReview.tsx; local spacing/weight in SingleRecipe.scss). It's dropped
+        // from this rule so this deep selector no longer overrides its pill shape.
+        // `.leave-review-btn` below is legacy markup (no current call site).
+        .leave-review-btn {
           font-size: 1rem;
           background: s.$primary;
           color: s.$primary-background;

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/AddReview.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/AddReview.tsx
@@ -66,7 +66,7 @@ const AddReview: FC<AddReviewProps> = ({
         value={newReviewText}
         onChange={e => setNewReviewText(e.target.value)}
       />
-      <button className='submit-review-btn btn' onClick={handleSubmitReview}>
+      <button className='submit-review-btn btn btn--primary' onClick={handleSubmitReview}>
         Submit Review
       </button>
     </div>

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ConfirmDeleteReviewModal.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ConfirmDeleteReviewModal.tsx
@@ -37,11 +37,11 @@ const ConfirmDeleteReviewModal: FC<ConfirmDeleteReviewModalProps> = ({
       </div>
       <p className='text'>This action is permanent and cannot be undone.</p>
       <div className='options'>
-        <button className='cancel btn' onClick={closeModal}>
+        <button className='cancel btn btn--outline' onClick={closeModal}>
           Cancel
         </button>
         <button
-          className='delete btn'
+          className='delete btn btn--danger-solid'
           onClick={() => {
             setDeleteLoading(true)
             handleDeleteReview().catch(() => {

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/EditingReviewOptions.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/EditingReviewOptions.tsx
@@ -16,11 +16,11 @@ const EditingReviewOptions: FC<EditingReviewOptionsProps> = ({
 }) => {
   const renderIsEditing = () => (
     <>
-      <button className='edit-btn btn' onClick={() => setEditing(true)}>
+      <button className='edit-btn btn btn--ghost' onClick={() => setEditing(true)}>
         Edit
       </button>
       <button
-        className='delete-btn btn'
+        className='delete-btn btn btn--ghost'
         onClick={() => setDeleteModalIsOpen(true)}
       >
         Delete
@@ -29,11 +29,11 @@ const EditingReviewOptions: FC<EditingReviewOptionsProps> = ({
   )
   const renderIsNotEditing = () => (
     <>
-      <button className='cancel btn' onClick={() => setEditing(false)}>
+      <button className='cancel btn btn--ghost' onClick={() => setEditing(false)}>
         Cancel
       </button>
       <button
-        className='edit-review btn'
+        className='edit-review btn btn--primary'
         onClick={handleEditReview}
         disabled={editLoading}
       >

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
@@ -103,7 +103,9 @@
           color: s.$tertiary-text;
         }
         button.delete-btn {
-          &:hover {
+          // :not(:disabled) to outrank `.btn--ghost:hover:not(:disabled)`
+          // (0,3,0) so the danger-red hover survives the ghost variant.
+          &:hover:not(:disabled) {
             color: s.$error-red;
           }
         }

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
@@ -92,46 +92,28 @@
         flex: 1;
         gap: 1.5rem;
 
+        // edit/delete/cancel are `.btn .btn--ghost` text-style links; only the
+        // small underlined link look is local. (Ghost supplies colour + hover —
+        // edit's hover→primary matches ghost, so it needs no override; delete
+        // keeps its bespoke red hover.)
         button {
           font-size: 0.875rem;
           font-weight: 600;
           text-decoration: underline;
           color: s.$tertiary-text;
         }
-        button.edit-btn {
-          &:hover {
-            color: s.$primary-text;
-          }
-          &:focus-visible {
-            @include s.outline();
-          }
-        }
         button.delete-btn {
           &:hover {
             color: s.$error-red;
           }
-          &:focus-visible {
-            @include s.outline();
-          }
         }
+        // `.btn .btn--primary`; the fixed height + loader positioning + compact
+        // padding (and undoing the link underline above) are local.
         button.edit-review {
           position: relative;
           text-decoration: none;
           padding: 0.5rem 1rem;
-          background: s.$primary;
           height: 45px;
-          color: s.$white;
-          border-radius: s.$border-radius;
-
-          display: flex;
-          justify-self: center;
-          align-items: center;
-        }
-      }
-      button.like-review-btn,
-      button.dislike-review-btn {
-        &:focus-visible {
-          @include s.outline();
         }
       }
     }
@@ -153,25 +135,14 @@
     display: flex;
     gap: 1.5rem;
     justify-content: center;
+    // cancel = `.btn .btn--outline`, delete = `.btn .btn--danger-solid`; only the
+    // larger modal-button font/padding (and the loader's positioning) are local.
     button {
       font-size: 1.125rem;
       padding: 0.75rem 1.25rem;
-      border-radius: s.$border-radius;
-      transition: all 0.3s linear;
-    }
-    button.cancel {
-      background: s.$gray-300;
-      &:hover {
-        background: s.$gray-400;
-      }
     }
     button.delete {
       position: relative;
-      background: s.$error-red;
-      color: s.$primary-background;
-      &:hover {
-        background: s.$error-red-hover;
-      }
     }
   }
 }

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
@@ -92,28 +92,32 @@
         flex: 1;
         gap: 1.5rem;
 
-        // edit/delete/cancel are `.btn .btn--ghost` text-style links; only the
-        // small underlined link look is local. (Ghost supplies colour + hover —
-        // edit's hover→primary matches ghost, so it needs no override; delete
-        // keeps its bespoke red hover.)
-        button {
+        // edit / delete / cancel are `.btn .btn--ghost` text-style links: the
+        // small underlined grey look + their hovers are local. SCOPED to
+        // `.btn--ghost` — a bare `button` selector here is (0,4,1) and would
+        // outrank `.btn--primary`'s colour (0,1,0), rendering the Submit button
+        // (edit-review) grey-on-orange. The resting colour also outranks the
+        // ghost variant's own hover, so each hover is restated locally.
+        button.btn--ghost {
           font-size: 0.875rem;
           font-weight: 600;
           text-decoration: underline;
           color: s.$tertiary-text;
-        }
-        button.delete-btn {
-          // :not(:disabled) to outrank `.btn--ghost:hover:not(:disabled)`
-          // (0,3,0) so the danger-red hover survives the ghost variant.
+
           &:hover:not(:disabled) {
-            color: s.$error-red;
+            color: s.$primary-text;
           }
         }
-        // `.btn .btn--primary`; the fixed height + loader positioning + compact
-        // padding (and undoing the link underline above) are local.
+        // delete keeps its bespoke red hover (wins over the ghost hover above by
+        // equal-specificity source order).
+        button.delete-btn:hover:not(:disabled) {
+          color: s.$error-red;
+        }
+        // `.btn .btn--primary` Submit — fixed height + loader anchor + compact
+        // padding are local; the white-on-orange comes from the variant (no
+        // underline to undo now that the link look is scoped to `.btn--ghost`).
         button.edit-review {
           position: relative;
-          text-decoration: none;
           padding: 0.5rem 1rem;
           height: 45px;
         }

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewsList.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewsList.tsx
@@ -46,7 +46,7 @@ const ReviewsList: FC<ReviewsListProps> = ({
       {isMoreReviews && (
         <div className='get-more-reviews'>
           <button
-            className='get-more-reviews-btn btn'
+            className='get-more-reviews-btn btn btn--ghost'
             onClick={getNextReviewsPage}
           >
             More Reviews

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
@@ -56,14 +56,12 @@
       b { color: s.$primary-text; font-weight: 800; }
     }
   }
+  // edit/delete are a bespoke "outline that fills on hover" pair on the `.btn`
+  // base (pill + reset); only the compact sizing, 1.5px border, and invert
+  // hovers are local.
   button {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
     border: 1.5px solid s.$gray-300;
     padding: 0.5rem 0.95rem;
-    border-radius: s.$radius-lg;
-    cursor: pointer;
     font-size: 0.9rem;
     font-weight: 700;
     color: s.$primary-text;
@@ -71,9 +69,6 @@
     .icon {
       height: 17px;
       width: 17px;
-    }
-    &:focus-visible {
-      @include s.outline();
     }
   }
   button.edit-btn {
@@ -173,30 +168,12 @@
       gap: 2rem;
       padding-top: 2rem;
 
-      button {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        font-size: 1rem;
-        font-weight: 600;
-        border-radius: s.$border-radius;
-        border: none;
+      // cancel = .btn--outline, confirm = .btn--danger-solid; only the fixed
+      // modal-button footprint is local.
+      .btn {
         width: 180px;
         height: 45px;
-        cursor: pointer;
-      }
-      button.cancel {
-        background: s.$secondary-background;
-        &:hover {
-          background: s.$tertiary-background;
-        }
-      }
-      button.confirm {
-        background: s.$error-red;
-        color: s.$primary-background;
-        &:hover {
-          opacity: 0.9;
-        }
+        font-size: 1rem;
       }
     }
   }

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.tsx
@@ -84,7 +84,7 @@ const RecipeControls: FC<RecipeControlsType> = ({
       </span>
       <div className='btns-container'>
         <button
-          className='edit-btn'
+          className='edit-btn btn'
           onClick={() => navigate(`/recipes/${recipeId}/edit`)}
           aria-label='Edit recipe'
         >
@@ -92,7 +92,7 @@ const RecipeControls: FC<RecipeControlsType> = ({
           Edit
         </button>
         <button
-          className='delete-btn'
+          className='delete-btn btn'
           onClick={() => setIsDeleteModalOpen(true)}
         >
           <TrashIcon className='icon' aria-hidden='true' />
@@ -133,11 +133,11 @@ const RecipeControls: FC<RecipeControlsType> = ({
           <p>This action cannot be undone.</p>
           {deleteError && <p className='error'>Error: {deleteError}</p>}
           <div className='btns'>
-            <button className='cancel' onClick={closeDeleteModal}>
+            <button className='cancel btn btn--outline' onClick={closeDeleteModal}>
               Cancel
             </button>
             <button
-              className='confirm'
+              className='confirm btn btn--danger-solid'
               onClick={handleDeleteRecipe}
               disabled={deleteLoading}
             >

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -399,15 +399,12 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
     margin: 0;
     width: auto;
     max-width: none;
+    // Teal-tinted "made it" toggle on the `.btn` base (pill + reset/layout); the
+    // tint fill/border/hover + sizing are bespoke, kept off the colour variants.
     .made-recipe {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.45rem;
       width: auto;
       height: auto;
       padding: 0.75rem 1.5rem;
-      border-radius: s.$radius-lg;
       font-weight: 700;
       font-size: 0.95rem;
       background: rgba(s.$secondary, 0.12);

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -162,34 +162,23 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
     gap: 0.6rem;
     flex-wrap: wrap;
     .save-recipe, .add-rating, .print-recipe { display: inline-flex; }
+    // rate/print are `.btn .btn--outline`; save is a bespoke AA-tuned toggle on
+    // the `.btn` base. Shared locally: the action bar's heavier 1.5px border,
+    // 700 weight, and 18px icons. (Layout/shape/padding come from `.btn`.)
     .save-recipe-btn, .add-rating-btn, .print-recipe-btn {
       position: relative;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      font-family: inherit;
       font-weight: 700;
-      font-size: 0.95rem;
-      padding: 0.7rem 1.25rem;
-      border-radius: s.$radius-lg;
-      cursor: pointer;
+      border-width: 1.5px;
       height: auto !important;
-      border: 1.5px solid s.$gray-300;
-      background: s.$white;
-      color: s.$primary-text;
-      transition: all 0.12s ease;
       .icon { height: 18px; width: 18px; }
-      &:hover { border-color: s.$primary-text; }
-      &:focus-visible { @include s.outline(); }
     }
     .save-recipe-btn {
-      // AA on-light brand fills (white text needs 4.5:1; vivid #ff5722/#00adb5
-      // give only ~3:1). Hovers darken one step further, still AA.
+      // Stateful save toggle. Kept off the generic `.btn--primary` because its
+      // $primary-hover (#e74e1d, white-on-it 3.81) fails AA; these fills/hovers
+      // are AA-tuned. is-saved flips to the accessible teal.
       background: s.$primary-accessible;
       border-color: s.$primary-accessible;
       color: s.$white;
-      // NB: not $primary-hover (#e74e1d, white-on-it 3.81 — fails AA); this
-      // button's base is the accessible orange, so its hover darkens further.
       &:hover { background: #a52f0a; border-color: #a52f0a; }
       &.is-saved {
         background: s.$secondary-accessible;
@@ -204,7 +193,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       align-items: center;
       justify-content: center;
       background: rgba(255, 255, 255, 0.6);
-      border-radius: s.$radius-lg;
+      border-radius: s.$radius-pill;
     }
   }
 
@@ -648,18 +637,11 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
         box-sizing: border-box;
         &:focus { outline: none; border-color: s.$primary; }
       }
+      // `.btn .btn--primary`; only the review-form spacing + weight are local.
       .submit-review-btn {
         margin-top: 0.85rem;
-        background: s.$primary;
-        color: s.$white;
-        border: none;
-        border-radius: s.$radius-lg;
-        padding: 0.6rem 1.25rem;
-        font-family: inherit;
         font-weight: 700;
         font-size: 0.9rem;
-        cursor: pointer;
-        &:hover { background: s.$primary-hover; }
       }
     }
   }


### PR DESCRIPTION
## Design `2-scss`: canonical pill `.btn` system

Wave 2 `2-scss` track from `docs/sweeps/ROADMAP.md`. Collapses ~70 ad-hoc button
styles across ~35 files onto **one pill `.btn` base + BEM modifiers**.

### The system (`src/index.scss`, documented in `docs/design/button-system.md`)
- Base `.btn` — reset + inline-flex layout + default (md) size + **pill** shape + transition + disabled.
- Sizes: `--sm` · `--lg` · `--block`.
- Colour variants: `--primary` · `--outline` · `--ghost` · `--danger` (outline→fill) · `--danger-solid`.
- Shape: `--icon` (circular, composes with a colour variant).
- One hover convention (explicit colour, not `filter`/`opacity`), one disabled treatment, danger = the single `$error-red` token; focus ring stays on the global `button:focus-visible`.

### Decisions (owner sign-off)
- **Pill everywhere** — finishes the migration the redesigned surfaces (Recipes/About/Home) already started; older form/settings/recipe-detail move onto it.
- **Non-admin scope** — Admin/Reports/BugReports button *colours* stay for the separate `$admin-*` lane.

### Kept bespoke (on the `.btn` base, no colour variant — deliberately)
- AA-tuned brand fills (`$primary-accessible`/`$secondary-accessible`, `#a52f0a`/`#006065`/`#f4501e` hovers) — the generic `--primary` hover fails white-on-fill AA.
- Auth submit stays **teal** (matches the auth brand mark).
- Stateful toggles (save/made-it), non-token green/slate (BugReport, AppErrorFallback).
- Nav CTAs go pill but stay off the variant system (theme-variable `--dnav-*` colours).

### Out of scope (documented)
- Selection controls (filter chips, segmented navs, toggle switches).
- The shared `SortDropdown` trigger (also used by the out-of-scope Recipes page) — left bespoke to avoid regressing Recipes.

### Verification
- `tsc` clean · production build clean · **543/2-skip Vitest green**.
- High-effort 4-angle code review (specificity, classname, lost-declaration, shared-spillover). 3 real bugs found & fixed: SavedRecipes clear-button lost its grey fill (dropped `--ghost`); RecipeReview-delete + PublicProfile-share hovers lost to the variant's `:hover:not(:disabled)` (qualified the local hovers); Settings `.sr-btn-icon` additive margin.
- Driven live (headless): home, recipes, recipe-detail (action bar + reviews), about, login, signup, 404, public profile — all render correct pills, no regressions.
- **Not driven visually** (no dev creds): Settings, SavedRecipes, AddRecipe form, review edit/delete, recipe owner controls — covered by tsc/build/tests/review. Can drive these with a throwaway account if desired.

Net **−81 lines**. Closes the Design-consistency `pill .btn system` follow-up (Wave 2 `2-scss`).

https://claude.ai/code/session_01Rn2MgxgPgbrC4QHYGTkpVK
