### PR TITLE
style(elevation): collapse ~40 ad-hoc box-shadows onto a 6-step $elevation scale

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -624,7 +624,7 @@ findings table.)*
       off-scale one-offs (5/7/9/11/13/18px) need ±1px normalization (design call), and the token-less admin
       files (`Admin/*`, `AdminRecipeControls`, `SavedFilterBar`) keep raw radii pending the import-wiring item
       below.
-    - `[x]` **Elevation/shadow scale** — DONE 2026-07-01 (PR #TBD, `worktree-feat+elevation-shadow-reauthor`).
+    - `[x]` **Elevation/shadow scale** — DONE 2026-07-01 (PR #218, `worktree-feat+elevation-shadow-reauthor`).
       Re-authored the interim `$shadow-soft`/`$shadow-chip`/`$card-box-shadow` stopgap into a documented 6-step
       `$elevation-1..6` ramp + `$shadow-brand`/`-strong`/`$shadow-teal` glow tokens in `helpers.scss` (owner
       sign-off via a temp `/elevation-audit` page). Migrated ~51 declarations across 28 files: 37 distinct old

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -624,12 +624,19 @@ findings table.)*
       off-scale one-offs (5/7/9/11/13/18px) need ±1px normalization (design call), and the token-less admin
       files (`Admin/*`, `AdminRecipeControls`, `SavedFilterBar`) keep raw radii pending the import-wiring item
       below.
-    - **Elevation/shadow scale** — partly done 2026-06-25: the two shadows that recur verbatim are now
-      `$shadow-soft` (warm card resting, ×8) and `$shadow-chip` (price/floating chips, ×3). **Remaining:** of
-      **75** total `box-shadow:` declarations, ~**52** are still distinct raw literals (verified 2026-06-26)
-      — nearly all unique, needing a re-authored scale (`$shadow-card`/`-hover`/`-glow-primary`), e.g. the
-      avatar-glow `rgba(255,87,34,0.18)` repeated in Account + PublicProfile (audit F5) — a re-author, not a
-      pixel-identical repoint.
+    - `[x]` **Elevation/shadow scale** — DONE 2026-07-01 (PR #TBD, `worktree-feat+elevation-shadow-reauthor`).
+      Re-authored the interim `$shadow-soft`/`$shadow-chip`/`$card-box-shadow` stopgap into a documented 6-step
+      `$elevation-1..6` ramp + `$shadow-brand`/`-strong`/`$shadow-teal` glow tokens in `helpers.scss` (owner
+      sign-off via a temp `/elevation-audit` page). Migrated ~51 declarations across 28 files: 37 distinct old
+      values → 9 tokens (2 value-identical). Unified tint — one slate `rgba($primary-text, …)` across the ramp,
+      replacing the old black/slate/warm mix; the repeated avatar-glow `rgba(255,87,34,0.18)` (audit F5) folded
+      onto `$shadow-brand`. Kept bespoke: the two-layer add-ingredient bar, the horizontal drawer, the two
+      upward sticky-bar shadows. No pixel regression beyond shadows (compiled-CSS diff vs development
+      byte-identical outside `box-shadow`). Documented in `docs/design/elevation.md`.
+    - **Focus-ring tokens** — surfaced 2026-07-01, deferred out of the elevation track (they're focus
+      indicators, not elevation). ~13 `box-shadow: 0 0 0 3px rgba(…)` rings across FormInput/FormStyles/Settings
+      controls/CreateUsername/Recipes/Help, in teal/error/ok-green/orange variants — a `$focus-ring-*` token
+      group would single-source them. Pairs loosely with the `$primary-hover` a11y `2-scss` track.
     - `[x]` **Breakpoint tokens/mixin** — DONE 2026-06-25 (PR `style/breakpoint-tokens`). Added an 8-tier
       `$bp-xs..4xl` scale + `$bp-nav`/`$bp-nav-up` and `below()`/`above()`/`between()` mixins; migrated all 69
       width queries. The recurring content breakpoints converged to tiers (7 approved small shifts ≤30px:
@@ -638,7 +645,7 @@ findings table.)*
       literal px to the mixins and keep their exact values. **Remaining (design call):** converge those
       deliberately-bespoke one-offs into the scale if/when their layouts are retuned.
   *(surfaced 2026-06-25 in the design-consistency sweep; cheap wins + radius/recurring-shadow scales applied,
-  type scale done 2026-07-01 PR #216; full elevation re-author still deferred.)*
+  type scale done 2026-07-01 PR #216; elevation re-author done 2026-07-01.)*
 - `[~]` **Collapse near-duplicate brand shades to one value**
     - `[x]` **Decorative tint** — DONE (PR #192): `$primary-tint: #ff8a5c` collapses the avatar/XP gradient
       stops (`Account.scss` ×2) + the `RecipePlaceholder` icon `#ff8a65`. Purely decorative, so independent

--- a/docs/design/elevation.md
+++ b/docs/design/elevation.md
@@ -1,0 +1,94 @@
+# Elevation / shadows
+
+Prepify's drop shadows had drifted: ~40 ad-hoc `box-shadow:` literals across ~30
+stylesheets, with no shared system. Resting cards alone used both `.06` and `.08`
+alpha over three different `y`/`blur` pairs; the raised/hover/dropdown tier spanned
+six visually-interchangeable values (`0 10px 26px` → `0 14px 30px`); and the tint
+was a mix of pure black, a slate `rgb(48,56,65)`, a warm `rgb(40,30,20)`, and
+`$admin-slate-900`. This doc names a **6-step elevation ramp** as the `$elevation-*`
+token group in `src/helpers.scss`, so a shadow is a decision drawn from one ramp —
+a *height*, not a number someone eyeballed in a single file.
+
+## The rules
+
+1. **Use an `$elevation-*` step, never a raw `box-shadow` value.** That's the whole
+   point — a new `box-shadow: 0 5px 15px rgba(0,0,0,.1)` re-introduces the drift the
+   ramp exists to kill. Pick the step nearest the surface's height (see the usage
+   notes per token below).
+2. **Steps read as height, not role.** Like `$gray-*` and `$radius-*`, this is a
+   *primitive* scale: `1` barely lifts a surface, `6` floats a full-screen overlay.
+   A surface's shadow should go up a step when it's raised (a card that lifts on
+   hover goes `$elevation-3` → `$elevation-4`), so resting/hover pairs read as one
+   consistent lift across the app.
+3. **One tint across the ramp.** Every step is `rgba($primary-text, …)` — the brand
+   text slate `rgb(48,56,65)` — not pure black. A single cool tint makes every
+   raised surface feel part of the same material; don't hand-roll a black or warm
+   shadow alongside these.
+4. **Glows are emphasis, not height — keep them separate.** The brand-tinted
+   `$shadow-brand*` / `$shadow-teal` tokens signal a CTA, not elevation. Don't fold
+   them into the neutral ramp, and don't reach for the ramp when you want an accent
+   glow.
+5. **Theming is a colour concern, so this stays SCSS.** Like the type scale, the
+   ramp gets no benefit from CSS custom properties until theming lands — and even
+   then it's the *colour* half (`$primary-text`) that becomes runtime-swappable, not
+   the geometry. Leave the ramp as Sass tokens.
+
+## The tokens
+
+The neutral elevation ramp — one slate tint, rising by height:
+
+| Token | Value | Use |
+|---|---|---|
+| `$elevation-1` | `0 1px 3px rgba($primary-text, .14)` | hairline — toggle knobs, faint insets |
+| `$elevation-2` | `0 2px 8px rgba($primary-text, .12)` | small — sticky nav, badges, price chips |
+| `$elevation-3` | `0 6px 18px rgba($primary-text, .10)` | resting cards — RecipeCard, Home cards, recipe panels |
+| `$elevation-4` | `0 12px 28px rgba($primary-text, .14)` | raised — card hovers, dropdowns, popovers |
+| `$elevation-5` | `0 18px 50px rgba($primary-text, .22)` | modals / dialogs |
+| `$elevation-6` | `0 24px 60px rgba($primary-text, .40)` | full-screen overlay backdrop |
+
+The colored brand "glow" shadows — accent shadows tinted to the brand hue, used on
+CTAs. Kept separate from the neutral ramp:
+
+| Token | Value | Use |
+|---|---|---|
+| `$shadow-brand` | `0 8px 20px rgba($primary, .18)` | primary CTA hover glow |
+| `$shadow-brand-strong` | `0 6px 16px rgba($primary, .28)` | stronger CTA glow (draft publish) |
+| `$shadow-teal` | `0 8px 18px rgba($secondary, .30)` | teal auth-submit glow |
+
+## Out of scope — left bespoke
+
+Four shadows are directional or multi-layer, where the ramp's geometry would be
+wrong. They stay as raw literals (not on the ramp):
+
+- **The two-layer add-ingredient bar** (`src/index.scss`) — a Stripe-style stacked
+  shadow (`… -2px, … -3px`) that reads as a floating toolbar; a single-layer ramp
+  step can't reproduce it.
+- **The horizontal off-canvas drawer** (`Recipes.scss`, `-8px 0 30px …`) — casts
+  sideways, not down.
+- **The two upward sticky-bar shadows** (`AccountStatusBanner`, `AddRecipeSummaryBar`,
+  `0 -2px/-3px …`) — bottom-anchored bars that cast *up* onto the page.
+
+**Focus rings** (`box-shadow: 0 0 0 3px …`) also use `box-shadow`, but they're focus
+indicators, not elevation — a separate concern, left for a later a11y pass (they
+pair loosely with the `$primary-hover` accessibility work). The two `0 0 0 1px`
+border-via-shadow uses (selected-state ring, hairline card border) are likewise
+outlines, not elevation, and stay put.
+
+## Notes
+
+- **Migration (2026-07-01).** 37 distinct old shadow values collapsed onto the 9
+  tokens; ~51 declarations across 28 files were repointed. Two mappings were
+  value-identical exact matches (the teal auth glow, the draft-publish brand glow);
+  the rest normalize onto the nearest step — the same intentional, documented
+  collapse the type scale and admin palette made. This retired the interim
+  `$card-box-shadow` / `$shadow-soft` / `$shadow-chip` tokens (added as a stopgap
+  while this re-author was deferred) and the local `$soft-shadow` in `SingleRecipe`.
+- **Verification.** The compiled-CSS diff vs `development` showed the non-shadow CSS
+  **byte-identical** — only `box-shadow` declarations changed — and a headless pass
+  across home / recipes / recipe-detail / about / profile (+ a card hover) confirmed
+  the shadows read cohesively with no surface looking heavier or flatter than
+  intended.
+- **The one visible shift** is the tint: ~30 previously pure-black shadows now cast
+  the slate tint, and a handful of surfaces snap a step (e.g. the ultra-soft warm
+  account cards move from `0 4px 14px /.05` onto `$elevation-3`, unifying "resting
+  card" to one height). All subtle and intentional.

--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -75,7 +75,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **2-iso** | Design: codify loading-state pattern | `[x]` | convention + `TailSpin`/skeleton outliers | #213 |
 | **2-scss** | Design: pill `.btn` system | `[x]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | #210 |
 | **2-scss** | Design: type scale (~520 `font-size:` literals) | `[x]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | #216 |
-| **2-scss** | Design: elevation/shadow re-author (~52 literals) | `[ ]` | **`helpers.scss` + page `.scss`** ⚠ chokepoint | — |
+| **2-scss** | Design: elevation/shadow re-author (~52 literals) | `[~]` | **`helpers.scss` + page `.scss`** ⚠ chokepoint | worktree-feat+elevation-shadow-reauthor (2026-07-01) |
 | **2-scss** | Design: one danger-red token | `[x]` | **`helpers.scss` + SingleRecipe/ReportControl/…** ⚠ chokepoint | #208 |
 | **2-scss** | Design: name the `$admin-*` sub-palette | `[x]` | **`helpers.scss` + Admin/moderation `.scss`** ⚠ chokepoint | #214 |
 | **2-scss** | A11y: `$primary-hover` AA-on-hover | `[ ]` | **`helpers.scss`** ⚠ chokepoint | — |
@@ -464,3 +464,11 @@ narrates the *why*.
   `f1ecadf`) — a manual two-pass `cypress-image-diff-js` check under `cypress/visual/` kept out of the CI suite
   (needs a separate baseline server; baselines not committed, owner's call). Remaining `2-scss` lane: elevation
   re-author, `$primary-hover`. **Worktree + both branches torn down.**
+- _2026-07-01_ — **Design: elevation/shadow re-author (~52 literals)** claimed (`worktree-feat+elevation-shadow-reauthor`,
+  `[ ]`→`[~]`) — **fifth `2-scss` lane to open.** Checked the lane is clear first: `git worktree list` shows only
+  the main checkout (type-scale #216 and its harness #215 both merged + torn down), `gh pr list` is empty, and the
+  Board has no `[~]`/`[P]` track in flight — so the serialized `2-scss` chokepoint is free (rule 1). Next-in-board-
+  order pick of the two remaining `2-scss` tracks (elevation → `$primary-hover`); `$primary-hover` is also `2-scss`
+  so it can't run alongside anyway. This track collapses the ~52 ad-hoc `box-shadow:` literals across `helpers.scss`
+  + page `.scss` onto a documented elevation token scale (next design-system doc after icon/button/admin-palette/
+  type-scale). Worktree on free ports 3001/4001.

--- a/docs/sweeps/ROADMAP.md
+++ b/docs/sweeps/ROADMAP.md
@@ -75,7 +75,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **2-iso** | Design: codify loading-state pattern | `[x]` | convention + `TailSpin`/skeleton outliers | #213 |
 | **2-scss** | Design: pill `.btn` system | `[x]` | **`index.scss` + many page `.scss`** ⚠ chokepoint | #210 |
 | **2-scss** | Design: type scale (~520 `font-size:` literals) | `[x]` | **`helpers.scss` + ~60 files** ⚠ chokepoint | #216 |
-| **2-scss** | Design: elevation/shadow re-author (~52 literals) | `[~]` | **`helpers.scss` + page `.scss`** ⚠ chokepoint | worktree-feat+elevation-shadow-reauthor (2026-07-01) |
+| **2-scss** | Design: elevation/shadow re-author (~52 literals) | `[P]` | **`helpers.scss` + page `.scss`** ⚠ chokepoint | #218 |
 | **2-scss** | Design: one danger-red token | `[x]` | **`helpers.scss` + SingleRecipe/ReportControl/…** ⚠ chokepoint | #208 |
 | **2-scss** | Design: name the `$admin-*` sub-palette | `[x]` | **`helpers.scss` + Admin/moderation `.scss`** ⚠ chokepoint | #214 |
 | **2-scss** | A11y: `$primary-hover` AA-on-hover | `[ ]` | **`helpers.scss`** ⚠ chokepoint | — |
@@ -472,3 +472,16 @@ narrates the *why*.
   so it can't run alongside anyway. This track collapses the ~52 ad-hoc `box-shadow:` literals across `helpers.scss`
   + page `.scss` onto a documented elevation token scale (next design-system doc after icon/button/admin-palette/
   type-scale). Worktree on free ports 3001/4001.
+- _2026-07-01_ — **Design: elevation/shadow re-author (~52 literals)** PR opened (#218, `[~]`→`[P]`) — **fifth
+  `2-scss` lane to reach review.** 51 declarations across 28 files repointed onto the 6-step `$elevation-1..6`
+  ramp + `$shadow-brand`/`-strong`/`$shadow-teal` glow tokens in `helpers.scss`; the interim
+  `$card-box-shadow`/`$shadow-soft`/`$shadow-chip` stopgap and the local `$soft-shadow` in `SingleRecipe` retired.
+  Two repoints value-identical (teal auth glow, draft-publish brand glow), the rest normalize onto the nearest
+  step. Left bespoke (directional/multi-layer): the two-layer add-ingredient bar, the horizontal off-canvas
+  drawer, and the two upward sticky-bar shadows; focus rings + the two `0 0 0 1px` outlines out of scope.
+  Verified two ways: masked compiled-CSS diff vs `development` (every `box-shadow` value blanked) is zero-byte —
+  nothing but shadow values moved — and a headless computed-`box-shadow` pass across home / recipes / recipe-
+  detail / about / profile (+ a card hover) read the intended token on every surface. Documented at
+  `docs/design/elevation.md` (fifth design-system doc); BACKLOG item flipped to done, run-log banner updated.
+  Remaining `2-scss` lane: `$primary-hover` (last track). Owner sign-off via a temp `/elevation-audit` page
+  (added then removed in-branch).

--- a/docs/sweeps/design-consistency.md
+++ b/docs/sweeps/design-consistency.md
@@ -5,8 +5,8 @@
 > decorative tint). **~10 follow-ups open** in [`../BACKLOG.md`](../BACKLOG.md#ux--visual-polish) +
 > [Tech debt](../BACKLOG.md#tech-debt--process--infra): pill `.btn` system, delete `RecipeThumbnail`,
 > ~~icon-per-concept~~ (done — PR #205; ~~single-family Lucide~~ done — PR #206), ~~modal style config~~ (done — PR #203),
-> ~~loading-state pattern~~ (done — PR #213), ~~toast punctuation~~ (done — PR #207); ~~type scale~~ (done — PR #216), elevation
-> re-author, ~~danger-red token~~ (done — PR #208), ~~`$admin-*` palette~~ (done — PR #214), ~~`RecipeFormInput` dup~~ (done — PR #204). *(See the [run log](README.md#run-log).)*
+> ~~loading-state pattern~~ (done — PR #213), ~~toast punctuation~~ (done — PR #207); ~~type scale~~ (done — PR #216), ~~elevation
+> re-author~~ (done — PR #TBD), ~~danger-red token~~ (done — PR #208), ~~`$admin-*` palette~~ (done — PR #214), ~~`RecipeFormInput` dup~~ (done — PR #204). *(See the [run log](README.md#run-log).)*
 
 Full-coverage visual/UX consistency audit: are colors, spacing, typography, radii, shadows, components,
 states, and copy voice drawn from a shared system — or has each page drifted? Catch the drift, unify the

--- a/docs/sweeps/design-consistency.md
+++ b/docs/sweeps/design-consistency.md
@@ -6,7 +6,7 @@
 > [Tech debt](../BACKLOG.md#tech-debt--process--infra): pill `.btn` system, delete `RecipeThumbnail`,
 > ~~icon-per-concept~~ (done — PR #205; ~~single-family Lucide~~ done — PR #206), ~~modal style config~~ (done — PR #203),
 > ~~loading-state pattern~~ (done — PR #213), ~~toast punctuation~~ (done — PR #207); ~~type scale~~ (done — PR #216), ~~elevation
-> re-author~~ (done — PR #TBD), ~~danger-red token~~ (done — PR #208), ~~`$admin-*` palette~~ (done — PR #214), ~~`RecipeFormInput` dup~~ (done — PR #204). *(See the [run log](README.md#run-log).)*
+> re-author~~ (done — PR #218), ~~danger-red token~~ (done — PR #208), ~~`$admin-*` palette~~ (done — PR #214), ~~`RecipeFormInput` dup~~ (done — PR #204). *(See the [run log](README.md#run-log).)*
 
 Full-coverage visual/UX consistency audit: are colors, spacing, typography, radii, shadows, components,
 states, and copy voice drawn from a shared system — or has each page drifted? Catch the drift, unify the

--- a/src/Components/AddToCollection/AddToCollection.scss
+++ b/src/Components/AddToCollection/AddToCollection.scss
@@ -56,7 +56,7 @@
   background: #fff;
   border: 1px solid s.$surface-warm-border;
   border-radius: s.$radius-2xl;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+  box-shadow: s.$elevation-3;
   padding: 0.6rem;
   text-align: left;
 

--- a/src/Components/Form/FormStyles.scss
+++ b/src/Components/Form/FormStyles.scss
@@ -35,7 +35,7 @@
     border: 1px solid rgba(255, 255, 255, 0.7);
     background: rgba(255, 255, 255, 0.92);
     backdrop-filter: blur(18px);
-    box-shadow: 0 22px 55px rgba(40, 30, 20, 0.18);
+    box-shadow: s.$elevation-5;
   }
 
   // Brand mark — teal rounded square with a thin, cursive-leaning white "P"
@@ -55,7 +55,7 @@
     letter-spacing: 0;
     color: s.$white;
     background: linear-gradient(135deg, #2ec0c8, s.$secondary);
-    box-shadow: 0 8px 18px rgba(0, 173, 181, 0.3);
+    box-shadow: s.$shadow-teal;
     margin-bottom: 1rem;
   }
 

--- a/src/Components/Layout/Layout.scss
+++ b/src/Components/Layout/Layout.scss
@@ -34,7 +34,7 @@
   color: s.$primary;
   font-weight: 600;
   border-radius: s.$border-radius;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: s.$elevation-2;
   transition: top 0.15s ease-in-out;
 
   &:focus {

--- a/src/Components/Navbar/Navbar.scss
+++ b/src/Components/Navbar/Navbar.scss
@@ -71,7 +71,7 @@
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border-bottom: 1px solid s.$gray-300;
-  box-shadow: 0 2px 14px rgba(48, 56, 65, 0.07);
+  box-shadow: s.$elevation-2;
 }
 
 // On any light nav surface the vivid orange wordmark is only 2.72:1 (large text,

--- a/src/Components/Navbar/desktop/DesktopNav.scss
+++ b/src/Components/Navbar/desktop/DesktopNav.scss
@@ -327,7 +327,7 @@
     background: s.$white;
     border: 1px solid s.$gray-300;
     border-radius: s.$border-radius;
-    box-shadow: 0 12px 28px rgba(48, 56, 65, 0.18);
+    box-shadow: s.$elevation-4;
 
     visibility: hidden;
     opacity: 0;

--- a/src/Components/Navbar/menu/NavMenu.scss
+++ b/src/Components/Navbar/menu/NavMenu.scss
@@ -94,7 +94,7 @@
     -webkit-backdrop-filter: blur(6px);
     border: 1px solid rgba(255, 255, 255, 0.9);
     border-radius: var(--menu-radius);
-    box-shadow: 0 4px 16px rgba(48, 56, 65, 0.08);
+    box-shadow: s.$elevation-2;
   }
   .menu-group__heading {
     margin: 0 0 0.35rem 0.5rem;

--- a/src/Components/RecipeCard/RecipeCard.scss
+++ b/src/Components/RecipeCard/RecipeCard.scss
@@ -5,14 +5,14 @@
   background: s.$white;
   border-radius: s.$radius-2xl;
   overflow: hidden;
-  box-shadow: rgba(0, 0, 0, 0.06) 0px 6px 18px;
+  box-shadow: s.$elevation-3;
   display: flex;
   flex-direction: column;
   transition: transform 0.16s ease, box-shadow 0.16s ease;
 
   &:hover {
     transform: translateY(-4px);
-    box-shadow: rgba(0, 0, 0, 0.14) 0px 14px 30px;
+    box-shadow: s.$elevation-4;
   }
 
   &__link {
@@ -66,7 +66,7 @@
     font-size: s.$text-caption;
     padding: 0.28rem 0.6rem;
     border-radius: s.$radius-pill;
-    box-shadow: s.$shadow-chip;
+    box-shadow: s.$elevation-2;
   }
 
   // Unified save control — floated over the image (sibling of the link).
@@ -84,7 +84,7 @@
     border: none;
     border-radius: s.$radius-pill;
     background: rgba(255, 255, 255, 0.92);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
+    box-shadow: s.$elevation-2;
     color: s.$secondary-text;
     font-size: s.$text-md;
     line-height: 1;

--- a/src/Components/ReportControl/ReportControl.scss
+++ b/src/Components/ReportControl/ReportControl.scss
@@ -79,7 +79,7 @@
     background: s.$white;
     border: 1px solid s.$admin-slate-200;
     border-radius: s.$radius-md;
-    box-shadow: 0 6px 20px rgba(s.$admin-slate-900, 0.12);
+    box-shadow: s.$elevation-3;
   }
 
   .report-menu-item {

--- a/src/Components/SearchRecipesInput/SearchRecipesInput.scss
+++ b/src/Components/SearchRecipesInput/SearchRecipesInput.scss
@@ -65,7 +65,7 @@
     background: s.$white;
     border: 1px solid s.$gray-300;
     border-radius: s.$border-radius;
-    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.14), 0 2px 6px rgba(0, 0, 0, 0.08);
+    box-shadow: s.$elevation-4;
     overflow: hidden;
 
     .ac-list {

--- a/src/helpers.scss
+++ b/src/helpers.scss
@@ -172,13 +172,31 @@ $border-radius: $radius-lg;
 
 $max-width: 1400px;
 
-$card-box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+// ── Elevation scale ──────────────────────────────────────────────────────────
+// A 6-step shadow ramp that the app's ~40 ad-hoc `box-shadow:` literals collapse
+// onto. Steps read as height: 1 barely lifts a surface, 6 floats a full-screen
+// overlay. One slate tint runs across the whole ramp — rgba($primary-text, …),
+// i.e. rgb(48,56,65), the brand text colour — replacing the old mix of pure-black,
+// slate, and warm shadows so every raised surface casts the same cool, on-brand
+// shadow. Documented in docs/design/elevation.md.
+//
+// Out of scope, kept bespoke (NOT on this ramp) — directional or multi-layer
+// shadows where the ramp geometry would be wrong: the two-layer add-ingredient
+// bar (index.scss), the horizontal off-canvas drawer (Recipes.scss), and the two
+// upward sticky-bar shadows (AccountStatusBanner / AddRecipeSummaryBar). Focus
+// rings (`box-shadow: 0 0 0 3px …`) are a separate concern, left for a later pass.
+$elevation-1: 0 1px 3px rgba($primary-text, 0.14); //   hairline — toggle knobs, faint insets
+$elevation-2: 0 2px 8px rgba($primary-text, 0.12); //   small — sticky nav, badges, chips
+$elevation-3: 0 6px 18px rgba($primary-text, 0.1); //   resting cards (RecipeCard, Home, panels)
+$elevation-4: 0 12px 28px rgba($primary-text, 0.14); // raised — hovers, dropdowns, popovers
+$elevation-5: 0 18px 50px rgba($primary-text, 0.22); // modals / dialogs
+$elevation-6: 0 24px 60px rgba($primary-text, 0.4); //  full-screen overlay backdrop
 
-// Elevation — only the shadows that recur verbatim are tokenized so repoints
-// stay value-identical; bespoke one-off shadows remain raw pending an
-// elevation-scale re-author (see docs/BACKLOG.md).
-$shadow-soft: 0 4px 14px rgba(0, 0, 0, 0.05); // soft resting shadow on warm account/settings cards
-$shadow-chip: 0 2px 6px rgba(0, 0, 0, 0.18);  // tight drop shadow on price / floating chips
+// Colored brand "glow" shadows — accent shadows tinted to the brand hue for CTAs.
+// Kept separate from the neutral elevation ramp: these signal emphasis, not height.
+$shadow-brand: 0 8px 20px rgba($primary, 0.18); //        primary CTA hover glow
+$shadow-brand-strong: 0 6px 16px rgba($primary, 0.28); // stronger CTA glow (draft publish)
+$shadow-teal: 0 8px 18px rgba($secondary, 0.3); //        teal auth-submit glow
 
 $font-family: 'Montserrat', sans-serif;
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -367,5 +367,5 @@ a {
 
 // Dnd
 .dragging {
-  box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+  box-shadow: s.$elevation-2;
 }

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -70,7 +70,7 @@
   .about-btn-primary {
     background-color: s.$primary-accessible;
     color: s.$white;
-    box-shadow: 0 6px 16px rgba(255, 87, 34, 0.22);
+    box-shadow: s.$shadow-brand-strong;
 
     &:hover svg {
       transform: translateX(3px);
@@ -142,7 +142,7 @@
   .about-card {
     background-color: s.$white;
     border-radius: s.$border-radius;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    box-shadow: s.$elevation-4;
     border: 1px solid s.$gray-200;
     overflow: hidden;
     width: 280px;
@@ -212,7 +212,7 @@
   .about-nutrition {
     background-color: s.$white;
     border-radius: s.$border-radius;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    box-shadow: s.$elevation-4;
     border: 1px solid s.$gray-200;
     padding: 1.25rem;
     width: 280px;
@@ -322,7 +322,7 @@
     height: 2.5rem;
     border-radius: s.$radius-pill;
     background-color: s.$white;
-    box-shadow: s.$card-box-shadow;
+    box-shadow: s.$elevation-2;
     color: s.$primary;
     font-weight: 800;
     font-size: s.$text-md;

--- a/src/pages/Account/Account.scss
+++ b/src/pages/Account/Account.scss
@@ -28,7 +28,7 @@
     border: 1px solid s.$surface-warm-border;
     border-radius: s.$radius-4xl;
     padding: 1.5rem;
-    box-shadow: s.$shadow-soft;
+    box-shadow: s.$elevation-3;
     margin-bottom: 1.75rem;
 
     @include s.below(s.$bp-3xl) {
@@ -50,7 +50,7 @@
     border-radius: s.$radius-circle;
     object-fit: cover;
     flex-shrink: 0;
-    box-shadow: 0 8px 22px rgba(255, 87, 34, 0.18);
+    box-shadow: s.$shadow-brand;
 
     &.not-set {
       display: flex;
@@ -130,7 +130,7 @@
 
     &:hover {
       border-color: rgba(s.$primary, 0.4);
-      box-shadow: 0 6px 18px rgba(255, 87, 34, 0.1);
+      box-shadow: s.$shadow-brand;
     }
   }
   .acct-levelcard-top {
@@ -151,7 +151,7 @@
     border: 1px solid rgba(s.$primary-text, 0.08);
     border-radius: s.$radius-pill;
     padding: 0.3rem 0.75rem 0.3rem 0.3rem;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
+    box-shadow: s.$elevation-1;
     white-space: nowrap;
   }
   .acct-lvl-chip-num {
@@ -263,7 +263,7 @@
     border: 1px solid s.$surface-warm-border;
     border-radius: s.$radius-3xl;
     padding: 0.6rem;
-    box-shadow: s.$shadow-soft;
+    box-shadow: s.$elevation-3;
     // Keep the rail in view while scrolling a long sub-page.
     position: sticky;
     top: calc(#{s.$nav-height} + 1rem);

--- a/src/pages/Account/Drafts/Drafts.scss
+++ b/src/pages/Account/Drafts/Drafts.scss
@@ -35,13 +35,13 @@
     background: s.$white;
     border: 1px solid s.$surface-warm-border;
     border-radius: s.$radius-3xl;
-    box-shadow: s.$shadow-soft;
+    box-shadow: s.$elevation-3;
     padding: 1.15rem 1.25rem;
     transition: transform 0.14s ease, box-shadow 0.14s ease;
 
     &:hover {
       transform: translateY(-2px);
-      box-shadow: 0 10px 26px rgba(0, 0, 0, 0.08);
+      box-shadow: s.$elevation-4;
     }
 
     .head {
@@ -137,7 +137,7 @@
         }
         &:hover {
           background: #f4501e;
-          box-shadow: 0 6px 16px rgba(255, 87, 34, 0.28);
+          box-shadow: s.$shadow-brand-strong;
         }
       }
 

--- a/src/pages/Account/SavedRecipes/SavedRecipes.scss
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.scss
@@ -33,7 +33,7 @@
       border-color 0.14s ease;
 
     &:hover {
-      box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+      box-shadow: s.$elevation-3;
       transform: translateY(-1px);
     }
     &.active {
@@ -257,7 +257,7 @@
       background: #fff;
       border: 1px solid s.$gray-300;
       border-radius: s.$radius-xl;
-      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.14);
+      box-shadow: s.$elevation-4;
       padding: 0.4rem;
       button {
         display: block;

--- a/src/pages/Account/UserRatings/UserRatings.scss
+++ b/src/pages/Account/UserRatings/UserRatings.scss
@@ -16,7 +16,7 @@
     background: #fff;
     border: 1px solid s.$surface-warm-border;
     border-radius: s.$radius-3xl;
-    box-shadow: s.$shadow-soft;
+    box-shadow: s.$elevation-3;
     overflow: hidden;
   }
 

--- a/src/pages/Account/UserRecipes/UserRecipeThumbnail.scss
+++ b/src/pages/Account/UserRecipes/UserRecipeThumbnail.scss
@@ -12,7 +12,7 @@
   background: #fff;
   border: 1px solid s.$surface-warm-border;
   border-radius: 18px;
-  box-shadow: s.$shadow-soft;
+  box-shadow: s.$elevation-3;
   text-decoration: none;
   color: s.$primary-text;
   transition: box-shadow 0.18s ease, transform 0.18s ease;
@@ -23,7 +23,7 @@
     @include s.outline();
   }
   &:hover {
-    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.1);
+    box-shadow: s.$elevation-4;
     transform: translateY(-2px);
     .go {
       color: s.$secondary;

--- a/src/pages/Account/components/AchievementsModal.scss
+++ b/src/pages/Account/components/AchievementsModal.scss
@@ -12,7 +12,7 @@
   flex-direction: column;
   background: #fff;
   border-radius: 18px;
-  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.25);
+  box-shadow: s.$elevation-5;
   overflow: hidden;
 
   .am-head {

--- a/src/pages/Home/Home.scss
+++ b/src/pages/Home/Home.scss
@@ -75,9 +75,9 @@
     overflow: hidden;
     text-decoration: none;
     color: s.$primary-text;
-    box-shadow: rgba(0, 0, 0, 0.06) 0px 6px 18px;
+    box-shadow: s.$elevation-3;
     transition: transform 0.15s ease, box-shadow 0.15s ease;
-    &:hover { transform: translateY(-3px); box-shadow: rgba(0, 0, 0, 0.12) 0px 12px 26px; }
+    &:hover { transform: translateY(-3px); box-shadow: s.$elevation-4; }
     .thumb {
       position: relative;
       // Container owns the 4/3 box; image and the hold-skeleton both fill it
@@ -95,7 +95,7 @@
         position: absolute; bottom: 0.6rem; right: 0.6rem;
         background: rgba(255, 255, 255, 0.95); color: s.$primary;
         font-weight: 800; font-size: s.$text-fine; padding: 0.28rem 0.6rem;
-        border-radius: s.$radius-pill; box-shadow: s.$shadow-chip;
+        border-radius: s.$radius-pill; box-shadow: s.$elevation-2;
       }
     }
     .body { padding: 0.85rem 1rem 1rem; }
@@ -125,7 +125,7 @@
     border: 1px solid #efe6db;
     border-radius: s.$radius-3xl;
     padding: 1.25rem;
-    box-shadow: rgba(0, 0, 0, 0.04) 0px 4px 14px;
+    box-shadow: s.$elevation-2;
 
     .meal-col-head {
       display: flex;

--- a/src/pages/Home/HomeCookSuggestion.scss
+++ b/src/pages/Home/HomeCookSuggestion.scss
@@ -9,7 +9,7 @@
   border-radius: s.$radius-3xl;
   overflow: hidden;
   text-align: left;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  box-shadow: s.$elevation-6;
   animation: cook-modal-pop 0.18s ease;
 
   // `.btn .btn--icon` — square/circular icon button. Local: its absolute
@@ -24,7 +24,7 @@
     background: rgba(255, 255, 255, 0.92);
     color: s.$primary-text;
     font-size: s.$text-lg;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    box-shadow: s.$elevation-2;
     &:hover { background: #fff; }
   }
 
@@ -54,7 +54,7 @@
       font-size: s.$text-fine;
       padding: 0.28rem 0.6rem;
       border-radius: s.$radius-pill;
-      box-shadow: s.$shadow-chip;
+      box-shadow: s.$elevation-2;
     }
     .reroll-veil {
       position: absolute;

--- a/src/pages/Home/HomeHero/HomeHero.scss
+++ b/src/pages/Home/HomeHero/HomeHero.scss
@@ -63,7 +63,7 @@
     background: s.$primary-accessible;
     color: s.$white;
     font-size: s.$text-md;
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+    box-shadow: s.$elevation-2;
 
     svg {
       font-size: s.$text-xl;

--- a/src/pages/PublicProfile/PublicProfile.scss
+++ b/src/pages/PublicProfile/PublicProfile.scss
@@ -51,7 +51,7 @@
     border-radius: s.$radius-circle;
     object-fit: cover;
     flex-shrink: 0;
-    box-shadow: 0 8px 22px rgba(255, 87, 34, 0.18);
+    box-shadow: s.$shadow-brand;
 
     &.not-set {
       display: flex;
@@ -198,14 +198,14 @@
     background: #fff;
     border: 1px solid s.$surface-warm-border;
     border-radius: s.$radius-2xl;
-    box-shadow: s.$shadow-soft;
+    box-shadow: s.$elevation-3;
     text-decoration: none;
     color: s.$primary-text;
     transition: transform 0.16s ease, box-shadow 0.16s ease;
 
     &:hover {
       transform: translateY(-2px);
-      box-shadow: 0 12px 26px rgba(0, 0, 0, 0.1);
+      box-shadow: s.$elevation-4;
     }
     &:focus-visible {
       outline: 2px solid s.$primary;
@@ -355,7 +355,7 @@
       pointer-events: none;
       &:hover {
         transform: none;
-        box-shadow: s.$shadow-soft;
+        box-shadow: s.$elevation-3;
       }
     }
   }

--- a/src/pages/Recipes/Recipes.scss
+++ b/src/pages/Recipes/Recipes.scss
@@ -164,7 +164,7 @@
       background: s.$white;
       border: 1px solid s.$gray-300;
       border-radius: s.$radius-xl;
-      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.14);
+      box-shadow: s.$elevation-4;
       padding: 0.4rem;
       button {
         display: block;
@@ -256,7 +256,7 @@
         color: s.$primary;
         border-color: s.$primary;
         transform: translateY(-2px);
-        box-shadow: 0 8px 20px rgba(255, 87, 34, 0.16);
+        box-shadow: s.$shadow-brand;
       }
       &:hover:not(:disabled) svg {
         transform: translateY(2px);

--- a/src/pages/Settings/Settings.scss
+++ b/src/pages/Settings/Settings.scss
@@ -114,7 +114,7 @@
     background: s.$white;
     border: 1px solid s.$surface-warm-border;
     border-radius: 18px;
-    box-shadow: s.$shadow-soft;
+    box-shadow: s.$elevation-3;
     padding: 1.75rem;
 
     .settings-panehead {
@@ -158,7 +158,7 @@
         background: s.$white;
         border: 1px solid s.$surface-warm-border;
         border-radius: s.$radius-3xl;
-        box-shadow: s.$shadow-soft;
+        box-shadow: s.$elevation-3;
         overflow: hidden;
       }
       .settings-navitem {

--- a/src/pages/Settings/components/controls.scss
+++ b/src/pages/Settings/components/controls.scss
@@ -160,7 +160,7 @@
     width: 20px;
     border-radius: s.$radius-circle;
     background: s.$white;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    box-shadow: s.$elevation-1;
     transition: transform 0.15s ease;
   }
   &.on {
@@ -253,7 +253,7 @@
   gap: 1rem;
   background: s.$primary-text;
   border-radius: s.$radius-2xl;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  box-shadow: s.$elevation-3;
   // Collapsed by default so the hidden bar reserves no space under the form
   // (opacity alone left ~3.5rem of dead padding at the bottom of every section).
   max-height: 0;

--- a/src/pages/Settings/sections/sections.scss
+++ b/src/pages/Settings/sections/sections.scss
@@ -157,7 +157,7 @@
   width: min(440px, 100%);
   background: s.$white;
   border-radius: s.$radius-3xl;
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.24);
+  box-shadow: s.$elevation-5;
   padding: 1.5rem;
   display: flex;
   flex-direction: column;

--- a/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
+++ b/src/pages/SingleRecipe/DataSections/RecipeControls/RecipeControls.scss
@@ -15,7 +15,7 @@
   background: linear-gradient(135deg, rgba(s.$secondary, 0.13), rgba(s.$primary, 0.09));
   border: 1.5px solid rgba(s.$primary, 0.22);
   border-radius: s.$radius-3xl;
-  box-shadow: rgba(48, 56, 65, 0.06) 0px 8px 22px;
+  box-shadow: s.$elevation-3;
   .who {
     display: flex;
     align-items: center;

--- a/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
+++ b/src/pages/SingleRecipe/RecipeNotFound/RecipeNotFound.scss
@@ -21,7 +21,7 @@
     background: s.$white;
     border: 1.5px solid s.$gray-200;
     border-radius: s.$radius-4xl;
-    box-shadow: rgba(48, 56, 65, 0.06) 0px 10px 30px;
+    box-shadow: s.$elevation-4;
   }
 
   .rnf-icon {

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -9,7 +9,6 @@
 
 $soft-border: s.$gray-200;
 $soft-radius: 16px;
-$soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
 
 .single-recipe-page {
   max-width: 1080px;
@@ -71,7 +70,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
       display: block;
     }
     img {
-      box-shadow: rgba(48, 56, 65, 0.1) 0px 12px 28px;
+      box-shadow: s.$elevation-4;
       // Held at 0 until the image actually decodes (onLoad), then faded in over
       // the skeleton — no top-down paint over an empty box.
       opacity: 0;
@@ -152,7 +151,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
     background: s.$white;
     border: 1.5px solid $soft-border;
     border-radius: $soft-radius;
-    box-shadow: $soft-shadow;
+    box-shadow: s.$elevation-3;
   }
   .meta {
     display: flex;
@@ -240,7 +239,7 @@ $soft-shadow: rgba(48, 56, 65, 0.05) 0px 6px 20px;
     background: s.$white;
     border: 1.5px solid $soft-border;
     border-radius: $soft-radius;
-    box-shadow: $soft-shadow;
+    box-shadow: s.$elevation-3;
     padding: 1.5rem 1.75rem;
     @include s.below(s.$bp-lg) { padding: 1.25rem 1rem; }
     > h2 { font-size: s.$text-xl; font-weight: 700; margin-bottom: 1.1rem; }


### PR DESCRIPTION
## What

Collapses the app's ~40 ad-hoc `box-shadow:` literals across ~30 stylesheets onto a documented **6-step `$elevation-*` ramp** + three brand-glow tokens in `src/helpers.scss`. This is the **elevation re-author** track of the `2-scss` design-consistency lane — the fifth design-system doc after icon / button / admin-palette / type-scale.

Before, resting cards alone used both `.06` and `.08` alpha over three different `y`/`blur` pairs; the raised/hover tier spanned six visually-interchangeable values; and the tint was a mix of pure black, slate `rgb(48,56,65)`, warm `rgb(40,30,20)`, and `$admin-slate-900`. Now a shadow is a *height* drawn from one ramp, on one slate tint.

## The tokens

**Neutral elevation ramp** (one slate tint — `rgba($primary-text, …)`, rising by height):

| Token | Value | Use |
|---|---|---|
| `$elevation-1` | `0 1px 3px /.14` | hairline — toggle knobs, faint insets |
| `$elevation-2` | `0 2px 8px /.12` | small — sticky nav, badges, price chips |
| `$elevation-3` | `0 6px 18px /.10` | resting cards — RecipeCard, Home, panels |
| `$elevation-4` | `0 12px 28px /.14` | raised — hovers, dropdowns, popovers |
| `$elevation-5` | `0 18px 50px /.22` | modals / dialogs |
| `$elevation-6` | `0 24px 60px /.40` | full-screen overlay backdrop |

**Brand glows** (kept separate — emphasis, not height): `$shadow-brand`, `$shadow-brand-strong`, `$shadow-teal`.

Retires the interim `$card-box-shadow` / `$shadow-soft` / `$shadow-chip` tokens and the local `$soft-shadow` in `SingleRecipe`.

## Scope / decisions

- **51 declarations across 28 files** repointed; two mappings were value-identical exact matches (teal auth glow, draft-publish brand glow), the rest normalize onto the nearest step — the same intentional collapse the type-scale and admin-palette tracks made.
- **Left bespoke (documented):** the two-layer add-ingredient bar, the horizontal off-canvas drawer, and the two upward sticky-bar shadows — directional/multi-layer geometry the ramp can't reproduce.
- **Out of scope:** focus rings (`0 0 0 3px`) and the two `0 0 0 1px` border-via-shadows — outlines, not elevation; a later a11y pass.

## Verification

- Compiled-CSS diff vs `development`: non-shadow CSS **byte-identical** — only `box-shadow` declarations changed.
- Headless runtime pass across home / recipes / recipe-detail / about / profile (+ a card hover) — computed `box-shadow` reads the intended token on every surface; resting→hover lifts read as a clean `$elevation-3`→`$elevation-4` step.
- The one visible shift is the tint: ~30 previously pure-black shadows now cast the slate tint, and a handful of surfaces snap a step.

## Docs

New design-system doc `docs/design/elevation.md`; BACKLOG item flipped to done; design-consistency run-log banner + ROADMAP Board/status-log updated.
