### PR TITLE
F1 · TimeInput NaN bug — hydrate from { hours, minutes } (edit/draft-resume blanked prep/cook time)

### DIFF
--- a/src/pages/AddRecipe/TimeInput/TimeInput.tsx
+++ b/src/pages/AddRecipe/TimeInput/TimeInput.tsx
@@ -21,9 +21,12 @@ const TimeInput: React.FC<TimeInputProps> = ({ label, val, setVal }) => {
   const [hours, setHours] = useState<number | ''>('')
 
   useEffect(() => {
-    if (Number(val) !== 0 && !minutes && !hours) {
-      setMinutes(Number(val) % 60)
-      setHours(Math.floor(Number(val) / 60))
+    // Hydrate from the parent's { hours, minutes } value (edit / draft-resume).
+    // `val` is an object, so the old `Number(val)` produced NaN and blanked the
+    // fields — read the members directly instead.
+    if (val && !minutes && !hours) {
+      setMinutes(val.minutes || '')
+      setHours(val.hours || '')
     }
     if (!val) {
       setMinutes('')

--- a/src/test/TimeInput.test.tsx
+++ b/src/test/TimeInput.test.tsx
@@ -59,3 +59,32 @@ describe('TimeInput validation', () => {
     expect(minutes.value).toBe('59')
   })
 })
+
+// Regression: on edit / draft-resume the parent passes a { hours, minutes } object.
+// The old effect did `Number(val)` (NaN for an object) and blanked both fields —
+// it should hydrate them from the object members instead.
+describe('TimeInput hydration', () => {
+  const renderWith = (val: { hours: number; minutes: number } | null) => {
+    render(<TimeInput label='Prep time' val={val} setVal={vi.fn()} />)
+    const [hours, minutes] = screen.getAllByPlaceholderText('0') as HTMLInputElement[]
+    return { hours, minutes }
+  }
+
+  it('populates both fields from a full { hours, minutes } value', () => {
+    const { hours, minutes } = renderWith({ hours: 1, minutes: 30 })
+    expect(hours.value).toBe('1')
+    expect(minutes.value).toBe('30')
+  })
+
+  it('shows the minutes and leaves hours empty when hours is 0', () => {
+    const { hours, minutes } = renderWith({ hours: 0, minutes: 45 })
+    expect(minutes.value).toBe('45')
+    expect(hours.value).toBe('')
+  })
+
+  it('leaves both fields empty for a null value', () => {
+    const { hours, minutes } = renderWith(null)
+    expect(hours.value).toBe('')
+    expect(minutes.value).toBe('')
+  })
+})


### PR DESCRIPTION
## F1 · TimeInput hydration NaN bug

**Wave 2 / Track F1** on the [backlog roadmap](../blob/development/docs/BACKLOG_ROADMAP.md).

### The bug
`TimeInput`'s hydration `useEffect` still treated its `val` prop as a **total-minutes number**:

```js
if (Number(val) !== 0 && !minutes && !hours) {
  setMinutes(Number(val) % 60)
  setHours(Math.floor(Number(val) / 60))
}
```

But `val` is a `{ hours: number; minutes: number } | null` **object**. `Number({...})` is `NaN`, so:
- `Number(val) !== 0` → `NaN !== 0` → **always true**
- both setters receive `NaN` → the hours/minutes fields **blank out**

Symptom: opening a recipe to **edit**, or **resuming a draft**, showed empty prep/cook time fields — it read as data loss even though the stored value was fine.

### The fix
Read the object members directly. A `0` component renders empty (placeholder) rather than a literal `"0"`, matching `minToHrMin`'s "renders empty when unset" intent.

```js
if (val && !minutes && !hours) {
  setMinutes(val.minutes || '')
  setHours(val.hours || '')
}
```

### Scope note
The board listed `AddRecipe.tsx:86-91,160-161` too, but those already convert stored minutes via `minToHrMin` into the object shape before passing it down — they were correct. The stale effect in `TimeInput` was the entire bug, so **`AddRecipe.tsx` is unchanged**. Per parallelism rule 4, F1 ships first/standalone so the AddRecipe lane (C1/R1) rebases onto it.

### Tests
The existing `TimeInput` tests only rendered with `val={null}` — they never exercised the object hydration path this bug lived in. Added a `TimeInput hydration` block: full `{hours, minutes}` populates both fields, `hours: 0` leaves hours empty, `null` leaves both empty.

### Gates
- `npx tsc --noEmit` — clean
- `npx vitest run` — **556 passed / 2 skipped**, 75 files (9 in TimeInput.test.tsx: 6 existing + 3 new)
- `npm run build` — clean
- App boots (client + dev API healthy); the new component tests run the fixed effect end-to-end in jsdom

https://claude.ai/code/session_01JwP511UkTUgU69S9MZTJ8x