### PR TITLE
perf(recipes): cache /recipes/facets to stop 3 full COLLSCANs per browse load

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -774,11 +774,33 @@ findings table.)*
   needs its own `{sortKey, _id}` index) and `getSingleUserReviews` (userId-keyed, still blocking-sorts on
   `{userId:1,reviewCreatedAt:-1}`/`{userId:1,rating:-1}`). All three additions went into `ensureIndexes()` so they
   deploy with the code; `createIndex` is idempotent and the new names don't collide with the migration's.)**
-- `[ ]` **Perf: `/recipes/facets` runs 3 unfiltered `distinct()` = 3 full `recipes` scans per browse load**
-  (`server/routes/recipes.js:167-181`, `distinct('cuisine'|'nutritionLabels'|'mealTypes')`). Called on every
-  `/recipes` page load to build the filter UI. Cache the result (short TTL) or maintain a small summary doc
-  (`{_id:'facets', cuisines, diets, mealTypes}`) refreshed on recipe insert/update. *(surfaced 2026-06-26 in the
-  Performance sweep.)*
+- `[x]` **Perf: `/recipes/facets` runs 3 unfiltered `distinct()` = 3 full `recipes` scans per browse load**
+  (`server/routes/recipes.js`, `distinct('cuisine'|'nutritionLabels'|'mealTypes')`). Called on every
+  `/recipes` page load to build the filter UI. *(surfaced 2026-06-26 in the Performance sweep.)* **DONE (this PR).
+  Chose the short-TTL in-process cache over a summary doc: a `distinct` with no predicate is a COLLSCAN that no
+  index can serve, and a summary doc buys nothing here — a delete or a cuisine-edit-away can't be reasoned about
+  incrementally (you can't know a value is gone everywhere without a rescan), so it would still need a full
+  recompute on those paths, at the cost of extra invalidation surface and a persisted doc to keep consistent. The
+  cache also preserves the exact all-statuses `distinct` semantics for free. New `server/util/facetsCache.js`: a
+  5-min TTL cache with single-flight (one scan serves a burst of cold-cache requests) and a generation guard (a
+  scan invalidated mid-flight returns to its caller but doesn't poison the cache). The route reads through it; the
+  write paths that can introduce a NEW value — `addRecipe`/`editRecipe` — plus `deleteRecipe` call
+  `invalidate()`, so a new cuisine/diet/mealType surfaces on the *next* load, not after the TTL. The rare bulk
+  removers (account-delete cascade, admin status flips) ride the TTL backstop; a chip lingering for a briefly-empty
+  cuisine is harmless and already possible today (the `distinct` is unfiltered by status, so hidden/pending recipes
+  already contribute chips). Client tolerance is high regardless — the browse page already React-Query-caches this
+  response for 10 min and only uses `cuisines` (to gray out empty filter chips; diets/mealTypes render from
+  hardcoded lists).
+  **Evidence (dev Mongo, `prepify-dev`; catalog is small so the plan is the proof, not the timing):**
+    - BEFORE — `explain('executionStats')` on each `distinct` (empty query): winningPlan stage **COLLSCAN**,
+      `totalDocsExamined = 12` (= full collection), `totalKeysExamined = 0` (no index possible). Three of these ran
+      per `/recipes` load.
+    - AFTER — live server, two back-to-back `GET /api/recipes/facets`: cold **0.223 s** (runs the three scans) →
+      warm **0.0013 s** (served from cache, no DB round-trip; ~170×), identical payload.
+    - Behaviour locked by tests: `__tests__/facetsCache.test.js` (compute-once-within-TTL, TTL expiry, invalidate,
+      single-flight, mid-flight-invalidate guard) and two `recipes.test.js` cases (a warm cache hides a direct DB
+      insert until busted; `POST /addRecipe` busts the cache so the new cuisine appears on the next load).
+    - Gates: server Jest **705 pass**, root Vitest **550 pass / 2 skip** (untouched), `tsc --noEmit` clean.**
 - `[ ]` **Perf: recipe-page CLS ≈ 0.10 from the conditional controls block popping in above the hero** —
   `RecipeControls` (`src/pages/SingleRecipe/SingleRecipe.tsx:296`) renders only after `currRecipe` resolves
   (`currRecipe && …`), with no reserved space, so on load it inserts above `header.hero` and pushes the hero +

--- a/server/__tests__/facetsCache.test.js
+++ b/server/__tests__/facetsCache.test.js
@@ -1,0 +1,93 @@
+const { createTTLCache, DEFAULT_TTL_MS } = require('../util/facetsCache')
+
+// A tiny controllable clock so TTL expiry is deterministic without fake timers.
+function fakeClock(start = 1000) {
+  let t = start
+  return { now: () => t, advance: (ms) => { t += ms } }
+}
+
+// A compute() whose resolution the test controls, to exercise in-flight sharing.
+function deferred() {
+  let resolve
+  const promise = new Promise((r) => { resolve = r })
+  return { promise, resolve }
+}
+
+describe('createTTLCache', () => {
+  it('computes once and serves subsequent hits from cache within the TTL', async () => {
+    const clock = fakeClock()
+    const cache = createTTLCache({ ttlMs: 1000, now: clock.now })
+    const compute = jest.fn().mockResolvedValue('v1')
+
+    expect(await cache.get(compute)).toBe('v1')
+    clock.advance(999) // still inside the window
+    expect(await cache.get(compute)).toBe('v1')
+
+    expect(compute).toHaveBeenCalledTimes(1)
+  })
+
+  it('recomputes after the TTL elapses', async () => {
+    const clock = fakeClock()
+    const cache = createTTLCache({ ttlMs: 1000, now: clock.now })
+    const compute = jest.fn()
+      .mockResolvedValueOnce('v1')
+      .mockResolvedValueOnce('v2')
+
+    expect(await cache.get(compute)).toBe('v1')
+    clock.advance(1000) // TTL is exclusive (now - at < ttl), so 1000 is expired
+    expect(await cache.get(compute)).toBe('v2')
+
+    expect(compute).toHaveBeenCalledTimes(2)
+  })
+
+  it('recomputes on the next get after invalidate()', async () => {
+    const clock = fakeClock()
+    const cache = createTTLCache({ ttlMs: 60000, now: clock.now })
+    const compute = jest.fn()
+      .mockResolvedValueOnce('v1')
+      .mockResolvedValueOnce('v2')
+
+    expect(await cache.get(compute)).toBe('v1')
+    cache.invalidate()
+    expect(await cache.get(compute)).toBe('v2') // well within the TTL, but busted
+
+    expect(compute).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares a single in-flight compute across concurrent callers', async () => {
+    const cache = createTTLCache({ ttlMs: 60000 })
+    const d = deferred()
+    const compute = jest.fn().mockReturnValue(d.promise)
+
+    const a = cache.get(compute)
+    const b = cache.get(compute) // arrives before the first resolves
+    d.resolve('shared')
+
+    expect(await a).toBe('shared')
+    expect(await b).toBe('shared')
+    expect(compute).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cache a result from a compute that was invalidated mid-flight', async () => {
+    const clock = fakeClock()
+    const cache = createTTLCache({ ttlMs: 60000, now: clock.now })
+    const d = deferred()
+    const compute = jest.fn()
+      .mockReturnValueOnce(d.promise) // slow, stale scan
+      .mockResolvedValueOnce('fresh')
+
+    const stale = cache.get(compute)
+    cache.invalidate() // a write landed while the scan was running
+    d.resolve('stale')
+
+    // The in-flight caller still gets its value…
+    expect(await stale).toBe('stale')
+    // …but it was NOT written to the cache, so the next get recomputes.
+    expect(await cache.get(compute)).toBe('fresh')
+    expect(compute).toHaveBeenCalledTimes(2)
+  })
+
+  it('defaults to a 5-minute TTL', () => {
+    expect(DEFAULT_TTL_MS).toBe(5 * 60 * 1000)
+  })
+})

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -251,6 +251,56 @@ describe('GET /recipes/facets', () => {
     // The empty-string cuisine from f-3 is filtered out.
     expect(res.body.cuisines).not.toContain('')
   })
+
+  it('serves a cached response — a direct DB insert is not reflected until the cache is busted', async () => {
+    const { facetsCache } = require('../util/facetsCache')
+    const db = getDB()
+
+    // Warm the cache.
+    const first = await request(server).get('/api/recipes/facets')
+    expect(first.body.cuisines.sort()).toEqual(['Italian', 'Mexican'])
+
+    // Insert straight into the collection, bypassing the write routes that bust
+    // the cache — so this new cuisine must NOT appear while the cache is warm.
+    await db.collection('recipes').insertOne({
+      ...BASE_RECIPE,
+      _id: 'f-cache',
+      cuisine: 'Thai',
+    })
+    const cached = await request(server).get('/api/recipes/facets')
+    expect(cached.body.cuisines.sort()).toEqual(['Italian', 'Mexican'])
+
+    // After an explicit bust, the next load rescans and picks it up.
+    facetsCache.invalidate()
+    const fresh = await request(server).get('/api/recipes/facets')
+    expect(fresh.body.cuisines.sort()).toEqual(['Italian', 'Mexican', 'Thai'])
+  })
+
+  it('surfaces a newly added recipe\'s cuisine on the next load (addRecipe busts the cache)', async () => {
+    // Warm the cache without the new cuisine.
+    const before = await request(server).get('/api/recipes/facets')
+    expect(before.body.cuisines).not.toContain('Thai')
+
+    // Adding through the real route must invalidate the cache…
+    const add = await request(server)
+      .post('/api/addRecipe')
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Pad See Ew',
+        description: 'Thai noodles',
+        ingredients: [{ id: 'i1', name: 'noodles' }],
+        instructions: [{ step: 'Stir fry' }],
+        cuisine: 'Thai',
+        mealTypes: ['dinner'],
+        nutritionLabels: ['vegetarian'],
+      })
+    expect(add.status).toBe(201)
+
+    // …so the next facets load (no explicit bust) already includes it.
+    const after = await request(server).get('/api/recipes/facets')
+    expect(after.body.cuisines).toContain('Thai')
+    expect(after.body.diets).toContain('vegetarian')
+  })
 })
 
 // ─── POST /addRecipe ──────────────────────────────────────────────────────────

--- a/server/__tests__/setup.js
+++ b/server/__tests__/setup.js
@@ -1,6 +1,7 @@
 const timers = require('node:timers')
 const { MongoMemoryReplSet } = require('mongodb-memory-server')
 const { connectDB, closeDB } = require('../db')
+const { facetsCache } = require('../util/facetsCache')
 
 // Under Node 26's jest environment the global timer functions aren't stable
 // across a fake-timer test: once a test runs `jest.useFakeTimers()` and then
@@ -24,6 +25,12 @@ const installRealTimers = () => {
 }
 installRealTimers()
 beforeEach(installRealTimers)
+
+// The /recipes/facets cache is a process-wide singleton that outlives the
+// per-test DB reset (recipes.test.js afterEach deleteMany). Clear it before
+// every test so a facets response cached from one test's seed data can't leak
+// into another test that seeded different recipes.
+beforeEach(() => facetsCache.invalidate())
 
 let mongod
 

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -18,6 +18,7 @@ const { gatherRecipeText, holdRecipeForReview, respondBlocked, worstVerdict, ope
 const { EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 const { teardownRecipeDocs } = require('../util/teardownRecipe')
+const { facetsCache } = require('../util/facetsCache')
 
 const router = Router()
 
@@ -164,20 +165,29 @@ router.get('/recipes', asyncHandler(async (req, res) => {
 // offer "Jamaican" when nothing is tagged Jamaican). `distinct` returns raw
 // stored values including null/'' — drop the empties; the client maps the rest
 // back to its curated label lists.
+//
+// Served from a short-TTL in-process cache (util/facetsCache): each distinct()
+// is an unavoidable full COLLSCAN, and this route is hit on every /recipes load,
+// so caching collapses three catalog scans per load to one refresh per TTL
+// window. Recipe writes (add/edit/delete) bust the cache so new values surface
+// on the next load; see facetsCache for the invalidation reasoning.
 router.get('/recipes/facets', asyncHandler(async (req, res) => {
-  const collection = getDB().collection('recipes')
-  const clean = (arr) =>
-    arr.filter((v) => typeof v === 'string' && v.trim() !== '')
-  const [cuisines, diets, mealTypes] = await Promise.all([
-    collection.distinct('cuisine'),
-    collection.distinct('nutritionLabels'),
-    collection.distinct('mealTypes'),
-  ])
-  res.json({
-    cuisines: clean(cuisines),
-    diets: clean(diets),
-    mealTypes: clean(mealTypes),
+  const facets = await facetsCache.get(async () => {
+    const collection = getDB().collection('recipes')
+    const clean = (arr) =>
+      arr.filter((v) => typeof v === 'string' && v.trim() !== '')
+    const [cuisines, diets, mealTypes] = await Promise.all([
+      collection.distinct('cuisine'),
+      collection.distinct('nutritionLabels'),
+      collection.distinct('mealTypes'),
+    ])
+    return {
+      cuisines: clean(cuisines),
+      diets: clean(diets),
+      mealTypes: clean(mealTypes),
+    }
   })
+  res.json(facets)
 }))
 
 // GET /searchAutoCompleteRecipes — quick title search for autocomplete.
@@ -486,6 +496,11 @@ router.post('/addRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncH
     views: 0,
   }
   await db.collection('recipes').insertOne(docToInsert)
+  // A new recipe can introduce a cuisine/diet/mealType the browse filter UI has
+  // never seen; bust the facets cache so it surfaces on the next load, not after
+  // the TTL. (Held/pending recipes count too — the facets distinct is unfiltered
+  // by status.)
+  facetsCache.invalidate()
   await db.collection('userRecipeData').updateOne(
     { _id: uid },
     { $push: { userRecipes: { recipeId: newId } } },
@@ -570,6 +585,9 @@ router.put('/editRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncH
   if (!updated) {
     return res.status(404).json({ error: 'Recipe not found' })
   }
+  // An edit can change cuisine/diet/mealType (introduce a new value or drop the
+  // last of an old one), so refresh the facets cache on the next load.
+  facetsCache.invalidate()
   if (shouldHold) {
     const held = await holdRecipeForReview(db, { recipeId, title: body.title, verdict })
     if (held) updated.status = 'pending_review'
@@ -605,6 +623,10 @@ router.delete('/deleteRecipe', verifyToken, asyncHandler(async (req, res) => {
   } finally {
     await session.endSession()
   }
+
+  // Deleting the last recipe of a cuisine/diet/mealType should drop its filter
+  // chip; busting the cache makes the next load recompute without it.
+  facetsCache.invalidate()
 
   // External side effect — runs after the transaction commits and never
   // fails the request (an orphaned image is preferable to a 500 here).

--- a/server/util/facetsCache.js
+++ b/server/util/facetsCache.js
@@ -1,0 +1,75 @@
+// In-process TTL cache for GET /recipes/facets.
+//
+// The endpoint answers with the distinct cuisine / nutritionLabels / mealTypes
+// values present in the catalog so the browse UI can gray out filter chips that
+// would match zero recipes. Each distinct() is an unavoidable COLLSCAN — a
+// distinct with no predicate has to examine every recipe doc (verified via
+// explain: winningPlan stage COLLSCAN, totalDocsExamined = collection size,
+// totalKeysExamined 0, no index possible) — and the route ran three of them on
+// every /recipes page load.
+//
+// Facets are read-mostly and highly staleness-tolerant: the browse page already
+// caches this response for 10 minutes (React Query staleTime) and only uses it
+// to hide empty filter chips. So a short server-side TTL cache is safe and
+// collapses the three scans to at most one refresh per TTL window per process.
+//
+// Invalidation correctness — "a newly added recipe's cuisine/diet/mealType must
+// surface in the filter UI":
+//   - New VALUES only ever enter the catalog via addRecipe / editRecipe. Those
+//     paths call invalidate() so the value is picked up on the very next load
+//     rather than waiting out the TTL (immediate, not merely eventual).
+//   - deleteRecipe also invalidates, so a removed value's chip drops on the next
+//     load (the fresh recompute simply no longer sees it).
+//   - The rare bulk removers (account-deletion cascade, admin status changes)
+//     are left to the TTL backstop. A chip lingering for a cuisine that briefly
+//     has no visible recipes is harmless and already possible today: the distinct
+//     is unfiltered by status, so hidden/pending recipes already contribute chips.
+//
+// A single in-flight compute is shared, so a burst of cold-cache requests (e.g.
+// right after a deploy or a cache bust) triggers one scan, not one per request.
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000
+
+// `now` is injectable so tests can advance the clock deterministically without
+// fake timers (which are fragile alongside supertest here — see __tests__/setup.js).
+function createTTLCache({ ttlMs = DEFAULT_TTL_MS, now = Date.now } = {}) {
+  let entry = null // { at: <ms>, value }
+  let inflight = null // Promise resolving to the freshly computed value, or null
+  // Bumped on every invalidate(). A compute that started before an invalidate
+  // must not write its (now-stale) result into the cache, so it captures the
+  // generation at the start and only commits if it still matches on resolve.
+  let generation = 0
+
+  async function get(compute) {
+    if (entry && now() - entry.at < ttlMs) return entry.value
+    if (inflight) return inflight
+    const startGen = generation
+    inflight = Promise.resolve()
+      .then(compute)
+      .then((value) => {
+        // Skip caching if an invalidate() landed while this scan was running
+        // (e.g. a recipe write committed after the scan read the collection).
+        // The value is still returned to callers awaiting this compute; it just
+        // doesn't poison the cache, so the next load recomputes fresh.
+        if (generation === startGen) entry = { at: now(), value }
+        return value
+      })
+      .finally(() => {
+        inflight = null
+      })
+    return inflight
+  }
+
+  function invalidate() {
+    entry = null
+    generation++
+  }
+
+  return { get, invalidate }
+}
+
+// The process-wide instance the /recipes/facets route and the recipe write
+// paths share. Tests reset it via invalidate() in __tests__/setup.js.
+const facetsCache = createTTLCache()
+
+module.exports = { facetsCache, createTTLCache, DEFAULT_TTL_MS }

--- a/server/util/facetsCache.js
+++ b/server/util/facetsCache.js
@@ -16,8 +16,13 @@
 // Invalidation correctness — "a newly added recipe's cuisine/diet/mealType must
 // surface in the filter UI":
 //   - New VALUES only ever enter the catalog via addRecipe / editRecipe. Those
-//     paths call invalidate() so the value is picked up on the very next load
-//     rather than waiting out the TTL (immediate, not merely eventual).
+//     paths call invalidate() so the value is picked up on the next load rather
+//     than waiting out the TTL. (One concurrency nuance: a scan already in flight
+//     when invalidate() lands is still shared with any request that arrives before
+//     it resolves, so that one request can return the pre-write result. The
+//     generation guard below keeps that stale result out of the cache, so the
+//     load after it recomputes fresh — the value surfaces within one extra load,
+//     never delayed to the TTL.)
 //   - deleteRecipe also invalidates, so a removed value's chip drops on the next
 //     load (the fresh recompute simply no longer sees it).
 //   - The rare bulk removers (account-deletion cascade, admin status changes)


### PR DESCRIPTION
## What & why

`GET /recipes/facets` — hit on **every `/recipes` page load** to build the filter UI — ran three unfiltered `distinct()` calls (`cuisine`, `nutritionLabels`, `mealTypes`). A `distinct` with no predicate is a **COLLSCAN no index can serve**, so unlike the PR #224 index work this can't be indexed away; the fix is to stop scanning.

## Approach — short-TTL in-process cache (not a summary doc)

New `server/util/facetsCache.js`: a 5-min TTL cache with
- **single-flight** — a burst of cold-cache requests triggers one scan, not one per request;
- **generation guard** — a scan invalidated mid-flight still returns to its caller but doesn't poison the cache (so a recipe write that lands during a scan can't cache a stale snapshot).

The route reads through it. The write paths that can introduce a **new** value — `addRecipe`/`editRecipe` — plus `deleteRecipe` call `invalidate()`, so a new cuisine/diet/mealType surfaces on the **next** load, not after the TTL. Rare bulk removers (account-delete cascade, admin status flips) ride the TTL backstop — a chip lingering for a briefly-empty cuisine is harmless and already possible today (the `distinct` is unfiltered by status, so hidden/pending recipes already contribute chips).

**Why not a maintained summary doc:** a delete or a cuisine-edit-away can't be reasoned about incrementally (you can't know a value is gone everywhere without a rescan), so a summary doc would still need a full recompute on those paths — more invalidation surface and a persisted doc to keep consistent, for the same outcome. The cache also preserves the exact all-statuses `distinct` semantics for free. Client tolerance is high regardless: the browse page already React-Query-caches this response for 10 min and only uses `cuisines` (diets/mealTypes render from hardcoded lists).

## Evidence (dev Mongo, `prepify-dev` — small catalog, so the plan is the proof)

- **BEFORE** — `explain('executionStats')` on each `distinct` (empty query): winningPlan stage **`COLLSCAN`**, `totalDocsExamined = 12` (= full collection), `totalKeysExamined = 0` (no index possible). Three per load.
- **AFTER** — live server, two back-to-back `GET /api/recipes/facets`: cold **0.223 s** (runs the scans) → warm **0.0013 s** (served from cache, no DB round-trip; ~170×), identical payload.
- **Tests** — `server/__tests__/facetsCache.test.js` (compute-once-within-TTL, TTL expiry, invalidate, single-flight, mid-flight-invalidate guard) + two `recipes.test.js` integration cases (warm cache hides a direct DB insert until busted; `POST /addRecipe` busts the cache so the new cuisine appears on the next load).

## Gates

- Server Jest: **705 pass**
- Root Vitest: **550 pass / 2 skip** (untouched)
- `tsc --noEmit`: clean

Backlog item flipped to `[x]` with this evidence in the same PR.

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ