### PR TITLE
F3 · Saved-tab memo — useCallback refreshAfterMutation so RecipeCard stays memoized

### DIFF
--- a/src/pages/Account/SavedRecipes/SavedRecipes.tsx
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.tsx
@@ -1,5 +1,5 @@
 import { BookmarkIcon, ChevronDownIcon, CloseIcon, EditIcon, FolderIcon, FolderPlusIcon, GridIcon, PlusIcon, SearchIcon, TrashIcon } from 'src/Components/icons'
-import React, { FC, useState, useEffect } from 'react'
+import React, { FC, useState, useEffect, useCallback } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import RecipeCard from 'src/Components/RecipeCard/RecipeCard'
@@ -130,10 +130,13 @@ const SavedRecipes: FC = () => {
   // refetch. The grid must refetch too — an unsave from the popover removes a
   // card even in the unfiltered "All saved" view — so reset to page 0 and
   // refetch unconditionally rather than only when a collection filter is active.
-  const refreshAfterMutation = () => {
+  // useCallback so the reference is stable across renders — it's passed as
+  // `onMutated` to the memoized RecipeCard grid, and a fresh function each
+  // render would defeat React.memo and re-render every saved card.
+  const refreshAfterMutation = useCallback(() => {
     invalidateSavedCaches(queryClient, uid)
     setCurrPage(0)
-  }
+  }, [queryClient, uid])
 
   const handleCreate = async () => {
     const name = newName.trim()


### PR DESCRIPTION
## What
`refreshAfterMutation` in `SavedRecipes.tsx` was a plain function rebuilt on **every** render and passed as `onMutated` to the memoized `RecipeCard` grid (`export default React.memo(RecipeCard)`). Because its identity changed each render, `React.memo(RecipeCard)` never held — **every** saved card re-rendered whenever the parent re-rendered (typing in search, changing sort, bumping the page, editing collections, etc.).

Wrap it in `useCallback` keyed on `[queryClient, uid]` — the only values it closes over (`setCurrPage` is a stable state setter) — so the reference is stable and the memoization it was defeating actually takes effect.

## Scope
- One file: `src/pages/Account/SavedRecipes/SavedRecipes.tsx` (add `useCallback` import + wrap the handler). Frontend-only.
- Board track **F3** (Wave 2), disjoint from the in-flight F1 (`TimeInput`/`AddRecipe`) and F2 (`AuthContext`) lanes.

## Verification
- `npx tsc --noEmit` — clean
- `npx vitest run` — 553 passed / 2 skipped (75 files)
- `npm run build` — clean
- App boots (client + dev API healthy, MongoDB connected)

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ