### PR TITLE
feat(server): rating-aggregate reconciliation + migration-state check (S6)

### DIFF
--- a/server/__tests__/recipeRating.test.js
+++ b/server/__tests__/recipeRating.test.js
@@ -1,0 +1,82 @@
+/**
+ * Unit coverage for util/recipeRating.js.
+ *
+ * recomputeRecipeRating is already exercised end-to-end through the review
+ * routes (reviews.test.js) and the deleteAccount cascade (auth.test.js). These
+ * tests pin the S6 split: `computeRecipeRating` is the PURE read half — it must
+ * return the same aggregate WITHOUT touching the recipe doc, so the read-only
+ * reconciliation dry-run can trust it. They also lock the two filtering rules
+ * (moderation-hidden excluded, review-only null-rating docs ignored) at the
+ * util level rather than only through a route.
+ */
+const { getDB } = require('../db')
+const {
+  computeRecipeRating,
+  recomputeRecipeRating,
+} = require('../util/recipeRating')
+
+const RECIPE_ID = 'recipe-rating-unit'
+
+async function seed(ratingDocs, storedAggregate) {
+  await getDB()
+    .collection('recipes')
+    .insertOne({ _id: RECIPE_ID, title: 'x', rating: storedAggregate })
+  if (ratingDocs.length) await getDB().collection('ratings').insertMany(ratingDocs)
+}
+
+afterEach(async () => {
+  await Promise.all([
+    getDB().collection('recipes').deleteMany({}),
+    getDB().collection('ratings').deleteMany({}),
+  ])
+})
+
+describe('computeRecipeRating (pure read)', () => {
+  it('averages only visible, numeric-rating docs', async () => {
+    await seed([
+      { recipeId: RECIPE_ID, userId: 'a', rating: 4 },
+      { recipeId: RECIPE_ID, userId: 'b', rating: '5' }, // legacy string rating
+      { recipeId: RECIPE_ID, userId: 'c', rating: 3, moderationHidden: true }, // hidden → excluded
+      { recipeId: RECIPE_ID, userId: 'd', rating: null }, // review-only → ignored
+    ], { rateCount: 0, rateValue: 0 })
+
+    const agg = await computeRecipeRating(getDB(), RECIPE_ID)
+    expect(agg).toEqual({ rateCount: 2, rateValue: 4.5 })
+  })
+
+  it('returns a zero aggregate for a recipe with no ratings', async () => {
+    await seed([], { rateCount: 0, rateValue: 0 })
+    expect(await computeRecipeRating(getDB(), RECIPE_ID)).toEqual({
+      rateCount: 0,
+      rateValue: 0,
+    })
+  })
+
+  it('does NOT write — the stored aggregate is left untouched', async () => {
+    // Seed a deliberately WRONG stored aggregate; a pure read must not fix it.
+    await seed([{ recipeId: RECIPE_ID, userId: 'a', rating: 4 }], {
+      rateCount: 99,
+      rateValue: 1,
+    })
+
+    await computeRecipeRating(getDB(), RECIPE_ID)
+
+    const recipe = await getDB().collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.rating).toEqual({ rateCount: 99, rateValue: 1 })
+  })
+})
+
+describe('recomputeRecipeRating (persisting)', () => {
+  it('heals a drifted stored aggregate onto the recipe doc', async () => {
+    await seed([{ recipeId: RECIPE_ID, userId: 'a', rating: 4 }], {
+      rateCount: 99,
+      rateValue: 1,
+    })
+
+    const returned = await recomputeRecipeRating(getDB(), RECIPE_ID)
+    expect(returned).toEqual({ rateCount: 1, rateValue: 4 })
+
+    const recipe = await getDB().collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.rating).toEqual({ rateCount: 1, rateValue: 4 })
+  })
+})

--- a/server/scripts/checkMigrationState.js
+++ b/server/scripts/checkMigrationState.js
@@ -1,0 +1,119 @@
+/**
+ * S6 — post-6-phase-refactor DB check (READ-ONLY).
+ *
+ * The Phase-5 data refactor and its sibling backfills each moved existing
+ * records to a new shape. This script confirms that no record is still stranded
+ * in the OLD shape — i.e. every one-time migration/backfill has fully run — so a
+ * "post-refactor DB check" leaves proof in-repo instead of being a memory of a
+ * manual mongosh session.
+ *
+ * It performs NO writes — only countDocuments() per known migration. Each check
+ * is a "records still pending this migration" query; a healthy database returns
+ * 0 for all of them.
+ *
+ * Checks (each maps to a shipped migration/backfill):
+ *   - recipes with a legacy string `_id`      → Phase 5-D _id string→ObjectId
+ *                                                (util/recipeIdQuery.js)
+ *   - ratings missing `userId`                → backfillRatingUserIds.js
+ *   - review reports missing `reportedUid`    → backfillRatingUserIds.js (reports half)
+ *   - recipes missing the `rating` aggregate  → reconcileRatingAggregates.js --apply
+ *
+ * This is a REPORT, not a fixer — it names the script to run for anything it
+ * finds pending. Run it before a prod cutover; re-run after applying the named
+ * backfills until every count is 0.
+ *
+ * Usage:
+ *   node server/scripts/checkMigrationState.js
+ *
+ * Reads MONGO_URI from server/.env (override the DB with DB_NAME, default
+ * "prepify"). Exit code 0 = all migrations complete, 2 = records pending,
+ * 1 = error.
+ */
+const path = require('path')
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') })
+const { MongoClient } = require('mongodb')
+
+// Each check: a human label, the collection, the "still in the old shape" filter,
+// and the script an operator runs to clear it. Keep filters as "match what is
+// still pending" (not "match what is migrated") so a healthy DB scores 0.
+const CHECKS = [
+  {
+    label: 'recipes with a legacy string _id (want native ObjectId)',
+    collection: 'recipes',
+    filter: { _id: { $type: 'string' } },
+    fix: 'Phase 5-D _id migration (string→ObjectId); see util/recipeIdQuery.js',
+  },
+  {
+    label: 'ratings docs missing a stable userId',
+    collection: 'ratings',
+    filter: { userId: { $exists: false } },
+    fix: 'node server/scripts/backfillRatingUserIds.js --apply',
+  },
+  {
+    label: 'review reports missing a stable reportedUid',
+    collection: 'reports',
+    filter: { targetType: 'review', reportedUid: { $exists: false } },
+    fix: 'node server/scripts/backfillRatingUserIds.js --apply',
+  },
+  {
+    label: 'recipes missing the rating aggregate field',
+    collection: 'recipes',
+    filter: { rating: { $exists: false } },
+    fix: 'node server/scripts/reconcileRatingAggregates.js --apply',
+  },
+]
+
+async function main() {
+  const uri = process.env.MONGO_URI
+  if (!uri) {
+    console.error('MONGO_URI is not set (looked in server/.env).')
+    process.exit(1)
+  }
+  const dbName = process.env.DB_NAME || 'prepify'
+
+  const client = new MongoClient(uri, {
+    tls: true,
+    serverSelectionTimeoutMS: 5000,
+    socketTimeoutMS: 45000,
+    maxPoolSize: 10,
+  })
+
+  try {
+    await client.connect()
+    const db = client.db(dbName)
+    console.log(`Connected to MongoDB (${dbName}). Post-refactor migration check (READ-ONLY).\n`)
+
+    const results = []
+    for (const check of CHECKS) {
+      const pending = await db.collection(check.collection).countDocuments(check.filter)
+      results.push({ ...check, pending })
+    }
+
+    const nameW = Math.max(...results.map((r) => r.label.length))
+    for (const r of results) {
+      const mark = r.pending === 0 ? '✓' : '✗'
+      console.log(`  ${mark} ${r.label.padEnd(nameW)}  ${String(r.pending).padStart(6)} pending`)
+      if (r.pending > 0) console.log(`      → fix: ${r.fix}`)
+    }
+
+    const stillPending = results.filter((r) => r.pending > 0)
+    console.log('\nSummary')
+    console.log('───────')
+    if (stillPending.length === 0) {
+      console.log('  All known migrations complete — no records need updating.')
+      process.exit(0)
+    } else {
+      console.log(
+        `  ${stillPending.length} migration(s) have pending records; run the fix(es) above and re-check.`
+      )
+      process.exit(2)
+    }
+  } catch (err) {
+    console.error('\nMigration check failed:', err.message)
+    process.exit(1)
+  } finally {
+    await client.close().catch(() => {})
+  }
+}
+
+main()

--- a/server/scripts/reconcileRatingAggregates.js
+++ b/server/scripts/reconcileRatingAggregates.js
@@ -30,7 +30,8 @@
  *   node server/scripts/reconcileRatingAggregates.js            # dry run (default)
  *   node server/scripts/reconcileRatingAggregates.js --apply    # actually write
  *
- * Reads MONGO_URI from server/.env. Exit code 0 = success, 1 = error.
+ * Reads MONGO_URI from server/.env (override the DB with DB_NAME, default
+ * "prepify"). Exit code 0 = success, 1 = error.
  */
 const path = require('path')
 require('dotenv').config({ path: path.join(__dirname, '..', '.env') })
@@ -84,6 +85,8 @@ async function main() {
     process.exit(1)
   }
 
+  const dbName = process.env.DB_NAME || 'prepify'
+
   const client = new MongoClient(uri, {
     tls: true,
     serverSelectionTimeoutMS: 5000,
@@ -93,9 +96,9 @@ async function main() {
 
   try {
     await client.connect()
-    const db = client.db('prepify')
+    const db = client.db(dbName)
     console.log(
-      `Connected to MongoDB (prepify). Mode: ${APPLY ? 'APPLY (writing)' : 'DRY RUN (read-only)'}\n`
+      `Connected to MongoDB (${dbName}). Mode: ${APPLY ? 'APPLY (writing)' : 'DRY RUN (read-only)'}\n`
     )
 
     let scanned = 0

--- a/server/scripts/reconcileRatingAggregates.js
+++ b/server/scripts/reconcileRatingAggregates.js
@@ -1,0 +1,166 @@
+/**
+ * S6 — one-off catalog-wide rating-aggregate reconciliation.
+ *
+ * Each recipe carries a denormalized `rating: { rateCount, rateValue }` that the
+ * server recomputes (util/recipeRating.js `recomputeRecipeRating`) on every
+ * rating add/edit/delete and on every moderation hide/restore. The denormalized
+ * value can nonetheless DRIFT from the source-of-truth `ratings` docs:
+ *   - legacy / pre-recompute data written before the recompute-on-every-change
+ *     rule shipped (PR #150),
+ *   - a past silent best-effort recompute failure (the deleteAccount path was
+ *     only hardened to retry+surface in S2 / PR #229),
+ *   - any recipe nobody has re-rated since, so the drift never self-heals.
+ *
+ * This script loops EVERY recipe, computes the true aggregate from its visible
+ * `ratings` docs via the same `computeRecipeRating` the server uses (so the
+ * math — REVIEW_VISIBLE exclusion, numeric-only averaging — cannot drift from
+ * production), and compares it to the stored value. Under --apply it heals each
+ * drifted recipe through the canonical `recomputeRecipeRating` (a fresh recompute
+ * + write, so a rating landing mid-run is still reflected).
+ *
+ * SAFE BY DEFAULT: this is a DRY RUN unless you pass --apply. The dry run reads
+ * only — it reports every drifted / missing aggregate and what it WOULD write.
+ * Verify the dry-run output first, then re-run with --apply.
+ *
+ * Idempotent: it writes only recipes whose stored aggregate disagrees with the
+ * recomputed one, so a second --apply run over an already-reconciled catalog is
+ * a no-op (0 corrected).
+ *
+ * Usage:
+ *   node server/scripts/reconcileRatingAggregates.js            # dry run (default)
+ *   node server/scripts/reconcileRatingAggregates.js --apply    # actually write
+ *
+ * Reads MONGO_URI from server/.env. Exit code 0 = success, 1 = error.
+ */
+const path = require('path')
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') })
+const { MongoClient } = require('mongodb')
+const {
+  computeRecipeRating,
+  recomputeRecipeRating,
+} = require('../util/recipeRating')
+
+const APPLY = process.argv.includes('--apply')
+
+// rateValue is an average (a division), so compare with a tolerance rather than
+// === — a stored 4.333333333333333 and a freshly recomputed one can differ in
+// the last binary place without being a real drift. rateCount is an integer:
+// exact. EPS well below any half-star boundary the UI renders.
+const EPS = 1e-9
+
+// Cap the per-recipe drift lines so a pathological run can't flood the terminal;
+// the summary counts are always exact and the cap is announced (no silent trim).
+const MAX_LISTED = 100
+
+function ratingsEqual(a, b) {
+  return a.rateCount === b.rateCount && Math.abs(a.rateValue - b.rateValue) < EPS
+}
+
+// The stored aggregate can be absent (legacy recipes predating the field),
+// partial, or string-typed. Normalize to numbers so the comparison and the
+// printout are well-defined; a missing/!finite field reads as NaN and will not
+// equal any real recomputed value, so it is correctly flagged.
+function readStored(rating) {
+  const rateCount = Number(rating && rating.rateCount)
+  const rateValue = Number(rating && rating.rateValue)
+  return {
+    present: !!rating && rating.rateCount != null && rating.rateValue != null,
+    rateCount,
+    rateValue,
+  }
+}
+
+function fmt(agg) {
+  if (agg.present === false) return '(absent)'
+  const c = Number.isFinite(agg.rateCount) ? agg.rateCount : '?'
+  const v = Number.isFinite(agg.rateValue) ? Number(agg.rateValue.toFixed(4)) : '?'
+  return `{ rateCount: ${c}, rateValue: ${v} }`
+}
+
+async function main() {
+  const uri = process.env.MONGO_URI
+  if (!uri) {
+    console.error('MONGO_URI is not set (looked in server/.env).')
+    process.exit(1)
+  }
+
+  const client = new MongoClient(uri, {
+    tls: true,
+    serverSelectionTimeoutMS: 5000,
+    socketTimeoutMS: 45000,
+    maxPoolSize: 10,
+  })
+
+  try {
+    await client.connect()
+    const db = client.db('prepify')
+    console.log(
+      `Connected to MongoDB (prepify). Mode: ${APPLY ? 'APPLY (writing)' : 'DRY RUN (read-only)'}\n`
+    )
+
+    let scanned = 0
+    let inSync = 0
+    let corrected = 0 // drifted (or absent) aggregates that were / would be written
+    let missing = 0 // subset of corrected: recipes with no stored aggregate at all
+    let listed = 0
+
+    // Stream every recipe; we only need _id + the stored aggregate.
+    const cursor = db.collection('recipes').find({}, { projection: { rating: 1 } })
+    for await (const recipe of cursor) {
+      scanned++
+      // recipeId is the STRING form everywhere in the app (ratings.recipeId, the
+      // route params). recipeIdQuery() maps it back to both ObjectId and legacy
+      // string _id shapes, so String(_id) is the correct key for both.
+      const recipeId = String(recipe._id)
+      const expected = await computeRecipeRating(db, recipeId)
+      const stored = readStored(recipe.rating)
+
+      if (stored.present && ratingsEqual(stored, expected)) {
+        inSync++
+        continue
+      }
+
+      corrected++
+      if (!stored.present) missing++
+
+      if (listed < MAX_LISTED) {
+        listed++
+        console.log(
+          `  drift  ${recipeId}: stored ${fmt(stored)} → ${APPLY ? 'wrote' : 'expected'} ${fmt({ ...expected, present: true })}`
+        )
+      } else if (listed === MAX_LISTED) {
+        listed++
+        console.log(`  … (further drifted recipes suppressed; see summary counts)`)
+      }
+
+      if (APPLY) {
+        // Heal through the canonical writer — a fresh recompute + write, so a
+        // rating that landed between our compute above and this write is still
+        // captured.
+        await recomputeRecipeRating(db, recipeId)
+      }
+    }
+
+    console.log('\nSummary')
+    console.log('───────')
+    console.log(`  recipes scanned:       ${scanned}`)
+    console.log(`  already in sync:       ${inSync}`)
+    console.log(
+      `  ${APPLY ? 'corrected' : 'would correct'}:  ${String(corrected).padStart(6)} (of which ${missing} had no stored aggregate)`
+    )
+
+    if (!APPLY) {
+      console.log('\nDRY RUN — nothing was written. Re-run with --apply to commit.')
+    } else {
+      console.log('\nDone. Rating aggregates reconciled.')
+    }
+    process.exit(0)
+  } catch (err) {
+    console.error('\nReconciliation failed:', err.message)
+    process.exit(1)
+  } finally {
+    await client.close().catch(() => {})
+  }
+}
+
+main()

--- a/server/util/recipeRating.js
+++ b/server/util/recipeRating.js
@@ -10,12 +10,13 @@ function hasNumericRating(rating) {
   return Number.isFinite(parseFloat(rating))
 }
 
-// Recompute and persist a recipe's aggregate rating from its ratings docs,
-// EXCLUDING any that have been taken down by moderation (REVIEW_VISIBLE). Called
-// whenever ratings change (new rating) or a review is hidden/restored, so a
-// moderated rating no longer influences the recipe's score. Returns the new
-// aggregate. count === 0 yields rateValue 0 (avoids divide-by-zero).
-async function recomputeRecipeRating(db, recipeId) {
+// Compute a recipe's aggregate rating from its ratings docs WITHOUT persisting,
+// EXCLUDING any taken down by moderation (REVIEW_VISIBLE). This is the pure read
+// half of recomputeRecipeRating — split out so read-only callers (e.g. the
+// catalog reconciliation script in server/scripts/) can diff the true aggregate
+// against the stored one without writing. count === 0 yields rateValue 0
+// (avoids divide-by-zero).
+async function computeRecipeRating(db, recipeId) {
   const docs = await db
     .collection('ratings')
     .find({ recipeId, ...REVIEW_VISIBLE })
@@ -28,10 +29,20 @@ async function recomputeRecipeRating(db, recipeId) {
   const rateValue = rateCount
     ? ratings.reduce((sum, r) => sum + parseFloat(r.rating), 0) / rateCount
     : 0
-  await db
-    .collection('recipes')
-    .updateOne(recipeIdQuery(recipeId), { $set: { rating: { rateCount, rateValue } } })
   return { rateCount, rateValue }
 }
 
-module.exports = { recomputeRecipeRating, hasNumericRating }
+// Recompute and persist a recipe's aggregate rating from its ratings docs,
+// EXCLUDING any that have been taken down by moderation (REVIEW_VISIBLE). Called
+// whenever ratings change (new rating) or a review is hidden/restored, so a
+// moderated rating no longer influences the recipe's score. Returns the new
+// aggregate. count === 0 yields rateValue 0 (avoids divide-by-zero).
+async function recomputeRecipeRating(db, recipeId) {
+  const agg = await computeRecipeRating(db, recipeId)
+  await db
+    .collection('recipes')
+    .updateOne(recipeIdQuery(recipeId), { $set: { rating: agg } })
+  return agg
+}
+
+module.exports = { computeRecipeRating, recomputeRecipeRating, hasNumericRating }


### PR DESCRIPTION
## S6 · rating-aggregate ops

Closes the two open rating-aggregate ops items from the backlog (Wave 1, S6). Both are read-first ops scripts under `server/scripts/`, dry-run/report by default, modeled on the existing `backfillRatingUserIds.js` / `backfillServingPrice.js`.

### 1. `reconcileRatingAggregates.js` — one-off catalog-wide reconciliation
Each recipe stores a denormalized `rating: { rateCount, rateValue }`. The server recomputes it on every rating change / moderation hide-restore, but legacy/pre-recompute data or a past silent best-effort failure can leave a recipe drifted — and a recipe nobody re-rates never self-heals.

The script loops **every** recipe, computes the true aggregate from its visible `ratings` docs via the **same** `computeRecipeRating` the server uses (so the math can't drift from production), and reports every mismatch. `--apply` heals each drifted recipe through the canonical `recomputeRecipeRating`. Idempotent — a second `--apply` over a reconciled catalog is a no-op.

### 2. `checkMigrationState.js` — post-6-phase-refactor DB check (READ-ONLY)
The backlog item was a "manual run-and-confirm; nothing in-repo proves it's been done." This makes it reproducible: counts records still pending each shipped migration and names the fix script for anything found.

| Check | Migration |
|---|---|
| recipes with a legacy string `_id` | Phase 5-D `_id` string→ObjectId (`util/recipeIdQuery.js`) |
| `ratings` missing `userId` | `backfillRatingUserIds.js` |
| review `reports` missing `reportedUid` | `backfillRatingUserIds.js` (reports half) |
| recipes missing the `rating` aggregate | `reconcileRatingAggregates.js --apply` |

Exit `0` = all complete, `2` = records pending, `1` = error — usable as a pre-cutover gate.

### Supporting refactor
To let the reconciliation dry-run diff without writing, the pure read half of `recomputeRecipeRating` is split into **`computeRecipeRating`**; `recomputeRecipeRating` now delegates to it then persists — **no behaviour change**. Added `recipeRating.test.js` pinning the read-only contract + the moderation/numeric-rating filter rules at the util level.

### Verification
- **Dev DB, live:** reconciliation caught and healed a real drift (a recipe storing `rateCount: 2` with only 1 visible rating), idempotent on re-run; the migration check surfaces dev's pending 5-D `_id` / `userId` records (exit 2).
- **Server Jest 741/741** (32 suites). New util tests pass in isolation and in-suite.

*No frontend changes.*