### PR TITLE
perf: route-level code-splitting — initial payload 393 → 274 kB gz (−30%)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /build
 /dist
 
+# local analysis output (`ANALYZE=1 npm run build` → reports/stats.html)
+/reports
+
 # misc
 .DS_Store
 .env

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -705,7 +705,7 @@ findings table.)*
   deleted, `FormInput` gained `size='md'|'compact'`, 8 call sites migrated; the Settings/BugReport raw-input
   half wasn't in #204's scope and no separate item tracks it — fold into the create-recipe dropdown
   UX-polish item if it comes up. Marker reconciled 2026-07-02 in the Wave-3 re-sweep.)**
-- `[ ]` **Perf: no route-level code-splitting — the whole app ships in one ~1.19 MB / 372 kB-gzip JS chunk**
+- `[x]` **Perf: no route-level code-splitting — the whole app ships in one ~1.19 MB / 372 kB-gzip JS chunk**
   — `npm run build` warns the main chunk is >500 kB; `src/App.tsx` statically imports every page (zero
   `React.lazy`/dynamic `import()` anywhere), and `vite.config.ts` has no `manualChunks`/visualizer. This is
   **the biggest lever for mobile**: against a prod preview, mobile Performance is 56–68 with LCP 7.8–10.7 s and
@@ -713,7 +713,21 @@ findings table.)*
   work. Desktop is fine (89–97). Fix: lazy-load the heavy/rare routes (Admin/* ≈ 5 pages, AddRecipe/EditRecipe
   + the ingredient parser + DnD, SingleRecipe) behind `Suspense`; add `manualChunks` + `rollup-plugin-visualizer`
   to inspect. Needs `App.tsx` route changes + a verification pass → not a blind fix. *(surfaced 2026-06-26 in the
-  Performance sweep; before/after Lighthouse in the sweep PR.)*
+  Performance sweep; before/after Lighthouse in the sweep PR.)* **(done 2026-07-02 — ~22 routes lazy via
+  `src/util/lazyRoute.ts` (React.lazy + one-shot stale-deploy reload guard: offline-aware, storage-safe,
+  never auto-re-armed; post-reload failures surface as `ChunkLoadError` to the app boundary, whose
+  "Try again" hard-reloads since React.lazy caches rejections) behind per-page-keyed `Suspense` inside the
+  Layout/outlet shells (keyed because react-router's `startTransition` only shows fallbacks of newly
+  mounted boundaries — unkeyed, lazy→lazy navigation freezes on the old page). Eager kept: Home, Recipes,
+  SingleRecipe, Login, Signup, 404 — landing surfaces; PublicProfile stays lazy despite being one because
+  eager-importing it hoists ~96 kB of shared graph into entry. Initial payload 393 → 274 kB gz (−30%:
+  JS 363→257, CSS 30→17), >500 kB warning gone; heaviest splits: AddRecipe 69 kB gz (dnd + react-select),
+  Help 11 kB gz (formspree + its stripe transitive). Known tradeoff: first visit to /account, /settings or
+  /admin per session loads shell then section chunks sequentially (both tiny, flash-guarded 220 ms so fast
+  loads show no spinner at all). Same-machine Lighthouse mobile: Home 69→72 (LCP 7.1→6.6 s), /recipes
+  66→67 (LCP 10.8→9.3 s); remaining LCP is image-bound, not JS-bound. `ANALYZE=1 npm run build` writes a
+  `rollup-plugin-visualizer` treemap to `reports/stats.html` (gitignored, outside the publish dir); no
+  `manualChunks` — rolldown's default shared-chunking already dedupes cleanly.)**
 - `[ ]` **Perf: hot read paths have no supporting MongoDB indexes** — `server/db.js` `ensureIndexes()` creates
   indexes for usernames/recipeDrafts/reports/bugReports/auditLog, but `recipes` is indexed only on
   `{ userId, createdAt }` and `ratings` only on `{ username }`. So the catalog's hottest queries fall back to

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "cypress-image-diff-js": "^2.8.0",
         "firebase-admin": "^13.9.0",
         "jsdom": "^29.1.0",
+        "rollup-plugin-visualizer": "^7.0.1",
         "start-server-and-test": "^2.1.5",
         "vite": "^8.0.11",
         "vitest": "^4.1.5"
@@ -3905,6 +3906,22 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cachedir": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
@@ -4511,6 +4528,49 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -5929,6 +5989,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5966,6 +6042,38 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-installed-globally": {
@@ -6030,6 +6138,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7383,6 +7507,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
@@ -7622,6 +7767,19 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
@@ -8281,6 +8439,128 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
+      "integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^11.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -9721,6 +10001,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "cypress-image-diff-js": "^2.8.0",
     "firebase-admin": "^13.9.0",
     "jsdom": "^29.1.0",
+    "rollup-plugin-visualizer": "^7.0.1",
     "start-server-and-test": "^2.1.5",
     "vite": "^8.0.11",
     "vitest": "^4.1.5"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,48 +1,118 @@
-import React, { FC, useEffect } from 'react'
+import React, { FC, ReactElement, Suspense, useEffect } from 'react'
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import AuthProvider from 'src/context/AuthContext'
 
+// Eager routes — the pages visitors land on directly (home, browse, shared
+// recipe and profile links, auth entries) plus the catch-all. Everything else
+// is a lazy chunk fetched on first navigation (see docs/BACKLOG.md
+// route-splitting item: the whole app used to ship as one >1 MB bundle).
 import Home from 'src/pages/Home/Home'
 import Recipes from 'src/pages/Recipes/Recipes'
+import SingleRecipe from 'src/pages/SingleRecipe/SingleRecipe'
 import Login from 'src/pages/Login/Login'
 import Signup from 'src/pages/Signup/Signup'
-import ForgotPassword from 'src/pages/ForgotPassword/ForgotPassword'
+import NotFound from 'src/pages/404/404'
 import PrivateRoute from 'src/Components/PrivateRoute'
 import AdminRoute from 'src/Components/AdminRoute'
-import AdminLayout from 'src/pages/Admin/AdminLayout'
-import Analytics from 'src/pages/Admin/Analytics/Analytics'
-import Reports from 'src/pages/Admin/Reports/Reports'
-import BugReports from 'src/pages/Admin/BugReports/BugReports'
-import Users from 'src/pages/Admin/Users/Users'
-import Audit from 'src/pages/Admin/Audit/Audit'
-import CreateUsername from 'src/pages/CreateUsername/CreateUsername'
-
-import Account from 'src/pages/Account/Account'
-import PublicProfile from 'src/pages/PublicProfile/PublicProfile'
-import SavedRecipes from 'src/pages/Account/SavedRecipes/SavedRecipes'
-import UserRatings from 'src/pages/Account/UserRatings/UserRatings'
-import UserRecipes from 'src/pages/Account/UserRecipes/UserRecipes'
-import Drafts from 'src/pages/Account/Drafts/Drafts'
-
-import AddRecipe from 'src/pages/AddRecipe/AddRecipe'
-import EditRecipe from 'src/pages/EditRecipe/EditRecipe'
 import Layout from 'src/Components/Layout/Layout'
-import Help from 'src/pages/Help/Help'
-import NotFound from 'src/pages/404/404'
-import SingleRecipe from 'src/pages/SingleRecipe/SingleRecipe'
-import About from 'src/pages/About/About'
-import Privacy from 'src/pages/Privacy/Privacy'
-import Terms from 'src/pages/Terms/Terms'
 
 import { Toaster } from 'react-hot-toast'
-import Settings from 'src/pages/Settings/Settings'
-import ProfileSection from 'src/pages/Settings/sections/ProfileSection'
-import AccountSection from 'src/pages/Settings/sections/AccountSection'
-import PrivacySection from 'src/pages/Settings/sections/PrivacySection'
-import DangerSection from 'src/pages/Settings/sections/DangerSection'
 import { Sentry } from 'src/util/sentry'
 import AppErrorFallback from 'src/Components/AppErrorFallback/AppErrorFallback'
+import RouteFallback from 'src/Components/RouteFallback/RouteFallback'
+import { lazyRoute } from 'src/util/lazyRoute'
+
+// Auth side flows.
+const ForgotPassword = lazyRoute(
+  () => import('src/pages/ForgotPassword/ForgotPassword')
+)
+const CreateUsername = lazyRoute(
+  () => import('src/pages/CreateUsername/CreateUsername')
+)
+
+// Admin section (admin-only — pure dead weight for everyone else).
+const AdminLayout = lazyRoute(() => import('src/pages/Admin/AdminLayout'))
+const Analytics = lazyRoute(
+  () => import('src/pages/Admin/Analytics/Analytics')
+)
+const Reports = lazyRoute(() => import('src/pages/Admin/Reports/Reports'))
+const BugReports = lazyRoute(
+  () => import('src/pages/Admin/BugReports/BugReports')
+)
+const Users = lazyRoute(() => import('src/pages/Admin/Users/Users'))
+const Audit = lazyRoute(() => import('src/pages/Admin/Audit/Audit'))
+
+// Account area. PublicProfile is a direct-landing surface (shared profile
+// links), but eager-importing it hoists ~100 kB of shared graph into the
+// entry chunk — so it stays lazy; the flash-guarded fallback means a fast
+// chunk load never even shows a spinner.
+const PublicProfile = lazyRoute(
+  () => import('src/pages/PublicProfile/PublicProfile')
+)
+const Account = lazyRoute(() => import('src/pages/Account/Account'))
+const SavedRecipes = lazyRoute(
+  () => import('src/pages/Account/SavedRecipes/SavedRecipes')
+)
+const UserRatings = lazyRoute(
+  () => import('src/pages/Account/UserRatings/UserRatings')
+)
+const UserRecipes = lazyRoute(
+  () => import('src/pages/Account/UserRecipes/UserRecipes')
+)
+const Drafts = lazyRoute(() => import('src/pages/Account/Drafts/Drafts'))
+
+// Recipe editor — the heaviest split (drag-and-drop + react-select live here).
+const AddRecipe = lazyRoute(() => import('src/pages/AddRecipe/AddRecipe'))
+const EditRecipe = lazyRoute(() => import('src/pages/EditRecipe/EditRecipe'))
+
+// Settings.
+const Settings = lazyRoute(() => import('src/pages/Settings/Settings'))
+const ProfileSection = lazyRoute(
+  () => import('src/pages/Settings/sections/ProfileSection')
+)
+const AccountSection = lazyRoute(
+  () => import('src/pages/Settings/sections/AccountSection')
+)
+const PrivacySection = lazyRoute(
+  () => import('src/pages/Settings/sections/PrivacySection')
+)
+const DangerSection = lazyRoute(
+  () => import('src/pages/Settings/sections/DangerSection')
+)
+
+// Company/legal + help (Help also keeps @formspree out of the entry chunk).
+const About = lazyRoute(() => import('src/pages/About/About'))
+const Privacy = lazyRoute(() => import('src/pages/Privacy/Privacy'))
+const Terms = lazyRoute(() => import('src/pages/Terms/Terms'))
+const Help = lazyRoute(() => import('src/pages/Help/Help'))
+
+// react-router v7 wraps navigation in React.startTransition, and a transition
+// only shows the fallback of a *newly mounted* Suspense boundary — an existing
+// one keeps the old page on screen, so navigating between two lazy siblings
+// (About → Help, Account tab → tab) would silently freeze until the chunk
+// arrives. Keying the boundary by the wrapped page component remounts it per
+// page (fallback shows), while shells (Account/Settings/AdminLayout) keep a
+// stable key across child-route changes so they don't re-spin on tab switches.
+let nextBoundaryKey = 0
+const boundaryKeys = new WeakMap<object, number>()
+const boundaryKeyFor = (type: unknown): number => {
+  let key = boundaryKeys.get(type as object)
+  if (key === undefined) {
+    key = ++nextBoundaryKey
+    boundaryKeys.set(type as object, key)
+  }
+  return key
+}
+
+// Suspense boundary for a lazy page. Sits inside Layout (and inside nested
+// outlets like Account/Settings/AdminLayout), so the surrounding shell stays
+// mounted while the chunk downloads — only the content area shows the spinner.
+const Lazy: FC<{ children: ReactElement }> = ({ children }) => (
+  <Suspense key={boundaryKeyFor(children.type)} fallback={<RouteFallback />}>
+    {children}
+  </Suspense>
+)
 
 const ScrollToTop: FC = () => {
   const { pathname } = useLocation()
@@ -54,7 +124,9 @@ const ScrollToTop: FC = () => {
 const App: FC = () => {
   return (
     <Sentry.ErrorBoundary
-      fallback={({ resetError }) => <AppErrorFallback resetError={resetError} />}
+      fallback={({ error, resetError }) => (
+        <AppErrorFallback error={error} resetError={resetError} />
+      )}
     >
       <HelmetProvider>
         <AuthProvider>
@@ -103,7 +175,9 @@ const App: FC = () => {
               path='/u/:username'
               element={
                 <Layout darkNavLinks={true}>
-                  <PublicProfile />
+                  <Lazy>
+                    <PublicProfile />
+                  </Lazy>
                 </Layout>
               }
             />
@@ -113,7 +187,9 @@ const App: FC = () => {
               path='/about'
               element={
                 <Layout darkNavLinks={true}>
-                  <About />
+                  <Lazy>
+                    <About />
+                  </Lazy>
                 </Layout>
               }
             />
@@ -121,7 +197,9 @@ const App: FC = () => {
               path='/privacy'
               element={
                 <Layout darkNavLinks={true}>
-                  <Privacy />
+                  <Lazy>
+                    <Privacy />
+                  </Lazy>
                 </Layout>
               }
             />
@@ -129,7 +207,9 @@ const App: FC = () => {
               path='/terms'
               element={
                 <Layout darkNavLinks={true}>
-                  <Terms />
+                  <Lazy>
+                    <Terms />
+                  </Lazy>
                 </Layout>
               }
             />
@@ -139,31 +219,98 @@ const App: FC = () => {
                 path='/account'
                 element={
                   <Layout darkNavLinks={true}>
-                    <Account />
+                    <Lazy>
+                      <Account />
+                    </Lazy>
                   </Layout>
                 }
               >
-                <Route path='saved-recipes' element={<SavedRecipes />} />
-                <Route path='ratings' element={<UserRatings />} />
-                <Route path='your-recipes' element={<UserRecipes />} />
-                <Route path='drafts' element={<Drafts />} />
+                <Route
+                  path='saved-recipes'
+                  element={
+                    <Lazy>
+                      <SavedRecipes />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='ratings'
+                  element={
+                    <Lazy>
+                      <UserRatings />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='your-recipes'
+                  element={
+                    <Lazy>
+                      <UserRecipes />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='drafts'
+                  element={
+                    <Lazy>
+                      <Drafts />
+                    </Lazy>
+                  }
+                />
               </Route>
               <Route
                 path='/settings'
                 element={
                   <Layout darkNavLinks={true}>
-                    <Settings />
+                    <Lazy>
+                      <Settings />
+                    </Lazy>
                   </Layout>
                 }
               >
                 {/* Index renders Profile so a direct /settings visit (and the
                     desktop landing) shows it; /settings/profile is the canonical
                     route the nav + mobile master-detail link to. */}
-                <Route path='' element={<ProfileSection />} />
-                <Route path='profile' element={<ProfileSection />} />
-                <Route path='account' element={<AccountSection />} />
-                <Route path='privacy' element={<PrivacySection />} />
-                <Route path='danger' element={<DangerSection />} />
+                <Route
+                  path=''
+                  element={
+                    <Lazy>
+                      <ProfileSection />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='profile'
+                  element={
+                    <Lazy>
+                      <ProfileSection />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='account'
+                  element={
+                    <Lazy>
+                      <AccountSection />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='privacy'
+                  element={
+                    <Lazy>
+                      <PrivacySection />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='danger'
+                  element={
+                    <Lazy>
+                      <DangerSection />
+                    </Lazy>
+                  }
+                />
                 {/* Old bookmark — the password form now lives under Account. */}
                 <Route
                   path='password'
@@ -174,7 +321,9 @@ const App: FC = () => {
                 path='/add-recipe'
                 element={
                   <Layout darkNavLinks={true}>
-                    <AddRecipe />
+                    <Lazy>
+                      <AddRecipe />
+                    </Lazy>
                   </Layout>
                 }
               />
@@ -182,7 +331,9 @@ const App: FC = () => {
                 path='/recipes/:recipeId/edit'
                 element={
                   <Layout darkNavLinks={true}>
-                    <EditRecipe />
+                    <Lazy>
+                      <EditRecipe />
+                    </Lazy>
                   </Layout>
                 }
               />
@@ -191,27 +342,84 @@ const App: FC = () => {
               path='/help'
               element={
                 <Layout darkNavLinks={true}>
-                  <Help />
+                  <Lazy>
+                    <Help />
+                  </Lazy>
                 </Layout>
               }
             />
             {/* Admin section — gated by AdminRoute (login + admin claim),
                 outside the public Layout (its own AdminLayout shell). */}
             <Route path='/admin' element={<AdminRoute />}>
-              <Route element={<AdminLayout />}>
+              <Route
+                element={
+                  <Lazy>
+                    <AdminLayout />
+                  </Lazy>
+                }
+              >
                 <Route index element={<Navigate to='/admin/analytics' replace />} />
-                <Route path='analytics' element={<Analytics />} />
-                <Route path='reports' element={<Reports />} />
-                <Route path='bug-reports' element={<BugReports />} />
-                <Route path='users' element={<Users />} />
-                <Route path='audit' element={<Audit />} />
+                <Route
+                  path='analytics'
+                  element={
+                    <Lazy>
+                      <Analytics />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='reports'
+                  element={
+                    <Lazy>
+                      <Reports />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='bug-reports'
+                  element={
+                    <Lazy>
+                      <BugReports />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='users'
+                  element={
+                    <Lazy>
+                      <Users />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='audit'
+                  element={
+                    <Lazy>
+                      <Audit />
+                    </Lazy>
+                  }
+                />
               </Route>
             </Route>
 
             <Route path='/login' element={<Login />} />
             <Route path='/signup' element={<Signup />} />
-            <Route path='/create-username' element={<CreateUsername />} />
-            <Route path='/forgot-password' element={<ForgotPassword />} />
+            <Route
+              path='/create-username'
+              element={
+                <Lazy>
+                  <CreateUsername />
+                </Lazy>
+              }
+            />
+            <Route
+              path='/forgot-password'
+              element={
+                <Lazy>
+                  <ForgotPassword />
+                </Lazy>
+              }
+            />
           </Routes>
         </AuthProvider>
       </HelmetProvider>

--- a/src/Components/AppErrorFallback/AppErrorFallback.tsx
+++ b/src/Components/AppErrorFallback/AppErrorFallback.tsx
@@ -4,13 +4,25 @@ import './AppErrorFallback.scss'
 interface AppErrorFallbackProps {
   /** Provided by Sentry.ErrorBoundary — clears the boundary's error state. */
   resetError: () => void
+  /** The caught error, when the boundary provides it. */
+  error?: unknown
 }
 
 // Shown by the global Sentry.ErrorBoundary in App.tsx when an unhandled render
 // error escapes a route. The error itself is already reported to Sentry by the
 // boundary; this is purely the friendly recovery UI. Kept dependency-free (no
 // router/auth) so it renders even if a provider is what crashed.
-const AppErrorFallback: FC<AppErrorFallbackProps> = ({ resetError }) => {
+const AppErrorFallback: FC<AppErrorFallbackProps> = ({ resetError, error }) => {
+  const tryAgain = () => {
+    // A failed route chunk (tagged by src/util/lazyRoute.ts) can't be retried
+    // by re-rendering — React.lazy caches the rejection — so recovery needs a
+    // fresh page load to get new lazy payloads (and a fresh asset manifest).
+    if (error instanceof Error && error.name === 'ChunkLoadError') {
+      window.location.reload()
+      return
+    }
+    resetError()
+  }
   return (
     <div className='app-error-fallback'>
       <div className='app-error-content'>
@@ -20,7 +32,7 @@ const AppErrorFallback: FC<AppErrorFallbackProps> = ({ resetError }) => {
           again, or head back to the homepage.
         </p>
         <div className='app-error-actions'>
-          <button className='btn' onClick={resetError}>
+          <button className='btn' onClick={tryAgain}>
             Try again
           </button>
           <a className='btn secondary' href='/'>

--- a/src/Components/RouteFallback/RouteFallback.scss
+++ b/src/Components/RouteFallback/RouteFallback.scss
@@ -1,0 +1,7 @@
+.route-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  // Tall enough that the footer doesn't jump into the viewport mid-load.
+  min-height: 60vh;
+}

--- a/src/Components/RouteFallback/RouteFallback.tsx
+++ b/src/Components/RouteFallback/RouteFallback.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react'
+import { TailSpin } from 'react-loader-spinner'
+import { spinnerColor } from 'src/util/loadingStyles'
+import { useDelayedLoading } from 'src/hooks/useDelayedLoading'
+import './RouteFallback.scss'
+
+// Suspense fallback shown while a lazy route's chunk downloads. Rendered
+// inside Layout, so the nav/footer shell stays mounted around it. The spinner
+// sits behind the house flash-guard (docs/design/loading-states.md): a chunk
+// that arrives quickly never shows one, while the container keeps its height
+// from the first frame so the footer doesn't jump.
+const RouteFallback: FC = () => {
+  const showSpinner = useDelayedLoading(true)
+  return (
+    <div className='route-fallback' role='status' aria-label='Loading page'>
+      {showSpinner && (
+        <TailSpin height='40' width='40' color={spinnerColor} ariaLabel='loading' />
+      )}
+    </div>
+  )
+}
+
+export default RouteFallback

--- a/src/test/lazyRoute.test.ts
+++ b/src/test/lazyRoute.test.ts
@@ -1,0 +1,96 @@
+import { vi } from 'vitest'
+import { withChunkReload } from 'src/util/lazyRoute'
+
+const FLAG = 'prepify:chunk-reload'
+
+describe('withChunkReload', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('passes a successful load through without touching the flag', async () => {
+    sessionStorage.setItem(FLAG, '1')
+    const reload = vi.fn()
+    const load = withChunkReload(
+      () => Promise.resolve({ default: 'page' }),
+      reload
+    )
+
+    await expect(load()).resolves.toEqual({ default: 'page' })
+    // Never auto-cleared — see the loop rationale in lazyRoute.ts.
+    expect(sessionStorage.getItem(FLAG)).toBe('1')
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('reloads once on a failed chunk load, then fails the route if the reload never happens', async () => {
+    vi.useFakeTimers()
+    const reload = vi.fn()
+    const load = withChunkReload(
+      () => Promise.reject(new Error('failed to fetch chunk')),
+      reload
+    )
+
+    const pending = load()
+    // Attach the rejection expectation before time advances (avoids an
+    // unhandled-rejection warning), then run out the 5 s stuck-reload window.
+    const assertion = expect(pending).rejects.toMatchObject({
+      name: 'ChunkLoadError',
+    })
+    await vi.advanceTimersByTimeAsync(5000)
+    await assertion
+
+    expect(reload).toHaveBeenCalledTimes(1)
+    expect(sessionStorage.getItem(FLAG)).toBe('1')
+  })
+
+  it('rethrows a tagged ChunkLoadError if a chunk still fails after a reload', async () => {
+    sessionStorage.setItem(FLAG, '1')
+    const reload = vi.fn()
+    const err = new Error('still failing')
+    const load = withChunkReload(() => Promise.reject(err), reload)
+
+    await expect(load()).rejects.toBe(err)
+    expect(err.name).toBe('ChunkLoadError')
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('does not reload while offline — the failure surfaces to the error boundary', async () => {
+    vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(false)
+    const reload = vi.fn()
+    const load = withChunkReload(
+      () => Promise.reject(new Error('failed to fetch chunk')),
+      reload
+    )
+
+    await expect(load()).rejects.toMatchObject({ name: 'ChunkLoadError' })
+    expect(reload).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem(FLAG)).toBeNull()
+  })
+
+  it('never reloads when sessionStorage is blocked (throws on access)', async () => {
+    // jsdom's Storage is a Proxy that vi.spyOn can't shadow — swap the whole
+    // global for one whose access throws, like a storage-blocked browser.
+    vi.stubGlobal('sessionStorage', {
+      getItem: () => {
+        throw new Error('storage blocked')
+      },
+      setItem: () => {
+        throw new Error('storage blocked')
+      },
+    })
+    const reload = vi.fn()
+    const load = withChunkReload(
+      () => Promise.reject(new Error('failed to fetch chunk')),
+      reload
+    )
+
+    await expect(load()).rejects.toMatchObject({ name: 'ChunkLoadError' })
+    expect(reload).not.toHaveBeenCalled()
+  })
+})

--- a/src/util/lazyRoute.ts
+++ b/src/util/lazyRoute.ts
@@ -1,0 +1,68 @@
+import { lazy } from 'react'
+import type { ComponentType } from 'react'
+
+const RELOAD_FLAG = 'prepify:chunk-reload'
+
+// sessionStorage access can throw (storage-blocked browsers, sandboxed
+// frames). If it's unreadable, report the flag as already set — that disables
+// the automatic reload entirely (so it can never loop) and routes failures to
+// the error boundary instead.
+const reloadFlagSet = (): boolean => {
+  try {
+    return sessionStorage.getItem(RELOAD_FLAG) !== null
+  } catch {
+    return true
+  }
+}
+const setReloadFlag = (): void => {
+  try {
+    sessionStorage.setItem(RELOAD_FLAG, '1')
+  } catch {
+    // Unwritable storage also reads as set (above), so no loop either way.
+  }
+}
+
+/**
+ * Wraps a route chunk's import with a stale-deploy guard. Hashed chunk URLs
+ * die when a deploy replaces the assets under an open tab; the first failed
+ * load reloads the page once to pick up the new index.html.
+ *
+ * The flag is scoped to the tab session and deliberately never auto-cleared:
+ * clearing it on a later successful load would re-arm the reload for a
+ * persistently failing sibling (nested shells load parent-then-child, so a
+ * healthy parent + broken child would reload forever). After the one reload,
+ * every failure is tagged `ChunkLoadError` and thrown to the app error
+ * boundary, whose "Try again" hard-reloads for this error class — React.lazy
+ * caches rejections, so a plain boundary reset can never recover a chunk.
+ */
+export function withChunkReload<T>(
+  importFn: () => Promise<T>,
+  // Injectable for tests — jsdom's window.location.reload can't be stubbed.
+  reload: () => void = () => window.location.reload()
+): () => Promise<T> {
+  return () =>
+    importFn().catch((err: unknown) => {
+      if (err instanceof Error) err.name = 'ChunkLoadError'
+      // A dropped connection isn't a stale deploy — reloading while offline
+      // would replace the working app with the browser's offline error page.
+      const offline =
+        typeof navigator !== 'undefined' && navigator.onLine === false
+      if (offline || reloadFlagSet()) throw err
+      setReloadFlag()
+      reload()
+      // Keep the Suspense fallback up while the page reloads — but if the
+      // reload is blocked (Settings' dirty-form beforeunload guard lets the
+      // user cancel it), fail the route into the error boundary rather than
+      // leaving navigation hung on a promise that never settles.
+      return new Promise<T>((_, rejectStuck) => {
+        setTimeout(() => rejectStuck(err), 5000)
+      })
+    })
+}
+
+/** React.lazy for route components, with the stale-deploy reload guard. */
+export function lazyRoute<T extends ComponentType<any>>(
+  importFn: () => Promise<{ default: T }>
+) {
+  return lazy(withChunkReload(importFn))
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,22 @@ import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(async () => ({
+  plugins: [
+    react(),
+    // Opt-in bundle analysis: `ANALYZE=1 npm run build` writes reports/stats.html
+    // (treemap of what each chunk is made of). Kept out of build/ so an analyze
+    // run can never leak the module map into the deployed site. Dynamic import
+    // because the plugin is ESM-only and this config loads as CJS.
+    ...(process.env.ANALYZE === '1'
+      ? [
+          (await import('rollup-plugin-visualizer')).visualizer({
+            filename: 'reports/stats.html',
+            gzipSize: true,
+          }),
+        ]
+      : []),
+  ],
   resolve: {
     alias: {
       src: path.resolve(__dirname, './src'),
@@ -13,6 +27,17 @@ export default defineConfig({
   server: {
     port: 3000,
     host: '0.0.0.0',
+    // Pre-transform the biggest lazy route chunks on dev-server start. With
+    // route-splitting, the dev server otherwise transforms a lazy page's whole
+    // module graph on first navigation — a pause Cypress specs with tight
+    // timeouts (AddRecipe, Admin) would feel as flake.
+    warmup: {
+      clientFiles: [
+        './src/pages/AddRecipe/AddRecipe.tsx',
+        './src/pages/Admin/AdminLayout.tsx',
+        './src/pages/Admin/Reports/Reports.tsx',
+      ],
+    },
   },
   build: {
     outDir: 'build',
@@ -39,4 +64,4 @@ export default defineConfig({
       ),
     },
   },
-})
+}))


### PR DESCRIPTION
Closes out the headline structural item the Performance sweep filed in `docs/BACKLOG.md`: the whole app shipped as one 1,170 kB (363 kB gz) JS chunk because `src/App.tsx` statically imported every page.

## What changed

- **~22 routes are now `React.lazy` chunks** fetched on first navigation: Admin/* (5 pages + shell), AddRecipe/EditRecipe (the heaviest split — dnd + react-select, 69 kB gz), Account + subpages, Settings + sections, About/Privacy/Terms/Help (Help alone keeps formspree + its Stripe transitive out of entry, 11 kB gz), CreateUsername, ForgotPassword, PublicProfile.
- **Eager (landing surfaces):** Home, Recipes, SingleRecipe, Login, Signup, 404. PublicProfile is a landing surface too but stays lazy — measured: eager-importing it hoists ~96 kB of shared graph into entry.
- **`src/util/lazyRoute.ts`** — one-shot stale-deploy guard (hashed chunk URLs die under open tabs when a deploy lands): first failure reloads once; offline-aware, storage-safe, never auto-re-armed (loop-proof for nested shell→child chunks); a reload vetoed by the Settings dirty-form guard fails the route after 5 s instead of hanging. Post-reload failures throw tagged `ChunkLoadError`.
- **`AppErrorFallback`** — "Try again" hard-reloads for `ChunkLoadError` (React.lazy caches rejections; a boundary reset can never recover a chunk error).
- **Per-page-keyed `Suspense`** — react-router v7 navigates inside `startTransition`, which only shows fallbacks of *newly mounted* boundaries; unkeyed, lazy→lazy navigation freezes on the old page with no feedback.
- **`RouteFallback`** spinner behind the house 220 ms flash-guard (`useDelayedLoading`) — fast chunk loads never flash a spinner.
- **Tooling:** `ANALYZE=1 npm run build` → `rollup-plugin-visualizer` treemap at `reports/stats.html` (gitignored, outside the publish dir); dev-server `warmup` pre-transforms the heavy lazy pages the Cypress specs hit under tight timeouts.

## Numbers (same-machine, prod preview + dev API, Lighthouse 13.4.0 mobile)

| | before | after |
|---|---|---|
| initial payload (gz) | 393.1 kB | **274.3 kB (−30%)** |
| initial JS (gz) | 362.76 kB | 257.3 kB |
| entry CSS (gz) | 30.30 kB | 17.0 kB |
| `>500 kB` build warning | yes | gone |
| Home perf / LCP | 69 / 7.1 s | **72 / 6.6 s** |
| /recipes perf / LCP | 66 / 10.8 s | **67 / 9.3 s** |

/recipes CLS 0.105 is identical before/after (pre-existing image reflow, not this change). Remaining mobile LCP is image-bound — that's the next lever, not JS.

## Verification

- `tsc` clean; Vitest 550 passed / 2 skipped (5 new `withChunkReload` tests: pass-through, reload-once + stuck-reload rejection, post-reload rethrow, offline no-reload, storage-blocked no-reload).
- Headless-Chrome click-through of every public route + logged-out gated-route redirect against the production preview (real chunk fetching, live dev API — 10 recipe cards render on /recipes).
- Adversarial multi-agent review (4 lenses → 14 confirmed findings): all fixed — reload-loop classes, offline teardown, unrecoverable Try-again, storage crashes, frozen lazy→lazy navigation, spinner flash — or explicitly documented (first `/account`–`/settings`–`/admin` visit per session loads shell→section chunks sequentially; both tiny and flash-guarded).

Known accepted tradeoff: direct-landing on a lazy route costs one extra roundtrip after entry (chunks are 1–10 kB gz).

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ