### PR TITLE
perf(db): index browse-popular + getReviews hot read paths

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -728,7 +728,7 @@ findings table.)*
   66→67 (LCP 10.8→9.3 s); remaining LCP is image-bound, not JS-bound. `ANALYZE=1 npm run build` writes a
   `rollup-plugin-visualizer` treemap to `reports/stats.html` (gitignored, outside the publish dir); no
   `manualChunks` — rolldown's default shared-chunking already dedupes cleanly.)**
-- `[ ]` **Perf: hot read paths have no supporting MongoDB indexes** — `server/db.js` `ensureIndexes()` creates
+- `[x]` **Perf: hot read paths have no supporting MongoDB indexes** — `server/db.js` `ensureIndexes()` creates
   indexes for usernames/recipeDrafts/reports/bugReports/auditLog, but `recipes` is indexed only on
   `{ userId, createdAt }` and `ratings` only on `{ username }`. So the catalog's hottest queries fall back to
   collection scans + in-memory sorts as the catalog grows:
@@ -743,6 +743,33 @@ findings table.)*
   reviewCreatedAt:-1}` and `{recipeId:1, rating:-1}`). Confirm each with `.explain()` before/after. Negligible at
   today's catalog size; grows linearly. *(surfaced 2026-06-26 in the Performance sweep; pairs with the autocomplete
   fuzzy-fallback scan item above, which is the same missing-index story for title search.)*
+  **(done 2026-07-02, PR #TBD — grounded in `.explain('executionStats')` against dev, not the proposed keys.
+  Two findings reshaped the fix: (1) the proposed `status`-leading compounds are WRONG — `RECIPE_VISIBLE` is
+  `status: { $nin: [...] }`, a low-selectivity RANGE, so by equality→sort→range it must stay a FETCH residual, not
+  a leading key (leading with it fragments the index into intervals and defeats the sort). (2) A prior manual
+  migration (`server/scripts/createModerationIndexes.js`) had already added `recipes {featured:-1,views:-1}`,
+  `{createdAt:-1}`, `{userId:1}` and `ratings {recipeId:1,username:1}`, `{userId:1,recipeId:1}` to dev/prod — so
+  two of the four paths were NOT actually unindexed. Net-new gaps, both confirmed COLLSCAN/blocking-SORT→IXSCAN:
+    - **`GET /recipes` default browse** (SORTS.popular) — added `recipes {numTimesSaved:-1, views:-1, _id:-1}`
+      (key order mirrors the sort exactly). BEFORE `SORT ← COLLSCAN`, docsExamined 12, in-memory sort. AFTER
+      `FETCH ← IXSCAN`, docsExamined 5 (=limit), **no blocking sort**. Bonus: the mealTypes/diets/cuisine-filtered
+      popular listings also ride it (filters become residuals) — sort eliminated there too.
+    - **`GET /getReviews`** — added `ratings {recipeId:1, reviewCreatedAt:-1}` (filter=new) and
+      `{recipeId:1, rating:-1}` (filter=top). BEFORE `SORT ← FETCH ← IXSCAN(recipeId_1_username_1)` — the recipeId
+      MATCH was indexed but the sort was a blocking in-memory sort; docsExamined 10. AFTER `FETCH ← IXSCAN`,
+      **no blocking sort**, docsExamined 6/8.
+    - **`GET /getTrendingRecipes`** — already optimal via the migration's `featured_-1_views_-1`
+      (`IXSCAN`, no sort, docsExamined = limit). No new index; backlog's "unindexed" was stale.
+    - **`GET /recipes/random`** — left as-is by design: the `$match` is `status: $nin` (+ `userId: $ne`), both
+      low-selectivity ranges, and `$sample` after a non-first-stage `$match` can't use the random-cursor
+      optimization, so any index would examine ~all docs anyway for negligible gain.
+  Multikey note: `mealTypes`/`nutritionLabels` are arrays — deliberately NOT indexed as leading keys here (each
+  would be a separate multikey index, and they're residual filters on the popular walk). `title`/`cuisine` regex
+  can't use a normal index (separate autocomplete fuzzy-fallback item; not regressed). Deferred siblings, both the
+  same story, low-frequency so not added: the non-popular browse sorts (createdAt/servingPrice/totalTime — each
+  needs its own `{sortKey, _id}` index) and `getSingleUserReviews` (userId-keyed, still blocking-sorts on
+  `{userId:1,reviewCreatedAt:-1}`/`{userId:1,rating:-1}`). All three additions went into `ensureIndexes()` so they
+  deploy with the code; `createIndex` is idempotent and the new names don't collide with the migration's.)**
 - `[ ]` **Perf: `/recipes/facets` runs 3 unfiltered `distinct()` = 3 full `recipes` scans per browse load**
   (`server/routes/recipes.js:167-181`, `distinct('cuisine'|'nutritionLabels'|'mealTypes')`). Called on every
   `/recipes` page load to build the filter UI. Cache the result (short TTL) or maintain a small summary doc

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -743,7 +743,7 @@ findings table.)*
   reviewCreatedAt:-1}` and `{recipeId:1, rating:-1}`). Confirm each with `.explain()` before/after. Negligible at
   today's catalog size; grows linearly. *(surfaced 2026-06-26 in the Performance sweep; pairs with the autocomplete
   fuzzy-fallback scan item above, which is the same missing-index story for title search.)*
-  **(done 2026-07-02, PR #TBD — grounded in `.explain('executionStats')` against dev, not the proposed keys.
+  **(done 2026-07-02, PR #224 — grounded in `.explain('executionStats')` against dev, not the proposed keys.
   Two findings reshaped the fix: (1) the proposed `status`-leading compounds are WRONG — `RECIPE_VISIBLE` is
   `status: { $nin: [...] }`, a low-selectivity RANGE, so by equality→sort→range it must stay a FETCH residual, not
   a leading key (leading with it fragments the index into intervals and defeats the sort). (2) A prior manual

--- a/server/db.js
+++ b/server/db.js
@@ -75,12 +75,48 @@ async function ensureIndexes() {
     console.error('Failed to create index on recipes.userId:', err.message)
   }
 
+  // Backs the default GET /recipes browse listing (the catalog page hit on every
+  // visit), which sorts by SORTS.popular = { numTimesSaved:-1, views:-1, _id:-1 }.
+  // Key order mirrors that sort EXACTLY so the walk is served in order and the
+  // blocking in-memory SORT is eliminated (before: SORT <- COLLSCAN over the whole
+  // visible catalog per page load). The public `status: { $nin: [...] }` visibility
+  // predicate (RECIPE_VISIBLE) is deliberately NOT led with here: it's a low-
+  // selectivity range ($nin), so by the equality->sort->range rule it stays a FETCH
+  // residual filter rather than a leading key (leading with it would fragment the
+  // index into multiple intervals and defeat the sort). The `_id:-1` tiebreak is in
+  // the index so pagination stays stable without a residual sort. Other browse sorts
+  // (createdAt/servingPrice/totalTime) intentionally aren't indexed here — popular is
+  // the default and dominant path; the rest are lower-frequency and can be added if
+  // they become hot.
+  try {
+    await db.collection('recipes').createIndex({ numTimesSaved: -1, views: -1, _id: -1 })
+  } catch (err) {
+    console.error('Failed to create browse-popular index on recipes:', err.message)
+  }
+
   // Backs GET /api/getSingleUserReviews (a user's ratings) and the ratings count
   // in GET /api/getAccountCounts, both of which filter ratings by username.
   try {
     await db.collection('ratings').createIndex({ username: 1 })
   } catch (err) {
     console.error('Failed to create index on ratings.username:', err.message)
+  }
+
+  // Backs GET /getReviews, the per-recipe review list on every recipe-detail page.
+  // It filters by `recipeId` (equality) then sorts either newest-first
+  // (filter=new -> { reviewCreatedAt:-1 }) or highest-rated (filter=top ->
+  // { rating:-1 }). The existing { recipeId, username } index serves the recipeId
+  // MATCH but not the sort, so the query fetched the matches and then ran a blocking
+  // in-memory SORT (verified via explain). These two compounds put the sort key
+  // right after the equality prefix so the sort is served by the index walk (ESR:
+  // recipeId=equality, then sort key; the `moderationHidden: { $ne: true }` /
+  // `reviewText` predicates stay FETCH residuals). Both are needed because a single
+  // recipeId-prefixed index can only order by one trailing key.
+  try {
+    await db.collection('ratings').createIndex({ recipeId: 1, reviewCreatedAt: -1 })
+    await db.collection('ratings').createIndex({ recipeId: 1, rating: -1 })
+  } catch (err) {
+    console.error('Failed to create getReviews indexes on ratings:', err.message)
   }
 
   // Moderation reports (P1/P2). The `reports` collection is new, so these build

--- a/server/db.js
+++ b/server/db.js
@@ -88,6 +88,17 @@ async function ensureIndexes() {
   // (createdAt/servingPrice/totalTime) intentionally aren't indexed here — popular is
   // the default and dominant path; the rest are lower-frequency and can be added if
   // they become hot.
+  //
+  // This (and the getReviews indexes below) live in startup rather than the deliberate
+  // `scripts/createModerationIndexes.js` step ON PURPOSE, even though they're on the
+  // large recipes/ratings collections: they back per-page-load hot paths, so the index
+  // must exist the instant the querying code goes live — putting them in the script
+  // would open a window where a deploy runs the new query against an unindexed
+  // collection until someone remembers to run it. The build is online (reads/writes
+  // keep working) and sub-second at current scale; if these collections ever grow big
+  // enough that a cold build stalls readiness, that concerns the whole awaited
+  // ensureIndexes() set, and the fix then is to make the heavy set non-blocking — not
+  // to special-case these two paths now.
   try {
     await db.collection('recipes').createIndex({ numTimesSaved: -1, views: -1, _id: -1 })
   } catch (err) {
@@ -111,7 +122,8 @@ async function ensureIndexes() {
   // right after the equality prefix so the sort is served by the index walk (ESR:
   // recipeId=equality, then sort key; the `moderationHidden: { $ne: true }` /
   // `reviewText` predicates stay FETCH residuals). Both are needed because a single
-  // recipeId-prefixed index can only order by one trailing key.
+  // recipeId-prefixed index can only order by one trailing key. (In startup, not the
+  // migration script — same hot-path rationale as the browse-popular index above.)
   try {
     await db.collection('ratings').createIndex({ recipeId: 1, reviewCreatedAt: -1 })
     await db.collection('ratings').createIndex({ recipeId: 1, rating: -1 })


### PR DESCRIPTION
## What & why
`ensureIndexes()` (server/db.js) gains **three compound indexes** for the catalog's hottest read paths. Every key was derived from `.explain('executionStats')` against dev — not the backlog's proposed keys, two of which turned out wrong (see below).

## Findings that reshaped the fix
1. **The proposed `status`-leading compounds are wrong.** `RECIPE_VISIBLE` is `status: { $nin: [...] }` — a *low-selectivity range*, not equality. By equality→sort→range it must stay a FETCH residual; leading with it fragments the index into intervals and defeats the sort.
2. **A prior manual migration already indexed two of the four paths.** `server/scripts/createModerationIndexes.js` had added `recipes {featured:-1,views:-1}` and `ratings {recipeId:1,username:1}` (etc.) to dev/prod, so `getTrendingRecipes` was already optimal and `getReviews`'s recipeId *match* was already indexed. The backlog's "unindexed" premise was partly stale.

## The three net-new indexes (before → after, `.explain` on dev)
| Path | Index added | Before | After |
|---|---|---|---|
| `GET /recipes` default browse (SORTS.popular) | `recipes {numTimesSaved:-1, views:-1, _id:-1}` | `SORT ← COLLSCAN`, docsExamined 12, **in-memory sort** | `FETCH ← IXSCAN`, docsExamined 5 (=limit), **no blocking sort** |
| `GET /getReviews` filter=new | `ratings {recipeId:1, reviewCreatedAt:-1}` | `SORT ← FETCH ← IXSCAN(recipeId_1_username_1)`, **blocking sort**, docsExamined 10 | `FETCH ← IXSCAN`, **no sort**, docsExamined 6 |
| `GET /getReviews` filter=top | `ratings {recipeId:1, rating:-1}` | same blocking sort | `FETCH ← IXSCAN`, **no sort**, docsExamined 8 |

Bonus: the mealTypes/diets/cuisine-filtered *popular* listings also ride the new browse index (filters become residuals) — sort eliminated there too.

## Left as-is (by design)
- **`GET /getTrendingRecipes`** — already `IXSCAN(featured_-1_views_-1)`, no sort, docsExamined = limit (migration covers it).
- **`GET /recipes/random`** — `$match` is `status:$nin` (+ `userId:$ne`), both low-selectivity ranges, and `$sample` after a non-first-stage `$match` can't use the random-cursor optimization, so an index would examine ~all docs for negligible gain.
- **Multikey / regex:** `mealTypes`/`nutritionLabels` are arrays (each would be a separate multikey index — kept as residual filters); `title`/`cuisine` regex can't use a normal index (separate autocomplete item, not regressed).
- **Deferred siblings:** non-popular browse sorts (createdAt/servingPrice/totalTime, each needs its own `{sortKey,_id}` index) and `getSingleUserReviews` (userId-keyed, still blocking-sorts) — same story, lower frequency.

## Idempotency
`createIndex` is idempotent; the three new index names don't collide with the migration's existing ones. They live in `ensureIndexes()` so they deploy with the code.

## Gates
- server Jest: **697/697** (30 suites)
- root Vitest: **550 passed, 2 skipped**
- `tsc --noEmit`: **clean**

Closes the "hot read paths have no supporting MongoDB indexes" BACKLOG item (flipped to `[x]` with this evidence in the same PR).

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ