### PR TITLE
test: Cypress visual-regression check for the type-scale migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@
 cypress/videos/
 cypress/screenshots/
 cypress.env.json
+# Visual-regression artifacts — regenerated per run, never a git-tracked baseline.
+cypress-image-diff-screenshots/
+cypress-image-diff-html-report/
 
 
 npm-debug.log*

--- a/cypress-image-diff.config.js
+++ b/cypress-image-diff.config.js
@@ -1,0 +1,24 @@
+// cypress-image-diff-js config — visual baseline check for the type-scale
+// migration. This file is TEST INFRA and is committed; the generated screenshot
+// and report directories it points at are gitignored (regenerated per run, not a
+// git-tracked baseline). Driven by cypress/e2e/visual/type-scale.cy.ts.
+module.exports = {
+  ROOT_DIR: '.',
+  SCREENSHOTS_DIR: 'cypress-image-diff-screenshots', // baseline/ comparison/ diff/
+  REPORT_DIR: 'cypress-image-diff-html-report', // html + json report
+
+  // Flag anything above 0.1% of pixels differing. Conservative on purpose: the
+  // expected type-scale shifts (<=2.8px, usually <=0.8px, on a line or two) stay
+  // well under this, while real reflow/truncation/overflow blows past it.
+  FAILURE_THRESHOLD: 0.001,
+
+  // The baseline pass runs against the development server with an empty baseline
+  // dir; this lets it auto-create baselines instead of failing.
+  FAIL_ON_MISSING_BASELINE: false,
+
+  // pixelmatch per-pixel antialiasing tolerance (lib default) — damps sub-pixel
+  // AA noise so it isn't mistaken for a layout change.
+  COMPARISON_OPTIONS: { threshold: 0.1 },
+
+  JSON_REPORT: { FILENAME: 'type-scale', OVERWRITE: true },
+}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress'
 import admin from 'firebase-admin'
+import getCompareSnapshotsPlugin from 'cypress-image-diff-js/plugin'
 
 export default defineConfig({
   projectId: 'k156x8',
@@ -7,6 +8,10 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {
+      // Visual-regression plugin (cypress-image-diff-js). Registers its own
+      // tasks + after:screenshot hook; Cypress merges these with the on('task')
+      // registration below.
+      const updatedConfig = getCompareSnapshotsPlugin(on, config)
       on('task', {
         // Accepts a bare uid, or { uid, claims } to bake developer claims (e.g.
         // { admin: true }) into the token — these propagate to the ID token's
@@ -26,7 +31,7 @@ export default defineConfig({
           return admin.auth().createCustomToken(uid, claims)
         },
       })
-      return config
+      return updatedConfig
     },
   },
 })

--- a/cypress.visual.config.ts
+++ b/cypress.visual.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'cypress'
+import base from './cypress.config'
+
+// Dedicated config for the MANUAL two-pass visual-regression run
+// (cypress/visual/type-scale.cy.ts). It extends the default config (same
+// plugins, tasks, support) but re-points specPattern at cypress/visual/ so the
+// visual spec runs ONLY when this config is selected explicitly:
+//
+//   npx cypress run --config-file cypress.visual.config.ts --config baseUrl=http://localhost:3012
+//
+// The default cypress.config.ts (used by `cypress run` in CI) keeps its default
+// specPattern of cypress/e2e/**, which does NOT match cypress/visual/ — so the
+// visual spec never runs in the automated suite.
+export default defineConfig({
+  ...base,
+  e2e: {
+    ...base.e2e,
+    specPattern: 'cypress/visual/**/*.cy.{ts,tsx}',
+  },
+})

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,4 +1,9 @@
 import './commands'
+import compareSnapshotCommand from 'cypress-image-diff-js/command'
+
+// Registers cy.compareSnapshot() for the visual-regression spec
+// (cypress/e2e/visual/type-scale.cy.ts). No-op for the other specs.
+compareSnapshotCommand()
 
 // Suppress known browser noise that doesn't indicate real app failures.
 // Return true (or nothing) for anything else so actual crashes still fail tests.

--- a/cypress/visual/type-scale.cy.ts
+++ b/cypress/visual/type-scale.cy.ts
@@ -1,0 +1,183 @@
+/// <reference types="cypress" />
+import { API_URL } from '../support/constants'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Visual-regression capture for the type-scale migration. DETECTION ONLY — this
+// spec adds no app/style edits; it screenshots the running app and pixel-diffs
+// the branch render against a `development` baseline (cypress-image-diff-js /
+// pixelmatch).
+//
+// MANUAL tool — deliberately NOT in the default `cypress run` / CI suite. It
+// lives under cypress/visual/ (outside the default cypress/e2e/** specPattern),
+// so CI never runs it, and it needs a separate development baseline server +
+// local baselines that don't exist in CI. Run it explicitly via its own config:
+//
+//   # 1. baseline pass — baseUrl -> the development test server; empty baseline
+//   #    dir, so each compareSnapshot AUTO-CREATES a baseline and passes.
+//   npx cypress run --config-file cypress.visual.config.ts \
+//     --config baseUrl=http://localhost:3012
+//   # 2. compare pass — baseUrl -> the branch test server; diffs against (1).
+//   npx cypress run --config-file cypress.visual.config.ts \
+//     --config baseUrl=http://localhost:3013
+//
+// One `it` PER (route, viewport) so a diff on one capture never skips another
+// (compareSnapshot throws when a diff exceeds the threshold). Mocking mirrors
+// the existing specs: full `${api()}/api/...` URLs from support/constants,
+// fixtures for the route's key data, incidental calls pass through (same
+// convention as browse/recipe.cy.ts). Both passes hit the same backend, so any
+// incidental variance cancels.
+//
+// Determinism: remote photos neutralised (visibility:hidden — keep box, kill
+// image variance); animations/transitions/caret killed; web font awaited; a
+// tall viewport + capture:'viewport' avoids Cypress fullPage stitching (which
+// duplicates the FIXED navbar). Public routes only — auth pages need
+// cypress.env.json (absent here), so they're skipped, not silently dropped.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const api = () => API_URL
+
+const STABILIZE_CSS = `
+  *, *::before, *::after {
+    animation: none !important;
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition: none !important;
+    caret-color: transparent !important;
+    scroll-behavior: auto !important;
+  }
+  img { visibility: hidden !important; }
+  [style*="background-image"] { background-image: none !important; }
+  [class*="oaster"], [class*="oast-"] { display: none !important; }
+`
+
+function capture(name: string) {
+  cy.document().then((doc) => {
+    if (!doc.getElementById('vqa-stabilize')) {
+      const s = doc.createElement('style')
+      s.id = 'vqa-stabilize'
+      s.innerHTML = STABILIZE_CSS
+      doc.head.appendChild(s)
+    }
+  })
+  cy.document().its('fonts.status').should('eq', 'loaded')
+  cy.document().then((doc) => {
+    const el = doc.activeElement as HTMLElement | null
+    if (el && typeof el.blur === 'function') el.blur()
+  })
+  cy.compareSnapshot({ name, cypressScreenshotOptions: { capture: 'viewport' } })
+}
+
+// Desktop + mobile ($bp-xs = 375). Tall heights so the page fits one viewport
+// capture (no fullPage stitching).
+const VIEWPORTS = {
+  desktop: { w: 1280, h: 3000 },
+  mobile: { w: 375, h: 4500 },
+} as const
+// Taller pages (single recipe, about) get extra height.
+const VIEWPORTS_TALL = {
+  desktop: { w: 1280, h: 3400 },
+  mobile: { w: 375, h: 5400 },
+} as const
+
+type RouteCfg = {
+  key: string
+  path: () => string
+  anchor: string
+  viewports: typeof VIEWPORTS
+  visitOpts?: Partial<Cypress.VisitOptions>
+  stub: () => void
+  note?: string
+}
+
+let recipeId = ''
+
+const ROUTES: RouteCfg[] = [
+  {
+    key: 'home',
+    path: () => '/',
+    // Loaded trending cards are <a.home-recipe-card>; skeletons are <div> with
+    // the same class — anchor on the anchor tag to wait past the skeleton.
+    anchor: 'a.home-recipe-card',
+    viewports: VIEWPORTS,
+    stub: () => {
+      cy.intercept('GET', `${api()}/api/getTrendingRecipes*`, { fixture: 'trending-recipes.json' })
+    },
+  },
+  {
+    key: 'recipes',
+    path: () => '/recipes',
+    anchor: '.recipe-card',
+    viewports: VIEWPORTS,
+    stub: () => {
+      cy.intercept('GET', `${api()}/api/getTrendingRecipes*`, { fixture: 'trending-recipes.json' })
+      cy.intercept('GET', `${api()}/api/recipes*`, { fixture: 'recipes.json' })
+      cy.intercept('GET', `${api()}/api/searchAutoCompleteRecipes*`, {
+        fixture: 'search-auto-complete-recipes.json',
+      })
+    },
+  },
+  {
+    key: 'recipe',
+    path: () => `/recipes/${recipeId}`,
+    anchor: '.ing', // ingredients present => recipe body fully rendered
+    viewports: VIEWPORTS_TALL,
+    note: 'densest — 49 migrations',
+    stub: () => {
+      cy.intercept('GET', `${api()}/api/getRecipe*`, { fixture: 'single-recipe.json' })
+      cy.intercept('GET', `${api()}/api/getReviews*`, { fixture: 'recipe-reviews.json' })
+      cy.intercept('GET', `${api()}/api/checkIfReviewed*`, { body: null })
+      cy.intercept('GET', `${api()}/api/getUsername*`, { body: null })
+      cy.intercept('GET', `${api()}/api/getSavedRecipe*`, { body: [] })
+    },
+  },
+  {
+    key: 'profile',
+    path: () => '/u/baduser',
+    anchor: '.pp-counts, .pp-bio, .pp-avatar',
+    viewports: VIEWPORTS,
+    stub: () => {
+      cy.intercept('GET', `${api()}/api/getPublicProfile*`, { fixture: 'public-profile.json' })
+      cy.intercept('GET', `${api()}/api/getUsername*`, { body: null })
+    },
+  },
+  {
+    // NOTE: About's clamp() hero headings are out-of-scope, but the rest of the
+    // page's text WAS migrated — a nonzero diff here is expected.
+    key: 'about',
+    path: () => '/about',
+    anchor: '.about-card',
+    viewports: VIEWPORTS_TALL,
+    stub: () => {},
+  },
+  {
+    // NOTE: the giant 404 numerals are out-of-scope; the surrounding copy was
+    // migrated, so a small diff is expected.
+    key: 'notfound',
+    path: () => '/no-such-page-xyz',
+    anchor: '.not-found-page',
+    viewports: VIEWPORTS,
+    visitOpts: { failOnStatusCode: false },
+    stub: () => {},
+  },
+]
+
+before(() => {
+  cy.fixture('single-recipe.json').then((r) => {
+    recipeId = r._id
+  })
+})
+
+ROUTES.forEach((route) => {
+  describe(`type-scale: ${route.key}${route.note ? ` (${route.note})` : ''}`, () => {
+    beforeEach(() => route.stub())
+    ;(Object.keys(route.viewports) as Array<keyof typeof VIEWPORTS>).forEach((vp) => {
+      it(`${route.key}-${vp}`, () => {
+        const v = route.viewports[vp]
+        cy.viewport(v.w, v.h)
+        cy.visit(route.path(), route.visitOpts)
+        cy.get(route.anchor, { timeout: 15000 }).should('be.visible')
+        capture(`${route.key}-${vp}`)
+      })
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^6.0.1",
         "cypress": "^15.14.2",
+        "cypress-image-diff-js": "^2.8.0",
         "firebase-admin": "^13.9.0",
         "jsdom": "^29.1.0",
         "start-server-and-test": "^2.1.5",
@@ -275,6 +276,16 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -4385,6 +4396,47 @@
         "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/cypress-image-diff-js": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/cypress-image-diff-js/-/cypress-image-diff-js-2.8.0.tgz",
+      "integrity": "sha512-5I7+LFxDsaj+65n/IX4gC1PfbLZ+pNVIwTAA0hF1wXw1dqIDw2iV10XIhvkrDgQ2cjEwNInHguQtwrY798ZE3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@colors/colors": "^1.5.0",
+        "arg": "^4.1.1",
+        "cypress-recurse": "^1.13.1",
+        "fs-extra": "^9.0.1",
+        "handlebars": "^4.7.7",
+        "lodash": "^4.17.21",
+        "pixelmatch": "^5.1.0",
+        "pngjs": "^3.4.0"
+      },
+      "bin": {
+        "cypress-image-diff": "bin/cypress-image-diff.js"
+      },
+      "peerDependencies": {
+        "cypress": ">=9.6.1"
+      }
+    },
+    "node_modules/cypress-image-diff-js/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cypress-recurse": {
+      "version": "1.37.2",
+      "resolved": "https://registry.npmjs.org/cypress-recurse/-/cypress-recurse-1.37.2.tgz",
+      "integrity": "sha512-HZ5vvrPTQD7SRuQyeLhoO0aCyuPz+xT9cB10WHx+AVM/ns3uRFIblamt1JR57uyWX4VaDYlPBXpyygkziujjjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-duration": "^3.27.3"
+      }
+    },
     "node_modules/cypress/node_modules/proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -5536,6 +5588,38 @@
         "react": "^16.8 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5726,6 +5810,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/humanize-duration": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.34.0.tgz",
+      "integrity": "sha512-NDxhYxiiRzsST6xULIHuYWRvsCtviJXRdjarhyWyh78S4Ou+MWhM2k4HQ+y7iegdrzreXe11isd0au1N2PB/pQ==",
+      "dev": true,
+      "license": "Unlicense",
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/idb": {
@@ -7122,6 +7216,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -7452,6 +7553,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
+      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^6.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pixelmatch/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/postcss": {
@@ -9092,6 +9226,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici": {
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
@@ -9503,6 +9651,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "cypress": "^15.14.2",
+    "cypress-image-diff-js": "^2.8.0",
     "firebase-admin": "^13.9.0",
     "jsdom": "^29.1.0",
     "start-server-and-test": "^2.1.5",


### PR DESCRIPTION
## What

Adds a **manual, two-pass visual-regression tool** (`cypress-image-diff-js` / pixelmatch) used to verify that the type-scale migration (SCSS `font-size` literals → 10-step `$text-*` scale) didn't break layout. Detection-only — **no app or style changes** in this PR.

Split out of the type-scale PR so that one stays a pure SCSS change.

## How it works

Two passes over 6 public routes × {desktop 1280, mobile 375} = 12 snapshots:
1. **baseline** — `baseUrl` → a `development` test server (auto-creates baselines)
2. **compare** — `baseUrl` → the branch test server (diffs against the baselines)

```bash
npx cypress run --config-file cypress.visual.config.ts --config baseUrl=http://localhost:3012  # baseline (dev)
npx cypress run --config-file cypress.visual.config.ts --config baseUrl=http://localhost:3013  # compare (branch)
```

Determinism: API mocked with the existing fixtures/intercepts; remote images neutralised (visibility:hidden — keeps geometry, kills photo variance); animations/caret killed; web font awaited; tall-viewport capture to avoid fixed-nav stitching.

## Not in CI — by design

The spec lives under `cypress/visual/` (outside the default `cypress/e2e/**` specPattern) and runs only via `cypress.visual.config.ts`. So `npx cypress run` in the CI e2e job never picks it up — it needs a separate baseline server + local baselines that don't exist in CI. Generated screenshots/reports are gitignored (regenerated per run, not a tracked baseline).

## Result of running it against this branch's base

Across all 12 surfaces the type-scale change was a **clean text reflow** — containers stable, out-of-scope display type (About `clamp()` hero, 404 numerals) untouched, no truncation/overflow. **No layout regression found.**

## Files

- `cypress/visual/type-scale.cy.ts` — the capture spec
- `cypress.visual.config.ts` — dedicated config (extends the default, repoints specPattern)
- `cypress-image-diff.config.js`, plugin wiring in `cypress.config.ts` + `cypress/support/e2e.ts`
- `package.json` devDep + `.gitignore` for the artifact dirs

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ