### PR TITLE
refactor(server): wrap nutrition/ingredients routes in asyncHandler (S5)

### DIFF
--- a/server/routes/ingredients.js
+++ b/server/routes/ingredients.js
@@ -3,6 +3,7 @@ const { ingredientParser } = require('@jclind/ingredient-parser')
 const { verifyToken } = require('../middleware/auth')
 const { makeUserLimiter } = require('../middleware/writeLimiter')
 const { GENERIC_500_MESSAGE } = require('../util/respondServerError')
+const { asyncHandler } = require('../util/asyncHandler')
 
 const router = Router()
 
@@ -49,7 +50,7 @@ function mapIngredientData(data) {
   return out
 }
 
-router.post('/parse', verifyToken, parseLimiter, async (req, res) => {
+router.post('/parse', verifyToken, parseLimiter, asyncHandler(async (req, res) => {
   const { ingredientString } = req.body
   if (!ingredientString || typeof ingredientString !== 'string') {
     return res.status(400).json({ error: 'ingredientString must be a non-empty string' })
@@ -89,6 +90,6 @@ router.post('/parse', verifyToken, parseLimiter, async (req, res) => {
     )
     return res.status(500).json({ error: GENERIC_500_MESSAGE })
   }
-})
+}))
 
 module.exports = router

--- a/server/routes/nutrition.js
+++ b/server/routes/nutrition.js
@@ -2,6 +2,7 @@ const { Router } = require('express')
 const { verifyToken } = require('../middleware/auth')
 const { makeUserLimiter } = require('../middleware/writeLimiter')
 const { GENERIC_500_MESSAGE } = require('../util/respondServerError')
+const { asyncHandler } = require('../util/asyncHandler')
 
 const router = Router()
 
@@ -17,7 +18,7 @@ const nutritionLimiter = makeUserLimiter({
   message: 'Too many nutrition lookups — wait a minute and try again.',
 })
 
-router.post('/details', verifyToken, nutritionLimiter, async (req, res) => {
+router.post('/details', verifyToken, nutritionLimiter, asyncHandler(async (req, res) => {
   const { ingr, title } = req.body
   if (
     !Array.isArray(ingr) ||
@@ -82,6 +83,6 @@ router.post('/details', verifyToken, nutritionLimiter, async (req, res) => {
     )
     return res.status(500).json({ error: GENERIC_500_MESSAGE })
   }
-})
+}))
 
 module.exports = router


### PR DESCRIPTION
## S5 · asyncHandler consistency (Wave 1)

The two remaining bare-`async` route handlers — `POST /api/nutrition/details` (`nutrition.js`) and `POST /api/ingredients/parse` (`ingredients.js`) — were the only handlers not wrapped in the shared `asyncHandler`. A rejection *outside* their inner try/catch had no `next(err)` path and could hang the request. This wraps both like every other route, restoring the "every handler is wrapped" invariant.

### What changed
- `server/routes/nutrition.js` — wrap `POST /details` in `asyncHandler(...)` + import
- `server/routes/ingredients.js` — wrap `POST /parse` in `asyncHandler(...)` + import

### Deliberately unchanged
Each route's existing try/catch is intentional soft-fail behaviour (route-specific log tags + graceful degradation to `null`/generic-500), not the boilerplate `asyncHandler` replaces. It's left intact; the wrapper is purely the safety net for any rejection outside the try. **No behaviour change.**

### Verification
- `node --check` clean on both files
- Server Jest: **734/734 green** (one unrelated `admin-recipe-curation` 401 flake on a full-suite run — passes 7/7 in isolation, cleared on re-run; a known inter-suite flake, not from these files)
- Live runtime: both routes return **401** unauthenticated (route resolves, middleware chain runs)

Roadmap: `docs/BACKLOG_ROADMAP.md` S5 · Wave 1.

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ