### PR TITLE
style(type-scale): collapse ~490 font-size literals onto a 10-step $text-* scale

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -452,6 +452,17 @@ findings table.)*
   annotation on every CI run (seen on PR #204). Bump both to the next major (`@v5`, or whatever is current
   when picked up) to clear the warning before the forced fallback is removed. Low-risk maintenance; not a
   1.0 blocker. *(surfaced 2026-06-29 in CI logs during the `RecipeFormInput`→`FormInput` track.)*
+- `[ ]` **Colour tokens → CSS custom properties when theming lands** — Jesse wants user-selectable
+  themes (dark mode + other palettes) **post-1.0**. That's a *colour* concern: themes swap colours, not
+  sizes — so the design tokens that need to become runtime-swappable are the colour groups (`$primary*`,
+  `$gray-*`, `$secondary*`, `$alert-*`, `$admin-*`), not the type/space/radius scales. Plan: migrate the
+  colour tokens from SCSS variables to CSS custom properties in `:root` (with a `[data-theme]` /
+  `.dark` override block per theme), keeping the SCSS-var scales (`$text-*`, `$radius-*`, `$bp-*`) as-is.
+  Entangled with the **brand-orange decision** (the blocked a11y lane) — the accessible-vs-vivid orange
+  call should be made *before* baking colours into a theme system. The `rem`-based type scale already
+  covers a "large text"/density mode via the root font-size, independent of this. *(surfaced 2026-06-30
+  during the type-scale sweep, when CSS-custom-properties-vs-SCSS was weighed for `$text-*` and correctly
+  deferred to the colour layer; see `docs/design/type-scale.md` rule 4.)* **(post-1.0; not a blocker)**
 - `[ ]` **Migrate off Edamam (nutrition source)** — Jesse wants to stop using Edamam for nutrition data
   eventually (filed 2026-06-25). Current state: nutrition is server-proxied via `POST /api/nutrition/details`
   (`server/routes/nutrition.js`, PR #182), so swapping the provider is now an isolated, server-only change —

--- a/docs/design/type-scale.md
+++ b/docs/design/type-scale.md
@@ -1,0 +1,82 @@
+# Type scale
+
+Prepify's text sizing had drifted: ~490 ad-hoc `font-size:` literals across ~60
+stylesheets, ~80 distinct values, many a sub-pixel apart (`0.82` vs `0.85` vs
+`0.875rem` for what is visually the same "small label"). This doc names a
+**10-step modular scale** as the `$text-*` token group in `src/helpers.scss`, so a
+size is a decision drawn from one ramp — not a number someone eyeballed in a
+single file.
+
+The steps are anchored on the values already in heaviest use, and the top half
+(`$text-lg` → `$text-4xl`) is identical to Tailwind's default scale — these aren't
+arbitrary numbers.
+
+## The rules
+
+1. **Use a `$text-*` step, never a raw `font-size` value.** That's the whole point
+   — a new `font-size: 0.83rem` re-introduces the drift the scale exists to kill.
+   Pick the step nearest the intent (see the usage notes per token below).
+2. **The unit is `rem`, deliberately.** Every step is `rem`, so the whole scale
+   honours the user's root font size — and a future "large text" / density mode is
+   a single `<html>` font-size change away, with zero token edits. Don't re-introduce
+   `px` for body text.
+3. **Steps go by size, not by role.** Like `helpers.scss` already does for `$gray-*`
+   and `$radius-*` (t-shirt/numeric scales), this is a *primitive* scale named by
+   size. A future semantic layer (`$text-body`, `$text-h1`) could alias onto it, but
+   isn't needed yet — don't pre-build it.
+4. **Theming is a colour concern, not a size one — so this scale stays SCSS.** Dark
+   mode and user-selectable themes swap *colours*, not font sizes, so the type scale
+   gets no benefit from CSS custom properties. When theming lands post-1.0, the
+   tokens that become runtime-swappable are the **colour** tokens; converting
+   `$text-*` then is a trivial rename if one mechanism everywhere is wanted. (Filed
+   in [`../BACKLOG.md`](../BACKLOG.md).)
+
+## The tokens
+
+```scss
+$text-caption  // 0.72rem  11.5px  tiny meta: timestamps, counts, eyebrow labels
+$text-fine     // 0.78rem  12.5px  small meta / dense secondary text
+$text-sm       // 0.85rem  13.6px  small UI: pills, chips, helper text (most common)
+$text-base     // 0.95rem  15.2px  default body / paragraph text
+$text-md       // 1rem     16px    emphasized body, standard control text
+$text-lg       // 1.125rem 18px    lead paragraphs, large controls
+$text-xl       // 1.25rem  20px    card titles, sub-headings
+$text-2xl      // 1.5rem   24px    section headings (h3)
+$text-3xl      // 1.875rem 30px    page headings (h2)
+$text-4xl      // 2.25rem  36px    hero / top-level headings (h1)
+```
+
+## Out of scope — left bespoke
+
+Four families are intentionally **not** on this scale; they're sized for a context
+the content ramp doesn't model:
+
+- **`PrintableRecipe.scss`** — uses `pt` throughout. `pt` is the correct unit for a
+  print stylesheet; it's a separate print scale.
+- **`About.scss` `clamp()` headings** — the marketing page uses six fluid
+  `clamp(min, vw, max)` headings. Fluid type is its own treatment; folding it onto
+  fixed steps would flatten the responsive intent.
+- **`404.scss` + PublicProfile display numerals** — the giant `404` glyph
+  (`6`–`11.25rem`) and the profile avatar initial (`2.6rem`) are decorative display,
+  not text on the ramp.
+- **Icon-relative `em`** (and one `14px` in `ImagePicker`) — `em` sizes a glyph
+  relative to its parent on purpose; it isn't a content size.
+
+## Notes
+
+- **Normalization happened — by design.** Of 491 in-scope uses, 218 (44%) land
+  exactly on a step; 273 normalize onto the nearest one. The typical shift is
+  ≤0.8px and the largest is 2.8px (a handful of rare display sizes like
+  `1.7`/`2.0rem` converging on `$text-3xl`). The big body clusters collapse as
+  intended: `0.82`/`0.85`/`0.875rem` → `$text-sm`, `0.9`/`0.95rem` → `$text-base`.
+- **No unintended change — proven mechanically.** The migrated `.scss` was compiled
+  to CSS on `development` vs. this branch; masking every `font-size` value and
+  diffing the two leaves **zero** differences — i.e. nothing but font-size values
+  moved, and every value in the output is a scale step or a documented out-of-scope
+  literal.
+- **Owner-approved against rendered glyphs.** The scale + every collapse was signed
+  off on a temporary `/type-scale` before/after page (the same way the Lucide track
+  used `/icon-audit`), removed before the PR.
+- Fourth design-system doc, after [`icon-system.md`](icon-system.md),
+  [`button-system.md`](button-system.md), and [`admin-palette.md`](admin-palette.md).
+```

--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -74,7 +74,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **2-iso** | Design: toast punctuation + string dedupe | `[x]` | ~10 toast call sites (TSX strings) | #207 |
 | **2-iso** | Design: codify loading-state pattern | `[x]` | convention + `TailSpin`/skeleton outliers | #213 |
 | **2-scss** | Design: pill `.btn` system | `[x]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | #210 |
-| **2-scss** | Design: type scale (~520 `font-size:` literals) | `[~]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | `worktree-feat+type-scale` · 2026-06-30 |
+| **2-scss** | Design: type scale (~520 `font-size:` literals) | `[P]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | #216 |
 | **2-scss** | Design: elevation/shadow re-author (~52 literals) | `[ ]` | **`helpers.scss` + page `.scss`** ⚠ chokepoint | — |
 | **2-scss** | Design: one danger-red token | `[x]` | **`helpers.scss` + SingleRecipe/ReportControl/…** ⚠ chokepoint | #208 |
 | **2-scss** | Design: name the `$admin-*` sub-palette | `[x]` | **`helpers.scss` + Admin/moderation `.scss`** ⚠ chokepoint | #214 |
@@ -445,3 +445,12 @@ narrates the *why*.
   hover`), per owner sign-off. This track collapses the ~520 ad-hoc `font-size:` literals across `helpers.scss` +
   ~60 files onto a documented modular type scale (next design-system doc after icon/button/admin-palette).
   Worktree on free ports 3001/4001.
+- _2026-06-30_ — **Design: type scale (~490 `font-size:` literals)** PR opened (#216, `[~]`→`[P]`). Ten-step
+  modular `$text-*` scale in `helpers.scss`; 62 `.scss` files repointed (218/491 land exactly on a step, 273
+  normalize onto the nearest — typical ≤0.8px, max 2.8px). Out of scope, left bespoke: PrintableRecipe `pt`, About
+  `clamp()` headings, 404/profile display numerals, icon `em`. New design doc `docs/design/type-scale.md` (fourth
+  after icon/button/admin-palette); BACKLOG item filed for colour tokens → CSS custom properties when theming lands.
+  Verified two ways: the masked-CSS compile diff (`development` vs branch, every `font-size` value blanked) is
+  zero-byte — nothing but font-size values moved; and a two-pass Cypress pixel-diff (tooling split to its own PR
+  #215, CI green) across 6 routes × {desktop, mobile} showed clean text reflow — containers stable, out-of-scope
+  display type untouched, no truncation/overflow.

--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -74,7 +74,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **2-iso** | Design: toast punctuation + string dedupe | `[x]` | ~10 toast call sites (TSX strings) | #207 |
 | **2-iso** | Design: codify loading-state pattern | `[x]` | convention + `TailSpin`/skeleton outliers | #213 |
 | **2-scss** | Design: pill `.btn` system | `[x]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | #210 |
-| **2-scss** | Design: type scale (~520 `font-size:` literals) | `[ ]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | — |
+| **2-scss** | Design: type scale (~520 `font-size:` literals) | `[~]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | `worktree-feat+type-scale` · 2026-06-30 |
 | **2-scss** | Design: elevation/shadow re-author (~52 literals) | `[ ]` | **`helpers.scss` + page `.scss`** ⚠ chokepoint | — |
 | **2-scss** | Design: one danger-red token | `[x]` | **`helpers.scss` + SingleRecipe/ReportControl/…** ⚠ chokepoint | #208 |
 | **2-scss** | Design: name the `$admin-*` sub-palette | `[x]` | **`helpers.scss` + Admin/moderation `.scss`** ⚠ chokepoint | #214 |
@@ -436,3 +436,12 @@ narrates the *why*.
   (Firebase `prepify-dev-58579` + `prepify-dev` Mongo), not prod. Run-log + design-consistency banner + BACKLOG
   flipped to done. Remaining `2-scss` lane: type scale, elevation, `$primary-hover`. Worktree kept up (owner still
   has the seeded dev admin account).
+- _2026-06-30_ — **Design: type scale (~520 `font-size:` literals)** claimed (`worktree-feat+type-scale`,
+  `[ ]`→`[~]`) — **fourth `2-scss` lane to open.** Checked the lane is clear first: `git worktree list` shows
+  only the main checkout (the #213 loading-state and #214 admin-palette worktrees are gone), `gh pr list` is
+  empty, and the Board has no `[~]`/`[P]` track in flight — so the serialized `2-scss` chokepoint is free (rule 1)
+  and the earlier line-level collision with the loading-state worktree's `font-size:` edits is moot now that #213
+  merged. Next-in-board-order pick of the three remaining `2-scss` tracks (type scale → elevation → `$primary-
+  hover`), per owner sign-off. This track collapses the ~520 ad-hoc `font-size:` literals across `helpers.scss` +
+  ~60 files onto a documented modular type scale (next design-system doc after icon/button/admin-palette).
+  Worktree on free ports 3001/4001.

--- a/src/Components/AccountStatusBanner/AccountStatusBanner.scss
+++ b/src/Components/AccountStatusBanner/AccountStatusBanner.scss
@@ -13,7 +13,7 @@
   bottom: 0;
   z-index: 200;
   padding: 0.7rem 1.25rem calc(0.7rem + env(safe-area-inset-bottom, 0px));
-  font-size: 0.9rem;
+  font-size: s.$text-base;
   line-height: 1.4;
   text-align: center;
   color: s.$primary-deep;

--- a/src/Components/AddToCollection/AddToCollection.scss
+++ b/src/Components/AddToCollection/AddToCollection.scss
@@ -20,7 +20,7 @@
   }
 
   &__caret {
-    font-size: 1.15rem;
+    font-size: s.$text-lg;
     margin-left: -0.1rem;
   }
 }
@@ -62,7 +62,7 @@
 
   .popover-title {
     font-weight: 800;
-    font-size: 0.82rem;
+    font-size: s.$text-sm;
     color: s.$primary-text;
     padding: 0.15rem 0.35rem 0.5rem;
   }
@@ -76,7 +76,7 @@
   }
 
   .popover-empty {
-    font-size: 0.78rem;
+    font-size: s.$text-fine;
     color: s.$secondary-text;
     padding: 0.4rem 0.35rem;
   }
@@ -100,7 +100,7 @@
     border-radius: 9px;
     padding: 0.5rem 0.4rem;
     font-family: inherit;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     color: s.$primary-text;
     cursor: pointer;
     text-align: left;
@@ -122,7 +122,7 @@
       border: 2px solid s.$gray-400;
       border-radius: 5px;
       color: #fff;
-      font-size: 0.7rem;
+      font-size: s.$text-caption;
     }
     &.checked .checkbox {
       background: s.$primary;
@@ -147,7 +147,7 @@
       flex: 1;
       min-width: 0;
       font-family: inherit;
-      font-size: 0.82rem;
+      font-size: s.$text-sm;
       padding: 0.45rem 0.55rem;
       border: 1px solid s.$gray-400;
       border-radius: 9px;
@@ -164,7 +164,7 @@
       flex-shrink: 0;
       width: 34px;
       padding: 0;
-      font-size: 1rem;
+      font-size: s.$text-md;
       &:disabled {
         opacity: 0.5;
       }

--- a/src/Components/AdminRecipeControls/AdminRecipeControls.scss
+++ b/src/Components/AdminRecipeControls/AdminRecipeControls.scss
@@ -12,7 +12,7 @@
   background: s.$admin-automod-bg;
 
   .arc-label {
-    font-size: 0.7rem;
+    font-size: s.$text-caption;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -23,7 +23,7 @@
   }
 
   .arc-pill {
-    font-size: 0.68rem;
+    font-size: s.$text-caption;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.03em;
@@ -62,7 +62,7 @@
     cursor: pointer;
     border-radius: s.$radius-sm;
     padding: 0.4rem 0.85rem;
-    font-size: 0.82rem;
+    font-size: s.$text-sm;
     font-weight: 600;
     border: 1px solid s.$admin-slate-300;
     background: s.$white;

--- a/src/Components/AppErrorFallback/AppErrorFallback.scss
+++ b/src/Components/AppErrorFallback/AppErrorFallback.scss
@@ -13,7 +13,7 @@
     text-align: center;
 
     h1 {
-      font-size: 1.75rem;
+      font-size: s.$text-3xl;
       margin-bottom: 0.75rem;
       color: #1f2430;
     }

--- a/src/Components/BugReport/BugReportModal.scss
+++ b/src/Components/BugReport/BugReportModal.scss
@@ -8,7 +8,7 @@
 // both classes — `bug-report-trigger btn ${variant}`).
 .bug-report-trigger.btn {
   color: s.$tertiary-text;
-  font-size: 0.8rem;
+  font-size: s.$text-fine;
   padding: 0.15rem 0.35rem;
 
   &:hover {
@@ -19,7 +19,7 @@
   &.button {
     border: 1px solid s.$admin-slate-300;
     padding: 0.4rem 0.75rem;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
   }
 }
 
@@ -28,13 +28,13 @@
 
   .bug-report-modal-title {
     margin: 0 0 0.35rem;
-    font-size: 1.25rem;
+    font-size: s.$text-xl;
   }
 
   .bug-report-modal-sub {
     margin: 0 0 1.25rem;
     color: s.$admin-slate-500;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
   }
 
   .bug-report-identity {
@@ -43,7 +43,7 @@
     background: s.$admin-slate-100;
     border-radius: s.$radius-sm;
     color: s.$admin-slate-700;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
 
     strong {
       font-weight: 600;
@@ -55,7 +55,7 @@
     flex-direction: column;
     gap: 0.35rem;
     margin-bottom: 1rem;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     font-weight: 600;
     color: s.$admin-slate-700;
 
@@ -63,7 +63,7 @@
     textarea,
     input {
       font-weight: 400;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       padding: 0.55rem 0.65rem;
       border: 1px solid s.$admin-slate-300;
       border-radius: s.$radius-sm;
@@ -87,7 +87,7 @@
     // font-size and the spinner anchor are local.
     button {
       padding: 0.55rem 1rem;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       position: relative;
     }
 

--- a/src/Components/ClassifierNote/ClassifierNote.scss
+++ b/src/Components/ClassifierNote/ClassifierNote.scss
@@ -5,7 +5,7 @@
 // on its own override class, which wins on specificity when nested under a parent.
 .classifier-note {
   margin: 0;
-  font-size: 0.8rem;
+  font-size: s.$text-fine;
   font-weight: 600;
   color: s.$admin-info-text;
   text-transform: capitalize;

--- a/src/Components/EmptyState/EmptyState.scss
+++ b/src/Components/EmptyState/EmptyState.scss
@@ -26,19 +26,19 @@
     border-radius: s.$radius-circle;
     background: rgba(255, 87, 34, 0.09);
     color: s.$primary;
-    font-size: 1.85rem;
+    font-size: s.$text-3xl;
   }
 
   &__title {
     margin: 0 0 0.5rem;
-    font-size: 1.4rem;
+    font-size: s.$text-2xl;
     font-weight: 800;
     color: s.$primary-text;
   }
 
   &__text {
     margin: 0;
-    font-size: 0.95rem;
+    font-size: s.$text-base;
     line-height: 1.55;
     color: s.$secondary-text;
   }
@@ -55,7 +55,7 @@
     color: #fff;
     font-family: inherit;
     font-weight: 700;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
     text-decoration: none;
     cursor: pointer;
     transition: filter 0.12s ease, transform 0.12s ease;

--- a/src/Components/Footer/Footer.scss
+++ b/src/Components/Footer/Footer.scss
@@ -51,7 +51,7 @@ $inner-max: s.$max-width;
   }
   .ftr-blurb {
     color: s.$secondary-text;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
     line-height: 1.55;
     max-width: 32ch;
   }
@@ -64,7 +64,7 @@ $inner-max: s.$max-width;
   gap: 0.35rem;
 }
 .footer-wordmark {
-  font-size: 1.5rem;
+  font-size: s.$text-2xl;
   font-weight: 800;
   letter-spacing: -0.02em;
   color: s.$primary;
@@ -97,7 +97,7 @@ $inner-max: s.$max-width;
   }
 }
 .footer-col-heading {
-  font-size: 0.78rem;
+  font-size: s.$text-fine;
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -110,7 +110,7 @@ $inner-max: s.$max-width;
   color: s.$secondary-text;
   text-decoration: none;
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: s.$text-base;
   transition: color 0.12s ease;
   &:hover { color: s.$primary; }
 }
@@ -121,7 +121,7 @@ $inner-max: s.$max-width;
   align-items: center;
   flex-wrap: wrap;
   gap: 0.75rem 1.25rem;
-  font-size: 0.82rem;
+  font-size: s.$text-sm;
   color: s.$tertiary-text;
   font-weight: 600;
   margin-top: 2.25rem;

--- a/src/Components/Form/FormInput.scss
+++ b/src/Components/Form/FormInput.scss
@@ -31,7 +31,7 @@
 
   .input-hint {
     margin-top: 0.35rem;
-    font-size: 0.75rem;
+    font-size: s.$text-caption;
 
     &--error {
       color: s.$error-red;
@@ -46,7 +46,7 @@
     .label-title {
       margin-bottom: 0.3rem;
       font-weight: 600;
-      font-size: 0.78rem;
+      font-size: s.$text-fine;
       color: s.$primary-text;
       text-transform: capitalize;
     }
@@ -63,7 +63,7 @@
         height: 48px;
         box-sizing: border-box;
         padding: 0 2.75rem;
-        font-size: 0.95rem;
+        font-size: s.$text-base;
         color: s.$primary-text;
         border: 1.5px solid s.$gray-300;
         background: s.$white;
@@ -89,7 +89,7 @@
         border: none;
         background: transparent;
         color: s.$tertiary-text;
-        font-size: 1.3rem;
+        font-size: s.$text-xl;
         cursor: pointer;
         transition: color 0.15s ease;
 
@@ -105,7 +105,7 @@
     .label-title {
       padding-bottom: 0.5rem;
       font-weight: 600;
-      font-size: 0.875rem;
+      font-size: s.$text-sm;
       text-transform: capitalize;
       color: s.$primary;
     }
@@ -123,7 +123,7 @@
       input {
         height: 100%;
         padding: 0 1rem;
-        font-size: 0.9rem;
+        font-size: s.$text-base;
         border: 1px solid s.$tertiary-text;
         background: none;
       }
@@ -132,7 +132,7 @@
     .input-beginning-text {
       position: absolute;
       left: 16px;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       font-weight: 600;
       color: s.$secondary-text;
     }

--- a/src/Components/Form/FormStyles.scss
+++ b/src/Components/Form/FormStyles.scss
@@ -48,7 +48,7 @@
     width: 52px;
     height: 52px;
     border-radius: s.$radius-3xl;
-    font-size: 2.3rem;
+    font-size: s.$text-4xl;
     font-weight: 300;
     font-style: italic;
     line-height: 1;
@@ -66,7 +66,7 @@
     text-align: center;
 
     .title {
-      font-size: 1.55rem;
+      font-size: s.$text-2xl;
       font-weight: 800;
       color: s.$primary-text;
       margin-bottom: 1.5rem;
@@ -76,7 +76,7 @@
       margin-top: -1.1rem;
       margin-bottom: 1.5rem;
       font-weight: 500;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       line-height: 1.45;
       color: s.$secondary-text;
       .prompt-btn {
@@ -99,7 +99,7 @@
       justify-content: space-between;
       gap: 0.75rem;
       margin-top: 0.9rem;
-      font-size: 0.82rem;
+      font-size: s.$text-sm;
 
       .remember {
         display: flex;
@@ -156,7 +156,7 @@
   // Terms/Privacy consent (signup) — sits between the fields and the CTA.
   .terms-consent {
     margin-top: 1rem;
-    font-size: 0.75rem;
+    font-size: s.$text-caption;
     line-height: 1.45;
     color: s.$tertiary-text;
     text-align: center;
@@ -175,7 +175,7 @@
   .error,
   .success {
     display: block;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     font-weight: 500;
     margin: 0 0 0.4rem;
     padding: 0.65rem 0.85rem;
@@ -198,7 +198,7 @@
   .not-available {
     margin-top: -0.55rem;
     font-weight: 600;
-    font-size: 0.75rem;
+    font-size: s.$text-caption;
     text-align: left;
   }
   .available {
@@ -214,7 +214,7 @@
     height: 48px;
     width: 100%;
     font-weight: 700;
-    font-size: 1rem;
+    font-size: s.$text-md;
   }
 
   // Submit CTA — intentionally the brand TEAL ($secondary-accessible), matching
@@ -237,7 +237,7 @@
     gap: 0.75rem;
     margin: 1.1rem 0;
     color: s.$tertiary-text;
-    font-size: 0.8rem;
+    font-size: s.$text-fine;
     font-weight: 500;
     &::before,
     &::after {
@@ -268,7 +268,7 @@
   // Bottom switch link ("Don't have an account? Sign up").
   .switch-prompt {
     margin-top: 1.4rem;
-    font-size: 0.88rem;
+    font-size: s.$text-sm;
     text-align: center;
     color: s.$secondary-text;
     .prompt-btn {

--- a/src/Components/Navbar/Navbar.scss
+++ b/src/Components/Navbar/Navbar.scss
@@ -98,11 +98,11 @@
   // `.nav--condensed .nav-logo` (0-2-0) loses to them and the shrink is silently
   // dropped.
   .prepify-logo.nav-link .nav-logo {
-    font-size: 1.7rem;
+    font-size: s.$text-3xl;
     transition: font-size 0.2s ease;
   }
   .prepify-logo.nav-link .beta-tag {
-    font-size: 0.7rem;
+    font-size: s.$text-caption;
     padding: 0.15rem 0.4rem;
   }
   .dnav {
@@ -117,7 +117,7 @@
     .dnav__icon-link {
       height: 38px;
       width: 38px;
-      font-size: 1.2rem;
+      font-size: s.$text-xl;
     }
     .dnav__create {
       padding-top: 0.4rem;
@@ -142,12 +142,12 @@
   text-decoration: none;
   text-transform: capitalize;
   text-decoration: none;
-  font-size: 1.125rem;
+  font-size: s.$text-lg;
   font-weight: 700;
   color: s.$primary-background;
 
   .nav-logo {
-    font-size: 2.25rem;
+    font-size: s.$text-4xl;
     font-weight: 700;
     font-style: italic;
     color: s.$primary;
@@ -161,7 +161,7 @@
 
   .beta-tag {
     text-transform: uppercase;
-    font-size: 0.875rem;
+    font-size: s.$text-sm;
     // AA: light text on the vivid teal was 2.78:1; the on-light teal + white
     // takes it to 5.27:1. (Cosmetic only — the tag is removed at the 1.0 cutover,
     // but this keeps the binary color-contrast audit passing in the meantime.)
@@ -228,10 +228,10 @@
 
   @include s.below(s.$bp-nav) {
     .nav-logo {
-      font-size: 1.875rem;
+      font-size: s.$text-3xl;
     }
     .beta-tag {
-      font-size: 0.75rem;
+      font-size: s.$text-caption;
     }
   }
 
@@ -240,10 +240,10 @@
   // the search room.
   @include s.between(s.$bp-nav-up, 860px) {
     .nav-logo {
-      font-size: 1.6rem;
+      font-size: s.$text-2xl;
     }
     .beta-tag {
-      font-size: 0.7rem;
+      font-size: s.$text-caption;
       padding: 0.18rem 0.4rem;
     }
   }

--- a/src/Components/Navbar/desktop/DesktopNav.scss
+++ b/src/Components/Navbar/desktop/DesktopNav.scss
@@ -138,7 +138,7 @@
   align-items: center;
   gap: 0.45rem;
   padding: 0.4rem 0.25rem;
-  font-size: 1.05rem;
+  font-size: s.$text-md;
   font-weight: 700;
   text-decoration: none;
   white-space: nowrap;
@@ -211,7 +211,7 @@
   border-radius: s.$radius-circle;
   flex-shrink: 0;
   color: var(--dnav-text);
-  font-size: 1.35rem;
+  font-size: s.$text-xl;
   text-decoration: none;
   transition: background 0.12s linear, color 0.12s linear;
   &:hover {
@@ -232,7 +232,7 @@
   padding: 0.5rem 1.1rem;
   // Pill shape; themed colours kept off the `.btn` variants (see .dnav__create).
   border-radius: s.$radius-pill;
-  font-size: 1rem;
+  font-size: s.$text-md;
   font-weight: 700;
   text-decoration: none;
   white-space: nowrap;
@@ -294,7 +294,7 @@
     justify-content: center;
     background: s.$primary-text;
     color: s.$white;
-    font-size: 1.4rem;
+    font-size: s.$text-2xl;
     font-weight: 600;
     border: 1px solid #{rgba(s.$white, 0.6)};
   }
@@ -345,7 +345,7 @@
 
   &__email {
     display: block;
-    font-size: 0.75rem;
+    font-size: s.$text-caption;
     font-weight: 500;
     color: s.$secondary-text;
     overflow: hidden;
@@ -365,7 +365,7 @@
     text-align: left;
     text-decoration: none;
     cursor: pointer;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
     font-weight: 600;
     color: s.$primary-text;
     .icon {
@@ -424,7 +424,7 @@
   justify-content: center;
   background: s.$primary-text;
   color: s.$white;
-  font-size: 1.25rem;
+  font-size: s.$text-xl;
   font-weight: 600;
 }
 .dnav-account__profile-meta {
@@ -433,7 +433,7 @@
   min-width: 0;
 }
 .dnav-account__profile-name {
-  font-size: 0.95rem;
+  font-size: s.$text-base;
   font-weight: 700;
   color: s.$primary-text;
   white-space: nowrap;
@@ -451,7 +451,7 @@
   border-radius: s.$border-radius;
   background: none;
   color: s.$primary-text;
-  font-size: 0.9rem;
+  font-size: s.$text-base;
   font-weight: 600;
   cursor: pointer;
   transition: border-color 0.12s linear, color 0.12s linear, background 0.12s linear;
@@ -581,7 +581,7 @@
   }
   // smaller search text so "Search All Recipes" isn't clipped in the tight band
   .dnav__search .search-recipes-form .search-recipes-input-label input {
-    font-size: 0.95rem;
+    font-size: s.$text-base;
     padding-left: 2.4rem;
   }
 }

--- a/src/Components/Navbar/menu/NavMenu.scss
+++ b/src/Components/Navbar/menu/NavMenu.scss
@@ -98,7 +98,7 @@
   }
   .menu-group__heading {
     margin: 0 0 0.35rem 0.5rem;
-    font-size: 0.72rem;
+    font-size: s.$text-caption;
     font-weight: 700;
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -114,7 +114,7 @@
     border-radius: var(--menu-radius);
     color: var(--menu-text);
     text-decoration: none;
-    font-size: 1.25rem;
+    font-size: s.$text-xl;
     font-weight: 600;
     transition: background 0.12s linear, color 0.12s linear;
 
@@ -163,7 +163,7 @@
     justify-content: center;
     background: var(--menu-avatar-bg);
     color: var(--menu-avatar-text);
-    font-size: 1.4rem;
+    font-size: s.$text-2xl;
     font-weight: 600;
   }
   .account-card__meta {
@@ -173,10 +173,10 @@
   }
   .account-card__name {
     font-weight: 700;
-    font-size: 1.05rem;
+    font-size: s.$text-md;
   }
   .account-card__email {
-    font-size: 0.82rem;
+    font-size: s.$text-sm;
     color: var(--menu-muted);
     white-space: nowrap;
     overflow: hidden;
@@ -193,7 +193,7 @@
     border-radius: var(--menu-radius);
     background: none;
     color: var(--menu-text);
-    font-size: 1rem;
+    font-size: s.$text-md;
     font-weight: 600;
     cursor: pointer;
     transition: border-color 0.12s linear, background 0.12s linear;
@@ -218,7 +218,7 @@
     justify-content: center;
     padding: 0.85rem;
     border-radius: var(--menu-radius);
-    font-size: 1.05rem;
+    font-size: s.$text-md;
     font-weight: 700;
     text-decoration: none;
     transition: filter 0.12s linear, background 0.12s linear;

--- a/src/Components/RecipeCard/RecipeCard.scss
+++ b/src/Components/RecipeCard/RecipeCard.scss
@@ -63,7 +63,7 @@
     background: rgba(255, 255, 255, 0.95);
     color: s.$primary;
     font-weight: 800;
-    font-size: 0.74rem;
+    font-size: s.$text-caption;
     padding: 0.28rem 0.6rem;
     border-radius: s.$radius-pill;
     box-shadow: s.$shadow-chip;
@@ -86,7 +86,7 @@
     background: rgba(255, 255, 255, 0.92);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
     color: s.$secondary-text;
-    font-size: 1.05rem;
+    font-size: s.$text-md;
     line-height: 1;
     cursor: pointer;
     transition: transform 0.12s ease, color 0.12s ease;
@@ -107,7 +107,7 @@
   }
 
   &__cuisine {
-    font-size: 0.7rem;
+    font-size: s.$text-caption;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -116,7 +116,7 @@
   }
 
   &__title {
-    font-size: 1.02rem;
+    font-size: s.$text-md;
     font-weight: 600;
     line-height: 1.3;
     text-transform: capitalize;
@@ -144,7 +144,7 @@
     justify-content: space-between;
     gap: 0.85rem;
     margin-top: auto;
-    font-size: 0.82rem;
+    font-size: s.$text-sm;
     font-weight: 600;
     color: s.$secondary-text;
   }
@@ -153,7 +153,7 @@
     align-items: center;
     gap: 0.25rem;
     svg {
-      font-size: 1rem;
+      font-size: s.$text-md;
     }
   }
   &__rating {
@@ -177,7 +177,7 @@
     &--none {
       color: s.$tertiary-text;
       font-weight: 600;
-      font-size: 0.78rem;
+      font-size: s.$text-fine;
     }
   }
 }

--- a/src/Components/ReleaseNotes/ReleaseNotes.scss
+++ b/src/Components/ReleaseNotes/ReleaseNotes.scss
@@ -26,12 +26,12 @@
     justify-content: center;
   }
   .heading {
-    // font-size: 1.875rem;
+    // font-size: s.$text-3xl;
     padding-top: 1rem;
     text-align: center;
   }
   .release-tag {
-    font-size: 1.125rem;
+    font-size: s.$text-lg;
     font-weight: 700;
     color: s.$primary;
     padding-top: 0.5rem;
@@ -55,7 +55,7 @@
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        font-size: 1.25rem;
+        font-size: s.$text-xl;
         font-weight: 700;
         // color: s.$primary;
         text-align: left;
@@ -92,7 +92,7 @@
   // `.btn .btn--ghost` (secondary-text comes from the variant); keeps the
   // underlined text-link treatment + left alignment + spacing.
   .all-release-notes-btn {
-    font-size: 1rem;
+    font-size: s.$text-md;
     text-decoration: underline;
     text-align: left;
     margin: 1rem 0 0;

--- a/src/Components/ReportControl/ReportControl.scss
+++ b/src/Components/ReportControl/ReportControl.scss
@@ -8,7 +8,7 @@
   cursor: pointer;
   color: s.$tertiary-text;
   font-family: inherit;
-  font-size: 0.8rem;
+  font-size: s.$text-fine;
   line-height: 1.2;
   padding: 0.15rem 0.35rem;
   border-radius: s.$radius-xs;
@@ -29,7 +29,7 @@
   &.button {
     border: 1px solid s.$admin-slate-300;
     padding: 0.4rem 0.75rem;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
 
     &:hover {
       border-color: s.$error-red;
@@ -53,7 +53,7 @@
     border-radius: s.$radius-circle;
     width: 1.9rem;
     height: 1.9rem;
-    font-size: 1.05rem;
+    font-size: s.$text-md;
     line-height: 1;
     transition: color 0.15s, background 0.15s;
 
@@ -93,7 +93,7 @@
     border-radius: s.$radius-sm;
     cursor: pointer;
     font-family: inherit;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     color: s.$admin-slate-700;
     text-align: left;
     white-space: nowrap;
@@ -101,7 +101,7 @@
 
     svg {
       flex-shrink: 0;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
     }
 
     &:hover {
@@ -122,13 +122,13 @@
 
   .report-modal-title {
     margin: 0 0 0.35rem;
-    font-size: 1.25rem;
+    font-size: s.$text-xl;
   }
 
   .report-modal-sub {
     margin: 0 0 1.25rem;
     color: s.$admin-slate-500;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
   }
 
   .report-field {
@@ -136,14 +136,14 @@
     flex-direction: column;
     gap: 0.35rem;
     margin-bottom: 1rem;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     font-weight: 600;
     color: s.$admin-slate-700;
 
     select,
     textarea {
       font-weight: 400;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       padding: 0.55rem 0.65rem;
       border: 1px solid s.$admin-slate-300;
       border-radius: s.$radius-sm;
@@ -167,7 +167,7 @@
       cursor: pointer;
       border-radius: s.$radius-sm;
       padding: 0.55rem 1rem;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       font-weight: 600;
       position: relative;
     }

--- a/src/Components/SavedFilters/SavedFilterBar.scss
+++ b/src/Components/SavedFilters/SavedFilterBar.scss
@@ -26,7 +26,7 @@
       background: transparent;
       color: #374151;
       padding: 0.3rem 0.5rem 0.3rem 0.7rem;
-      font-size: 0.8rem;
+      font-size: s.$text-fine;
       cursor: pointer;
 
       &:hover {
@@ -39,7 +39,7 @@
       background: transparent;
       color: #9ca3af;
       padding: 0.3rem 0.55rem 0.3rem 0.2rem;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       line-height: 1;
       cursor: pointer;
 
@@ -55,7 +55,7 @@
     color: #6b7280;
     padding: 0.3rem 0.7rem;
     border-radius: s.$radius-pill;
-    font-size: 0.8rem;
+    font-size: s.$text-fine;
     cursor: pointer;
 
     &:hover {

--- a/src/Components/SearchRecipesInput/SearchRecipesInput.scss
+++ b/src/Components/SearchRecipesInput/SearchRecipesInput.scss
@@ -25,7 +25,7 @@
       border-radius: s.$border-radius;
       height: 50px;
       width: 100%;
-      font-size: 1.1rem;
+      font-size: s.$text-lg;
       padding: 0.1rem 2.75rem;
       padding-right: 7.25rem;
       color: s.$primary-text;
@@ -37,7 +37,7 @@
     .search-recipes-btn {
       position: absolute;
       right: 5px;
-      font-size: 1.1rem;
+      font-size: s.$text-lg;
       height: 80%;
       padding: 0 1.25rem;
     }
@@ -46,7 +46,7 @@
         padding-right: 6.25rem;
       }
       .search-recipes-btn {
-        font-size: 1rem;
+        font-size: s.$text-md;
         padding: 0 1rem;
       }
     }
@@ -148,7 +148,7 @@
         min-width: 0;
       }
       &__title {
-        font-size: 0.98rem;
+        font-size: s.$text-md;
         font-weight: 600;
         text-transform: capitalize;
         color: s.$primary-text;
@@ -165,7 +165,7 @@
         display: inline-flex;
         align-items: center;
         gap: 0.25rem;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         font-weight: 500;
         white-space: nowrap;
         color: s.$secondary-text;
@@ -184,7 +184,7 @@
         max-width: 9rem;
       }
       &__tag {
-        font-size: 0.62rem;
+        font-size: s.$text-caption;
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.02em;
@@ -233,7 +233,7 @@
     .ac-corrected {
       margin: 0;
       padding: 0.55rem 0.85rem;
-      font-size: 0.8rem;
+      font-size: s.$text-fine;
       font-weight: 600;
       color: s.$secondary-text;
       background: s.$primary-background;
@@ -252,7 +252,7 @@
         color: s.$primary-text;
       }
       &__hint {
-        font-size: 0.85rem;
+        font-size: s.$text-sm;
         color: s.$tertiary-text;
       }
     }
@@ -270,7 +270,7 @@
       border-top: 1px solid s.$gray-200;
       background: s.$white;
       color: s.$primary;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       font-weight: 700;
       cursor: pointer;
       transition: background 0.1s ease;

--- a/src/helpers.scss
+++ b/src/helpers.scss
@@ -182,6 +182,29 @@ $shadow-chip: 0 2px 6px rgba(0, 0, 0, 0.18);  // tight drop shadow on price / fl
 
 $font-family: 'Montserrat', sans-serif;
 
+// ── Type scale ───────────────────────────────────────────────────────────────
+// A 10-step modular scale that the app's ~490 ad-hoc `font-size:` literals
+// collapse onto. Steps are anchored on the frequency peaks already in use, so
+// the most-common sizes (.85/.95/1/1.25rem) are kept verbatim and the long tail
+// of near-dupes (drift like .82≈.85, .9≈.95, 1.4≈1.5) normalizes onto the
+// nearest step — an intentional, documented collapse (the biggest single shift
+// is 2.8px, the typical one ≤0.8px). `rem` so the scale honours the user's root
+// font size. Documented in docs/design/type-scale.md.
+//
+// Out of scope (kept bespoke, NOT on this scale): the PrintableRecipe `pt` print
+// scale, the About `clamp()` fluid headings, the 404/PublicProfile giant display
+// numerals, and the icon-relative `em` sizes.
+$text-caption: 0.72rem; // 11.5px — tiny meta: timestamps, counts, eyebrow labels
+$text-fine: 0.78rem; //    12.5px — small meta / dense secondary text
+$text-sm: 0.85rem; //      13.6px — small UI: pills, chips, helper text (most common)
+$text-base: 0.95rem; //    15.2px — default body / paragraph text
+$text-md: 1rem; //         16px   — emphasized body, standard control text
+$text-lg: 1.125rem; //     18px   — lead paragraphs, large controls
+$text-xl: 1.25rem; //      20px   — card titles, sub-headings
+$text-2xl: 1.5rem; //      24px   — section headings (h3)
+$text-3xl: 1.875rem; //    30px   — page headings (h2)
+$text-4xl: 2.25rem; //     36px   — hero / top-level headings (h1)
+
 // Responsive breakpoints. Canonical "down" (max-width) tiers, anchored on the
 // values already used most across the app. Queries reach them through the
 // below()/above()/between() mixins so the breakpoint list lives in one place.

--- a/src/index.scss
+++ b/src/index.scss
@@ -30,15 +30,15 @@ body {
 
 h2 {
   font-weight: 600;
-  font-size: 1.5rem;
+  font-size: s.$text-2xl;
 }
 h3 {
   font-weight: 500;
-  font-size: 1.5rem;
+  font-size: s.$text-2xl;
 }
 h4 {
   font-weight: 500;
-  font-size: 1.125rem;
+  font-size: s.$text-lg;
 }
 p {
   line-height: 1.75;
@@ -114,7 +114,7 @@ a {
   line-height: 1;
   font-family: inherit;
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: s.$text-base;
   padding: 0.6rem 1.3rem;
   color: s.$primary-text;
   background: none;
@@ -138,11 +138,11 @@ a {
 // Sizes (default = md, baked into `.btn`)
 .btn--sm {
   padding: 0.45rem 0.95rem;
-  font-size: 0.85rem;
+  font-size: s.$text-sm;
 }
 .btn--lg {
   padding: 0.7rem 1.6rem;
-  font-size: 1rem;
+  font-size: s.$text-md;
 }
 .btn--block {
   width: 100%;
@@ -222,7 +222,7 @@ a {
   border: 1px solid s.$gray-400;
   margin: 0 auto;
   border-radius: s.$border-radius;
-  font-size: 1.3rem;
+  font-size: s.$text-xl;
   white-space: nowrap;
 
   &:hover {
@@ -230,7 +230,7 @@ a {
   }
 
   @include s.below(s.$bp-xs) {
-    font-size: 1.25rem;
+    font-size: s.$text-xl;
   }
 }
 
@@ -314,7 +314,7 @@ a {
   border-radius: s.$border-radius;
 
   font-weight: 600;
-  font-size: 1rem;
+  font-size: s.$text-md;
 
   .content {
     flex: 1;
@@ -346,7 +346,7 @@ a {
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 1.5rem;
+  font-size: s.$text-2xl;
   font-weight: 700;
   height: 100vh;
   width: 100%;

--- a/src/pages/404/404.scss
+++ b/src/pages/404/404.scss
@@ -93,16 +93,16 @@
     // 1.5rem type, heavier weight, and the top spacing are local.
     button.home-btn {
       padding: 0.75rem 2rem;
-      font-size: 1.5rem;
+      font-size: s.$text-2xl;
       font-weight: 700;
       margin-top: 2rem;
     }
     @include s.below(s.$bp-sm) {
       h1 {
-        font-size: 1.5rem;
+        font-size: s.$text-2xl;
       }
       p.text {
-        font-size: 0.875rem;
+        font-size: s.$text-sm;
       }
     }
   }

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -22,7 +22,7 @@
   .about-moment-kicker {
     text-transform: uppercase;
     letter-spacing: 0.16em;
-    font-size: 0.6875rem;
+    font-size: s.$text-caption;
     font-weight: 600;
     color: s.$primary-accessible;
     margin: 0 0 0.65rem;
@@ -54,7 +54,7 @@
   // hover, and the icon nudge are local.
   .about-btn {
     padding: 0.65rem 1.35rem;
-    font-size: 0.9375rem;
+    font-size: s.$text-base;
     text-decoration: none;
 
     svg {
@@ -175,7 +175,7 @@
     background-color: s.$primary-accessible;
     color: s.$white;
     font-weight: 700;
-    font-size: 0.8125rem;
+    font-size: s.$text-fine;
     padding: 0.3rem 0.65rem;
     border-radius: s.$radius-pill;
   }
@@ -185,7 +185,7 @@
   }
 
   .about-card-title {
-    font-size: 1.0625rem;
+    font-size: s.$text-md;
     font-weight: 700;
     margin: 0 0 0.6rem;
     color: s.$primary-text;
@@ -195,7 +195,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
-    font-size: 0.8125rem;
+    font-size: s.$text-fine;
     color: s.$secondary-text;
 
     span {
@@ -226,14 +226,14 @@
   .about-nutrition-label {
     text-transform: uppercase;
     letter-spacing: 0.12em;
-    font-size: 0.6875rem;
+    font-size: s.$text-caption;
     font-weight: 600;
     color: s.$tertiary-text;
     margin: 0 0 0.45rem;
   }
 
   .about-nutrition-cal {
-    font-size: 2rem;
+    font-size: s.$text-3xl;
     font-weight: 800;
     letter-spacing: -0.02em;
     color: s.$primary-text;
@@ -241,7 +241,7 @@
     line-height: 1;
 
     span {
-      font-size: 0.875rem;
+      font-size: s.$text-sm;
       font-weight: 600;
       color: s.$tertiary-text;
     }
@@ -262,18 +262,18 @@
   }
 
   .about-macro-value {
-    font-size: 1rem;
+    font-size: s.$text-md;
     font-weight: 700;
     color: s.$primary-text;
   }
 
   .about-macro-label {
-    font-size: 0.6875rem;
+    font-size: s.$text-caption;
     color: s.$secondary-text;
   }
 
   .about-showcase-caption {
-    font-size: 0.875rem;
+    font-size: s.$text-sm;
     color: s.$secondary-text;
     max-width: 460px;
     margin: 1.85rem auto 0;
@@ -325,19 +325,19 @@
     box-shadow: s.$card-box-shadow;
     color: s.$primary;
     font-weight: 800;
-    font-size: 1.0625rem;
+    font-size: s.$text-md;
     margin-bottom: 1rem;
   }
 
   .about-step-label {
-    font-size: 1.1875rem;
+    font-size: s.$text-lg;
     font-weight: 700;
     margin: 0 0 0.55rem;
     color: s.$primary-text;
   }
 
   .about-step-body {
-    font-size: 0.9375rem;
+    font-size: s.$text-base;
     line-height: 1.6;
     color: s.$secondary-text;
     margin: 0 auto;
@@ -372,7 +372,7 @@
     border-radius: s.$border-radius;
     background-color: rgba(255, 87, 34, 0.08);
     color: s.$primary;
-    font-size: 1.2rem;
+    font-size: s.$text-xl;
   }
 
   .about-feature-text {
@@ -380,14 +380,14 @@
   }
 
   .about-feature-title {
-    font-size: 1rem;
+    font-size: s.$text-md;
     font-weight: 700;
     margin: 0.15rem 0 0.35rem;
     color: s.$primary-text;
   }
 
   .about-feature-body {
-    font-size: 0.875rem;
+    font-size: s.$text-sm;
     line-height: 1.55;
     color: s.$secondary-text;
     margin: 0;
@@ -400,7 +400,7 @@
     text-align: left;
 
     p {
-      font-size: 1rem;
+      font-size: s.$text-md;
       line-height: 1.7;
       color: s.$secondary-text;
       margin: 0 0 1.25rem;
@@ -435,7 +435,7 @@
     gap: 1.75rem;
     margin-top: 2.5rem;
     color: s.$gray-300;
-    font-size: 1.4rem;
+    font-size: s.$text-2xl;
   }
 
   // ---- Responsive ----

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -58,7 +58,7 @@
       justify-content: center;
       color: s.$primary;
       font-weight: 600;
-      font-size: 2.25rem;
+      font-size: s.$text-4xl;
       background: s.$primary-text;
     }
   }
@@ -66,7 +66,7 @@
     min-width: 0;
   }
   .acct-name {
-    font-size: 1.7rem;
+    font-size: s.$text-3xl;
     font-weight: 800;
     letter-spacing: -0.02em;
     line-height: 1.1;
@@ -74,20 +74,20 @@
   .acct-meta {
     color: s.$tertiary-text;
     font-weight: 600;
-    font-size: 0.84rem;
+    font-size: s.$text-sm;
     margin-top: 0.3rem;
   }
   .acct-bio {
     color: s.$secondary-text;
     line-height: 1.55;
-    font-size: 0.93rem;
+    font-size: s.$text-base;
     margin-top: 0.6rem;
     max-width: 600px;
   }
   .acct-bio-empty {
     display: inline-block;
     margin-top: 0.6rem;
-    font-size: 0.86rem;
+    font-size: s.$text-sm;
     font-weight: 600;
     color: s.$tertiary-text;
     text-decoration: none;
@@ -144,7 +144,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
-    font-size: 0.78rem;
+    font-size: s.$text-fine;
     font-weight: 700;
     color: s.$secondary-text;
     background: #fff;
@@ -157,7 +157,7 @@
   .acct-lvl-chip-num {
     flex-shrink: 0;
     white-space: nowrap;
-    font-size: 0.72rem;
+    font-size: s.$text-caption;
     font-weight: 800;
     color: #fff;
     background: linear-gradient(135deg, s.$primary, s.$primary-tint);
@@ -166,11 +166,11 @@
   }
   .acct-rewards-cta {
     font-weight: 800;
-    font-size: 0.8rem;
+    font-size: s.$text-fine;
     color: s.$primary;
     white-space: nowrap;
     span {
-      font-size: 1rem;
+      font-size: s.$text-md;
     }
   }
   .acct-xpbar {
@@ -189,7 +189,7 @@
     .acct-xpbar-label {
       display: block;
       margin-top: 0.35rem;
-      font-size: 0.72rem;
+      font-size: s.$text-caption;
       font-weight: 700;
       color: s.$tertiary-text;
     }
@@ -207,13 +207,13 @@
   .acct-btn {
     font-weight: 700;
     svg {
-      font-size: 1.05rem;
+      font-size: s.$text-md;
     }
   }
   // Warm-palette outline pill on the `.btn` base — bespoke cream border + brand
   // hover, so no colour variant. Tighter padding + smaller text than the base.
   .acct-edit {
-    font-size: 0.86rem;
+    font-size: s.$text-sm;
     color: s.$secondary-text;
     background: #fff;
     border: 1px solid #e3d9ca;
@@ -285,7 +285,7 @@
     gap: 0.7rem;
     font-family: inherit;
     font-weight: 700;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
     color: s.$secondary-text;
     text-decoration: none;
     border-radius: 11px;
@@ -304,7 +304,7 @@
 
     .acct-seg-icon {
       display: flex;
-      font-size: 1.15rem;
+      font-size: s.$text-lg;
     }
     // The short label is phone-only (≤600px); the full label shows otherwise.
     .acct-seg-label-short {
@@ -312,7 +312,7 @@
     }
     .acct-seg-count {
       margin-left: auto;
-      font-size: 0.72rem;
+      font-size: s.$text-caption;
       font-weight: 800;
       color: s.$secondary-text;
       background: s.$gray-200;
@@ -332,16 +332,16 @@
       justify-content: center;
       text-align: center;
       padding: 0.65rem 0.25rem;
-      font-size: 0.8rem;
+      font-size: s.$text-fine;
       .acct-seg-icon {
-        font-size: 1.3rem;
+        font-size: s.$text-xl;
       }
       .acct-seg-count {
         position: absolute;
         top: 0.25rem;
         right: 0.4rem;
         margin-left: 0;
-        font-size: 0.58rem;
+        font-size: s.$text-caption;
         padding: 0.05rem 0.3rem;
       }
     }
@@ -381,7 +381,7 @@
       width: 76px;
       height: 76px;
       &.not-set {
-        font-size: 2rem;
+        font-size: s.$text-3xl;
       }
     }
     .acct-id-text {
@@ -390,7 +390,7 @@
       align-items: center;
     }
     .acct-name {
-      font-size: 1.5rem;
+      font-size: s.$text-2xl;
     }
     .acct-bio {
       max-width: 100%;
@@ -417,7 +417,7 @@
         display: none;
       }
       svg {
-        font-size: 1.1rem;
+        font-size: s.$text-lg;
       }
     }
     .acct-iconbtn {
@@ -430,7 +430,7 @@
     // phones we just shrink the cells and swap "Your Recipes" → "Recipes" so a
     // single line fits.
     .acct-seg {
-      font-size: 0.7rem;
+      font-size: s.$text-caption;
       padding: 0.55rem 0.2rem;
       line-height: 1;
 

--- a/src/pages/Account/Drafts/Drafts.scss
+++ b/src/pages/Account/Drafts/Drafts.scss
@@ -60,12 +60,12 @@
       border-radius: 13px;
       background: #fdf3ec;
       color: s.$primary;
-      font-size: 1.25rem;
+      font-size: s.$text-xl;
     }
     .title {
       flex: 1;
       min-width: 0;
-      font-size: 1.08rem;
+      font-size: s.$text-lg;
       font-weight: 700;
       color: s.$primary-text;
       margin: 0;
@@ -84,7 +84,7 @@
       display: flex;
       flex-direction: column;
       gap: 0.4rem;
-      font-size: 0.84rem;
+      font-size: s.$text-sm;
       color: s.$tertiary-text;
 
       // The ingredient/step summary is the primary fact — give it a touch more
@@ -98,9 +98,9 @@
         display: inline-flex;
         align-items: center;
         gap: 0.3rem;
-        font-size: 0.78rem;
+        font-size: s.$text-fine;
         svg {
-          font-size: 0.8rem;
+          font-size: s.$text-fine;
         }
       }
     }
@@ -127,13 +127,13 @@
         // width (that intrinsic min is what forced the overflow); with flex-wrap
         // it shares the row when it fits and drops Delete below when it doesn't.
         min-width: 0;
-        font-size: 0.9rem;
+        font-size: s.$text-base;
         font-weight: 700;
         padding: 0.55rem 1rem;
         background: s.$primary-accessible;
         color: #fff;
         svg {
-          font-size: 1rem;
+          font-size: s.$text-md;
         }
         &:hover {
           background: #f4501e;
@@ -145,13 +145,13 @@
       // tinted hover don't match `.btn--danger`'s fill, so kept bespoke.
       .del {
         flex-shrink: 0;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         font-weight: 700;
         padding: 0.5rem 0.85rem;
         border: 1px solid #ecd9d9;
         color: s.$secondary-text;
         svg {
-          font-size: 1rem;
+          font-size: s.$text-md;
         }
         &:hover:not(:disabled) {
           color: s.$error-red;

--- a/src/pages/Account/SavedRecipes/SavedRecipes.scss
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.scss
@@ -59,7 +59,7 @@
         object-fit: cover;
       }
       &.empty svg {
-        font-size: 1.3rem;
+        font-size: s.$text-xl;
       }
       // Loading placeholder fills the fixed 88px thumb box.
       .cc-thumb-sk {
@@ -78,7 +78,7 @@
         background: rgba(s.$primary, 0.1);
         color: s.$primary;
         svg {
-          font-size: 1.6rem;
+          font-size: s.$text-2xl;
         }
       }
     }
@@ -94,7 +94,7 @@
     }
     &__name {
       font-weight: 800;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       line-height: 1.25;
       display: -webkit-box;
       -webkit-line-clamp: 2;
@@ -104,7 +104,7 @@
     &__count {
       color: s.$tertiary-text;
       font-weight: 700;
-      font-size: 0.72rem;
+      font-size: s.$text-caption;
     }
   }
 
@@ -117,7 +117,7 @@
     border-color: s.$primary;
     color: s.$primary;
     font-weight: 800;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
 
     &:hover {
       background: s.$gray-50;
@@ -136,7 +136,7 @@
         width: 100%;
         box-sizing: border-box;
         font-family: inherit;
-        font-size: 0.85rem;
+        font-size: s.$text-sm;
         padding: 0.45rem 0.6rem;
         border: 1px solid s.$gray-400;
         border-radius: s.$radius-md;
@@ -149,7 +149,7 @@
       // `.btn .btn--primary`; only the heavier weight + compact size are local.
       .new-submit {
         font-weight: 800;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         padding: 0.4rem 0.7rem;
         &:disabled {
           opacity: 0.5;
@@ -178,7 +178,7 @@
       left: 0.95rem;
       top: 50%;
       transform: translateY(-50%);
-      font-size: 1.05rem;
+      font-size: s.$text-md;
       color: s.$tertiary-text;
       pointer-events: none;
     }
@@ -187,7 +187,7 @@
       height: 44px;
       box-sizing: border-box;
       font-family: inherit;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       padding: 0 2.6rem;
       border: 1px solid s.$gray-400;
       border-radius: s.$radius-pill;
@@ -228,7 +228,7 @@
       padding: 0 1rem;
       font-family: inherit;
       font-weight: 700;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       color: s.$primary-text;
       background: #fff;
       border: 1px solid s.$gray-400;
@@ -236,7 +236,7 @@
       cursor: pointer;
       white-space: nowrap;
       .chev {
-        font-size: 1rem;
+        font-size: s.$text-md;
         transition: transform 0.14s ease;
       }
       &:hover {
@@ -266,7 +266,7 @@
         border: none;
         background: none;
         font-family: inherit;
-        font-size: 0.88rem;
+        font-size: s.$text-sm;
         font-weight: 600;
         color: s.$primary-text;
         padding: 0.45rem 0.6rem;
@@ -294,7 +294,7 @@
 
     h2 {
       margin: 0;
-      font-size: 1.25rem;
+      font-size: s.$text-xl;
     }
   }
   .saved-collection-actions {
@@ -305,7 +305,7 @@
   // `.btn .btn--outline` base; the compact size + secondary-text resting colour
   // are local, and the `.ghost`/`.danger` modifiers stay as local tweaks.
   .btn-small {
-    font-size: 0.82rem;
+    font-size: s.$text-sm;
     padding: 0.35rem 0.6rem;
     color: s.$secondary-text;
     &.ghost {
@@ -327,7 +327,7 @@
     gap: 0.4rem;
     input {
       font-family: inherit;
-      font-size: 1rem;
+      font-size: s.$text-md;
       padding: 0.4rem 0.6rem;
       border: 1px solid s.$gray-400;
       border-radius: s.$radius-md;

--- a/src/pages/Account/UserRatings/UserRatings.scss
+++ b/src/pages/Account/UserRatings/UserRatings.scss
@@ -75,7 +75,7 @@
     .sr-title {
       flex: 1;
       min-width: 0; // allow the title to shrink + ellipsize, leaving room for the date
-      font-size: 0.98rem;
+      font-size: s.$text-md;
       font-weight: 800;
       color: s.$primary-text;
       text-transform: capitalize;
@@ -84,7 +84,7 @@
       text-overflow: ellipsis;
     }
     .sr-date {
-      font-size: 0.74rem;
+      font-size: s.$text-caption;
       font-weight: 700;
       color: s.$tertiary-text;
       white-space: nowrap;
@@ -96,14 +96,14 @@
       gap: 0.45rem;
       margin-top: 0.25rem;
       .sr-num {
-        font-size: 0.78rem;
+        font-size: s.$text-fine;
         font-weight: 800;
         color: s.$primary;
       }
     }
     .sr-text {
       color: s.$secondary-text;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       font-weight: 500;
       line-height: 1.45;
       margin-top: 0.4rem;
@@ -114,7 +114,7 @@
       overflow: hidden;
       svg {
         color: s.$secondary;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         margin-right: 0.35rem;
         vertical-align: -0.1rem;
       }

--- a/src/pages/Account/UserRecipes/UserRecipeThumbnail.scss
+++ b/src/pages/Account/UserRecipes/UserRecipeThumbnail.scss
@@ -55,7 +55,7 @@
       min-width: 0;
     }
     .title {
-      font-size: 1.05rem;
+      font-size: s.$text-md;
       font-weight: 700;
       line-height: 1.25;
       text-transform: capitalize;
@@ -70,20 +70,20 @@
       gap: 0.55rem;
       margin-top: 0.3rem;
       .price {
-        font-size: 0.72rem;
+        font-size: s.$text-caption;
         font-weight: 800;
         text-transform: uppercase;
         letter-spacing: 0.04em;
         color: s.$primary;
       }
       .date {
-        font-size: 0.74rem;
+        font-size: s.$text-caption;
         font-weight: 600;
         color: s.$tertiary-text;
       }
     }
     .go {
-      font-size: 1.2rem;
+      font-size: s.$text-xl;
       color: s.$tertiary-text;
       transition: color 0.18s ease, transform 0.18s ease;
     }
@@ -106,14 +106,14 @@
       padding: 0.45rem 0.4rem;
       .ic {
         color: s.$primary;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
       }
       b {
-        font-size: 1rem;
+        font-size: s.$text-md;
         font-weight: 800;
       }
       small {
-        font-size: 0.6rem;
+        font-size: s.$text-caption;
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.04em;
@@ -133,12 +133,12 @@
       display: inline-flex;
       align-items: center;
       gap: 0.35rem;
-      font-size: 0.82rem;
+      font-size: s.$text-sm;
       font-weight: 700;
       color: s.$secondary-text;
       svg {
         color: s.$secondary;
-        font-size: 1rem;
+        font-size: s.$text-md;
       }
     }
   }

--- a/src/pages/Account/components/AchievementsModal.scss
+++ b/src/pages/Account/components/AchievementsModal.scss
@@ -23,11 +23,11 @@
     border-bottom: 1px solid #f0e8dd;
   }
   .am-title {
-    font-size: 1.2rem;
+    font-size: s.$text-xl;
     font-weight: 800;
   }
   .am-progress {
-    font-size: 0.8rem;
+    font-size: s.$text-fine;
     font-weight: 700;
     color: s.$tertiary-text;
     background: #efe6da;
@@ -48,7 +48,7 @@
     cursor: pointer;
     transition: all 0.12s ease;
     svg {
-      font-size: 1.1rem;
+      font-size: s.$text-lg;
     }
     &:hover {
       border-color: s.$primary;
@@ -78,7 +78,7 @@
     }
   }
   .am-icon {
-    font-size: 1.4rem;
+    font-size: s.$text-2xl;
     flex-shrink: 0;
   }
   .am-text {
@@ -88,11 +88,11 @@
   }
   .am-name {
     font-weight: 700;
-    font-size: 0.95rem;
+    font-size: s.$text-base;
     color: s.$primary-text;
   }
   .am-desc {
-    font-size: 0.82rem;
+    font-size: s.$text-sm;
     color: s.$secondary-text;
   }
 }

--- a/src/pages/AddRecipe/AddLabel/AddLabel.scss
+++ b/src/pages/AddRecipe/AddLabel/AddLabel.scss
@@ -22,7 +22,7 @@
       color: s.$primary;
     }
     .text {
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       font-weight: 600;
     }
     &:hover {

--- a/src/pages/AddRecipe/AddRecipe.scss
+++ b/src/pages/AddRecipe/AddRecipe.scss
@@ -34,7 +34,7 @@
   }
 
   h1 {
-    font-size: 2rem;
+    font-size: s.$text-3xl;
     font-weight: 700;
     text-align: center;
   }
@@ -46,12 +46,12 @@
     align-items: center;
     gap: 0.4rem;
     margin: 0 0 0.65rem;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     color: s.$secondary-text;
 
     .icon {
       flex-shrink: 0;
-      font-size: 1rem;
+      font-size: s.$text-md;
       color: s.$primary;
     }
   }
@@ -91,7 +91,7 @@
         .text {
           color: s.$primary-accessible;
           font-weight: 700;
-          font-size: 1rem;
+          font-size: s.$text-md;
           text-transform: uppercase;
           letter-spacing: 0.08em;
           white-space: nowrap;
@@ -102,7 +102,7 @@
           background: s.$gray-400;
         }
         .req {
-          font-size: 0.7rem;
+          font-size: s.$text-caption;
           font-weight: 600;
           text-transform: uppercase;
           letter-spacing: 0.06em;
@@ -120,7 +120,7 @@
         .input-container {
           input,
           textarea {
-            font-size: 1rem;
+            font-size: s.$text-md;
             border-radius: s.$border-radius;
           }
           textarea {

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.scss
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.scss
@@ -40,7 +40,7 @@
       flex-direction: column;
 
       dt {
-        font-size: 0.625rem;
+        font-size: s.$text-caption;
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.08em;
@@ -48,7 +48,7 @@
       }
       dd {
         margin: 0;
-        font-size: 1rem;
+        font-size: s.$text-md;
         font-weight: 700;
         color: s.$primary-text;
 
@@ -72,7 +72,7 @@
     flex-shrink: 0;
     height: 46px;
     padding: 0 1.25rem;
-    font-size: 1rem;
+    font-size: s.$text-md;
     font-weight: 600;
     background: none;
     color: s.$secondary-text;
@@ -93,7 +93,7 @@
     flex-shrink: 0;
     width: 170px;
     height: 46px;
-    font-size: 1rem;
+    font-size: s.$text-md;
     font-weight: 600;
   }
   .submit-btn.invalid {
@@ -136,12 +136,12 @@
     .submit-btn {
       width: 132px;
       height: 42px;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
     }
     .cancel-btn {
       height: 42px;
       padding: 0 0.9rem;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
     }
   }
 }

--- a/src/pages/AddRecipe/DraftResumeBanner.scss
+++ b/src/pages/AddRecipe/DraftResumeBanner.scss
@@ -31,13 +31,13 @@
     min-width: 0;
 
     .banner-title {
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       font-weight: 600;
       color: s.$primary-text;
     }
 
     .banner-sub {
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       color: s.$tertiary-text;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -74,7 +74,7 @@
     // AA-orange CTA on the `.btn` base — kept off the generic `.btn--primary`
     // (whose hover fails white-on-fill AA); these fills are AA-tuned.
     .resume-btn {
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       font-weight: 600;
       white-space: nowrap;
       padding: 0.4rem 0.9rem;
@@ -97,7 +97,7 @@
     }
 
     .view-all {
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       color: s.$tertiary-text;
       text-decoration: none;
       white-space: nowrap;
@@ -117,7 +117,7 @@
       cursor: pointer;
       color: s.$tertiary-text;
       padding: 0.25rem;
-      font-size: 1rem;
+      font-size: s.$text-md;
 
       &:hover {
         color: s.$primary-text;

--- a/src/pages/AddRecipe/DraftSaveStatus.scss
+++ b/src/pages/AddRecipe/DraftSaveStatus.scss
@@ -8,12 +8,12 @@
   // Reserve the line height even when idle/empty so showing or hiding the
   // status never nudges the form below it.
   min-height: 1.25rem;
-  font-size: 0.85rem;
+  font-size: s.$text-sm;
   font-weight: 500;
   color: s.$tertiary-text;
 
   svg {
-    font-size: 1rem;
+    font-size: s.$text-md;
     flex-shrink: 0;
   }
 

--- a/src/pages/AddRecipe/Ingredients/IngredientList/IngredientList.scss
+++ b/src/pages/AddRecipe/Ingredients/IngredientList/IngredientList.scss
@@ -71,7 +71,7 @@
       flex: 1;
       min-width: 0;
       text-align: start;
-      font-size: 1rem;
+      font-size: s.$text-md;
       font-weight: 500;
       padding-right: 0;
     }
@@ -89,7 +89,7 @@
       border: none;
       cursor: pointer;
       .text {
-        font-size: 0.95rem;
+        font-size: s.$text-base;
         font-weight: 700;
         color: s.$primary;
         white-space: nowrap;
@@ -107,7 +107,7 @@
       min-width: 56px;
       text-align: right;
       font-weight: 700;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       color: s.$secondary-text;
       &.na {
         color: s.$tertiary-text;

--- a/src/pages/AddRecipe/Ingredients/IngredientsContainer/IngredientsContainer.scss
+++ b/src/pages/AddRecipe/Ingredients/IngredientsContainer/IngredientsContainer.scss
@@ -36,7 +36,7 @@
     }
 
     .ingredients-subtotal {
-      font-size: 0.82rem;
+      font-size: s.$text-sm;
       font-weight: 600;
       color: s.$secondary-text;
       b {
@@ -47,7 +47,7 @@
 
     // Generic right-aligned meta (e.g. instruction step count).
     .footer-meta {
-      font-size: 0.82rem;
+      font-size: s.$text-sm;
       font-weight: 600;
       color: s.$secondary-text;
     }

--- a/src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem.scss
+++ b/src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem.scss
@@ -55,7 +55,7 @@
     background: s.$primary-text;
     color: s.$white;
     font-weight: 700;
-    font-size: 1rem;
+    font-size: s.$text-md;
     border-radius: s.$radius-circle;
   }
 
@@ -63,7 +63,7 @@
     flex: 1;
     min-width: 0;
     text-align: start;
-    font-size: 0.95rem;
+    font-size: s.$text-base;
     font-weight: 500;
     line-height: 1.55;
     padding-top: 4px;
@@ -82,7 +82,7 @@
     border: none;
     cursor: pointer;
     .text {
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       font-weight: 700;
       color: s.$primary;
       white-space: nowrap;

--- a/src/pages/AddRecipe/ListComponents/Item.scss
+++ b/src/pages/AddRecipe/ListComponents/Item.scss
@@ -1,3 +1,5 @@
+@use '../../../helpers.scss' as s;
+
 .item {
   position: relative;
   justify-content: center;
@@ -48,7 +50,7 @@
     background: none;
     padding-right: 2rem;
     .text {
-      font-size: 1rem;
+      font-size: s.$text-md;
       font-weight: 700;
       text-align: start;
       transition: all 0.1s linear;

--- a/src/pages/AddRecipe/RecipeFormTextArea.scss
+++ b/src/pages/AddRecipe/RecipeFormTextArea.scss
@@ -11,7 +11,7 @@
   .label-title {
     padding-bottom: 0.5rem;
     font-weight: 600;
-    font-size: 0.875rem;
+    font-size: s.$text-sm;
     text-transform: capitalize;
     color: s.$primary;
   }
@@ -29,7 +29,7 @@
       width: 100%;
       height: 10ch;
       padding: 1rem;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       font-weight: 500;
       resize: none;
     }

--- a/src/pages/AddRecipe/TimeInput/TimeInput.scss
+++ b/src/pages/AddRecipe/TimeInput/TimeInput.scss
@@ -4,7 +4,7 @@
   width: 100%;
   .label-title {
     font-weight: 600;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
     text-transform: capitalize;
     color: s.$secondary-text;
   }

--- a/src/pages/Admin/AdminLayout.scss
+++ b/src/pages/Admin/AdminLayout.scss
@@ -20,7 +20,7 @@
       align-items: center;
       gap: 0.5rem;
       font-weight: 700;
-      font-size: 1.15rem;
+      font-size: s.$text-lg;
 
       a {
         color: s.$white;
@@ -28,7 +28,7 @@
       }
 
       .admin-badge {
-        font-size: 0.65rem;
+        font-size: s.$text-caption;
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.05em;
@@ -49,7 +49,7 @@
         text-decoration: none;
         padding: 0.5rem 0.75rem;
         border-radius: s.$radius-sm;
-        font-size: 0.95rem;
+        font-size: s.$text-base;
         transition: background 0.15s, color 0.15s;
 
         &:hover {

--- a/src/pages/Admin/Analytics/Analytics.scss
+++ b/src/pages/Admin/Analytics/Analytics.scss
@@ -13,7 +13,7 @@
 
     h1 {
       margin: 0;
-      font-size: 1.6rem;
+      font-size: s.$text-2xl;
     }
   }
 
@@ -43,7 +43,7 @@
       color: s.$admin-slate-600;
       padding: 0.35rem 0.75rem;
       border-radius: s.$radius-pill;
-      font-size: 0.82rem;
+      font-size: s.$text-sm;
       cursor: pointer;
       transition: all 0.15s;
 
@@ -61,7 +61,7 @@
 
   .analytics-state {
     color: s.$admin-slate-500;
-    font-size: 0.95rem;
+    font-size: s.$text-base;
 
     &.error {
       color: s.$admin-danger-text;
@@ -70,7 +70,7 @@
 
   .section-eyebrow {
     margin: 0 0 0.6rem;
-    font-size: 0.72rem;
+    font-size: s.$text-caption;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -93,7 +93,7 @@
       padding: 1rem 1.1rem;
 
       .stat-value {
-        font-size: 1.9rem;
+        font-size: s.$text-3xl;
         font-weight: 700;
         color: s.$admin-slate-900;
         line-height: 1.1;
@@ -108,7 +108,7 @@
       }
 
       .stat-label {
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.03em;
@@ -117,7 +117,7 @@
 
       .stat-sub {
         margin-top: 0.3rem;
-        font-size: 0.78rem;
+        font-size: s.$text-fine;
         color: s.$admin-slate-400;
       }
     }
@@ -137,14 +137,14 @@
 
       h2 {
         margin: 0 0 0.75rem;
-        font-size: 0.92rem;
+        font-size: s.$text-base;
         font-weight: 600;
         color: s.$admin-slate-700;
       }
 
       .trend-note {
         margin: 0.6rem 0 0;
-        font-size: 0.72rem;
+        font-size: s.$text-caption;
         color: s.$admin-slate-400;
       }
     }
@@ -187,7 +187,7 @@
       display: flex;
       justify-content: space-between;
       margin-top: 0.4rem;
-      font-size: 0.72rem;
+      font-size: s.$text-caption;
       color: s.$admin-slate-400;
     }
   }
@@ -200,7 +200,7 @@
 
     h2 {
       margin: 0 0 0.5rem;
-      font-size: 0.92rem;
+      font-size: s.$text-base;
       font-weight: 600;
       color: s.$admin-slate-700;
     }
@@ -252,7 +252,7 @@
 
       .action-line {
         margin: 0;
-        font-size: 0.9rem;
+        font-size: s.$text-base;
         color: s.$admin-slate-700;
 
         .actor,
@@ -268,7 +268,7 @@
 
       .action-time {
         margin: 0.2rem 0 0;
-        font-size: 0.74rem;
+        font-size: s.$text-caption;
         color: s.$admin-slate-400;
       }
     }

--- a/src/pages/Admin/Audit/Audit.scss
+++ b/src/pages/Admin/Audit/Audit.scss
@@ -11,11 +11,11 @@
 
     h1 {
       margin: 0;
-      font-size: 1.6rem;
+      font-size: s.$text-2xl;
     }
 
     .total-count {
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       font-weight: 600;
       color: s.$admin-slate-600;
       background: s.$admin-slate-100;
@@ -37,7 +37,7 @@
       color: s.$admin-slate-700;
       padding: 0.4rem 0.7rem;
       border-radius: s.$radius-md;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       cursor: pointer;
     }
 
@@ -52,7 +52,7 @@
         color: s.$admin-slate-600;
         padding: 0.35rem 0.8rem;
         border-radius: s.$radius-pill;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         cursor: pointer;
         transition: all 0.15s;
 
@@ -71,7 +71,7 @@
 
   .audit-state {
     color: s.$admin-slate-500;
-    font-size: 0.95rem;
+    font-size: s.$text-base;
 
     &.error {
       color: s.$admin-danger-text;
@@ -121,7 +121,7 @@
 
     .audit-line {
       margin: 0;
-      font-size: 0.92rem;
+      font-size: s.$text-base;
       color: s.$admin-slate-700;
 
       .actor {
@@ -137,14 +137,14 @@
 
     .audit-reason {
       margin: 0.25rem 0 0;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       font-style: italic;
       color: s.$admin-slate-500;
     }
 
     .audit-time {
       margin: 0.25rem 0 0;
-      font-size: 0.76rem;
+      font-size: s.$text-fine;
       color: s.$admin-slate-400;
     }
   }
@@ -154,7 +154,7 @@
     align-items: center;
     gap: 1rem;
     margin-top: 1.5rem;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     color: s.$admin-slate-600;
 
     button {

--- a/src/pages/Admin/BugReports/BugReports.scss
+++ b/src/pages/Admin/BugReports/BugReports.scss
@@ -11,11 +11,11 @@
 
     h1 {
       margin: 0;
-      font-size: 1.6rem;
+      font-size: s.$text-2xl;
     }
 
     .open-count {
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       font-weight: 600;
       color: s.$admin-warn-text;
       background: s.$admin-warn-bg;
@@ -37,7 +37,7 @@
       color: s.$admin-slate-600;
       padding: 0.4rem 0.9rem;
       border-radius: s.$radius-pill;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       cursor: pointer;
       transition: all 0.15s;
 
@@ -59,14 +59,14 @@
       color: s.$admin-slate-700;
       padding: 0.4rem 0.7rem;
       border-radius: s.$radius-md;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       cursor: pointer;
     }
   }
 
   .bug-reports-state {
     color: s.$admin-slate-500;
-    font-size: 0.95rem;
+    font-size: s.$text-base;
 
     &.error {
       color: s.$admin-danger-text;
@@ -89,7 +89,7 @@
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       color: s.$admin-slate-700;
       cursor: pointer;
     }
@@ -102,7 +102,7 @@
         cursor: pointer;
         border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         font-weight: 600;
         border: 1px solid transparent;
         white-space: nowrap;
@@ -165,7 +165,7 @@
       flex-wrap: wrap;
 
       span {
-        font-size: 0.7rem;
+        font-size: s.$text-caption;
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.03em;
@@ -211,7 +211,7 @@
 
     .bug-report-description {
       margin: 0;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       color: s.$admin-slate-900;
       line-height: 1.5;
       white-space: pre-wrap;
@@ -225,7 +225,7 @@
       gap: 0.4rem;
 
       .ctx {
-        font-size: 0.78rem;
+        font-size: s.$text-fine;
         color: s.$admin-slate-600;
         background: s.$admin-slate-100;
         padding: 0.1rem 0.4rem;
@@ -239,7 +239,7 @@
 
     .bug-report-ua {
       margin: 0.4rem 0 0;
-      font-size: 0.72rem;
+      font-size: s.$text-caption;
       color: s.$admin-slate-400;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -248,7 +248,7 @@
 
     .bug-report-foot {
       margin: 0.6rem 0 0;
-      font-size: 0.78rem;
+      font-size: s.$text-fine;
       color: s.$admin-slate-400;
     }
 
@@ -262,7 +262,7 @@
         cursor: pointer;
         border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         font-weight: 600;
         border: 1px solid transparent;
         white-space: nowrap;
@@ -296,7 +296,7 @@
     margin-top: 1.5rem;
 
     .page-info {
-      font-size: 0.82rem;
+      font-size: s.$text-sm;
       color: s.$admin-slate-500;
     }
 
@@ -306,7 +306,7 @@
       gap: 0.75rem;
 
       .page-indicator {
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         color: s.$admin-slate-700;
       }
 
@@ -317,7 +317,7 @@
         color: s.$admin-slate-700;
         border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         font-weight: 600;
 
         &:hover:not(:disabled) {

--- a/src/pages/Admin/Reports/Reports.scss
+++ b/src/pages/Admin/Reports/Reports.scss
@@ -11,11 +11,11 @@
 
     h1 {
       margin: 0;
-      font-size: 1.6rem;
+      font-size: s.$text-2xl;
     }
 
     .open-count {
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       font-weight: 600;
       color: s.$admin-warn-text;
       background: s.$admin-warn-bg;
@@ -35,7 +35,7 @@
       color: s.$admin-slate-600;
       padding: 0.4rem 0.9rem;
       border-radius: s.$radius-pill;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       cursor: pointer;
       transition: all 0.15s;
 
@@ -53,7 +53,7 @@
 
   .reports-state {
     color: s.$admin-slate-500;
-    font-size: 0.95rem;
+    font-size: s.$text-base;
 
     &.error {
       color: s.$admin-danger-text;
@@ -76,7 +76,7 @@
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       color: s.$admin-slate-700;
       cursor: pointer;
     }
@@ -89,7 +89,7 @@
         cursor: pointer;
         border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         font-weight: 600;
         border: 1px solid transparent;
         white-space: nowrap;
@@ -155,7 +155,7 @@
       flex-wrap: wrap;
 
       span {
-        font-size: 0.7rem;
+        font-size: s.$text-caption;
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.03em;
@@ -236,7 +236,7 @@
       }
 
       .preview-meta {
-        font-size: 0.85rem;
+        font-size: s.$text-sm;
         color: s.$admin-slate-600;
         margin-bottom: 0.3rem;
 
@@ -249,14 +249,14 @@
         margin: 0;
         font-style: italic;
         color: s.$admin-slate-700;
-        font-size: 0.9rem;
+        font-size: s.$text-base;
       }
     }
 
     .hidden-pill {
       display: inline-block;
       margin-left: 0.4rem;
-      font-size: 0.65rem;
+      font-size: s.$text-caption;
       font-weight: 700;
       text-transform: uppercase;
       background: s.$admin-danger-bg;
@@ -268,18 +268,18 @@
     .preview-missing {
       color: s.$admin-slate-400;
       font-style: italic;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
     }
 
     .report-details {
       margin: 0.6rem 0 0;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       color: s.$admin-slate-700;
     }
 
     .report-foot {
       margin: 0.6rem 0 0;
-      font-size: 0.78rem;
+      font-size: s.$text-fine;
       color: s.$admin-slate-400;
     }
 
@@ -293,7 +293,7 @@
         cursor: pointer;
         border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         font-weight: 600;
         border: 1px solid transparent;
         white-space: nowrap;

--- a/src/pages/Admin/Users/Users.scss
+++ b/src/pages/Admin/Users/Users.scss
@@ -8,7 +8,7 @@
 
     h1 {
       margin: 0;
-      font-size: 1.6rem;
+      font-size: s.$text-2xl;
     }
   }
 
@@ -22,7 +22,7 @@
       border: 1px solid s.$admin-slate-300;
       border-radius: s.$radius-md;
       padding: 0.55rem 0.8rem;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
     }
 
     .clear-btn {
@@ -31,7 +31,7 @@
       color: s.$admin-slate-600;
       border-radius: s.$radius-md;
       padding: 0.55rem 1.1rem;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       font-weight: 600;
       cursor: pointer;
 
@@ -43,7 +43,7 @@
 
   .users-meta {
     margin: 0 0 0.75rem;
-    font-size: 0.82rem;
+    font-size: s.$text-sm;
     color: s.$admin-slate-400;
   }
 
@@ -60,7 +60,7 @@
       color: s.$admin-slate-700;
       border-radius: s.$radius-md;
       padding: 0.45rem 1rem;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       font-weight: 600;
       cursor: pointer;
 
@@ -75,14 +75,14 @@
     }
 
     .page-indicator {
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       color: s.$admin-slate-500;
     }
   }
 
   .users-state {
     color: s.$admin-slate-500;
-    font-size: 0.95rem;
+    font-size: s.$text-base;
 
     &.error {
       color: s.$admin-danger-text;
@@ -130,7 +130,7 @@
     }
 
     .status-pill {
-      font-size: 0.68rem;
+      font-size: s.$text-caption;
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.03em;
@@ -152,13 +152,13 @@
 
     .user-email {
       margin: 0 0 0.3rem;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       color: s.$admin-slate-600;
     }
 
     .user-counts {
       margin: 0;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       color: s.$admin-slate-500;
 
       .has-reports {
@@ -169,7 +169,7 @@
 
     .user-reason {
       margin: 0.4rem 0 0;
-      font-size: 0.82rem;
+      font-size: s.$text-sm;
       color: s.$admin-slate-700;
       font-style: italic;
     }
@@ -186,14 +186,14 @@
         border: 1px solid s.$admin-slate-300;
         border-radius: s.$radius-sm;
         padding: 0.35rem 0.5rem;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
       }
 
       .apply-btn {
         cursor: pointer;
         border-radius: s.$radius-sm;
         padding: 0.4rem 0.8rem;
-        font-size: 0.82rem;
+        font-size: s.$text-sm;
         font-weight: 600;
         border: 1px solid s.$admin-chrome;
         background: s.$admin-chrome;

--- a/src/pages/CreateUsername/CreateUsername.scss
+++ b/src/pages/CreateUsername/CreateUsername.scss
@@ -15,7 +15,7 @@
     cursor: pointer;
     text-decoration: underline;
     font-weight: 500;
-    font-size: 0.875rem;
+    font-size: s.$text-sm;
     color: s.$secondary-text;
     width: fit-content;
     align-self: center;
@@ -28,7 +28,7 @@
     gap: 0.6rem;
     margin: 0.15rem 0;
     color: s.$tertiary-text;
-    font-size: 0.72rem;
+    font-size: s.$text-caption;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -47,7 +47,7 @@
     box-sizing: border-box;
     padding: 0.65rem 0.85rem;
     font-family: inherit;
-    font-size: 0.95rem;
+    font-size: s.$text-base;
     font-weight: 500;
     color: s.$primary-text;
     border: 1.5px solid s.$gray-300;

--- a/src/pages/Help/Help.scss
+++ b/src/pages/Help/Help.scss
@@ -35,7 +35,7 @@
   // so they're outside `.form` and styled here rather than inheriting the
   // FormStyles `.form .title` / `.prompt` rules.
   .title {
-    font-size: 1.55rem;
+    font-size: s.$text-2xl;
     font-weight: 800;
     color: s.$primary-text;
     margin-bottom: 0.4rem;
@@ -44,7 +44,7 @@
     margin: 0 auto 1.5rem;
     max-width: 34ch;
     font-weight: 500;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
     line-height: 1.5;
     color: s.$secondary-text;
   }
@@ -68,14 +68,14 @@
       background: s.$white;
       color: s.$secondary-text;
       font-weight: 600;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       cursor: pointer;
       transition: border-color 0.15s ease, color 0.15s ease,
         background 0.15s ease, box-shadow 0.15s ease;
 
       .chip-icon {
         display: flex;
-        font-size: 1.45rem;
+        font-size: s.$text-2xl;
         color: s.$tertiary-text;
         transition: color 0.15s ease;
       }
@@ -115,7 +115,7 @@
         box-sizing: border-box;
         padding: 0.7rem 0.85rem;
         font-family: inherit;
-        font-size: 0.95rem;
+        font-size: s.$text-base;
         font-weight: 500;
         line-height: 1.5;
         color: s.$primary-text;
@@ -147,7 +147,7 @@
       background: transparent;
       color: s.$secondary;
       font-weight: 600;
-      font-size: 0.82rem;
+      font-size: s.$text-sm;
       cursor: pointer;
       &:hover {
         text-decoration: underline;
@@ -158,7 +158,7 @@
   // "Prefer email?" fallback for people who'd rather not use the form.
   .email-fallback {
     margin-top: 1.5rem;
-    font-size: 0.82rem;
+    font-size: s.$text-sm;
     color: s.$tertiary-text;
     // The address is one unbreakable token — let it wrap rather than force the
     // card wider than a narrow viewport.

--- a/src/pages/Home/Home.scss
+++ b/src/pages/Home/Home.scss
@@ -40,13 +40,13 @@
     align-items: end;
     column-gap: 1rem;
     margin-bottom: 1.35rem;
-    h2 { grid-area: title; font-size: 1.7rem; font-weight: 700; letter-spacing: -0.015em; }
-    p { grid-area: desc; color: s.$tertiary-text; font-size: 0.95rem; margin-top: 0.2rem; }
+    h2 { grid-area: title; font-size: s.$text-3xl; font-weight: 700; letter-spacing: -0.015em; }
+    p { grid-area: desc; color: s.$tertiary-text; font-size: s.$text-base; margin-top: 0.2rem; }
     .see-all {
       grid-area: see;
       align-self: end;
       display: inline-flex; align-items: center; gap: 0.2rem;
-      text-decoration: none; color: s.$primary-accessible; font-weight: 700; font-size: 0.95rem;
+      text-decoration: none; color: s.$primary-accessible; font-weight: 700; font-size: s.$text-base;
       white-space: nowrap;
       &:hover { text-decoration: underline; }
     }
@@ -94,18 +94,18 @@
       .price-chip {
         position: absolute; bottom: 0.6rem; right: 0.6rem;
         background: rgba(255, 255, 255, 0.95); color: s.$primary;
-        font-weight: 800; font-size: 0.78rem; padding: 0.28rem 0.6rem;
+        font-weight: 800; font-size: s.$text-fine; padding: 0.28rem 0.6rem;
         border-radius: s.$radius-pill; box-shadow: s.$shadow-chip;
       }
     }
     .body { padding: 0.85rem 1rem 1rem; }
     h3 {
-      font-size: 1.02rem; font-weight: 600; line-height: 1.3;
+      font-size: s.$text-md; font-weight: 600; line-height: 1.3;
       text-transform: capitalize; margin-bottom: 0.55rem; min-height: 2.6em;
     }
     .meta {
       display: flex; align-items: center; gap: 0.85rem;
-      font-size: 0.82rem; color: s.$secondary-text; font-weight: 600; flex-wrap: wrap;
+      font-size: s.$text-sm; color: s.$secondary-text; font-weight: 600; flex-wrap: wrap;
       svg { vertical-align: -2px; margin-right: 0.15rem; }
       .cuisine { margin-left: auto; color: s.$tertiary-text; }
     }
@@ -134,8 +134,8 @@
       margin-bottom: 0.9rem;
       padding-bottom: 0.6rem;
       border-bottom: 2px solid s.$primary;
-      h3 { font-size: 1.1rem; font-weight: 700; }
-      .meal-see-all { font-size: 0.82rem; font-weight: 700; color: s.$primary-accessible; text-decoration: none; &:hover { text-decoration: underline; } }
+      h3 { font-size: s.$text-lg; font-weight: 700; }
+      .meal-see-all { font-size: s.$text-sm; font-weight: 700; color: s.$primary-accessible; text-decoration: none; &:hover { text-decoration: underline; } }
     }
     ul { list-style: none; }
     li + li { margin-top: 0.5rem; }
@@ -156,11 +156,11 @@
     // skeleton (which reserves exactly two title lines) — keeps the swap
     // shift-free.
     .title {
-      font-weight: 600; font-size: 0.92rem; text-transform: capitalize; line-height: 1.25;
+      font-weight: 600; font-size: s.$text-base; text-transform: capitalize; line-height: 1.25;
       display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
     }
     .sub {
-      font-size: 0.74rem; color: s.$tertiary-text; font-weight: 600;
+      font-size: s.$text-caption; color: s.$tertiary-text; font-weight: 600;
       svg { vertical-align: -2px; }
     }
     .skeleton-row {
@@ -183,7 +183,7 @@
       }
     }
     .empty-row {
-      padding: 0.6rem 0.4rem; color: s.$tertiary-text; font-size: 0.85rem; font-weight: 600;
+      padding: 0.6rem 0.4rem; color: s.$tertiary-text; font-size: s.$text-sm; font-weight: 600;
     }
 
     // Mid-range (3 narrow columns): tighten padding and shrink rows so recipe
@@ -191,10 +191,10 @@
     // rules above — same specificity, so source order decides.
     @include s.between(851px, s.$bp-4xl) {
       padding: 0.85rem;
-      .meal-col-head h3 { font-size: 1rem; }
+      .meal-col-head h3 { font-size: s.$text-md; }
       a { gap: 0.6rem; padding: 0.3rem; img { width: 44px; height: 44px; } }
-      .title { font-size: 0.85rem; }
-      .sub { font-size: 0.7rem; }
+      .title { font-size: s.$text-sm; }
+      .sub { font-size: s.$text-caption; }
       // Match the skeleton thumb + padding to the shrunken real rows above.
       .skeleton-row {
         gap: 0.6rem; padding: 0.3rem;
@@ -219,10 +219,10 @@
     padding: 0.95rem 2rem;
     border-radius: s.$radius-pill;
     font-weight: 700;
-    font-size: 1rem;
+    font-size: s.$text-md;
     text-decoration: none;
     transition: background 0.12s ease, transform 0.12s ease;
-    svg { font-size: 1.3rem; }
+    svg { font-size: s.$text-xl; }
     &:hover { background: s.$primary-hover; transform: translateY(-2px); }
   }
 }

--- a/src/pages/Home/HomeCookSuggestion.scss
+++ b/src/pages/Home/HomeCookSuggestion.scss
@@ -23,7 +23,7 @@
     height: 30px;
     background: rgba(255, 255, 255, 0.92);
     color: s.$primary-text;
-    font-size: 1.1rem;
+    font-size: s.$text-lg;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     &:hover { background: #fff; }
   }
@@ -51,7 +51,7 @@
       background: rgba(255, 255, 255, 0.95);
       color: s.$primary;
       font-weight: 800;
-      font-size: 0.78rem;
+      font-size: s.$text-fine;
       padding: 0.28rem 0.6rem;
       border-radius: s.$radius-pill;
       box-shadow: s.$shadow-chip;
@@ -75,7 +75,7 @@
 
   .body { padding: 0.9rem 1rem 1rem; }
   h3 {
-    font-size: 1.1rem;
+    font-size: s.$text-lg;
     font-weight: 600;
     line-height: 1.3;
     text-transform: capitalize;
@@ -95,7 +95,7 @@
     align-items: center;
     gap: 0.7rem;
     color: #6b7480;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     margin-bottom: 0.95rem;
     overflow: hidden;
     span { display: inline-flex; align-items: center; gap: 0.25rem; white-space: nowrap; }
@@ -109,11 +109,11 @@
   .primary,
   .ghost {
     flex: 1;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
     padding: 0.6rem 1rem;
     text-decoration: none;
     transition: filter 0.12s ease, background 0.12s ease;
-    svg { font-size: 1.1rem; }
+    svg { font-size: s.$text-lg; }
   }
   .primary { background: s.$primary-accessible; color: #fff; &:hover { filter: brightness(1.06); } }
   .ghost {

--- a/src/pages/Home/HomeHero/HomeHero.scss
+++ b/src/pages/Home/HomeHero/HomeHero.scss
@@ -41,7 +41,7 @@
     text-align: center;
     margin-top: calc(#{s.$nav-height} / 4);
     margin-bottom: 2.5rem;
-    font-size: 1.55rem;
+    font-size: s.$text-2xl;
     font-weight: 500;
   }
 }
@@ -62,11 +62,11 @@
     padding: 0.7rem 1.4rem;
     background: s.$primary-accessible;
     color: s.$white;
-    font-size: 1rem;
+    font-size: s.$text-md;
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
 
     svg {
-      font-size: 1.25rem;
+      font-size: s.$text-xl;
     }
     &:hover {
       transform: translateY(-1px);

--- a/src/pages/Login/Login.scss
+++ b/src/pages/Login/Login.scss
@@ -16,7 +16,7 @@
 //     .signup-prompt {
 //       padding-bottom: 2rem;
 //       font-weight: 500;
-//       font-size: 1rem;
+//       font-size: s.$text-md;
 //       color: $secondary-text;
 //       .signup-btn {
 //         color: $secondary;
@@ -32,7 +32,7 @@
 //       .forgot-password-prompt {
 //         text-decoration: none;
 //         font-weight: 500;
-//         font-size: 0.875rem;
+//         font-size: s.$text-sm;
 //         color: $secondary-text;
 //         width: fit-content;
 //       }
@@ -58,7 +58,7 @@
 //     align-items: center;
 //     justify-content: center;
 //     gap: 0.5rem;
-//     font-size: 1.125rem;
+//     font-size: s.$text-lg;
 //     .icon {
 //       height: 40px;
 //       width: 40px;

--- a/src/pages/PublicProfile/PublicProfile.scss
+++ b/src/pages/PublicProfile/PublicProfile.scss
@@ -22,7 +22,7 @@
 
   .pp-notfound {
     h1 {
-      font-size: 1.8rem;
+      font-size: s.$text-3xl;
       font-weight: 800;
       margin-bottom: 0.5rem;
     }
@@ -70,7 +70,7 @@
     margin-top: 0.8rem;
   }
   .pp-handle {
-    font-size: 1.4rem;
+    font-size: s.$text-2xl;
     font-weight: 800;
     letter-spacing: -0.01em;
   }
@@ -82,7 +82,7 @@
     height: 30px;
     color: s.$tertiary-text;
     svg {
-      font-size: 0.95rem;
+      font-size: s.$text-base;
     }
     // :not(:disabled) to outrank `.btn--ghost:hover:not(:disabled)` (0,3,0) so
     // the brand-orange hover survives the ghost variant.
@@ -108,11 +108,11 @@
       flex-direction: column;
     }
     b {
-      font-size: 1.25rem;
+      font-size: s.$text-xl;
       font-weight: 800;
     }
     span {
-      font-size: 0.8rem;
+      font-size: s.$text-fine;
       color: s.$tertiary-text;
     }
     .pp-div {
@@ -135,7 +135,7 @@
     align-items: center;
     gap: 0.4rem;
     color: s.$tertiary-text;
-    font-size: 0.86rem;
+    font-size: s.$text-sm;
     font-weight: 600;
     margin-top: 0.5rem;
     svg {
@@ -145,7 +145,7 @@
       color: s.$gray-400;
     }
     .pp-lvl {
-      font-size: 0.76rem;
+      font-size: s.$text-fine;
       font-weight: 800;
       color: s.$primary-accessible;
       // Solid (not a translucent brand tint): the tint composited against the
@@ -169,7 +169,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
-    font-size: 0.78rem;
+    font-size: s.$text-fine;
     font-weight: 700;
     color: s.$secondary-text;
     background: #fdf3ec;
@@ -178,7 +178,7 @@
     padding: 0.32rem 0.7rem;
     svg {
       color: s.$primary;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
     }
   }
 
@@ -234,7 +234,7 @@
         justify-content: center;
         background: #fdf3ec;
         color: s.$primary;
-        font-size: 1.6rem;
+        font-size: s.$text-2xl;
       }
     }
     &:hover .pp-tile-media img {
@@ -252,10 +252,10 @@
       background: rgba(0, 0, 0, 0.55);
       backdrop-filter: blur(2px);
       color: #fff;
-      font-size: 0.72rem;
+      font-size: s.$text-caption;
       font-weight: 700;
       svg {
-        font-size: 0.8rem;
+        font-size: s.$text-fine;
       }
     }
 
@@ -266,7 +266,7 @@
       padding: 0.7rem 0.75rem 0.8rem;
     }
     .pp-tile-title {
-      font-size: 0.92rem;
+      font-size: s.$text-base;
       font-weight: 700;
       line-height: 1.3;
       text-transform: capitalize;
@@ -285,7 +285,7 @@
       justify-content: space-between;
       gap: 0.35rem 0.75rem;
       margin-top: auto;
-      font-size: 0.78rem;
+      font-size: s.$text-fine;
       font-weight: 700;
       color: s.$secondary-text;
     }
@@ -295,7 +295,7 @@
       gap: 0.28rem;
       svg {
         color: s.$secondary;
-        font-size: 0.85rem;
+        font-size: s.$text-sm;
       }
     }
     .pp-tile-cost {
@@ -311,7 +311,7 @@
     margin-top: 1.5rem;
 
     .pp-more-count {
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       font-weight: 600;
       color: s.$tertiary-text;
     }

--- a/src/pages/Recipes/Recipes.scss
+++ b/src/pages/Recipes/Recipes.scss
@@ -9,14 +9,14 @@
   .recipes-header {
     margin-bottom: 1.4rem;
     h1 {
-      font-size: 1.9rem;
+      font-size: s.$text-3xl;
       font-weight: 800;
       letter-spacing: -0.015em;
     }
     p {
       color: s.$tertiary-text;
       margin-top: 0.2rem;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
     }
   }
 
@@ -43,7 +43,7 @@
         border: 1px solid s.$gray-400;
         border-radius: s.$radius-pill;
         background: s.$white;
-        font-size: 0.95rem;
+        font-size: s.$text-base;
         padding: 0.1rem 6.5rem 0.1rem 2.85rem;
         transition: border-color 0.14s ease, box-shadow 0.14s ease;
         &::placeholder {
@@ -59,7 +59,7 @@
         transform: translateY(-50%);
         right: 6px;
         height: 36px;
-        font-size: 0.9rem;
+        font-size: s.$text-base;
         padding: 0 1.15rem;
         border-radius: s.$radius-pill;
       }
@@ -94,7 +94,7 @@
     color: s.$primary-text;
     font-family: inherit;
     font-weight: 700;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     padding: 0 1.1rem;
     box-sizing: border-box;
     min-height: 44px; // compact, matches the search pill (G06 sizing)
@@ -103,7 +103,7 @@
     white-space: nowrap;
     flex-shrink: 0;
     svg {
-      font-size: 1rem;
+      font-size: s.$text-md;
     }
     &:hover {
       background: s.$primary-text;
@@ -118,7 +118,7 @@
       background: s.$primary;
       color: s.$white;
       border-radius: s.$radius-pill;
-      font-size: 0.72rem;
+      font-size: s.$text-caption;
     }
   }
 
@@ -135,7 +135,7 @@
       padding: 0 1rem;
       font-family: inherit;
       font-weight: 700;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       color: s.$primary-text;
       background: s.$white;
       border: 1px solid s.$gray-400;
@@ -143,7 +143,7 @@
       cursor: pointer;
       white-space: nowrap;
       .chev {
-        font-size: 1rem;
+        font-size: s.$text-md;
         transition: transform 0.14s ease;
       }
       &:hover {
@@ -173,7 +173,7 @@
         border: none;
         background: none;
         font-family: inherit;
-        font-size: 0.88rem;
+        font-size: s.$text-sm;
         font-weight: 600;
         color: s.$primary-text;
         padding: 0.45rem 0.6rem;
@@ -202,7 +202,7 @@
       background: rgba(255, 87, 34, 0.1);
       color: s.$primary;
       font-weight: 700;
-      font-size: 0.78rem;
+      font-size: s.$text-fine;
       padding: 0.35rem 0.75rem;
       border-radius: s.$radius-pill;
       cursor: pointer;
@@ -213,7 +213,7 @@
       background: none;
       color: s.$secondary-text;
       font-weight: 700;
-      font-size: 0.8rem;
+      font-size: s.$text-fine;
       text-decoration: underline;
       cursor: pointer;
     }
@@ -243,13 +243,13 @@
       border-radius: s.$radius-pill;
       font-family: inherit;
       font-weight: 700;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       padding: 0.85rem 2.2rem;
       cursor: pointer;
       transition: color 0.16s ease, border-color 0.16s ease,
         transform 0.16s ease, box-shadow 0.16s ease;
       svg {
-        font-size: 1.2rem;
+        font-size: s.$text-xl;
         transition: transform 0.16s ease;
       }
       &:hover:not(:disabled) {
@@ -296,12 +296,12 @@
     &__title {
       margin: 0 0 0.5rem;
       color: s.$primary-text;
-      font-size: 1.4rem;
+      font-size: s.$text-2xl;
       font-weight: 700;
     }
     &__msg {
       margin: 0 0 1.75rem;
-      font-size: 1rem;
+      font-size: s.$text-md;
       line-height: 1.5;
       color: s.$secondary-text;
       strong {
@@ -319,7 +319,7 @@
       border: none;
       cursor: pointer;
       font-weight: 700;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       padding: 0.7rem 1.6rem;
       border-radius: s.$radius-pill;
       transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
@@ -378,13 +378,13 @@
       padding: 1.25rem 1.5rem;
       border-bottom: 1px solid s.$gray-200;
       h2 {
-        font-size: 1.3rem;
+        font-size: s.$text-xl;
         font-weight: 800;
       }
       button {
         border: none;
         background: none;
-        font-size: 1.1rem;
+        font-size: s.$text-lg;
         cursor: pointer;
         color: s.$secondary-text;
       }
@@ -397,7 +397,7 @@
         margin-top: 1.5rem;
       }
       h3 {
-        font-size: 0.78rem;
+        font-size: s.$text-fine;
         text-transform: uppercase;
         letter-spacing: 0.05em;
         color: s.$tertiary-text;
@@ -444,7 +444,7 @@
     border: 1px solid s.$gray-400;
     background: s.$white;
     color: s.$secondary-text;
-    font-size: 0.82rem;
+    font-size: s.$text-sm;
     font-weight: 600;
     cursor: pointer;
     white-space: nowrap;

--- a/src/pages/Settings/Settings.scss
+++ b/src/pages/Settings/Settings.scss
@@ -8,7 +8,7 @@
   padding-bottom: 2rem;
 
   .settings-title {
-    font-size: 1.7rem;
+    font-size: s.$text-3xl;
     font-weight: 800;
     letter-spacing: -0.02em;
     color: s.$primary-text;
@@ -40,7 +40,7 @@
     border: none;
     background: transparent;
     font-family: inherit;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
     font-weight: 600;
     color: s.$secondary-text;
     text-decoration: none;
@@ -96,7 +96,7 @@
     align-self: flex-start;
     color: #057780;
     font-weight: 700;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
     text-decoration: none;
     margin-bottom: 1rem;
 
@@ -120,13 +120,13 @@
     .settings-panehead {
       margin-bottom: 1.5rem;
       h2 {
-        font-size: 1.25rem;
+        font-size: s.$text-xl;
         font-weight: 800;
         color: s.$primary-text;
         margin: 0 0 0.25rem;
       }
       p {
-        font-size: 0.85rem;
+        font-size: s.$text-sm;
         color: s.$tertiary-text;
         margin: 0;
       }
@@ -184,14 +184,14 @@
           color: s.$secondary-text;
         }
         .settings-navlabel {
-          font-size: 0.95rem;
+          font-size: s.$text-base;
           font-weight: 700;
           color: s.$primary-text;
           white-space: normal;
         }
         .settings-navblurb {
           display: block;
-          font-size: 0.78rem;
+          font-size: s.$text-fine;
           font-weight: 500;
           color: s.$tertiary-text;
           margin-top: 0.1rem;

--- a/src/pages/Settings/components/controls.scss
+++ b/src/pages/Settings/components/controls.scss
@@ -49,12 +49,12 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    font-size: 0.82rem;
+    font-size: s.$text-sm;
     font-weight: 700;
     color: s.$primary-text;
 
     .sr-counter {
-      font-size: 0.72rem;
+      font-size: s.$text-caption;
       font-weight: 600;
       color: s.$tertiary-text;
     }
@@ -67,7 +67,7 @@
     background: s.$white;
     border: 1px solid #e2dccf;
     border-radius: 11px;
-    font-size: 0.95rem;
+    font-size: s.$text-base;
     font-family: inherit;
     color: s.$primary-text;
     padding: 0.6rem 0.75rem;
@@ -96,7 +96,7 @@
     &.has-prefix .sr-input-prefix {
       position: absolute;
       left: 0.75rem;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       font-weight: 600;
       color: s.$tertiary-text;
       pointer-events: none;
@@ -107,7 +107,7 @@
   }
 
   .sr-field-hint {
-    font-size: 0.76rem;
+    font-size: s.$text-fine;
     color: s.$tertiary-text;
 
     &.is-success {
@@ -116,7 +116,7 @@
     }
   }
   .sr-field-error {
-    font-size: 0.76rem;
+    font-size: s.$text-fine;
     font-weight: 600;
     color: s.$error-red;
   }
@@ -188,12 +188,12 @@
     gap: 0.15rem;
 
     .sr-row-label {
-      font-size: 0.92rem;
+      font-size: s.$text-base;
       font-weight: 600;
       color: s.$primary-text;
     }
     .sr-row-desc {
-      font-size: 0.8rem;
+      font-size: s.$text-fine;
       color: s.$tertiary-text;
       line-height: 1.45;
     }
@@ -211,7 +211,7 @@
    sizing (and the outline's deliberate teal hover + warm border) stays local. */
 .sr-btn-primary {
   // Compact size parity (base `.btn` is 0.95rem / .6rem 1.3rem).
-  font-size: 0.88rem;
+  font-size: s.$text-sm;
   padding: 0.6rem 1.2rem;
 }
 
@@ -219,7 +219,7 @@
   // Warm border + teal hover are deliberate, not the `.btn--outline` defaults.
   // `:not(:disabled)` matches the variant hover's specificity so the teal wins.
   border-color: #d9d2c6;
-  font-size: 0.85rem;
+  font-size: s.$text-sm;
   padding: 0.45rem 0.95rem;
   &:hover:not(:disabled) {
     border-color: s.$secondary;
@@ -228,18 +228,18 @@
 }
 
 .sr-btn-text {
-  font-size: 0.85rem;
+  font-size: s.$text-sm;
   padding: 0.45rem 0.5rem;
 }
 
 .sr-btn-danger {
   // Colour + hover come from `.btn--danger`; only the compact size is local.
-  font-size: 0.85rem;
+  font-size: s.$text-sm;
   padding: 0.5rem 1rem;
 }
 
 .sr-hint {
-  font-size: 0.74rem;
+  font-size: s.$text-caption;
   color: s.$tertiary-text;
 }
 
@@ -277,7 +277,7 @@
 
   .sr-savebar-msg {
     color: s.$white;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     font-weight: 600;
   }
   .sr-savebar-actions {
@@ -311,7 +311,7 @@
     z-index: 50;
 
     .sr-savebar-msg {
-      font-size: 0.78rem;
+      font-size: s.$text-fine;
       line-height: 1.2;
     }
   }

--- a/src/pages/Settings/sections/sections.scss
+++ b/src/pages/Settings/sections/sections.scss
@@ -26,7 +26,7 @@
 
     .sr-subhead {
       margin: 0;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       font-weight: 700;
       color: s.$primary-text;
     }
@@ -50,7 +50,7 @@
       align-items: center;
       gap: 0.3rem;
       margin-top: 1.7rem;
-      font-size: 0.8rem;
+      font-size: s.$text-fine;
       font-weight: 600;
       white-space: nowrap;
 
@@ -77,7 +77,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
-    font-size: 0.82rem;
+    font-size: s.$text-sm;
     font-weight: 600;
     color: s.$secondary-text;
 
@@ -123,7 +123,7 @@
     color: s.$error-red;
   }
   .sr-row-desc {
-    font-size: 0.8rem;
+    font-size: s.$text-fine;
     color: s.$secondary-text;
     line-height: 1.45;
     max-width: 46ch;
@@ -171,7 +171,7 @@
 
     h3 {
       margin: 0;
-      font-size: 1.15rem;
+      font-size: s.$text-lg;
       font-weight: 800;
       color: s.$primary-text;
     }
@@ -190,7 +190,7 @@
 
   .sr-modal-body {
     margin: 0;
-    font-size: 0.88rem;
+    font-size: s.$text-sm;
     line-height: 1.5;
     color: s.$secondary-text;
   }

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/RatingsAndReviews.scss
@@ -33,7 +33,7 @@
       }
 
       .text {
-        font-size: 1rem;
+        font-size: s.$text-md;
         color: s.$secondary-text;
         font-weight: 500;
       }
@@ -46,11 +46,11 @@
           width: 30px;
         }
         .number {
-          font-size: 1.875rem;
+          font-size: s.$text-3xl;
           font-weight: 600;
         }
         .count {
-          font-size: 1rem;
+          font-size: s.$text-md;
           font-weight: 500;
           color: s.$secondary-text;
         }
@@ -72,7 +72,7 @@
       .user-rate-container {
         height: 30px !important;
         .text {
-          font-size: 1.125rem;
+          font-size: s.$text-lg;
           font-weight: 600;
           color: s.$primary-text;
           &:focus-visible {
@@ -84,7 +84,7 @@
         .remove-rating {
           padding: 0;
           margin-left: 0.5rem;
-          font-size: 0.8125rem;
+          font-size: s.$text-fine;
           text-decoration: underline;
         }
       }
@@ -114,7 +114,7 @@
         margin: 0 auto;
         margin-bottom: 4rem;
         text-align: center;
-        font-size: 1.125rem;
+        font-size: s.$text-lg;
         font-weight: 600;
       }
 
@@ -126,7 +126,7 @@
         // (replaces the old centered orange heading in an orange box).
         .heading {
           text-align: left;
-          font-size: 0.78rem;
+          font-size: s.$text-fine;
           font-weight: 700;
           letter-spacing: 0.06em;
           text-transform: uppercase;
@@ -161,7 +161,7 @@
           text-decoration: underline;
           background: none;
           cursor: pointer;
-          font-size: 0.9rem;
+          font-size: s.$text-base;
           font-weight: 500;
           color: s.$secondary-text;
         }
@@ -179,7 +179,7 @@
           textarea.review-text-area {
             width: 100%;
             height: 10ch;
-            font-size: 1rem;
+            font-size: s.$text-md;
             padding: 0.5rem;
             box-sizing: border-box;
             resize: none;
@@ -188,7 +188,7 @@
             margin-left: auto;
           }
           .review-input-title {
-            font-size: 1.125rem;
+            font-size: s.$text-lg;
             font-weight: 500;
           }
         }
@@ -205,7 +205,7 @@
         width: 100%;
 
         .get-more-reviews-btn {
-          font-size: 1.125rem;
+          font-size: s.$text-lg;
           padding-top: 2rem;
           margin: 0 auto;
           text-align: center;

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
@@ -23,7 +23,7 @@
     .date {
       flex: 1;
       text-align: right;
-      font-size: 0.8rem;
+      font-size: s.$text-fine;
       font-weight: 500;
       color: s.$tertiary-text;
     }
@@ -37,7 +37,7 @@
         max-width: 300px;
         column-gap: 0.35rem;
         .name {
-          font-size: 0.875rem;
+          font-size: s.$text-sm;
         }
       }
       .rating {
@@ -50,7 +50,7 @@
         position: absolute;
         color: s.$tertiary-text;
         right: 0;
-        font-size: 0.75rem;
+        font-size: s.$text-caption;
       }
     }
     @include s.below(s.$bp-xs) {
@@ -61,7 +61,7 @@
   }
   .body {
     .text {
-      font-size: 1rem;
+      font-size: s.$text-md;
       font-weight: 500;
       color: s.$primary-text;
       line-height: 1.5;
@@ -99,7 +99,7 @@
         // (edit-review) grey-on-orange. The resting colour also outranks the
         // ghost variant's own hover, so each hover is restated locally.
         button.btn--ghost {
-          font-size: 0.875rem;
+          font-size: s.$text-sm;
           font-weight: 600;
           text-decoration: underline;
           color: s.$tertiary-text;
@@ -128,7 +128,7 @@
 
 .delete-modal {
   .heading {
-    font-size: 1.25rem;
+    font-size: s.$text-xl;
     font-weight: 600;
     margin-bottom: 0.5rem;
   }
@@ -144,7 +144,7 @@
     // cancel = `.btn .btn--outline`, delete = `.btn .btn--danger-solid`; only the
     // larger modal-button font/padding (and the loader's positioning) are local.
     button {
-      font-size: 1.125rem;
+      font-size: s.$text-lg;
       padding: 0.75rem 1.25rem;
     }
     button.delete {

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
@@ -20,7 +20,7 @@
     display: flex;
     align-items: center;
     gap: 0.6rem;
-    font-size: 0.92rem;
+    font-size: s.$text-base;
     font-weight: 700;
     color: s.$secondary-text;
     .icon {
@@ -49,7 +49,7 @@
       display: inline-flex;
       align-items: center;
       gap: 0.4rem;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       font-weight: 600;
       color: s.$secondary-text;
       .icon { height: 17px; width: 17px; color: s.$secondary; }
@@ -62,7 +62,7 @@
   button {
     border: 1.5px solid s.$gray-300;
     padding: 0.5rem 0.95rem;
-    font-size: 0.9rem;
+    font-size: s.$text-base;
     font-weight: 700;
     color: s.$primary-text;
     background: s.$white;
@@ -104,7 +104,7 @@
     padding: 1rem 1.1rem;
     .who {
       flex-basis: 100%;
-      font-size: 0.88rem;
+      font-size: s.$text-sm;
     }
     .btns-container {
       width: 100%;
@@ -126,7 +126,7 @@
         flex: 1;
         min-width: 0;
         justify-content: center;
-        font-size: 0.8rem;
+        font-size: s.$text-fine;
         white-space: nowrap;
         .icon { height: 15px; width: 15px; }
         & + .stat { border-left: 1px solid rgba(s.$primary, 0.15); }
@@ -152,7 +152,7 @@
     align-items: center;
     h4 {
       font-weight: 700;
-      font-size: 1.2rem;
+      font-size: s.$text-xl;
       padding-bottom: 1rem;
     }
     p {
@@ -173,7 +173,7 @@
       .btn {
         width: 180px;
         height: 45px;
-        font-size: 1rem;
+        font-size: s.$text-md;
       }
     }
   }

--- a/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
+++ b/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
@@ -38,7 +38,7 @@
   }
 
   h1 {
-    font-size: 1.85rem;
+    font-size: s.$text-3xl;
     font-weight: 700;
     letter-spacing: -0.02em;
     margin: 0 0 0.6rem;
@@ -61,7 +61,7 @@
       justify-content: center;
       gap: 0.4rem;
       margin-bottom: 0.6rem;
-      font-size: 0.75rem;
+      font-size: s.$text-caption;
       font-weight: 700;
       letter-spacing: 0.06em;
       text-transform: uppercase;
@@ -81,7 +81,7 @@
       background: s.$primary;
       color: s.$white;
       font-weight: 700;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       text-decoration: none;
       transition: background 0.12s ease;
       &:hover { background: s.$primary-hover; }
@@ -91,7 +91,7 @@
 
   .rnf-help {
     margin: 1.6rem 0 0;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     color: s.$tertiary-text;
     .contact-link {
       color: s.$secondary;

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -30,10 +30,10 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       align-items: center;
       gap: 0.3rem;
       font-weight: 700;
-      font-size: 0.9rem;
+      font-size: s.$text-base;
       color: s.$secondary-text;
       text-decoration: none;
-      svg { font-size: 1.2rem; }
+      svg { font-size: s.$text-xl; }
       &:hover { color: s.$primary; }
       &:focus-visible { @include s.outline(); }
     }
@@ -85,7 +85,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
     gap: 1.35rem;
     padding: 0.5rem 0;
     h1 {
-      font-size: 2.3rem;
+      font-size: s.$text-4xl;
       font-weight: 700;
       letter-spacing: -0.02em;
       line-height: 1.18;
@@ -96,13 +96,13 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       .title-skeleton { display: block; }
     }
     .eyebrow {
-      font-size: 0.75rem;
+      font-size: s.$text-caption;
       font-weight: 700;
       letter-spacing: 0.15em;
       text-transform: uppercase;
       color: s.$secondary-accessible;
     }
-    .description { color: s.$secondary-text; line-height: 1.7; font-size: 1rem; }
+    .description { color: s.$secondary-text; line-height: 1.7; font-size: s.$text-md; }
     // Compact rating echo by the title (see SingleRecipe.tsx). Pulled snug under
     // the heading rather than treated as its own stacked block.
     .hero-rating {
@@ -110,9 +110,9 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       align-items: center;
       gap: 0.3rem;
       margin-top: -0.6rem;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       color: s.$primary-text;
-      .hr-star { color: #f5a623; font-size: 1rem; }
+      .hr-star { color: #f5a623; font-size: s.$text-md; }
       .hr-val { font-weight: 700; }
       .hr-count { color: s.$tertiary-text; font-weight: 500; }
     }
@@ -121,7 +121,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       color: s.$tertiary-text;
       strong { color: s.$primary-text; font-weight: 700; }
       .avatar {
@@ -133,7 +133,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        font-size: 0.85rem;
+        font-size: s.$text-sm;
         font-weight: 800;
         flex-shrink: 0;
       }
@@ -168,13 +168,13 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       & + .m-item { border-left: 1px solid s.$gray-300; }
     }
     .m-top { display: inline-flex; align-items: baseline; gap: 0.45rem; }
-    .m-ic { align-self: center; color: s.$primary; font-size: 1.1rem; }
-    .m-v { font-weight: 800; font-size: 1.1rem; }
+    .m-ic { align-self: center; color: s.$primary; font-size: s.$text-lg; }
+    .m-v { font-weight: 800; font-size: s.$text-lg; }
     // cost tile: the per-serving price is a headline number, so color it brand
     // primary to pull the eye — this is the "make pricing prominent" beat
     .m-cost .m-v { color: s.$primary-accessible; }
     .m-l {
-      font-size: 0.72rem;
+      font-size: s.$text-caption;
       color: s.$tertiary-text;
       font-weight: 700;
       text-transform: uppercase;
@@ -243,7 +243,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
     box-shadow: $soft-shadow;
     padding: 1.5rem 1.75rem;
     @include s.below(s.$bp-lg) { padding: 1.25rem 1rem; }
-    > h2 { font-size: 1.35rem; font-weight: 700; margin-bottom: 1.1rem; }
+    > h2 { font-size: s.$text-xl; font-weight: 700; margin-bottom: 1.1rem; }
   }
 
   // ── ingredients (two-up grid, square thumb, left check, servings pill) ──────
@@ -291,7 +291,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
         display: flex;
         align-items: center;
         justify-content: center;
-        font-size: 1.05rem;
+        font-size: s.$text-md;
         color: s.$primary-text;
         &:hover { background: s.$primary; color: s.$white; }
       }
@@ -303,12 +303,12 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
         background: none;
         text-align: center;
         font-weight: 700;
-        font-size: 0.9rem;
+        font-size: s.$text-base;
         outline: none;
         color: s.$primary-text;
         padding: 0;
       }
-      .serv-unit { font-size: 0.85rem; color: s.$secondary-text; margin: 0 0.35rem 0 0.05rem; }
+      .serv-unit { font-size: s.$text-sm; color: s.$secondary-text; margin: 0 0.35rem 0 0.05rem; }
     }
     .ing-list {
       list-style: none;
@@ -327,7 +327,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
         padding: 0.5rem 0.4rem;
         border-radius: s.$radius-lg;
         cursor: pointer;
-        font-size: 0.94rem;
+        font-size: s.$text-base;
         &:hover { background: s.$primary-background; }
         &:focus-visible { @include s.outline(); }
         // qty + name flow as one inline text block, so a long name wraps
@@ -342,7 +342,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
           align-items: center;
           justify-content: center;
           color: transparent;
-          font-size: 1.2rem;
+          font-size: s.$text-xl;
         }
         .thumb {
           width: 40px;
@@ -383,7 +383,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
     }
     .price-line {
       margin-top: 1rem;
-      font-size: 0.88rem;
+      font-size: s.$text-sm;
       color: s.$tertiary-text;
       strong { color: s.$primary-accessible; }
     }
@@ -438,7 +438,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       color: s.$secondary;
       padding: 0.35rem 0.85rem;
       border-radius: s.$radius-pill;
-      font-size: 0.85rem;
+      font-size: s.$text-sm;
       font-weight: 600;
       text-decoration: none;
       &:hover { background: rgba(s.$secondary, 0.2); }
@@ -458,7 +458,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       height: auto;
       padding: 0.75rem 1.5rem;
       font-weight: 700;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       background: rgba(s.$secondary, 0.12);
       color: s.$secondary;
       border: 1.5px solid rgba(s.$secondary, 0.4);
@@ -473,9 +473,9 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       align-items: baseline;
       gap: 0.6rem;
       margin-bottom: 1rem;
-      h3 { font-size: 1.35rem; font-weight: 700; }
+      h3 { font-size: s.$text-xl; font-weight: 700; }
       .nd-per {
-        font-size: 0.72rem;
+        font-size: s.$text-caption;
         color: s.$tertiary-text;
         font-weight: 700;
         text-transform: uppercase;
@@ -490,11 +490,11 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       @include s.below(700px) { grid-template-columns: 1fr; }
     }
     .nd-cal {
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       color: s.$secondary-text;
       margin-bottom: 1rem;
-      strong { font-size: 1.6rem; color: s.$primary-text; }
-      &.solo { margin-bottom: 0; strong { font-size: 2rem; } }
+      strong { font-size: s.$text-2xl; color: s.$primary-text; }
+      &.solo { margin-bottom: 0; strong { font-size: s.$text-3xl; } }
     }
     .nd-facts-only { max-width: 420px; }
     .nd-macros { display: flex; flex-direction: column; gap: 0.65rem; }
@@ -502,7 +502,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       .nd-macro-top {
         display: flex;
         justify-content: space-between;
-        font-size: 0.85rem;
+        font-size: s.$text-sm;
         font-weight: 700;
         margin-bottom: 0.3rem;
         span:last-child { color: s.$secondary; }
@@ -516,10 +516,10 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       td {
         padding: 0.5rem 0;
         border-bottom: 1px solid s.$gray-200;
-        font-size: 0.9rem;
+        font-size: s.$text-base;
         &:last-child { text-align: right; font-weight: 700; }
       }
-      tr:first-child td { font-weight: 800; font-size: 0.95rem; }
+      tr:first-child td { font-weight: 800; font-size: s.$text-base; }
       tr:last-child td { border-bottom: none; }
     }
   }
@@ -541,14 +541,14 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       gap: 1.5rem;
       flex-wrap: wrap;
       margin-bottom: 1.5rem;
-      .title { width: auto; text-align: left; font-size: 1.45rem; font-weight: 700; margin: 0; }
+      .title { width: auto; text-align: left; font-size: s.$text-2xl; font-weight: 700; margin: 0; }
       .rr-avg {
         display: flex;
         align-items: center;
         gap: 0.85rem;
-        .big { font-size: 2.4rem; font-weight: 800; line-height: 1; color: s.$primary; }
+        .big { font-size: s.$text-4xl; font-weight: 800; line-height: 1; color: s.$primary; }
         .stars { display: flex; align-items: center; }
-        .count { font-size: 0.8rem; color: s.$tertiary-text; font-weight: 600; }
+        .count { font-size: s.$text-fine; color: s.$tertiary-text; font-weight: 600; }
       }
     }
 
@@ -594,13 +594,13 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
         width: auto;
         max-width: none;
         .user-rate-container { width: auto; height: auto !important; }
-        .rate-heading { font-size: 0.95rem; font-weight: 700; color: s.$primary-text; }
+        .rate-heading { font-size: s.$text-base; font-weight: 700; color: s.$primary-text; }
         .rate-active {
           display: flex;
           align-items: center;
           flex-wrap: wrap;
           gap: 0.4rem 0.6rem;
-          .rate-hint { font-size: 0.8rem; color: s.$tertiary-text; font-weight: 700; }
+          .rate-hint { font-size: s.$text-fine; color: s.$tertiary-text; font-weight: 700; }
         }
         .signin-rate {
           display: inline-flex;
@@ -609,7 +609,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
           gap: 0.4rem 0.6rem;
           text-decoration: none;
           .signin-label {
-            font-size: 0.85rem;
+            font-size: s.$text-sm;
             font-weight: 700;
             // keep the pill on one line; flex-wrap drops it below the stars when
             // space is tight rather than collapsing it into a circle
@@ -633,7 +633,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       background: linear-gradient(135deg, rgba(s.$secondary, 0.1), rgba(s.$primary, 0.06));
       border: 1.5px solid $soft-border;
       border-radius: $soft-radius;
-      font-size: 0.92rem;
+      font-size: s.$text-base;
       font-weight: 600;
       color: s.$secondary-text;
     }
@@ -654,7 +654,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       border: 1px solid $soft-border;
       border-radius: s.$radius-xl;
       margin-bottom: 1rem;
-      .body .text { color: s.$secondary-text; line-height: 1.6; font-size: 0.92rem; }
+      .body .text { color: s.$secondary-text; line-height: 1.6; font-size: s.$text-base; }
       // hide the empty options bar on others' reviews (the beta like/dislike was
       // removed); owners still get their edit/delete row
       .review-options:empty { display: none; }
@@ -680,13 +680,13 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       border: 1px solid $soft-border;
       border-radius: $soft-radius;
       .write-review-title {
-        font-size: 0.95rem;
+        font-size: s.$text-base;
         font-weight: 700;
         color: s.$primary-text;
         margin-bottom: 0.6rem;
         span { color: s.$tertiary-text; font-weight: 600; }
       }
-      .error { color: s.$error-red; font-size: 0.85rem; margin-bottom: 0.6rem; }
+      .error { color: s.$error-red; font-size: s.$text-sm; margin-bottom: 0.6rem; }
       .review-text-area {
         width: 100%;
         min-height: 72px;
@@ -695,7 +695,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
         border-radius: s.$radius-lg;
         padding: 0.65rem 0.8rem;
         font-family: inherit;
-        font-size: 0.9rem;
+        font-size: s.$text-base;
         color: s.$primary-text;
         box-sizing: border-box;
         &:focus { outline: none; border-color: s.$primary; }
@@ -704,7 +704,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       .submit-review-btn {
         margin-top: 0.85rem;
         font-weight: 700;
-        font-size: 0.9rem;
+        font-size: s.$text-base;
       }
     }
   }
@@ -720,9 +720,9 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
     margin-top: 2.5rem;
     padding-top: 1.5rem;
     border-top: 1px solid s.$gray-200;
-    font-size: 0.85rem;
+    font-size: s.$text-sm;
     color: s.$tertiary-text;
-    .report-control-trigger { font-size: 0.85rem; font-weight: 700; }
+    .report-control-trigger { font-size: s.$text-sm; font-weight: 700; }
   }
 
   // ── responsive ──────────────────────────────────────────────────────────────
@@ -734,7 +734,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
   }
 
   @include s.below(s.$bp-lg) {
-    .hero-text h1 { font-size: 1.9rem; }
+    .hero-text h1 { font-size: s.$text-3xl; }
 
     // ── action bar: stack the meta over a full-width, equal 3-up button row ──
     .action-bar {
@@ -766,9 +766,9 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
         gap: 0.12rem;
         padding: 0;
         .m-top { display: inline-flex; align-items: center; gap: 0.3rem; }
-        .m-ic { font-size: 0.9rem; }
-        .m-v { font-size: 1rem; white-space: nowrap; }
-        .m-l { text-align: center; font-size: 0.62rem; }
+        .m-ic { font-size: s.$text-base; }
+        .m-v { font-size: s.$text-md; white-space: nowrap; }
+        .m-l { text-align: center; font-size: s.$text-caption; }
         & + .m-item { border-left: 1px solid s.$gray-300; }
       }
     }
@@ -794,7 +794,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       grid-template-columns: 18px 30px 1fr;
       gap: 0.45rem;
       padding: 0.45rem 0.1rem;
-      font-size: 0.92rem;
+      font-size: s.$text-base;
       .box { width: 18px; height: 18px; }
       .thumb { width: 30px; height: 30px; img { width: 24px; height: 24px; } }
     }
@@ -804,7 +804,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       grid-template-columns: 26px 1fr;
       gap: 0.7rem;
       margin-bottom: 1.25rem;
-      .num { width: 26px; height: 26px; font-size: 0.8rem; }
+      .num { width: 26px; height: 26px; font-size: s.$text-fine; }
       p { line-height: 1.6; }
     }
   }

--- a/src/pages/legal/LegalDocument.scss
+++ b/src/pages/legal/LegalDocument.scss
@@ -17,7 +17,7 @@
     margin-bottom: 2.5rem;
 
     h1 {
-      font-size: 2.25rem;
+      font-size: s.$text-4xl;
       font-weight: 800;
       letter-spacing: -0.02em;
       color: s.$primary-text;
@@ -26,7 +26,7 @@
 
     .effective-date {
       color: s.$tertiary-text;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       font-weight: 600;
       margin-bottom: 1.5rem;
     }
@@ -37,7 +37,7 @@
       color: s.$alert-warning-amber-text;
       border-radius: s.$border-radius;
       padding: 1rem 1.25rem;
-      font-size: 0.95rem;
+      font-size: s.$text-base;
       line-height: 1.6;
 
       strong {
@@ -48,7 +48,7 @@
 
   .legal-document-body {
     color: s.$secondary-text;
-    font-size: 1rem;
+    font-size: s.$text-md;
     line-height: 1.7;
 
     section {
@@ -56,7 +56,7 @@
     }
 
     h2 {
-      font-size: 1.35rem;
+      font-size: s.$text-xl;
       font-weight: 700;
       color: s.$primary-text;
       margin-bottom: 0.75rem;


### PR DESCRIPTION
## What

Consolidates ~490 ad-hoc `font-size:` literals across ~60 stylesheets onto a **10-step modular `$text-*` scale** in `src/helpers.scss`, killing the sub-pixel drift (`0.82`/`0.85`/`0.875rem` all meaning the same "small label"). A size is now a decision drawn from one ramp, not a number eyeballed per file. Documented in [`docs/design/type-scale.md`](docs/design/type-scale.md).

## Scope

- New `$text-caption … $text-4xl` tokens (top half identical to Tailwind's default scale; steps anchored on the frequency peaks already in use).
- **62 `.scss` files** repointed onto the scale.
- **Out of scope, left bespoke:** `PrintableRecipe` `pt` print scale, About `clamp()` fluid headings, 404 / profile display numerals, icon-relative `em`.

## Normalization

Of 491 in-scope uses, 218 (44%) land exactly on a step; 273 normalize onto the nearest one — typical shift ≤0.8px, largest 2.8px. An intentional, documented collapse (see the design doc).

## Verification

- **Mechanical:** compiling every changed `.scss` on `development` vs this branch and masking all `font-size` *values* yields a **zero-byte diff** — nothing but font-size values moved.
- **Visual:** two-pass Cypress pixel-diff (tooling in #215) across 6 routes × {desktop, mobile} — clean text reflow, containers stable, out-of-scope display type untouched, **no truncation/overflow**.

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ