### PR TITLE
security(auth): harden account routes — export bodies, privacy limiter, non-silent recompute (S2)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -91,10 +91,12 @@ The triage date stamped on items is the date they were filed here, not when they
   filter to both `find` and `countDocuments` and does no post-fetch filtering, so its count stays
   consistent. This bug is ratings-only.)** Fix: count post-visibility-filter, or paginate via an
   aggregation `$lookup` that excludes hidden recipes before the count.
-- `[~]` **Data export omits saved-recipe content** — `exportMyData` now exports full recipes, drafts,
-  ratings, and profile, but `savedRecipes` is still the raw reference array — `recipeId` + metadata
+- `[~]` **Data export omits saved-recipe content** — was: `exportMyData` exported full recipes, drafts,
+  ratings, and profile, but `savedRecipes` was still the raw reference array — `recipeId` + metadata
   (`collectionIds`/`savedAt`), no recipe bodies (`server/routes/auth.js:355`; verified 2026-06-26).
-  Expand it to full saved-recipe content. *(partially addressed)*
+  **Addressed in S2/PR #229 (open):** each saved entry is now hydrated with its recipe body (through
+  `publicRecipeProjection`, since saved recipes are other users'), keeping the ref with `recipe: null` for
+  deleted/hidden ones. Flip to `[x]` on merge.
 
 ## UX / visual polish
 
@@ -459,6 +461,19 @@ findings table.)*
   Verified against the live DEV endpoint with a minted token + seeded stamped recipe (response carried only the
   10 card fields). *(caught 2026-07-02 in the same code review that found the list-endpoint leak; see the #397
   item above. Fixed 2026-07-03.)*
+- `[ ]` **`exportMyData` returns the author's own `recipes`/`drafts` as full Mongo docs** — same leak class
+  as #397/#446, on the last unprojected account read. `GET /exportMyData` (`server/routes/auth.js:344`) builds
+  its `recipes`/`drafts` arrays with `db.collection('recipes').find({ userId: uid }).toArray()` (and the
+  `recipeDrafts` equivalent) — **no projection** — so any of the user's own recipes that an admin ever
+  moderated/featured carries `moderatedBy`/`featuredBy`/`publishUpdatedBy` (admin Firebase uids) straight into
+  the exported JSON the (non-admin) owner downloads. Narrowest audience of the three (only the recipe's own
+  author, and only via an explicit data export), which is why it wasn't bundled into the S2 fix. Note the
+  **saved-recipe** bodies on this same endpoint are NOT affected — S2/PR #229 hydrates them through
+  `publicRecipeProjection`; this is only the owner's *own* `recipes`/`drafts`. **Decision needed:** a data
+  export arguably *should* be higher-fidelity than a card, so the fix isn't necessarily the card whitelist —
+  more likely strip just the six admin stamps (a small shared `RECIPE_INTERNAL_STAMPS` exclusion) while
+  keeping the full user-authored body. Pre-existing; not a regression. Low (PII = internal admin uids, and the
+  owner already authored everything else in the doc). *(caught 2026-07-03 in local review of S2.)*
 - `[ ]` **Recipe numeric/array fields aren't range- or type-validated server-side** —
   `validateRecipeBounds` (`server/util/recipeLimits.js`, used by add/editRecipe) bounds title/description
   length, ingredient/instruction counts, and instruction-content length, but NOT the numeric fields

--- a/docs/BACKLOG_ROADMAP.md
+++ b/docs/BACKLOG_ROADMAP.md
@@ -66,7 +66,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | Wave | Track | Backlog items covered | Status | Domain (collision surface) | Notes / deps |
 |---|---|---|---|---|---|
 | **1** | **S1 · recipes.js write-safety** | `save` TOCTOU (`recipes.js:778-801`); numeric/array bounds in `recipeLimits.js` | `[ ]` | `server/routes/recipes.js`, `server/util/recipeLimits.js` | blocks **I3** (also edits recipes.js) |
-| **1** | **S2 · auth.js account routes** | data-export saved-recipe bodies (`:355`); `updatePrivacy` writeLimiter (`:310`); harden `deleteAccount` recompute (`:454-461`) | `[~]` `worktree-feat+s2-auth-account-routes` 2026-07-03 | `server/routes/auth.js` | recompute pairs with **S6** |
+| **1** | **S2 · auth.js account routes** | data-export saved-recipe bodies (`:355`); `updatePrivacy` writeLimiter (`:310`); harden `deleteAccount` recompute (`:454-461`) | `[P]` `worktree-feat+s2-auth-account-routes` 2026-07-03 | `server/routes/auth.js` | recompute pairs with **S6** |
 | **1** | **S3 · reviews.js correctness** | ratings Load-More count (`:281-308`); admin-takedown username→userId (`:318-353`) | `[ ]` | `server/routes/reviews.js` | — |
 | **1** | **S4 · rate-limit breadth** | reports per-uid limiter (`reports.js:69`); `acknowledgeAchievements` limiter (`gamification.js:31`) | `[ ]` | `server/routes/reports.js`, `server/routes/gamification.js` | disjoint from S2 |
 | **1** | **S5 · asyncHandler consistency** | `nutrition.js` `/details` + `ingredients.js` `/parse` bare async → wrapper | `[ ]` | `server/routes/nutrition.js`, `ingredients.js` | trivial |

--- a/docs/BACKLOG_ROADMAP.md
+++ b/docs/BACKLOG_ROADMAP.md
@@ -66,7 +66,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | Wave | Track | Backlog items covered | Status | Domain (collision surface) | Notes / deps |
 |---|---|---|---|---|---|
 | **1** | **S1 · recipes.js write-safety** | `save` TOCTOU (`recipes.js:778-801`); numeric/array bounds in `recipeLimits.js` | `[ ]` | `server/routes/recipes.js`, `server/util/recipeLimits.js` | blocks **I3** (also edits recipes.js) |
-| **1** | **S2 · auth.js account routes** | data-export saved-recipe bodies (`:355`); `updatePrivacy` writeLimiter (`:310`); harden `deleteAccount` recompute (`:454-461`) | `[ ]` | `server/routes/auth.js` | recompute pairs with **S6** |
+| **1** | **S2 · auth.js account routes** | data-export saved-recipe bodies (`:355`); `updatePrivacy` writeLimiter (`:310`); harden `deleteAccount` recompute (`:454-461`) | `[~]` `worktree-feat+s2-auth-account-routes` 2026-07-03 | `server/routes/auth.js` | recompute pairs with **S6** |
 | **1** | **S3 · reviews.js correctness** | ratings Load-More count (`:281-308`); admin-takedown username→userId (`:318-353`) | `[ ]` | `server/routes/reviews.js` | — |
 | **1** | **S4 · rate-limit breadth** | reports per-uid limiter (`reports.js:69`); `acknowledgeAchievements` limiter (`gamification.js:31`) | `[ ]` | `server/routes/reports.js`, `server/routes/gamification.js` | disjoint from S2 |
 | **1** | **S5 · asyncHandler consistency** | `nutrition.js` `/details` + `ingredients.js` `/parse` bare async → wrapper | `[ ]` | `server/routes/nutrition.js`, `ingredients.js` | trivial |

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -653,6 +653,47 @@ describe('GET /exportMyData', () => {
     expect(res.body.savedRecipes[0].recipeId).toBe('hidden-1')
     expect(res.body.savedRecipes[0].recipe).toBeNull()
   })
+
+  it('does not leak another user\'s admin moderation stamps into the hydrated body', async () => {
+    await seedUser(TEST_UID, 'saver')
+    const db = getDB()
+    // A saved recipe is someone else's recipe, and it may carry internal admin
+    // stamps (admin Firebase uids) from a prior moderation/curation action. The
+    // export must hydrate it through the public whitelist, not the raw doc.
+    await db.collection('recipes').insertOne({
+      _id: 'stamped-1',
+      userId: 'other',
+      title: 'Stamped Stew',
+      status: 'published',
+      ingredients: [{ name: 'water' }],
+      moderatedBy: 'admin-uid-1',
+      moderatedAt: '2026-01-01',
+      featuredBy: 'admin-uid-2',
+      featuredAt: '2026-01-02',
+      publishUpdatedBy: 'admin-uid-3',
+      publishUpdatedAt: '2026-01-03',
+    })
+    await db
+      .collection('userRecipeData')
+      .insertOne({ _id: TEST_UID, savedRecipes: [{ recipeId: 'stamped-1', dateSaved: '1' }] })
+
+    const res = await request(app).get('/api/exportMyData').set(AUTH_HEADER)
+
+    const { recipe } = res.body.savedRecipes[0]
+    // Public content still hydrates...
+    expect(recipe.title).toBe('Stamped Stew')
+    // ...but none of the six admin-uid moderation/curation stamps ride along.
+    for (const field of [
+      'moderatedBy',
+      'moderatedAt',
+      'featuredBy',
+      'featuredAt',
+      'publishUpdatedBy',
+      'publishUpdatedAt',
+    ]) {
+      expect(recipe).not.toHaveProperty(field)
+    }
+  })
 })
 
 // ─── POST /deleteAccount ─────────────────────────────────────────────────────

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -605,6 +605,54 @@ describe('GET /exportMyData', () => {
     expect(res.body.recipes).toEqual([])
     expect(res.body.ratings).toEqual([])
   })
+
+  it('hydrates saved-recipe references into full recipe bodies', async () => {
+    await seedUser(TEST_UID, 'saver')
+    const db = getDB()
+    // A live recipe the user saved (owned by someone else) + a dangling ref
+    // whose recipe has since been deleted.
+    await db
+      .collection('recipes')
+      .insertOne({ _id: 'saved-1', userId: 'other', title: 'Saved Soup', status: 'published' })
+    await db.collection('userRecipeData').insertOne({
+      _id: TEST_UID,
+      savedRecipes: [
+        { recipeId: 'saved-1', dateSaved: '100' },
+        { recipeId: 'missing', dateSaved: '200' },
+      ],
+    })
+
+    const res = await request(app).get('/api/exportMyData').set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    const [hit, miss] = res.body.savedRecipes
+    // Original save metadata is preserved on both entries.
+    expect(hit.recipeId).toBe('saved-1')
+    expect(hit.dateSaved).toBe('100')
+    // The live recipe is hydrated into its full body...
+    expect(hit.recipe.title).toBe('Saved Soup')
+    // ...and a since-deleted one keeps its reference with recipe: null.
+    expect(miss.recipeId).toBe('missing')
+    expect(miss.dateSaved).toBe('200')
+    expect(miss.recipe).toBeNull()
+  })
+
+  it('does not leak the body of a saved recipe that was later hidden', async () => {
+    await seedUser(TEST_UID, 'saver')
+    const db = getDB()
+    await db
+      .collection('recipes')
+      .insertOne({ _id: 'hidden-1', userId: 'other', title: 'Gone', status: 'hidden' })
+    await db
+      .collection('userRecipeData')
+      .insertOne({ _id: TEST_UID, savedRecipes: [{ recipeId: 'hidden-1', dateSaved: '1' }] })
+
+    const res = await request(app).get('/api/exportMyData').set(AUTH_HEADER)
+
+    expect(res.body.savedRecipes).toHaveLength(1)
+    expect(res.body.savedRecipes[0].recipeId).toBe('hidden-1')
+    expect(res.body.savedRecipes[0].recipe).toBeNull()
+  })
 })
 
 // ─── POST /deleteAccount ─────────────────────────────────────────────────────
@@ -801,6 +849,40 @@ describe('POST /deleteAccount', () => {
       expect(
         await db.collection('ratings').findOne({ userId: KEEPER_UID, recipeId: 'kept' })
       ).not.toBeNull()
+    })
+
+    it('retries, alerts, and records a failed post-commit recompute instead of swallowing it', async () => {
+      await seedCascade()
+      // Force the surviving-recipe recompute ('kept') to fail on every attempt.
+      const recipeRating = require('../util/recipeRating')
+      const Sentry = require('@sentry/node')
+      const recomputeSpy = jest
+        .spyOn(recipeRating, 'recomputeRecipeRating')
+        .mockRejectedValue(new Error('mongo down'))
+      const sentrySpy = jest
+        .spyOn(Sentry, 'captureException')
+        .mockImplementation(() => {})
+
+      try {
+        const res = await request(app).post('/api/deleteAccount').set(AUTH_HEADER)
+
+        // Best-effort: the account delete still completes despite the failure.
+        expect(res.status).toBe(200)
+        expect(admin.__deleteUser).toHaveBeenCalledWith(TEST_UID)
+        // The one surviving reviewed recipe ('kept') is retried before giving up.
+        expect(recomputeSpy).toHaveBeenCalledTimes(3)
+        expect(recomputeSpy).toHaveBeenCalledWith(expect.anything(), 'kept')
+        // Escalated to Sentry — not silently console.error'd.
+        expect(sentrySpy).toHaveBeenCalledTimes(1)
+        // And left a durable, queryable to-do on the audit entry for S6 reconciliation.
+        const entry = await getDB()
+          .collection('auditLog')
+          .findOne({ action: 'user.delete' })
+        expect(entry.metadata.staleRatingRecipeIds).toEqual(['kept'])
+      } finally {
+        recomputeSpy.mockRestore()
+        sentrySpy.mockRestore()
+      }
     })
   })
 })

--- a/server/__tests__/writeLimiter.wiring.test.js
+++ b/server/__tests__/writeLimiter.wiring.test.js
@@ -43,6 +43,7 @@ describe('per-surface write limiters are wired onto every moderated write route'
     ['auth', authRouter, 'post', '/updateProfile', profileWriteLimiter],
     ['auth', authRouter, 'post', '/updatePhoto', profileWriteLimiter],
     ['auth', authRouter, 'post', '/updateDisplayName', profileWriteLimiter],
+    ['auth', authRouter, 'post', '/updatePrivacy', profileWriteLimiter],
   ]
 
   it.each(cases)(

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const admin = require('firebase-admin')
+const Sentry = require('@sentry/node')
 const { asyncHandler } = require('../util/asyncHandler')
 const router = express.Router()
 const { getDB, getClient } = require('../db')
@@ -7,7 +8,12 @@ const { verifyToken, requireActive } = require('../middleware/auth')
 const { profileWriteLimiter } = require('../middleware/writeLimiter')
 const { recordAudit } = require('../util/auditLog')
 const { deleteRecipeImage, deleteProfilePhoto } = require('../util/firebaseStorage')
-const { recomputeRecipeRating } = require('../util/recipeRating')
+// Imported as a namespace (not a destructured binding) so tests can spy on the
+// recompute — deleteAccount's post-commit reconciliation must survive a failing
+// recompute without going silent.
+const recipeRating = require('../util/recipeRating')
+const { recipeIdInQuery } = require('../util/recipeIdQuery')
+const { RECIPE_VISIBLE } = require('../util/moderation')
 const { moderateText } = require('../util/textModeration')
 const { moderateImage } = require('../util/imageModeration')
 const { respondBlocked } = require('../util/automod')
@@ -307,7 +313,7 @@ router.post('/updateDisplayName', verifyToken, requireActive, profileWriteLimite
 // Upserts the authenticated user's privacy toggles (public-profile +
 // hide-location). These gate the public /u/:username view served by
 // GET /getPublicProfile.
-router.post('/updatePrivacy', verifyToken, requireActive, asyncHandler(async (req, res) => {
+router.post('/updatePrivacy', verifyToken, requireActive, profileWriteLimiter, asyncHandler(async (req, res) => {
   const { isPublic, hideLocation } = req.body || {}
   const validationError = validatePrivacy(isPublic, hideLocation)
   if (validationError) {
@@ -341,6 +347,27 @@ router.get('/exportMyData', verifyToken, asyncHandler(async (req, res) => {
     db.collection('ratings').find({ userId: uid }).toArray(),
   ])
 
+  // Hydrate the saved-recipe references into the actual recipe bodies so the
+  // export is a self-contained, portable archive rather than a list of opaque
+  // ids. Each element keeps its original save metadata (dateSaved, collectionIds)
+  // and gains a `recipe` field. A saved recipe that's since been deleted — or
+  // hidden by moderation (RECIPE_VISIBLE, matching what GET /getSavedRecipes will
+  // serve) — is preserved as its bare reference with `recipe: null`, so the user
+  // never loses the record of what they saved and we never leak a hidden body.
+  const savedRefs = userRecipeData?.savedRecipes ?? []
+  const savedIds = savedRefs.map((e) => e.recipeId).filter(Boolean)
+  const savedBodies = savedIds.length
+    ? await db
+        .collection('recipes')
+        .find({ ...recipeIdInQuery(savedIds), ...RECIPE_VISIBLE })
+        .toArray()
+    : []
+  const savedById = new Map(savedBodies.map((r) => [String(r._id), r]))
+  const savedRecipes = savedRefs.map((entry) => ({
+    ...entry,
+    recipe: savedById.get(String(entry.recipeId)) ?? null,
+  }))
+
   const data = {
     exportedAt: new Date().toISOString(),
     username,
@@ -352,7 +379,7 @@ router.get('/exportMyData', verifyToken, asyncHandler(async (req, res) => {
           hideLocation: profile.hideLocation ?? false,
         }
       : null,
-    savedRecipes: userRecipeData?.savedRecipes ?? [],
+    savedRecipes,
     recipes,
     drafts,
     ratings,
@@ -365,6 +392,24 @@ router.get('/exportMyData', verifyToken, asyncHandler(async (req, res) => {
   res.setHeader('Content-Type', 'application/json')
   res.send(JSON.stringify(data, null, 2))
 }))
+
+// Retry a recipe-rating recompute a few times before giving up. The recompute
+// is a single read + single write, so a failure is almost always a transient
+// Mongo blip — one more attempt usually clears it rather than leaving a stale
+// aggregate. Throws the last error if every attempt fails, so the caller can
+// escalate instead of swallowing.
+const RECOMPUTE_ATTEMPTS = 3
+async function recomputeWithRetry(db, recipeId) {
+  let lastErr
+  for (let attempt = 1; attempt <= RECOMPUTE_ATTEMPTS; attempt++) {
+    try {
+      return await recipeRating.recomputeRecipeRating(db, recipeId)
+    } catch (err) {
+      lastErr = err
+    }
+  }
+  throw lastErr
+}
 
 // POST /deleteAccount
 // Permanently deletes the authenticated user and all of their data. Removes the
@@ -450,12 +495,23 @@ router.post('/deleteAccount', verifyToken, asyncHandler(async (req, res) => {
 
   // D4: recompute the aggregate for recipes the user reviewed but did NOT own
   // (the ones they owned are gone). Post-commit, so it reflects the removed
-  // reviews. Best-effort: a recompute failure must not block the account delete.
+  // reviews. Best-effort: a recompute failure must not block the account delete —
+  // but it must NOT be silent either. A surviving recipe whose recompute failed
+  // now carries a stale aggregate that still counts the just-deleted user's
+  // review, so we retry, then escalate any hold-outs to Sentry AND stamp their
+  // ids onto the audit entry below — a durable to-do the S6 reconciliation script
+  // can sweep — instead of losing them in a console line.
+  const staleRatingRecipeIds = []
   for (const recipeId of reviewedRecipeIds) {
     if (ownRecipeIds.has(recipeId)) continue
     try {
-      await recomputeRecipeRating(db, recipeId)
+      await recomputeWithRetry(db, recipeId)
     } catch (err) {
+      staleRatingRecipeIds.push(recipeId)
+      Sentry.captureException(err, {
+        tags: { area: 'deleteAccount.recompute' },
+        extra: { uid, recipeId },
+      })
       console.error('deleteAccount: rating recompute failed for', recipeId, err.message)
     }
   }
@@ -480,6 +536,9 @@ router.post('/deleteAccount', verifyToken, asyncHandler(async (req, res) => {
     targetType: 'user',
     targetId: uid,
     targetLabel: username ? `@${username}` : null,
+    // Only present when a post-commit recompute couldn't be salvaged — leaves a
+    // durable, queryable record of which surviving recipes need reconciliation.
+    metadata: staleRatingRecipeIds.length ? { staleRatingRecipeIds } : null,
   })
 
   await admin.auth().deleteUser(uid)

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -14,6 +14,7 @@ const { deleteRecipeImage, deleteProfilePhoto } = require('../util/firebaseStora
 const recipeRating = require('../util/recipeRating')
 const { recipeIdInQuery } = require('../util/recipeIdQuery')
 const { RECIPE_VISIBLE } = require('../util/moderation')
+const { publicRecipeProjection } = require('../util/recipeFields')
 const { moderateText } = require('../util/textModeration')
 const { moderateImage } = require('../util/imageModeration')
 const { respondBlocked } = require('../util/automod')
@@ -354,12 +355,21 @@ router.get('/exportMyData', verifyToken, asyncHandler(async (req, res) => {
   // hidden by moderation (RECIPE_VISIBLE, matching what GET /getSavedRecipes will
   // serve) — is preserved as its bare reference with `recipe: null`, so the user
   // never loses the record of what they saved and we never leak a hidden body.
+  //
+  // Saved recipes are, by definition, OTHER users' recipes, so hydrate through
+  // publicRecipeProjection — the same non-owner whitelist the public reads use.
+  // Without it the export would ship the internal admin-uid moderation stamps
+  // (moderatedBy/moderatedAt, featuredBy/featuredAt, publishUpdatedBy/At) of
+  // another user's recipe to this user, re-leaking exactly what #226/#227 sealed.
   const savedRefs = userRecipeData?.savedRecipes ?? []
   const savedIds = savedRefs.map((e) => e.recipeId).filter(Boolean)
   const savedBodies = savedIds.length
     ? await db
         .collection('recipes')
-        .find({ ...recipeIdInQuery(savedIds), ...RECIPE_VISIBLE })
+        .find(
+          { ...recipeIdInQuery(savedIds), ...RECIPE_VISIBLE },
+          { projection: publicRecipeProjection }
+        )
         .toArray()
     : []
   const savedById = new Map(savedBodies.map((r) => [String(r._id), r]))


### PR DESCRIPTION
## S2 · `server/routes/auth.js` account routes

Three security/correctness hardenings on the authenticated account routes, plus a leak fix found in local review.

### Changes

**1 · `GET /exportMyData` — hydrate saved-recipe bodies (`:355`)**
Saved recipes were exported as opaque `{recipeId, dateSaved}` refs. Each entry is now hydrated with the full `recipe` body so the export is a self-contained archive. A since-deleted or moderation-hidden recipe keeps its bare reference with `recipe: null` (never loses the record, never leaks a hidden body). Bodies are fetched through **`publicRecipeProjection`** — saved recipes are *other users'* recipes, so the raw doc would have shipped the six internal admin-uid moderation/curation stamps (`moderatedBy/moderatedAt`, `featuredBy/featuredAt`, `publishUpdatedBy/At`) into the requester's export, re-opening what #226/#227 sealed on the list reads.

**2 · `POST /updatePrivacy` — add `profileWriteLimiter` (`:310`)**
It was the one profile-write route missing the per-uid limiter the other four (`setUsername`/`updateProfile`/`updatePhoto`/`updateDisplayName`) all carry. Wiring test extended.

**3 · `POST /deleteAccount` — non-silent post-commit recompute (`:454`)**
The best-effort rating recompute for surviving reviewed recipes was a swallowed `console.error`, leaving a stale aggregate with no trace. Now: retry 3× → on persistent failure escalate to **Sentry** *and* stamp the recipe ids onto the `user.delete` audit entry (`metadata.staleRatingRecipeIds`) — a durable, queryable to-do for the S6 reconciliation script. Still non-blocking; a failure never blocks the delete. `recomputeRecipeRating` is imported as a namespace so the retry is spy-able.

### Tests
- Server Jest **720 passed** (+5: export hydration, hidden-body guard, admin-stamp leak guard, non-silent recompute, `updatePrivacy` limiter wiring)
- `npx tsc --noEmit` clean; server-only diff (client Vitest/build unaffected)

### Manual verification
All three exercised end-to-end against dev infra with a real Firebase token: export hydrates + drops admin stamps + nulls hidden/dangling refs; `updatePrivacy` returns 30×200 then 429 (`RATE_LIMITED`); `deleteAccount` recomputes a survivor's aggregate `{2,3}→{1,4}`, purges the cascade, writes the audit entry (`metadata: null` on the happy path), and deletes the Firebase account.

https://claude.ai/code/session_01JwP511UkTUgU69S9MZTJ8x