### PR TITLE
security(recipes): S1 write-safety — atomic save/unsave + input bounds

### DIFF
--- a/docs/BACKLOG_ROADMAP.md
+++ b/docs/BACKLOG_ROADMAP.md
@@ -65,7 +65,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 
 | Wave | Track | Backlog items covered | Status | Domain (collision surface) | Notes / deps |
 |---|---|---|---|---|---|
-| **1** | **S1 · recipes.js write-safety** | `save` TOCTOU (`recipes.js:778-801`); numeric/array bounds in `recipeLimits.js` | `[ ]` | `server/routes/recipes.js`, `server/util/recipeLimits.js` | blocks **I3** (also edits recipes.js) |
+| **1** | **S1 · recipes.js write-safety** | `save` TOCTOU (`recipes.js:778-801`); numeric/array bounds in `recipeLimits.js` | `[~]` `worktree-feat+recipes-write-safety` (2026-07-03) | `server/routes/recipes.js`, `server/util/recipeLimits.js` | blocks **I3** (also edits recipes.js) |
 | **1** | **S2 · auth.js account routes** | data-export saved-recipe bodies (`:355`); `updatePrivacy` writeLimiter (`:310`); harden `deleteAccount` recompute (`:454-461`) | `[ ]` | `server/routes/auth.js` | recompute pairs with **S6** |
 | **1** | **S3 · reviews.js correctness** | ratings Load-More count (`:281-308`); admin-takedown username→userId (`:318-353`) | `[ ]` | `server/routes/reviews.js` | — |
 | **1** | **S4 · rate-limit breadth** | reports per-uid limiter (`reports.js:69`); `acknowledgeAchievements` limiter (`gamification.js:31`) | `[ ]` | `server/routes/reports.js`, `server/routes/gamification.js` | disjoint from S2 |

--- a/docs/BACKLOG_ROADMAP.md
+++ b/docs/BACKLOG_ROADMAP.md
@@ -65,7 +65,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 
 | Wave | Track | Backlog items covered | Status | Domain (collision surface) | Notes / deps |
 |---|---|---|---|---|---|
-| **1** | **S1 · recipes.js write-safety** | `save` TOCTOU (`recipes.js:778-801`); numeric/array bounds in `recipeLimits.js` | `[~]` `worktree-feat+recipes-write-safety` (2026-07-03) | `server/routes/recipes.js`, `server/util/recipeLimits.js` | blocks **I3** (also edits recipes.js) |
+| **1** | **S1 · recipes.js write-safety** | `save` TOCTOU (`recipes.js:778-801`); numeric/array bounds in `recipeLimits.js` | `[P]` [#228](https://github.com/jclind/prepify/pull/228) (2026-07-03) | `server/routes/recipes.js`, `server/util/recipeLimits.js` | blocks **I3** (also edits recipes.js) |
 | **1** | **S2 · auth.js account routes** | data-export saved-recipe bodies (`:355`); `updatePrivacy` writeLimiter (`:310`); harden `deleteAccount` recompute (`:454-461`) | `[ ]` | `server/routes/auth.js` | recompute pairs with **S6** |
 | **1** | **S3 · reviews.js correctness** | ratings Load-More count (`:281-308`); admin-takedown username→userId (`:318-353`) | `[ ]` | `server/routes/reviews.js` | — |
 | **1** | **S4 · rate-limit breadth** | reports per-uid limiter (`reports.js:69`); `acknowledgeAchievements` limiter (`gamification.js:31`) | `[ ]` | `server/routes/reports.js`, `server/routes/gamification.js` | disjoint from S2 |

--- a/docs/BACKLOG_ROADMAP.md
+++ b/docs/BACKLOG_ROADMAP.md
@@ -181,6 +181,13 @@ Verified-present but intentionally not scheduled — decisions, post-1.0, or own
   `$primary-accessible` to vivid `#ff5722`). *Note: the shade literals this item wanted to dedupe are now
   **STALE in source** — see below.*
 - **Ideas needing a decision** — friend system · AI-search paid membership · fridge/freezer-life fields — all post-1.0.
+- **`numTimesSaved` counter ↔ save-list cross-collection atomicity** — *filed while reviewing S1.* Save/unsave/made
+  each write the user's list (`userRecipeData`) and the recipe's tally (`recipes.numTimesSaved`/`numTimesMade`) as
+  **two separate `updateOne`s with no transaction**, so a crash/failure between them drifts the counter (list says
+  saved, tally not bumped, or vice-versa on unsave). S1 fixed the *concurrency* double-count within each write, but
+  not this cross-collection seam. **Low severity** (a soft popularity counter used only for the `popular` sort, ±1
+  drift, self-heals on the `$max`-floored unsave), and a real fix needs a **multi-document transaction** (client
+  session + `withTransaction`, requires the replica-set deployment) — hence an infra/design call, not a quick patch.
 
 ---
 
@@ -212,3 +219,9 @@ Append-only; newest at the bottom. Mirror each merge into the item's box in [`BA
 
 - **2026-07-03** — Roadmap created. All 39 open BACKLOG items verified against the tree (5 parallel verification
   agents); 3 pulled as STALE, the rest placed on Waves 1–5. No tracks started yet.
+- **2026-07-03** — **S1** implemented in `worktree-feat+recipes-write-safety`: atomic conditional `save` (kills the
+  `numTimesSaved` double-count TOCTOU) + numeric/per-ingredient bounds in `validateRecipeBounds`. Local code review
+  extended the atomic fix to the symmetric **unsave** TOCTOU (`DELETE /recipes/:id/save` was still read-then-write).
+  Two follow-ups filed off-board: the cross-collection counter-atomicity seam (see Deferred, needs a txn), and
+  wiring the client `INGREDIENT_MAX_LENGTH` guard into `IngredientsInput` (done in-lane). Verified via the running
+  API + full test gates; not yet PR'd.

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -904,6 +904,40 @@ describe('DELETE /recipes/:id/save', () => {
     const recipe = await db.collection('recipes').findOne({ _id: RECIPE_ID })
     expect(recipe.numTimesSaved).toBe(0)
   })
+
+  it('lands exactly one decrement across concurrent unsaves', async () => {
+    // The atomic conditional $pull makes this correct BY CONSTRUCTION: single-
+    // document update semantics guarantee only one racing write removes the
+    // entry (modifiedCount 1) and thus decrements; the rest see recipeId absent
+    // (modifiedCount 0) and 404 without touching the counter. This test asserts
+    // that invariant on the fixed code and exercises the concurrent path.
+    //
+    // NOTE (verified, not assumed): unlike the save-side concurrency test — which
+    // reliably reproduces its pre-fix race because concurrent upserts on a
+    // not-yet-existing doc all read null and multi-$push — the pre-fix unsave
+    // race (read isSaved, then $pull) does NOT reproduce at this HTTP layer even
+    // at 20-way concurrency: the first request's $pull commits before the others'
+    // read resolves, so racy code serializes to the same 1×200/N×404 here. So
+    // this test is path coverage + the atomicity contract, not a regression trap
+    // for that specific TOCTOU — the guarantee rests on the single-doc update,
+    // and reviewers should treat a regression to read-then-write as un-caught by
+    // CI. Seed the counter high so a decrement is observable, not floored at 0.
+    const db = getDB()
+    await db.collection('recipes').updateOne({ _id: RECIPE_ID }, { $set: { numTimesSaved: 5 } })
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        request(server).delete(`/api/recipes/${RECIPE_ID}/save`).set(AUTH_HEADER)
+      )
+    )
+    expect(results.filter(r => r.status === 200)).toHaveLength(1)
+    expect(results.filter(r => r.status === 404)).toHaveLength(4)
+
+    const recipe = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.numTimesSaved).toBe(4)
+    const userData = await db.collection('userRecipeData').findOne({ _id: TEST_UID })
+    expect(userData.savedRecipes).toHaveLength(0)
+  })
 })
 
 // ─── GET /getSavedRecipeIds ────────────────────────────────────────────────────

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -556,6 +556,37 @@ describe('POST /addRecipe', () => {
       await expectRejected({ instructions }, /instruction cannot exceed/i)
     })
 
+    it('rejects an ingredient line over 200 characters', async () => {
+      const ingredients = [
+        { id: 'i1', parsedIngredient: { originalIngredientString: 'x'.repeat(201) } },
+      ]
+      await expectRejected({ ingredients }, /ingredient cannot exceed/i)
+    })
+
+    it('rejects a negative prep time', async () => {
+      await expectRejected({ prepTime: -5 }, /Prep time must be between/)
+    })
+
+    it('rejects a non-numeric servings', async () => {
+      await expectRejected({ servings: '4' }, /Servings must be a number/)
+    })
+
+    it('rejects a fractional servings', async () => {
+      await expectRejected({ servings: 2.5 }, /Servings must be a whole number/)
+    })
+
+    it('rejects zero servings', async () => {
+      await expectRejected({ servings: 0 }, /Servings must be between/)
+    })
+
+    it('rejects a serving price over the cap', async () => {
+      await expectRejected({ servingPrice: 5_000_000 }, /Serving price must be between/)
+    })
+
+    it('rejects an absurdly large total time', async () => {
+      await expectRejected({ totalTime: Number.MAX_VALUE }, /Total time must be between/)
+    })
+
     it('accepts a payload exactly at the limits (201)', async () => {
       const res = await request(server)
         .post('/api/addRecipe')
@@ -564,6 +595,23 @@ describe('POST /addRecipe', () => {
           ...validBody(),
           title: 'A'.repeat(50),
           description: 'A'.repeat(2000),
+        })
+      expect(res.status).toBe(201)
+    })
+
+    it('accepts valid numeric fields (201)', async () => {
+      const res = await request(server)
+        .post('/api/addRecipe')
+        .set(AUTH_HEADER)
+        .send({
+          ...validBody(),
+          prepTime: 15,
+          cookTime: 30,
+          totalTime: 45,
+          servings: 4,
+          fridgeLife: 3,
+          freezerLife: 90,
+          servingPrice: 250,
         })
       expect(res.status).toBe(201)
     })
@@ -746,6 +794,27 @@ describe('POST /recipes/:id/save', () => {
 
     expect(res.status).toBe(409)
     expect(res.body.error).toMatch(/already saved/)
+  })
+
+  it('does not double-count numTimesSaved under concurrent saves (TOCTOU)', async () => {
+    // Fire several saves of the SAME recipe from the SAME user at once. The old
+    // read-check-then-write let two both pass the "already saved?" check and
+    // double-push / double-inc; the atomic conditional write must land exactly
+    // one save and one increment, the rest 409. (No userRecipeData doc exists
+    // yet, so this also exercises the concurrent-insert / dup-retry path.)
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        request(server).post(`/api/recipes/${RECIPE_ID}/save`).set(AUTH_HEADER)
+      )
+    )
+    expect(results.filter(r => r.status === 200)).toHaveLength(1)
+    expect(results.filter(r => r.status === 409)).toHaveLength(4)
+
+    const db = getDB()
+    const recipe = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.numTimesSaved).toBe(1)
+    const userData = await db.collection('userRecipeData').findOne({ _id: TEST_UID })
+    expect(userData.savedRecipes).toHaveLength(1)
   })
 })
 

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -844,15 +844,23 @@ router.delete('/recipes/:id/save', verifyToken, requireActive, asyncHandler(asyn
     return res.status(400).json({ error: 'recipeId is required' })
   }
   const uid = req.uid
-  const savedData = await db.collection('userRecipeData').findOne({ _id: uid })
-  const isSaved = savedData?.savedRecipes?.some(e => e.recipeId === recipeId) ?? false
-  if (!isSaved) {
-    return res.status(404).json({ error: 'Recipe not in saved list' })
-  }
-  await db.collection('userRecipeData').updateOne(
-    { _id: uid },
+  // Remove the recipe from savedRecipes in ONE atomic conditional write, and
+  // decrement numTimesSaved only when that pull actually removed an entry. This
+  // mirrors the save route: the old read-check-then-write shape let two
+  // concurrent unsaves both pass the `isSaved` check and both decrement, skewing
+  // the global tally low (the $max floor stops it going negative but not the
+  // over-decrement). Requiring the recipeId be PRESENT in the filter means only
+  // one racing write matches — MongoDB re-checks it under the document write
+  // lock — so modifiedCount reports whether this request is the one that removed
+  // it. No upsert here: unsaving a recipe the user never saved is a 404, not a
+  // doc to create.
+  const pullResult = await db.collection('userRecipeData').updateOne(
+    { _id: uid, 'savedRecipes.recipeId': recipeId },
     { $pull: { savedRecipes: { recipeId } } }
   )
+  if (pullResult.modifiedCount === 0) {
+    return res.status(404).json({ error: 'Recipe not in saved list' })
+  }
   await db.collection('recipes').updateOne(
     recipeIdQuery(recipeId),
     [{ $set: { numTimesSaved: { $max: [{ $subtract: ['$numTimesSaved', 1] }, 0] } } }]

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -12,6 +12,7 @@ const { fuzzyRankTitles } = require('../util/recipeTitleMatch')
 const { recordAudit } = require('../util/auditLog')
 const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
+const { upsertWithDupRetry } = require('../util/upsertWithDupRetry')
 const { moderateText } = require('../util/textModeration')
 const { moderateImage } = require('../util/imageModeration')
 const { gatherRecipeText, holdRecipeForReview, respondBlocked, worstVerdict, openAutomodReportQuery, restoreHeldRecipe } = require('../util/automod')
@@ -783,16 +784,27 @@ router.post('/recipes/:id/save', verifyToken, requireActive, asyncHandler(async 
     return res.status(400).json({ error: 'recipeId is required' })
   }
   const uid = req.uid
-  const existingData = await db.collection('userRecipeData').findOne({ _id: uid })
-  const alreadySaved = existingData?.savedRecipes?.some(e => e.recipeId === recipeId) ?? false
-  if (alreadySaved) {
+  // Add the recipe to savedRecipes in ONE atomic conditional write, and bump
+  // numTimesSaved only when that push actually landed. The old shape read the
+  // user doc, checked `alreadySaved`, then pushed + $inc'd — a TOCTOU where two
+  // concurrent saves (double-click, retried request) both passed the check and
+  // double-pushed / double-counted the global save tally. savedRecipes entries
+  // carry a dateSaved, so $addToSet can't dedup them the way madeRecipe does;
+  // instead the filter requires the recipeId be ABSENT, which MongoDB re-checks
+  // under the document write lock, so only one racing write can match. The
+  // write result reports whether it landed (fresh user doc ⇒ upsert; new list
+  // member ⇒ modifiedCount 1). upsertWithDupRetry covers the first-ever save
+  // racing a concurrent insert of this user's doc (unique _id ⇒ E11000 ⇒ retry
+  // as a plain update against the doc that now exists).
+  const addResult = await upsertWithDupRetry(
+    db.collection('userRecipeData'),
+    { _id: uid, 'savedRecipes.recipeId': { $ne: recipeId } },
+    { $push: { savedRecipes: { recipeId, dateSaved: Date.now().toString() } } }
+  )
+  const newlySaved = addResult.upsertedCount > 0 || addResult.modifiedCount > 0
+  if (!newlySaved) {
     return res.status(409).json({ error: 'Recipe already saved' })
   }
-  await db.collection('userRecipeData').updateOne(
-    { _id: uid },
-    { $push: { savedRecipes: { recipeId, dateSaved: Date.now().toString() } } },
-    { upsert: true }
-  )
   await db.collection('recipes').updateOne(
     recipeIdQuery(recipeId),
     { $inc: { numTimesSaved: 1 } }

--- a/server/util/recipeLimits.js
+++ b/server/util/recipeLimits.js
@@ -1,6 +1,8 @@
-// Server-side bounds for recipe input. Mirrors src/util/recipeLimits.ts — keep
-// the two files in sync. This is the authoritative, defense-in-depth check:
-// the client enforces the same limits, but never trust the client.
+// Server-side bounds for recipe input. The string/count limits below mirror
+// src/util/recipeLimits.ts — keep those two in sync. The numeric range bounds
+// are server-only: the client constrains those through stricter input-widget
+// caps, so they aren't mirrored client-side. Either way this is the
+// authoritative, defense-in-depth check: never trust the client.
 const TITLE_MAX_LENGTH = 50
 const DESCRIPTION_MAX_LENGTH = 2000
 const INSTRUCTION_MAX_LENGTH = 1000
@@ -14,7 +16,9 @@ const MAX_INSTRUCTIONS = 50
 // an absurdly large value that skews sorts/aggregates — so clamp type AND range
 // here too. Times are whole minutes: the client's max prep+cook is ~12000 min, so a
 // shared two-week ceiling covers legitimate long cures/ferments while rejecting
-// garbage. Storage life is in whole days; servingPrice is in whole US cents.
+// garbage. Storage life is in whole days. servingPrice is in US cents but is
+// derived (rounded) rather than typed, so it's bounded and non-negative but not
+// integer-pinned — see the `integer: false` note on NUMERIC_RECIPE_FIELDS below.
 const MAX_TIME_MINUTES = 60 * 24 * 14 // 20160 (two weeks)
 const MAX_STORAGE_DAYS = 365
 const MAX_SERVINGS = 1000

--- a/server/util/recipeLimits.js
+++ b/server/util/recipeLimits.js
@@ -4,8 +4,51 @@
 const TITLE_MAX_LENGTH = 50
 const DESCRIPTION_MAX_LENGTH = 2000
 const INSTRUCTION_MAX_LENGTH = 1000
+const INGREDIENT_MAX_LENGTH = 200
 const MAX_INGREDIENTS = 50
 const MAX_INSTRUCTIONS = 50
+
+// Numeric bounds. Recipes carry a handful of user-entered numbers. The client UI
+// already constrains them (TimeInput caps hours ≤ 99 / minutes ≤ 59, etc.), but a
+// hand-crafted request can send anything — a string, NaN, Infinity, a negative, or
+// an absurdly large value that skews sorts/aggregates — so clamp type AND range
+// here too. Times are whole minutes: the client's max prep+cook is ~12000 min, so a
+// shared two-week ceiling covers legitimate long cures/ferments while rejecting
+// garbage. Storage life is in whole days; servingPrice is in whole US cents.
+const MAX_TIME_MINUTES = 60 * 24 * 14 // 20160 (two weeks)
+const MAX_STORAGE_DAYS = 365
+const MAX_SERVINGS = 1000
+const MAX_SERVING_PRICE_CENTS = 1_000_000 // $10,000 / serving
+
+// Per-field numeric spec, checked by validateRecipeBounds. `min`/`max` are
+// inclusive; `integer: true` additionally requires a whole number. Every numeric
+// field is OPTIONAL at this layer — absent or explicitly null skips the check
+// (required-field presence is validated separately). servingPrice is derived
+// (rounded cents) so it isn't integer-pinned, just non-negative and bounded.
+const NUMERIC_RECIPE_FIELDS = {
+  prepTime: { min: 0, max: MAX_TIME_MINUTES, integer: true, label: 'Prep time' },
+  cookTime: { min: 0, max: MAX_TIME_MINUTES, integer: true, label: 'Cook time' },
+  totalTime: { min: 0, max: MAX_TIME_MINUTES, integer: true, label: 'Total time' },
+  servings: { min: 1, max: MAX_SERVINGS, integer: true, label: 'Servings' },
+  fridgeLife: { min: 0, max: MAX_STORAGE_DAYS, integer: true, label: 'Fridge life' },
+  freezerLife: { min: 0, max: MAX_STORAGE_DAYS, integer: true, label: 'Freezer life' },
+  servingPrice: { min: 0, max: MAX_SERVING_PRICE_CENTS, integer: false, label: 'Serving price' },
+}
+
+// Returns an error string when `value` violates `spec`, or null when it's in
+// bounds. Callers only invoke this for present, non-null values.
+function validateNumericField(value, spec) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return `${spec.label} must be a number`
+  }
+  if (spec.integer && !Number.isInteger(value)) {
+    return `${spec.label} must be a whole number`
+  }
+  if (value < spec.min || value > spec.max) {
+    return `${spec.label} must be between ${spec.min} and ${spec.max}`
+  }
+  return null
+}
 
 // Fields a recipe must carry to be created or edited. Shared by both routes so
 // the requirement can't drift between create and edit.
@@ -36,8 +79,25 @@ function validateRecipeBounds(body) {
   ) {
     return `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`
   }
-  if (Array.isArray(body.ingredients) && body.ingredients.length > MAX_INGREDIENTS) {
-    return `A recipe cannot have more than ${MAX_INGREDIENTS} ingredients`
+  if (Array.isArray(body.ingredients)) {
+    if (body.ingredients.length > MAX_INGREDIENTS) {
+      return `A recipe cannot have more than ${MAX_INGREDIENTS} ingredients`
+    }
+    // Per-element cap (mirrors the per-instruction one below): a small ingredient
+    // array whose individual raw lines are huge is just as abusive as a long one.
+    // The ingredient union nests the user's typed line under parsedIngredient;
+    // only check it when that string is present, consistent with the rest of this
+    // function (label rows and un-parsed entries simply have nothing to check).
+    const ingredientTooLong = body.ingredients.some(
+      ing =>
+        ing &&
+        ing.parsedIngredient &&
+        typeof ing.parsedIngredient.originalIngredientString === 'string' &&
+        ing.parsedIngredient.originalIngredientString.length > INGREDIENT_MAX_LENGTH
+    )
+    if (ingredientTooLong) {
+      return `An ingredient cannot exceed ${INGREDIENT_MAX_LENGTH} characters`
+    }
   }
   if (Array.isArray(body.instructions)) {
     if (body.instructions.length > MAX_INSTRUCTIONS) {
@@ -53,6 +113,13 @@ function validateRecipeBounds(body) {
       return `An instruction cannot exceed ${INSTRUCTION_MAX_LENGTH} characters`
     }
   }
+  // Numeric type + range clamps. Skip fields that are absent or null (all are
+  // optional here) — only validate the ones the client actually sent.
+  for (const [field, spec] of Object.entries(NUMERIC_RECIPE_FIELDS)) {
+    if (body[field] == null) continue
+    const numericError = validateNumericField(body[field], spec)
+    if (numericError) return numericError
+  }
   return null
 }
 
@@ -60,4 +127,9 @@ module.exports = {
   validateRequiredRecipeFields,
   validateRecipeBounds,
   DESCRIPTION_MAX_LENGTH,
+  INGREDIENT_MAX_LENGTH,
+  MAX_TIME_MINUTES,
+  MAX_STORAGE_DAYS,
+  MAX_SERVINGS,
+  MAX_SERVING_PRICE_CENTS,
 }

--- a/src/pages/AddRecipe/Ingredients/IngredientsInput.tsx
+++ b/src/pages/AddRecipe/Ingredients/IngredientsInput.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState } from 'react'
 import FormInput from 'src/Components/Form/FormInput'
+import { INGREDIENT_MAX_LENGTH } from 'src/util/recipeLimits'
 
 type IngredientsInputProps = {
   // Hands the raw entry to the container, which adds it optimistically and runs
@@ -18,6 +19,13 @@ const IngredientsInput: FC<IngredientsInputProps> = ({ onAdd }) => {
     const trimmed = inputVal.trim()
     if (!trimmed) {
       setHint('Enter an ingredient before adding it.')
+      return
+    }
+    // Mirror the server's per-ingredient cap (validateRecipeBounds) so an
+    // over-long line is caught here with the same message, not bounced as a 400
+    // after the user has moved on.
+    if (trimmed.length > INGREDIENT_MAX_LENGTH) {
+      setHint(`An ingredient cannot exceed ${INGREDIENT_MAX_LENGTH} characters.`)
       return
     }
 

--- a/src/test/IngredientsInput.test.tsx
+++ b/src/test/IngredientsInput.test.tsx
@@ -3,9 +3,11 @@ import { vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import IngredientsInput from 'src/pages/AddRecipe/Ingredients/IngredientsInput'
+import { INGREDIENT_MAX_LENGTH } from 'src/util/recipeLimits'
 
 const PLACEHOLDER = 'Add ingredients to your recipe.'
 const HINT = 'Enter an ingredient before adding it.'
+const TOO_LONG_HINT = `An ingredient cannot exceed ${INGREDIENT_MAX_LENGTH} characters.`
 
 const setup = () => {
   const onAdd = vi.fn()
@@ -41,5 +43,41 @@ describe('IngredientsInput', () => {
     expect(onAdd).toHaveBeenCalledWith('2 cups flour')
     expect(input.value).toBe('')
     expect(screen.queryByText(HINT)).toBeNull()
+  })
+
+  it('accepts a line exactly at the length cap', async () => {
+    const user = userEvent.setup()
+    const { onAdd } = setup()
+    const line = 'x'.repeat(INGREDIENT_MAX_LENGTH)
+    const input = screen.getByPlaceholderText(PLACEHOLDER)
+    await user.click(input)
+    await user.paste(line)
+    await user.keyboard('{enter}')
+    expect(onAdd).toHaveBeenCalledWith(line)
+    expect(screen.queryByText(TOO_LONG_HINT)).toBeNull()
+  })
+
+  it('rejects a line over the length cap with a server-parity hint', async () => {
+    const user = userEvent.setup()
+    const { onAdd } = setup()
+    const input = screen.getByPlaceholderText(PLACEHOLDER)
+    await user.click(input)
+    await user.paste('x'.repeat(INGREDIENT_MAX_LENGTH + 1))
+    await user.keyboard('{enter}')
+    expect(onAdd).not.toHaveBeenCalled()
+    expect(screen.getByText(TOO_LONG_HINT)).toBeInTheDocument()
+  })
+
+  it('caps on trimmed length, not whitespace padding', async () => {
+    const user = userEvent.setup()
+    const { onAdd } = setup()
+    // Real content is exactly at the cap; the surrounding spaces trim away, so
+    // this is accepted rather than rejected on raw length.
+    const line = 'x'.repeat(INGREDIENT_MAX_LENGTH)
+    const input = screen.getByPlaceholderText(PLACEHOLDER)
+    await user.click(input)
+    await user.paste(`  ${line}  `)
+    await user.keyboard('{enter}')
+    expect(onAdd).toHaveBeenCalledWith(line)
   })
 })

--- a/src/util/recipeLimits.ts
+++ b/src/util/recipeLimits.ts
@@ -1,18 +1,16 @@
-// Shared bounds for recipe input. Enforced on the client (input caps +
-// validation) and mirrored server-side in server/util/recipeLimits.js — keep
-// the two files in sync.
+// Shared string/count bounds for recipe input. Enforced on the client (input
+// caps + validation in AddRecipe) and mirrored server-side in
+// server/util/recipeLimits.js — keep these two files in sync.
+//
+// The server's NUMERIC range bounds (times, servings, storage life, serving
+// price) are intentionally NOT mirrored here: the client constrains those
+// through stricter input-widget caps (ServingsInput 1–99, TimeInput 99h/59m)
+// and serving price is derived, never typed — so validating them against a
+// shared ceiling on the client would be dead code that never fires. The server
+// owns those as defense-in-depth; see server/util/recipeLimits.js.
 export const TITLE_MAX_LENGTH = 50
 export const DESCRIPTION_MAX_LENGTH = 2000
 export const INSTRUCTION_MAX_LENGTH = 1000
 export const INGREDIENT_MAX_LENGTH = 200
 export const MAX_INGREDIENTS = 50
 export const MAX_INSTRUCTIONS = 50
-
-// Numeric bounds — the server enforces these as defense-in-depth in
-// server/util/recipeLimits.js (validateRecipeBounds); mirrored here so the two
-// files stay in sync. Times are whole minutes, storage life whole days,
-// servingPrice whole US cents.
-export const MAX_TIME_MINUTES = 60 * 24 * 14 // 20160 (two weeks)
-export const MAX_STORAGE_DAYS = 365
-export const MAX_SERVINGS = 1000
-export const MAX_SERVING_PRICE_CENTS = 1_000_000 // $10,000 / serving

--- a/src/util/recipeLimits.ts
+++ b/src/util/recipeLimits.ts
@@ -4,5 +4,15 @@
 export const TITLE_MAX_LENGTH = 50
 export const DESCRIPTION_MAX_LENGTH = 2000
 export const INSTRUCTION_MAX_LENGTH = 1000
+export const INGREDIENT_MAX_LENGTH = 200
 export const MAX_INGREDIENTS = 50
 export const MAX_INSTRUCTIONS = 50
+
+// Numeric bounds — the server enforces these as defense-in-depth in
+// server/util/recipeLimits.js (validateRecipeBounds); mirrored here so the two
+// files stay in sync. Times are whole minutes, storage life whole days,
+// servingPrice whole US cents.
+export const MAX_TIME_MINUTES = 60 * 24 * 14 // 20160 (two weeks)
+export const MAX_STORAGE_DAYS = 365
+export const MAX_SERVINGS = 1000
+export const MAX_SERVING_PRICE_CENTS = 1_000_000 // $10,000 / serving


### PR DESCRIPTION
## S1 · `recipes.js` write-safety (Wave 1)

Closes the `save`/`unsave` TOCTOU double-count on `numTimesSaved` and adds numeric/per-element input bounds as server-side defense-in-depth. Mirrors the already-shipped `madeRecipe` pattern.

### Changes
- **Atomic `save`** (`POST /recipes/:id/save`) — single conditional `$push` filtered on `savedRecipes.recipeId: {$ne}`, re-checked under the document write lock, with `upsertWithDupRetry` covering the first-save/concurrent-insert race. Kills the read-check-then-write TOCTOU that double-pushed and double-incremented the tally.
- **Atomic `unsave`** (`DELETE /recipes/:id/save`) — the symmetric fix, found in local review: conditional `$pull` on the recipeId being present, decrement gated on `modifiedCount`, so concurrent unsaves can't over-decrement.
- **Input bounds** (`validateRecipeBounds`) — numeric type+range clamps (times, servings, storage life, serving price) and a per-ingredient line-length cap; rejects NaN/Infinity/negatives/absurd values that skew sorts.
- **Client cleanup** — wired `INGREDIENT_MAX_LENGTH` into `IngredientsInput` (server-parity feedback) and dropped four dead numeric constants the client's stricter input-widget caps make redundant. Reconciled the `servingPrice` "whole cents" comment with its `integer:false` spec.
- **Backlog** — filed the cross-collection counter-atomicity seam (needs a multi-doc transaction) in Deferred + a status-log entry.

### Testing
- Backend Jest: **725 pass** — includes a save concurrency regression test (5 concurrent → one 200 / four 409, `numTimesSaved` +1 not +5) that I verified fails against the pre-fix code.
- Frontend: `tsc` clean · Vitest **553 pass** (incl. new `IngredientsInput` length-guard cases) · production build clean.

> Note on the unsave concurrency test: verified that the pre-fix unsave race does **not** reproduce at the HTTP layer even at 20-way concurrency (unlike the save race), so that test is path-coverage + the atomicity contract, not a race trap — the guarantee rests on single-document update semantics. Documented inline.

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ