### PR TITLE
ci(test): add Static job — tsc --noEmit typecheck + vite build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,28 @@ jobs:
         run: npm install @rolldown/binding-linux-x64-gnu --no-save
       - run: npm test
 
+  static:
+    name: Static (typecheck + build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+      # vite build needs the platform-specific rolldown binding (see frontend job).
+      - name: Install platform-specific rolldown binding
+        run: npm install @rolldown/binding-linux-x64-gnu --no-save
+      # Typecheck first — it's fast and fails clearly before the heavier build.
+      # `tsc --noEmit` enforces the tsconfig `strict` setting, which `vite build`
+      # (per-file esbuild/rolldown transpile) does NOT check.
+      - name: Typecheck (tsc --noEmit)
+        run: npm run typecheck
+      # Verify the production bundle actually builds (Netlify parity).
+      - name: Production build (vite build)
+        run: npm run build
+
   e2e:
     name: E2e (Cypress)
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "start": "vite",
     "start-port": "vite --port 1337",
     "build": "vite build",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "gen:brand": "node scripts/generate-brand-assets.mjs",
     "test": "vitest run",


### PR DESCRIPTION
## What
Adds a **Static (typecheck + build)** job to the Tests workflow (runs on every PR):

- **`tsc --noEmit`** — enforces the `tsconfig` `strict` setting. `vite build` transpiles per-file (esbuild/rolldown) and never typechecks, so today a real type error can merge green.
- **`vite build`** — verifies the production bundle actually compiles (Netlify parity). No job built the prod bundle before.

Also adds a `typecheck` npm script so it's runnable locally.

## Why
Fills the two biggest gaps in CI: no type-checking despite `strict: true`, and no production-build verification.

## Verification
Both pass locally on `development`: `tsc --noEmit` exit 0, `vite build` ✓. Job mirrors the existing `frontend` job's install + rolldown-binding pattern.