### PR TITLE
security(recipes): project public recipe reads to a client-facing whitelist

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -443,6 +443,18 @@ findings table.)*
       fields" (both profile endpoints). Gates: server Jest **714/714**, `tsc --noEmit` clean. Low (PII =
       internal admin uids, not user-facing). *(surfaced 2026-06-26 in the security sweep; list-endpoint leak
       caught 2026-07-02 in code review of the fix.)*
+- `[ ]` **`getCreatedRecipes` leaks the same admin moderation stamps to the (non-admin) author** —
+  `GET /getCreatedRecipes` (`server/routes/users.js:61`), the account "My Recipes" list, returns full recipe
+  docs with **no projection** (`.find(filter).sort(...).toArray()`, `filter = { userId: uid,
+  ...RECIPE_OWNER_VISIBLE }`). If any of the author's own recipes was ever moderated/featured, the doc carries
+  `moderatedBy`/`featuredBy`/`publishUpdatedBy` (admin Firebase uids), so the response ships them to the
+  non-admin author — the **same leak class** as the #397 public-projection item, just on an authenticated
+  owner endpoint (narrower audience: only the recipe's own author, not anonymous). Pre-existing; not touched by
+  PR #226 (which scoped to *public* reads). Note the plain card projection won't do here: the owner list needs
+  `status` to badge held recipes, so use `publicRecipeProjection` (keeps `status`/`userId`, drops the six
+  stamps) or a small owner-card projection. Sibling reads are already clean — `getSavedRecipes` uses
+  `SAVED_CARD_PROJECTION`. Low. *(caught 2026-07-02 in the same code review that found the list-endpoint leak;
+  see the #397 item above.)*
 - `[ ]` **Recipe numeric/array fields aren't range- or type-validated server-side** —
   `validateRecipeBounds` (`server/util/recipeLimits.js`, used by add/editRecipe) bounds title/description
   length, ingredient/instruction counts, and instruction-content length, but NOT the numeric fields

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -400,14 +400,24 @@ findings table.)*
   `publishUpdatedBy`/`publishUpdatedAt` — admin Firebase uids + moderation metadata) leaked to
   anonymous clients on any recipe that was ever featured/unhidden. `publicProfile.js:74` & `:157` shared the
   full-doc pattern (only `RECIPE_VISIBLE`/active recipes, so no moderation-state leak, but they still exposed
-  the author uid + other internal fields the card never reads).
+  the author uid + other internal fields the card never reads). A follow-up code review found the same full-doc
+  leak on the two highest-traffic public LIST reads too: `GET /recipes` (browse) and `GET /getTrendingRecipes`
+  both `.toArray()`'d unprojected docs — and trending sorts `featured:-1` first, so it was the read *most*
+  likely to surface `featuredBy` (an admin uid) to anonymous callers. (The other list reads —
+  `searchAutoCompleteRecipes`, `getForYouRecipes`, `recipes/random` — already projected to a card shape.)
   - **DONE (PR #226).** Added a shared **whitelist** (not a blacklist of the six stamps, so a future internal
     field can't silently leak) in `server/util/recipeFields.js`: `publicRecipeProjection` = exactly the client
     `RecipeType` shape, built on `CREATABLE_RECIPE_FIELDS` so new user-content fields propagate automatically;
-    and a lighter `publicRecipeCardProjection` (drops `userId`/`status` too) for profile cards.
-    - `getRecipe` public (`findOneAndUpdate`) + owner-preview (`findOne`) paths now project to
-      `publicRecipeProjection`; the **admin** path keeps the full doc. `publicProfile.js` `getPublicProfile` +
-      `getPublicProfileRecipes` project to `publicRecipeCardProjection`.
+    and a lighter `publicRecipeCardProjection` — the single lean card shape (image/title/cuisine/time/price/
+    rating/saves + the tag arrays For-You scores on; drops `userId`/`status` and all the heavy detail fields)
+    now **shared by every public list surface**. This absorbed the pre-existing local `RECIPE_CARD_PROJECTION`
+    in `recipes.js` (was used by For-You/random), so there's one card projection instead of two divergent ones.
+    - `getRecipe` public (`findOneAndUpdate`) + owner-preview (`findOne`) paths project to
+      `publicRecipeProjection`; the **admin** path keeps the full doc. The list reads —
+      `GET /recipes` (browse), `getTrendingRecipes`, `getForYouRecipes`, `recipes/random`, and both
+      `publicProfile.js` endpoints — project to `publicRecipeCardProjection`. (Browse/trending sort on
+      `views`/`featured`/`createdAt`, which stay sortable even though they're not in the projected shape —
+      Mongo sorts the stored doc, then projects.)
     - **FE-read check first** (Explore over `src/`): the client reads `userId` (owner-gating on
       `SingleRecipe`/`EditRecipe`) and `status` (owner "held for review" notice) — both **kept** on the detail
       response — but reads **none** of the six stamps anywhere, and the profile page reads neither `userId`
@@ -418,10 +428,21 @@ findings table.)*
       views` → **zero** moderation stamps; `userId`/`status` retained; `views` still incremented 10→11 (the
       `$inc` coexists with the projection). Profile cards (`getPublicProfile` + paged): stamps **and**
       `userId`/`status` absent, display fields (title/rating/totalTime/servingPrice/numTimesSaved) present.
+      **Browse + trending** (anon, recipe seeded with all six stamps + `featured:true`): both return exactly the
+      10 card keys (`_id, cuisine, mealTypes, numTimesSaved, nutritionLabels, rating, recipeImage, servingPrice,
+      title, totalTime`) — zero stamps, no `userId`/`status`, and none of the heavy detail fields; the
+      featured-first sort still surfaced the recipe, confirming sort-on-unprojected-field.
+    - **FE-read check for the card shape** (Explore over `src/`): browse (`RecipeCard`), trending/For-You
+      (`HomeRecipeCard`), and the public-profile tiles all read only the 10 card fields — none read `userId`,
+      `status`, or any detail field — so narrowing browse/trending/profile to the shared card shape drops
+      nothing the UI renders (and made the profile cards lighter, since the old `publicRecipeCardProjection`
+      still shipped the full `nutritionData`/ingredients/instructions a card never uses).
     - Tests: `recipes.test.js` "GET /getRecipe — public projection" (anon strips stamps, keeps client fields,
-      view still increments, **admin still gets full doc**, owner-preview stripped) + `publicProfile.test.js`
-      "cards omit internal fields" (both profile endpoints). Gates: server Jest **712/712**, `tsc --noEmit`
-      clean. Low (PII = internal admin uids, not user-facing). *(surfaced 2026-06-26 in the security sweep.)*
+      view still increments, **admin still gets full doc**, owner-preview stripped) + "public list endpoints —
+      card projection" (browse + trending omit uid/stamps) + `publicProfile.test.js` "cards omit internal
+      fields" (both profile endpoints). Gates: server Jest **714/714**, `tsc --noEmit` clean. Low (PII =
+      internal admin uids, not user-facing). *(surfaced 2026-06-26 in the security sweep; list-endpoint leak
+      caught 2026-07-02 in code review of the fix.)*
 - `[ ]` **Recipe numeric/array fields aren't range- or type-validated server-side** —
   `validateRecipeBounds` (`server/util/recipeLimits.js`, used by add/editRecipe) bounds title/description
   length, ingredient/instruction counts, and instruction-content length, but NOT the numeric fields

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -394,15 +394,34 @@ findings table.)*
   lines deleted from local `.env` (`VITE_OPEN_AI_API_KEY`) and `server/.env` (`SPOONACULAR_API_KEY`); swept
   the tree afterward, no other on-disk copies remain. The `.env.example` comment noting the key is unneeded
   was left in place.)**
-- `[ ]` **Public recipe reads return the full Mongo doc, leaking internal fields** — `GET /getRecipe`'s
-  public path (`server/routes/recipes.js:411-437`) returns the entire recipe document with no projection,
+- `[x]` **Public recipe reads return the full Mongo doc, leaking internal fields** — `GET /getRecipe`'s
+  public path (`server/routes/recipes.js:411-437`) returned the entire recipe document with no projection,
   so internal curation/moderation stamps (`moderatedBy`/`moderatedAt`/`featuredBy`/`featuredAt`/
-  `publishUpdatedBy`/`publishUpdatedAt`/`status` — admin Firebase uids + moderation metadata) leak to
-  anonymous clients on any recipe that was ever featured/unhidden. `publicProfile.js:74` & `:157` share the
-  full-doc pattern (only `RECIPE_VISIBLE`/active recipes, so no moderation-state leak, but they still expose
-  the author uid + other internal fields the card never reads). Fix: a shared public-recipe projection /
-  output whitelist (verify the FE doesn't read the stamped fields first). Low (PII = internal admin uids,
-  not user-facing). *(surfaced 2026-06-26 in the security sweep.)*
+  `publishUpdatedBy`/`publishUpdatedAt` — admin Firebase uids + moderation metadata) leaked to
+  anonymous clients on any recipe that was ever featured/unhidden. `publicProfile.js:74` & `:157` shared the
+  full-doc pattern (only `RECIPE_VISIBLE`/active recipes, so no moderation-state leak, but they still exposed
+  the author uid + other internal fields the card never reads).
+  - **DONE (PR #226).** Added a shared **whitelist** (not a blacklist of the six stamps, so a future internal
+    field can't silently leak) in `server/util/recipeFields.js`: `publicRecipeProjection` = exactly the client
+    `RecipeType` shape, built on `CREATABLE_RECIPE_FIELDS` so new user-content fields propagate automatically;
+    and a lighter `publicRecipeCardProjection` (drops `userId`/`status` too) for profile cards.
+    - `getRecipe` public (`findOneAndUpdate`) + owner-preview (`findOne`) paths now project to
+      `publicRecipeProjection`; the **admin** path keeps the full doc. `publicProfile.js` `getPublicProfile` +
+      `getPublicProfileRecipes` project to `publicRecipeCardProjection`.
+    - **FE-read check first** (Explore over `src/`): the client reads `userId` (owner-gating on
+      `SingleRecipe`/`EditRecipe`) and `status` (owner "held for review" notice) — both **kept** on the detail
+      response — but reads **none** of the six stamps anywhere, and the profile page reads neither `userId`
+      nor `status`. So the whitelist keeps every field the UI consumes and drops only the unread internal ones.
+    - **Evidence — live dev server, anonymous `GET /api/getRecipe` on a recipe seeded with all six stamps +
+      `featured:true`:** response keys = `_id, authorUsername, cuisine, description, featured, ingredients,
+      instructions, mealTypes, numTimesMade, numTimesSaved, nutritionLabels, rating, status, title, userId,
+      views` → **zero** moderation stamps; `userId`/`status` retained; `views` still incremented 10→11 (the
+      `$inc` coexists with the projection). Profile cards (`getPublicProfile` + paged): stamps **and**
+      `userId`/`status` absent, display fields (title/rating/totalTime/servingPrice/numTimesSaved) present.
+    - Tests: `recipes.test.js` "GET /getRecipe — public projection" (anon strips stamps, keeps client fields,
+      view still increments, **admin still gets full doc**, owner-preview stripped) + `publicProfile.test.js`
+      "cards omit internal fields" (both profile endpoints). Gates: server Jest **712/712**, `tsc --noEmit`
+      clean. Low (PII = internal admin uids, not user-facing). *(surfaced 2026-06-26 in the security sweep.)*
 - `[ ]` **Recipe numeric/array fields aren't range- or type-validated server-side** —
   `validateRecipeBounds` (`server/util/recipeLimits.js`, used by add/editRecipe) bounds title/description
   length, ingredient/instruction counts, and instruction-content length, but NOT the numeric fields

--- a/server/__tests__/publicProfile.test.js
+++ b/server/__tests__/publicProfile.test.js
@@ -325,3 +325,66 @@ describe('GET /getPublicProfileRecipes', () => {
     expect(res.body.totalCount).toBe(2)
   })
 })
+
+// A profile card renders image/title/rating/time/price/saves only, so the
+// endpoints project to a card shape that omits the author's Firebase uid and the
+// internal moderation fields the card never reads. See util/recipeFields.
+describe('public profile recipe cards omit internal fields', () => {
+  const CARD_INTERNAL = [
+    'userId',
+    'status',
+    'moderatedBy',
+    'moderatedAt',
+    'featuredBy',
+    'featuredAt',
+    'publishUpdatedBy',
+    'publishUpdatedAt',
+  ]
+
+  const seedStampedProfileRecipe = async () => {
+    await seedUser(PUB_UID, 'CoolUser')
+    await seedRecipes([
+      {
+        _id: 'card1',
+        userId: PUB_UID,
+        title: 'Shown On A Card',
+        createdAt: '2000',
+        status: 'published',
+        rating: { rateCount: 1, rateValue: 5 },
+        totalTime: 30,
+        servingPrice: 4,
+        numTimesSaved: 2,
+        recipeImage: 'https://example.com/card1.jpg',
+        moderatedBy: 'admin-uid-AAA',
+        featuredBy: 'admin-uid-BBB',
+        publishUpdatedBy: 'admin-uid-CCC',
+      },
+    ])
+  }
+
+  it('GET /getPublicProfile card carries display fields but no author uid / internal fields', async () => {
+    await seedStampedProfileRecipe()
+    const res = await request(app).get('/api/getPublicProfile?username=CoolUser')
+    expect(res.status).toBe(200)
+    const card = res.body.recipes.find(r => r._id === 'card1')
+    expect(card).toBeDefined()
+    for (const k of CARD_INTERNAL) expect(card).not.toHaveProperty(k)
+    // The fields the profile page actually renders are still present.
+    expect(card).toMatchObject({
+      title: 'Shown On A Card',
+      totalTime: 30,
+      servingPrice: 4,
+      numTimesSaved: 2,
+    })
+    expect(card.rating).toEqual({ rateCount: 1, rateValue: 5 })
+  })
+
+  it('GET /getPublicProfileRecipes card omits the same internal fields', async () => {
+    await seedStampedProfileRecipe()
+    const res = await request(app).get('/api/getPublicProfileRecipes?username=CoolUser')
+    expect(res.status).toBe(200)
+    const card = res.body.recipes.find(r => r._id === 'card1')
+    expect(card).toBeDefined()
+    for (const k of CARD_INTERNAL) expect(card).not.toHaveProperty(k)
+  })
+})

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -303,6 +303,81 @@ describe('GET /recipes/facets', () => {
   })
 })
 
+// ─── GET /getRecipe — public projection ───────────────────────────────────────
+
+// The internal moderation/curation stamps carry admin Firebase uids + curation
+// metadata and must never reach public callers; the client-facing fields must
+// still come through. See util/recipeFields.publicRecipeProjection.
+describe('GET /getRecipe — public projection', () => {
+  const STAMPS = ['moderatedBy', 'moderatedAt', 'featuredBy', 'featuredAt', 'publishUpdatedBy', 'publishUpdatedAt']
+
+  // A published recipe stamped as if it had been moderated + featured by an admin.
+  const seedStamped = (over = {}) =>
+    seedRecipe({
+      ...BASE_RECIPE,
+      _id: 'r-stamped',
+      userId: TEST_UID,
+      status: 'published',
+      featured: true,
+      moderatedBy: 'admin-uid-AAA',
+      moderatedAt: new Date().toISOString(),
+      featuredBy: 'admin-uid-BBB',
+      featuredAt: new Date().toISOString(),
+      publishUpdatedBy: 'admin-uid-CCC',
+      publishUpdatedAt: new Date().toISOString(),
+      ...over,
+    })
+
+  afterEach(() => admin.__resetClaims())
+
+  it('strips the internal moderation stamps from an anonymous read', async () => {
+    await seedStamped()
+    const res = await request(server).get('/api/getRecipe?id=r-stamped')
+    expect(res.status).toBe(200)
+    for (const k of STAMPS) expect(res.body).not.toHaveProperty(k)
+  })
+
+  it('keeps the client-facing fields the UI depends on', async () => {
+    await seedStamped()
+    const res = await request(server).get('/api/getRecipe?id=r-stamped')
+    // userId → owner-gating; status → owner "held for review" notice; plus the
+    // display fields.
+    expect(res.body).toMatchObject({
+      _id: 'r-stamped',
+      title: BASE_RECIPE.title,
+      userId: TEST_UID,
+      status: 'published',
+      featured: true,
+    })
+    expect(res.body.rating).toEqual(BASE_RECIPE.rating)
+  })
+
+  it('still increments the view counter through the projection', async () => {
+    await seedStamped({ views: 4 })
+    const res = await request(server).get('/api/getRecipe?id=r-stamped')
+    expect(res.body.views).toBe(5)
+  })
+
+  it('an admin read still sees the full doc (moderation stamps intact)', async () => {
+    await seedStamped()
+    admin.__setClaims({ admin: true })
+    const res = await request(server).get('/api/getRecipe?id=r-stamped').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    for (const k of STAMPS) expect(res.body).toHaveProperty(k)
+    expect(res.body.moderatedBy).toBe('admin-uid-AAA')
+  })
+
+  it('an owner previewing their own held recipe gets it without the admin stamps', async () => {
+    await seedStamped({ _id: 'r-stamped-held', status: 'pending_review' })
+    const res = await request(server).get('/api/getRecipe?id=r-stamped-held').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body._id).toBe('r-stamped-held')
+    // The owner needs status (the held-for-review notice) but not the admin uids.
+    expect(res.body.status).toBe('pending_review')
+    for (const k of STAMPS) expect(res.body).not.toHaveProperty(k)
+  })
+})
+
 // ─── POST /addRecipe ──────────────────────────────────────────────────────────
 
 describe('POST /addRecipe', () => {

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -378,6 +378,60 @@ describe('GET /getRecipe — public projection', () => {
   })
 })
 
+// The public LIST surfaces (browse + trending) render recipe cards, so they
+// project to the lighter card shape — which, like the detail projection, keeps
+// the internal moderation stamps (and the author uid) off anonymous responses.
+describe('public list endpoints — card projection', () => {
+  const CARD_INTERNAL = [
+    'userId',
+    'status',
+    'moderatedBy',
+    'moderatedAt',
+    'featuredBy',
+    'featuredAt',
+    'publishUpdatedBy',
+    'publishUpdatedAt',
+  ]
+
+  // A published, featured recipe carrying all six admin stamps.
+  const seedStampedCard = () =>
+    seedRecipe({
+      ...BASE_RECIPE,
+      _id: 'card-stamped',
+      userId: TEST_UID,
+      status: 'published',
+      featured: true,
+      moderatedBy: 'admin-uid-AAA',
+      moderatedAt: new Date().toISOString(),
+      featuredBy: 'admin-uid-BBB',
+      featuredAt: new Date().toISOString(),
+      publishUpdatedBy: 'admin-uid-CCC',
+      publishUpdatedAt: new Date().toISOString(),
+    })
+
+  it('GET /recipes browse card omits the author uid + internal stamps', async () => {
+    await seedStampedCard()
+    const res = await request(server).get('/api/recipes')
+    expect(res.status).toBe(200)
+    const card = res.body.recipeList.find((r) => r._id === 'card-stamped')
+    expect(card).toBeDefined()
+    for (const k of CARD_INTERNAL) expect(card).not.toHaveProperty(k)
+    // The fields the browse card renders are still present.
+    expect(card).toMatchObject({ title: BASE_RECIPE.title, cuisine: 'Italian' })
+    expect(card.rating).toEqual(BASE_RECIPE.rating)
+  })
+
+  it('GET /getTrendingRecipes card omits the author uid + internal stamps (incl. featuredBy)', async () => {
+    await seedStampedCard()
+    const res = await request(server).get('/api/getTrendingRecipes')
+    expect(res.status).toBe(200)
+    const card = res.body.find((r) => r._id === 'card-stamped')
+    expect(card).toBeDefined()
+    for (const k of CARD_INTERNAL) expect(card).not.toHaveProperty(k)
+    expect(card).toMatchObject({ title: BASE_RECIPE.title })
+  })
+})
+
 // ─── POST /addRecipe ──────────────────────────────────────────────────────────
 
 describe('POST /addRecipe', () => {

--- a/server/routes/publicProfile.js
+++ b/server/routes/publicProfile.js
@@ -6,6 +6,7 @@ const { getDB } = require('../db')
 const { getAccountCountsFor } = require('../util/accountCounts')
 const { computeGamification } = require('../util/gamification')
 const { RECIPE_VISIBLE } = require('../util/moderation')
+const { publicRecipeCardProjection } = require('../util/recipeFields')
 
 const PROFILE_RECIPE_LIMIT = 12
 
@@ -72,6 +73,9 @@ router.get('/getPublicProfile', asyncHandler(async (req, res) => {
       // a held or taken-down recipe never appears on someone's public profile.
       .collection('recipes')
       .find({ userId: uid, ...RECIPE_VISIBLE })
+      // Card projection: a profile card renders image/title/rating/time/price/
+      // saves only, so don't ship the author's uid or internal fields it never reads.
+      .project(publicRecipeCardProjection)
       // _id tiebreaker keeps ordering deterministic and aligned with the paged
       // /getPublicProfileRecipes endpoint (same sort) across the page boundary.
       .sort({ createdAt: -1, _id: 1 })
@@ -156,6 +160,8 @@ router.get('/getPublicProfileRecipes', asyncHandler(async (req, res) => {
     db
       .collection('recipes')
       .find(filter)
+      // Card projection — see /getPublicProfile above: no author uid / internal fields.
+      .project(publicRecipeCardProjection)
       // _id tiebreaker matches /getPublicProfile's sort so paging stays aligned
       // (no skipped/duplicated recipe when two share a createdAt at a boundary).
       .sort({ createdAt: -1, _id: 1 })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -15,7 +15,7 @@ const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/
 const { moderateText } = require('../util/textModeration')
 const { moderateImage } = require('../util/imageModeration')
 const { gatherRecipeText, holdRecipeForReview, respondBlocked, worstVerdict, openAutomodReportQuery, restoreHeldRecipe } = require('../util/automod')
-const { EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields } = require('../util/recipeFields')
+const { EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields, publicRecipeProjection } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 const { teardownRecipeDocs } = require('../util/teardownRecipe')
 const { facetsCache } = require('../util/facetsCache')
@@ -421,7 +421,10 @@ router.get('/getRecipe', optionalAuth, asyncHandler(async (req, res) => {
   const recipe = await db.collection('recipes').findOneAndUpdate(
     { ...recipeIdQuery(id), ...RECIPE_VISIBLE },
     { $inc: { views: 1 } },
-    { returnDocument: 'after' }
+    // Public response: project to the client-facing recipe shape so the internal
+    // moderation/curation stamps (admin uids + timestamps) never reach anonymous
+    // callers on an ever-featured/unhidden recipe. See util/recipeFields.
+    { returnDocument: 'after', projection: publicRecipeProjection }
   )
 
   if (!recipe) {
@@ -432,7 +435,12 @@ router.get('/getRecipe', optionalAuth, asyncHandler(async (req, res) => {
     if (req.uid) {
       const own = await db
         .collection('recipes')
-        .findOne({ ...recipeIdQuery(id), userId: req.uid, ...RECIPE_OWNER_VISIBLE })
+        .findOne(
+          { ...recipeIdQuery(id), userId: req.uid, ...RECIPE_OWNER_VISIBLE },
+          // Same public projection: the owner needs status (the held-for-review
+          // notice) + their own userId, but not the admin moderation stamps.
+          { projection: publicRecipeProjection }
+        )
       if (own) return res.json(own)
     }
     return res.status(404).json({ error: 'Not found' })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -15,7 +15,7 @@ const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/
 const { moderateText } = require('../util/textModeration')
 const { moderateImage } = require('../util/imageModeration')
 const { gatherRecipeText, holdRecipeForReview, respondBlocked, worstVerdict, openAutomodReportQuery, restoreHeldRecipe } = require('../util/automod')
-const { EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields, publicRecipeProjection } = require('../util/recipeFields')
+const { EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields, publicRecipeProjection, publicRecipeCardProjection } = require('../util/recipeFields')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 const { teardownRecipeDocs } = require('../util/teardownRecipe')
 const { facetsCache } = require('../util/facetsCache')
@@ -25,20 +25,6 @@ const router = Router()
 // Hard ceiling on client-requested page sizes so a single request can never
 // dump a whole collection (audit §4.5). Shared by every paginated route here.
 const MAX_PER_PAGE = 50
-
-// Fields the home recipe cards (For You row + "What should I cook?" pick) need
-// to render. Shared so the personalized routes project an identical shape.
-const RECIPE_CARD_PROJECTION = {
-  title: 1,
-  recipeImage: 1,
-  cuisine: 1,
-  totalTime: 1,
-  servingPrice: 1,
-  rating: 1,
-  mealTypes: 1,
-  nutritionLabels: 1,
-  numTimesSaved: 1,
-}
 
 // The id-shape variants (string + ObjectId) for a list of recipe ids, ready to
 // drop into an `_id: { $nin: [...] }` clause. Thin wrapper over recipeIdInQuery
@@ -153,7 +139,14 @@ router.get('/recipes', asyncHandler(async (req, res) => {
 
   const collection = db.collection('recipes')
   const [recipes, totalCount] = await Promise.all([
-    collection.find(filter).sort(sort).skip(skip).limit(limit).toArray(),
+    // Card projection: browse renders recipe cards only, so ship the card shape
+    // (no author uid / internal moderation stamps) — see util/recipeFields.
+    collection
+      .find(filter, { projection: publicRecipeCardProjection })
+      .sort(sort)
+      .skip(skip)
+      .limit(limit)
+      .toArray(),
     collection.countDocuments(filter),
   ])
 
@@ -270,7 +263,10 @@ router.get('/getTrendingRecipes', asyncHandler(async (req, res) => {
   // the usual most-viewed ordering fills the rest.
   const recipes = await db
     .collection('recipes')
-    .find({ ...RECIPE_VISIBLE })
+    // Card projection: the trending row renders cards. This row sorts featured
+    // recipes to the front, so it's the read most likely to surface `featuredBy`
+    // (an admin uid) — project it out with the rest of the internal stamps.
+    .find({ ...RECIPE_VISIBLE }, { projection: publicRecipeCardProjection })
     .sort({ featured: -1, views: -1 })
     .limit(limit)
     .toArray()
@@ -306,7 +302,7 @@ router.get('/getForYouRecipes', verifyToken, asyncHandler(async (req, res) => {
     .collection('recipes')
     .find(
       { ...RECIPE_VISIBLE, userId: { $ne: uid }, _id: { $nin: excludeVariants } },
-      { projection: RECIPE_CARD_PROJECTION }
+      { projection: publicRecipeCardProjection }
     )
     .toArray()
 
@@ -350,7 +346,7 @@ router.get('/recipes/random', optionalAuth, asyncHandler(async (req, res) => {
             userId: { $ne: uid },
             _id: { $nin: [...seenVariants, ...excludeVariants] },
           },
-          { projection: RECIPE_CARD_PROJECTION }
+          { projection: publicRecipeCardProjection }
         )
         .toArray()
 
@@ -376,7 +372,7 @@ router.get('/recipes/random', optionalAuth, asyncHandler(async (req, res) => {
     const match = notIds.length ? { ...baseMatch, _id: { $nin: notIds } } : baseMatch
     const [doc] = await db
       .collection('recipes')
-      .aggregate([{ $match: match }, { $sample: { size: 1 } }, { $project: RECIPE_CARD_PROJECTION }])
+      .aggregate([{ $match: match }, { $sample: { size: 1 } }, { $project: publicRecipeCardProjection }])
       .toArray()
     return doc
   }

--- a/server/util/recipeFields.js
+++ b/server/util/recipeFields.js
@@ -70,13 +70,27 @@ const PUBLIC_RECIPE_FIELDS = [
   'automodClassifier',
 ]
 
-// The lighter shape for recipe CARDS on a public profile. A card renders only
-// image/title/rating/time/price/saves, so it never reads the author uid or the
-// moderation state — drop them here so the profile lists don't ship the author's
-// Firebase uid to anonymous callers.
-const PUBLIC_RECIPE_CARD_FIELDS = PUBLIC_RECIPE_FIELDS.filter(
-  (f) => !['userId', 'status', 'automodClassifier'].includes(f)
-)
+// The lighter shape for recipe CARDS — the single projection shared by every
+// public LIST surface: browse (`GET /recipes`), the home trending / For-You /
+// random rows, and the public-profile tiles. A card renders only
+// image/title/cuisine/time/price/rating/saves, and the For-You/random
+// personalization scores on the tag arrays — none of it needs the heavy detail
+// fields (ingredients/instructions/nutritionData/description) or the author uid /
+// moderation state. An explicit lean whitelist (not the full public shape minus a
+// few keys): cards stay small, and — like the detail whitelist — it structurally
+// can't carry the internal moderation stamps to anonymous callers.
+const PUBLIC_RECIPE_CARD_FIELDS = [
+  '_id',
+  'title',
+  'recipeImage',
+  'cuisine',
+  'totalTime',
+  'servingPrice',
+  'rating',
+  'mealTypes',
+  'nutritionLabels',
+  'numTimesSaved',
+]
 
 // Mongo inclusion projections derived from the whitelists above, for use as the
 // `projection`/`.project()` argument on the public recipe reads.

--- a/server/util/recipeFields.js
+++ b/server/util/recipeFields.js
@@ -42,6 +42,48 @@ const CREATABLE_RECIPE_FIELDS = [
   'editedAt',
 ]
 
+// The recipe fields safe to return on PUBLIC (unauthenticated / non-admin)
+// responses. This is exactly the shape the client's `RecipeType` consumes; the
+// internal moderation/curation stamps are deliberately excluded because no
+// client reads them and they carry admin Firebase uids + curation metadata:
+//   moderatedBy, moderatedAt, featuredBy, featuredAt, publishUpdatedBy, publishUpdatedAt
+// A whitelist (not a blacklist of those six) so a future internal stamp added to
+// the doc can't silently leak — it stays out of public responses until added
+// here on purpose. Built on CREATABLE_RECIPE_FIELDS so new user-content fields
+// propagate automatically, matching the drafts/edit whitelists above.
+const PUBLIC_RECIPE_FIELDS = [
+  '_id',
+  ...CREATABLE_RECIPE_FIELDS,
+  // Server-maintained stats/social counters + the curation flag the client renders.
+  'rating',
+  'views',
+  'numTimesSaved',
+  'numTimesMade',
+  'featured',
+  // Author uid — the recipe-detail client compares it to the signed-in user to
+  // gate the owner-only Edit/Delete controls, so it must reach the detail response.
+  'userId',
+  // Moderation state — drives the owner's "held for review" notice (and the
+  // admin controls); benign on a publicly-visible recipe, where it's 'published'.
+  'status',
+  // Only ever populated in-memory on the admin getRecipe path; absent otherwise.
+  'automodClassifier',
+]
+
+// The lighter shape for recipe CARDS on a public profile. A card renders only
+// image/title/rating/time/price/saves, so it never reads the author uid or the
+// moderation state — drop them here so the profile lists don't ship the author's
+// Firebase uid to anonymous callers.
+const PUBLIC_RECIPE_CARD_FIELDS = PUBLIC_RECIPE_FIELDS.filter(
+  (f) => !['userId', 'status', 'automodClassifier'].includes(f)
+)
+
+// Mongo inclusion projections derived from the whitelists above, for use as the
+// `projection`/`.project()` argument on the public recipe reads.
+const toProjection = (fields) => Object.fromEntries(fields.map((f) => [f, 1]))
+const publicRecipeProjection = toProjection(PUBLIC_RECIPE_FIELDS)
+const publicRecipeCardProjection = toProjection(PUBLIC_RECIPE_CARD_FIELDS)
+
 // Copy only the whitelisted keys that are present in `body`. Absent keys are
 // left out (callers merge via $set), so a field the client doesn't send is
 // untouched rather than overwritten.
@@ -53,4 +95,13 @@ function pickFields(body, fields) {
   return out
 }
 
-module.exports = { RECIPE_CONTENT_FIELDS, EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields }
+module.exports = {
+  RECIPE_CONTENT_FIELDS,
+  EDITABLE_RECIPE_FIELDS,
+  CREATABLE_RECIPE_FIELDS,
+  PUBLIC_RECIPE_FIELDS,
+  PUBLIC_RECIPE_CARD_FIELDS,
+  publicRecipeProjection,
+  publicRecipeCardProjection,
+  pickFields,
+}


### PR DESCRIPTION
## What

`GET /getRecipe`'s public path returned the **full Mongo doc** with no projection, so internal moderation/curation stamps — `moderatedBy`/`moderatedAt`, `featuredBy`/`featuredAt`, `publishUpdatedBy`/`publishUpdatedAt` (**admin Firebase uids** + curation metadata) — leaked to **anonymous** clients on any recipe that was ever featured/unhidden. The two `publicProfile.js` recipe reads shared the pattern, shipping the author uid + unused internal fields on every profile card.

## Fix

A shared **whitelist** in `server/util/recipeFields.js` (whitelist, not a blacklist of the six stamps — a future internal field then can't silently leak):

- **`publicRecipeProjection`** = exactly the client `RecipeType` shape, built on `CREATABLE_RECIPE_FIELDS` so new user-content fields propagate automatically. Applied to `getRecipe`'s public (`findOneAndUpdate`) and owner-preview (`findOne`) paths.
- **`publicRecipeCardProjection`** additionally drops `userId`/`status` (a profile card reads neither). Applied to `getPublicProfile` + `getPublicProfileRecipes`.
- The **admin** `getRecipe` path is untouched — admins still receive the full doc (they read `status`/`automodClassifier` + the moderation controls).

## FE-read check (done first)

An Explore pass over `src/` established what the client actually reads off a recipe:
- **`userId`** — owner-gating on `SingleRecipe`/`EditRecipe` → **kept** on the detail response.
- **`status`** — owner "held for review" notice → **kept** on the detail response.
- **None** of the six stamps are read anywhere; the public profile page reads neither `userId` nor `status`.

So the whitelist keeps every field the UI consumes and drops only the unread internal ones.

## Evidence (live dev server)

Anonymous `GET /api/getRecipe` on a recipe seeded with all six stamps + `featured:true`:
```
keys: _id, authorUsername, cuisine, description, featured, ingredients,
      instructions, mealTypes, numTimesMade, numTimesSaved, nutritionLabels,
      rating, status, title, userId, views
LEAKED admin stamps: (none)
userId kept: author-uid-XYZ   status kept: published   views: 10 -> 11 (still incremented)
```
Profile cards (`getPublicProfile` + paged `getPublicProfileRecipes`): stamps **and** `userId`/`status` absent; display fields (title/rating/totalTime/servingPrice/numTimesSaved) present.

## Tests / gates

- `recipes.test.js` → **GET /getRecipe — public projection**: anon strips stamps, keeps client fields, view still increments, **admin still gets the full doc**, owner-preview stripped.
- `publicProfile.test.js` → **cards omit internal fields**: both profile endpoints.
- Server Jest **712/712**; `tsc --noEmit` clean.

Closes the "public recipe reads leak internal fields" security-sweep BACKLOG item (flipped to `[x]`).

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ