### PR TITLE
security(rate-limit): per-uid limiters on reports + acknowledgeAchievements (S4)

### DIFF
--- a/server/__tests__/reports.test.js
+++ b/server/__tests__/reports.test.js
@@ -296,6 +296,26 @@ describe('GET /api/reports', () => {
     expect(reviewReport.target.review.reviewText).toBe('nasty')
   })
 
+  it('previews a reported review by the stable userId, surviving an author rename', async () => {
+    admin.__setClaims({ admin: true })
+    await seedRecipe({ _id: 'recipe-001', title: 'Reported Dish', recipeImage: 'img', userId: 'owner' })
+    // The review author has since renamed: the ratings doc is keyed by the
+    // stable userId 'bad-uid' and now carries the CURRENT handle 'newhandle'.
+    // The report snapshotted the OLD handle plus the uid (D1).
+    await seedRating({ userId: 'bad-uid', username: 'newhandle', recipeId: 'recipe-001', reviewText: 'nasty', rating: 1 })
+    await getDB().collection('reports').insertOne({
+      _id: new ObjectId(), targetType: 'review', recipeId: 'recipe-001',
+      reportedUsername: 'oldhandle', reportedUid: 'bad-uid',
+      reporterUid: 'u2', reason: 'offensive', status: 'open', createdAt: new Date(),
+    })
+
+    const res = await request(app).get('/api/reports').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    const reviewReport = res.body.reports.find((r) => r.targetType === 'review')
+    // Matched by the snapshotted userId, not the stale handle → preview resolves.
+    expect(reviewReport.target.review.reviewText).toBe('nasty')
+  })
+
   it('surfaces a user report in the queue with no recipe/review snapshot', async () => {
     admin.__setClaims({ admin: true })
     await getDB().collection('reports').insertOne({

--- a/server/__tests__/writeLimiter.wiring.test.js
+++ b/server/__tests__/writeLimiter.wiring.test.js
@@ -23,6 +23,8 @@ const recipesRouter = require('../routes/recipes')
 const reviewsRouter = require('../routes/reviews')
 const authRouter = require('../routes/auth')
 const ingredientsRouter = require('../routes/ingredients')
+const gamificationRouter = require('../routes/gamification')
+const reportsRouter = require('../routes/reports')
 
 // Ordered handler chain for a single route on a router, or throws if missing.
 const routeHandlers = (router, method, path) => {
@@ -72,5 +74,23 @@ describe('per-surface write limiters are wired onto every moderated write route'
     const handlers = routeHandlers(ingredientsRouter, 'post', '/parse')
     expect(handlers[0]).toBe(verifyToken)
     expect(handlers).toHaveLength(3) // verifyToken, parseLimiter, handler
+  })
+
+  it('gamification POST /acknowledgeAchievements mounts profileWriteLimiter after verifyToken', () => {
+    // A userProfiles write that shares the profile budget. Unlike the profile
+    // routes above it has no requireActive, so assert only verifyToken → limiter.
+    const handlers = routeHandlers(gamificationRouter, 'post', '/acknowledgeAchievements')
+    expect(handlers).toContain(verifyToken)
+    expect(handlers).toContain(profileWriteLimiter)
+    expect(handlers.indexOf(verifyToken)).toBeLessThan(handlers.indexOf(profileWriteLimiter))
+  })
+
+  it('reports POST /reports mounts a breadth limiter after verifyToken + requireActive', () => {
+    // reportLimiter is internal to the route file (not exported), so assert
+    // structurally: verifyToken → requireActive → (limiter) → handler.
+    const handlers = routeHandlers(reportsRouter, 'post', '/reports')
+    expect(handlers[0]).toBe(verifyToken)
+    expect(handlers[1]).toBe(requireActive)
+    expect(handlers).toHaveLength(4) // verifyToken, requireActive, reportLimiter, handler
   })
 })

--- a/server/routes/gamification.js
+++ b/server/routes/gamification.js
@@ -3,6 +3,7 @@ const { asyncHandler } = require('../util/asyncHandler')
 const router = express.Router()
 const { getDB } = require('../db')
 const { verifyToken } = require('../middleware/auth')
+const { profileWriteLimiter } = require('../middleware/writeLimiter')
 const { getAccountCountsFor } = require('../util/accountCounts')
 const { computeGamification, ACHIEVEMENTS } = require('../util/gamification')
 
@@ -28,7 +29,12 @@ router.get('/getGamification', verifyToken, asyncHandler(async (req, res) => {
 // Records that the given achievement ids have been shown to the user, so the
 // unlock toast won't fire again. Body: { ids: string[] }. Unknown ids are
 // ignored; $addToSet makes it idempotent.
-router.post('/acknowledgeAchievements', verifyToken, asyncHandler(async (req, res) => {
+//
+// profileWriteLimiter mirrors the sibling userProfiles writes (updateProfile,
+// updatePrivacy, …): cheap + idempotent, but it's still an authed per-user write,
+// so it shares the same per-uid write budget rather than relying only on the
+// coarse global per-IP backstop.
+router.post('/acknowledgeAchievements', verifyToken, profileWriteLimiter, asyncHandler(async (req, res) => {
   const { ids } = req.body || {}
   if (!Array.isArray(ids)) {
     return res.status(400).json({ error: 'ids must be an array' })

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -198,10 +198,18 @@ router.get('/reports', verifyToken, requireAdmin, asyncHandler(async (req, res) 
         : null
       let review = null
       if (r.targetType === 'review') {
+        // ratings are keyed by the stable userId; username is a renameable
+        // display field, so matching the stored handle blanks the preview once
+        // the author renames (the reports.js twin of the S3 reviews.js fix).
+        // Prefer the uid snapshotted on the report (D1); fall back to the handle
+        // only for legacy/edge reports that never captured a reportedUid.
+        const authorMatch = r.reportedUid
+          ? { userId: r.reportedUid }
+          : { username: r.reportedUsername }
         review = await db
           .collection('ratings')
           .findOne(
-            { username: r.reportedUsername, recipeId: r.recipeId },
+            { ...authorMatch, recipeId: r.recipeId },
             { projection: { reviewText: 1, rating: 1, moderationHidden: 1 } }
           )
       }

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -3,6 +3,7 @@ const { asyncHandler } = require('../util/asyncHandler')
 const { ObjectId } = require('mongodb')
 const { getDB } = require('../db')
 const { verifyToken, requireAdmin, requireActive } = require('../middleware/auth')
+const { makeUserLimiter } = require('../middleware/writeLimiter')
 const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { recordAudit, recordAuditMany } = require('../util/auditLog')
 const { restoreHeldRecipe } = require('../util/automod')
@@ -31,6 +32,20 @@ const { notifyInBackground, notifyReportResolved, notifyReportResolvedMany } = r
 const isAutomodRecipeReport = (r) => r && r.source === 'automod' && r.targetType === 'recipe'
 
 const router = Router()
+
+// Per-user breadth limiter for filing reports, keyed by req.uid (an independent
+// bucket from the content-write limiters — see middleware/writeLimiter). The
+// one-open-report-per-(reporter,target) rule below already stops re-filing the
+// SAME target, but nothing caps the breadth: one account could open a report
+// against a distinct recipe/user/review every few seconds and bloat the
+// moderation queue, with only the coarse global per-IP backstop applying. 10/min
+// is far above any human's manual report cadence (read → pick a reason → submit)
+// yet bounds a scripted breadth-spam run hard. Mounted after verifyToken so
+// req.uid is set; skipped under Jest like every makeUserLimiter instance.
+const reportLimiter = makeUserLimiter({
+  limit: 10,
+  message: 'You’re filing reports too quickly — wait a minute and try again.',
+})
 
 // A report targets a recipe, a single review, or a whole user. Reviews have no
 // stable id (they live in `ratings` keyed by username+recipeId), so a review
@@ -64,9 +79,10 @@ function targetMatch({ targetType, recipeId, reportedUsername }) {
     : { targetType, recipeId, ...handle }
 }
 
-// POST /reports — any logged-in user files a report. Rate-limited to one OPEN
-// report per (reporter, target) so a single user can't flood the queue.
-router.post('/reports', verifyToken, requireActive, asyncHandler(async (req, res) => {
+// POST /reports — any logged-in user files a report. Rate-limited two ways: a
+// per-user breadth cap (reportLimiter, 10/min across all targets) and, below, one
+// OPEN report per (reporter, target) so a single user can't flood the queue.
+router.post('/reports', verifyToken, requireActive, reportLimiter, asyncHandler(async (req, res) => {
   const db = getDB()
   const { targetType, recipeId, reportedUsername, reason, details } = req.body
 


### PR DESCRIPTION
## S4 · rate-limit breadth

Closes the two authed-write surfaces that relied only on the coarse global per-IP backstop (from the security sweep; roadmap Wave 1, track **S4**).

### Changes
- **`POST /reports`** (`server/routes/reports.js`) — the existing one-open-report-per-`(reporter,target)` rule stops re-filing the *same* target but does not cap **breadth**: one account could open a report against a distinct recipe/user/review every few seconds and bloat the moderation queue. Added a dedicated per-uid **`reportLimiter`** (10/min, its own bucket via `makeUserLimiter`), mounted after `verifyToken` + `requireActive`.
- **`POST /acknowledgeAchievements`** (`server/routes/gamification.js`) — a `userProfiles` write with no per-user limiter, unlike its sibling profile writes. Mounted the shared **`profileWriteLimiter`** after `verifyToken`.

### Also folded in (same file, out of rate-limit scope)
- **`GET /reports` review preview** — the admin moderation-queue preview fetched each review snapshot by `{ username: reportedUsername, recipeId }`, but `ratings` are keyed by the **stable `userId`**, so a renameable handle blanked the preview once the author renamed. This is the `reports.js` twin of the rename-staleness bug **S3** just fixed in `reviews.js`. Now prefers the `reportedUid` already snapshotted on the report (D1), falling back to the handle only for legacy/edge reports without one. Bundled here because it lives in `reports.js` and would otherwise stay a logged S4 follow-up.

### Why 10/min for reports
Far above any human's manual report cadence (read → pick a reason → submit), but bounds a scripted breadth-spam run hard. An independent bucket, so report-filing doesn't share a budget with profile/content writes (the "one limiter per surface" pattern).

### Tests
- Extended `writeLimiter.wiring.test.js` to prove both limiter mounts (presence + order).
- Added a `GET /reports` regression test for the rename-staleness preview fix — **proven to fail on the old lookup** (null preview → `TypeError`) and pass on the fix.
- The shared limiter factory's real 429 behavior is covered by `writeLimiter.test.js` (limiters `skip` under `NODE_ENV=test`).
- Full server suite green locally: **733 passed**. Server-only change (no frontend/TS touched).

### Runtime verification
Drove both limiters against the live dev server with real Firebase tokens: `profileWriteLimiter` engages at exactly 30/min, `reportLimiter` at 10/min (independent buckets), keyed by `req.uid` (a second user on the same IP got a fresh bucket), 429s carry `code: RATE_LIMITED`. No dev-DB side effects (no-op/invalid bodies). The preview fix is admin-gated and verified via the supertest regression test above.

https://claude.ai/code/session_01JwP511UkTUgU69S9MZTJ8x