### PR TITLE
security(users): stop getCreatedRecipes leaking admin moderation stamps to the author

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -443,18 +443,22 @@ findings table.)*
       fields" (both profile endpoints). Gates: server Jest **714/714**, `tsc --noEmit` clean. Low (PII =
       internal admin uids, not user-facing). *(surfaced 2026-06-26 in the security sweep; list-endpoint leak
       caught 2026-07-02 in code review of the fix.)*
-- `[ ]` **`getCreatedRecipes` leaks the same admin moderation stamps to the (non-admin) author** —
-  `GET /getCreatedRecipes` (`server/routes/users.js:61`), the account "My Recipes" list, returns full recipe
+- `[x]` **`getCreatedRecipes` leaks the same admin moderation stamps to the (non-admin) author** — DONE.
+  `GET /getCreatedRecipes` (`server/routes/users.js`), the account "My Recipes" list, returned full recipe
   docs with **no projection** (`.find(filter).sort(...).toArray()`, `filter = { userId: uid,
-  ...RECIPE_OWNER_VISIBLE }`). If any of the author's own recipes was ever moderated/featured, the doc carries
-  `moderatedBy`/`featuredBy`/`publishUpdatedBy` (admin Firebase uids), so the response ships them to the
+  ...RECIPE_OWNER_VISIBLE }`). If any of the author's own recipes was ever moderated/featured, the doc carried
+  `moderatedBy`/`featuredBy`/`publishUpdatedBy` (admin Firebase uids), so the response shipped them to the
   non-admin author — the **same leak class** as the #397 public-projection item, just on an authenticated
   owner endpoint (narrower audience: only the recipe's own author, not anonymous). Pre-existing; not touched by
-  PR #226 (which scoped to *public* reads). Note the plain card projection won't do here: the owner list needs
-  `status` to badge held recipes, so use `publicRecipeProjection` (keeps `status`/`userId`, drops the six
-  stamps) or a small owner-card projection. Sibling reads are already clean — `getSavedRecipes` uses
-  `SAVED_CARD_PROJECTION`. Low. *(caught 2026-07-02 in the same code review that found the list-endpoint leak;
-  see the #397 item above.)*
+  PR #226 (which scoped to *public* reads). **Fix:** added a lean whitelist `CREATED_CARD_PROJECTION` local to
+  `users.js` (mirrors `SAVED_CARD_PROJECTION`) covering exactly the 10 fields `UserRecipeThumbnail` renders
+  (`_id`/title/image/price/`createdAt`/views/saves/made/`totalTime`/rating) — structurally drops the six stamps
+  *and* the heavy body (ingredients/instructions/nutritionData) the list never showed. The earlier note here
+  assumed the list needed `status` for a "held for review" badge, but the thumbnail renders no such badge, so
+  the plain card shape is correct (no `status`/`userId`); a comment flags where to add them if a badge lands.
+  Verified against the live DEV endpoint with a minted token + seeded stamped recipe (response carried only the
+  10 card fields). *(caught 2026-07-02 in the same code review that found the list-endpoint leak; see the #397
+  item above. Fixed 2026-07-03.)*
 - `[ ]` **Recipe numeric/array fields aren't range- or type-validated server-side** —
   `validateRecipeBounds` (`server/util/recipeLimits.js`, used by add/editRecipe) bounds title/description
   length, ingredient/instruction counts, and instruction-content length, but NOT the numeric fields

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -301,6 +301,71 @@ describe('GET /getCreatedRecipes', () => {
     expect(res.body.recipes).toHaveLength(1)
     expect(res.body.recipes[0]._id).toBe('r1')
   })
+
+  it('projects to the card shape — never leaks internal moderation stamps to the author', async () => {
+    // Regression: the endpoint used to return full recipe docs, so the admin-uid
+    // moderation/curation stamps ($set by the moderation routes) reached the
+    // non-admin author. The card projection is a whitelist, so they can't.
+    await seedRecipes([
+      {
+        _id: 'r1',
+        title: 'Mine',
+        userId: TEST_UID,
+        createdAt: '1000',
+        recipeImage: 'img.jpg',
+        servingPrice: 3,
+        totalTime: 20,
+        views: 5,
+        numTimesSaved: 2,
+        numTimesMade: 1,
+        rating: { rateValue: 4, rateCount: 3 },
+        // Heavy body the card never renders + the internal stamps that must not leak.
+        ingredients: [{ name: 'flour' }],
+        instructions: ['mix'],
+        nutritionData: { calories: 100 },
+        moderatedBy: 'admin-uid',
+        moderatedAt: '2000',
+        featuredBy: 'admin-uid',
+        featuredAt: '3000',
+        publishUpdatedBy: 'admin-uid',
+        publishUpdatedAt: '4000',
+      },
+    ])
+
+    const res = await request(app)
+      .get('/api/getCreatedRecipes')
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    const recipe = res.body.recipes[0]
+    // The six admin-uid stamps and the heavy body are gone.
+    for (const key of [
+      'moderatedBy',
+      'moderatedAt',
+      'featuredBy',
+      'featuredAt',
+      'publishUpdatedBy',
+      'publishUpdatedAt',
+      'ingredients',
+      'instructions',
+      'nutritionData',
+    ]) {
+      expect(recipe).not.toHaveProperty(key)
+    }
+    // The fields the thumbnail renders survive.
+    expect(recipe).toMatchObject({
+      _id: 'r1',
+      title: 'Mine',
+      recipeImage: 'img.jpg',
+      servingPrice: 3,
+      createdAt: '1000',
+      totalTime: 20,
+      views: 5,
+      numTimesSaved: 2,
+      numTimesMade: 1,
+      rating: { rateValue: 4, rateCount: 3 },
+    })
+  })
 })
 
 // ─── getAccountCountsFor (shared helper) ──────────────────────────────────────

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -24,6 +24,27 @@ const SAVED_CARD_PROJECTION = {
   rating: 1,
 }
 
+// The "My Recipes" grid (UserRecipeThumbnail) renders only these fields — the
+// image/title, a price + created date, the three-up views/saves/made strip, and
+// a time/rating footer. Projecting to them keeps this list off the full recipe
+// bodies (ingredients, instructions, nutritionData) it never shows, and — being
+// a whitelist, like the public projections — structurally keeps the internal
+// moderation stamps (moderatedBy/moderatedAt, featuredBy/featuredAt,
+// publishUpdatedBy/publishUpdatedAt, which carry admin Firebase uids) out of the
+// author's response. _id rides along by default. No status/userId: the thumbnail
+// renders neither (add them here if a "held for review" badge is introduced).
+const CREATED_CARD_PROJECTION = {
+  title: 1,
+  recipeImage: 1,
+  servingPrice: 1,
+  createdAt: 1,
+  views: 1,
+  numTimesSaved: 1,
+  numTimesMade: 1,
+  totalTime: 1,
+  rating: 1,
+}
+
 // Field sorts order by attributes that live on the recipe docs (title, rating,
 // cook time) rather than on the saved-entry (dateSaved), so getSavedRecipes
 // has to fetch the docs before it can sort. Save-time orders ('newAdd'/'oldAdd'
@@ -59,7 +80,7 @@ router.get('/getCreatedRecipes', verifyToken, asyncHandler(async (req, res) => {
   const filter = { userId: uid, ...RECIPE_OWNER_VISIBLE }
   const [recipes, totalCount] = await Promise.all([
     collection
-      .find(filter)
+      .find(filter, { projection: CREATED_CARD_PROJECTION })
       .sort(sort)
       .skip(pageNum * perPage)
       .limit(perPage)


### PR DESCRIPTION
## What

`GET /getCreatedRecipes` (the account **My Recipes** list) returned full recipe docs with **no projection**. Once any of the author's own recipes had been moderated or featured, its doc carries the internal admin-uid stamps (`moderatedBy`/`moderatedAt`, `featuredBy`/`featuredAt`, `publishUpdatedBy`/`publishUpdatedAt`), so the response shipped those admin Firebase uids to the (non-admin) author.

This is the **same leak class** as the #397 public-projection fix (#226), just on the authenticated owner endpoint that PR scoped out (it covered *public* reads only). Narrower audience — only the recipe's own author, not anonymous — hence Low, filed as a follow-up while reviewing #226.

## Fix

Add `CREATED_CARD_PROJECTION`, a lean whitelist local to `users.js` mirroring the existing `SAVED_CARD_PROJECTION`, covering exactly the 10 fields `UserRecipeThumbnail` renders (`_id`, title, image, price, `createdAt`, views, saves, made, `totalTime`, rating). Being a whitelist it:

- structurally excludes the six admin stamps — and a *future* internal stamp can't silently leak either;
- also drops the heavy body (`ingredients`/`instructions`/`nutritionData`) the list never displays, shrinking the payload — same rationale as `getSavedRecipes`.

No `status`/`userId`: the thumbnail renders neither. (The backlog note assumed the list needed `status` for a "held for review" badge, but there's no such badge in `UserRecipeThumbnail` — a code comment flags where to add both fields if one lands.)

## Verification

- **Live DEV endpoint** — minted a real Firebase ID token for a throwaway uid, seeded one recipe owned by it carrying all six stamps + a heavy body, hit `GET /api/getCreatedRecipes` on the running server: response carried **only** the 10 card fields (no stamps, no body). Seed cleaned up after.
- **Regression test** — `server/__tests__/users.test.js` now asserts the six stamps + heavy body are absent and the card fields survive. Full `getCreatedRecipes` group green.

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ