### PR TITLE
C4 · SearchRecipesInput lane: footer-label debounce fix + press-/ focus

### DIFF
--- a/src/Components/Layout/Layout.tsx
+++ b/src/Components/Layout/Layout.tsx
@@ -2,6 +2,7 @@ import React, { FC, ReactElement } from 'react'
 import Navbar from 'src/Components/Navbar/Navbar'
 import Footer from 'src/Components/Footer/Footer'
 import AccountStatusBanner from 'src/Components/AccountStatusBanner/AccountStatusBanner'
+import { useSlashFocusSearch } from 'src/hooks/useSlashFocusSearch'
 
 import './Layout.scss'
 
@@ -16,6 +17,9 @@ const Layout: FC<LayoutProps> = ({
   darkNavLinks = false,
   navBackgroundColor = 'none',
 }) => {
+  // Press `/` anywhere (outside a text field) to jump to the recipe search.
+  useSlashFocusSearch()
+
   return (
     <div className='app-shell'>
       <a href='#main-content' className='skip-to-content'>

--- a/src/Components/SearchRecipesInput/SearchRecipesInput.tsx
+++ b/src/Components/SearchRecipesInput/SearchRecipesInput.tsx
@@ -198,6 +198,14 @@ const SearchRecipesInput: FC<SearchRecipesInputProps> = ({
   const handleSubmit = (e: React.SyntheticEvent) => {
     e.preventDefault()
 
+    // Navigate with the *live* value, not the debounced `trimmedQuery` the
+    // footer label quotes. This is intentional: submit is shared with Enter and
+    // the top Search button, which must fire the freshest query — including
+    // <3-char ones that never trigger the (debounced) autocomplete at all.
+    // During the 300ms debounce window the footer can read the older query while
+    // a click searches the newer one; that skew is one-directional (a click
+    // always searches what's currently typed, never something staler) and
+    // self-corrects, so it's preferred over making Enter search a stale value.
     if (slugify(searchRecipeVal)) {
       navigate(`/recipes?q=${slugify(searchRecipeVal)}`)
     } else {

--- a/src/Components/SearchRecipesInput/SearchRecipesInput.tsx
+++ b/src/Components/SearchRecipesInput/SearchRecipesInput.tsx
@@ -333,7 +333,11 @@ const SearchRecipesInput: FC<SearchRecipesInputProps> = ({
                 onClick={handleSubmit}
               >
                 <SearchIcon className='ac-footer__icon' />
-                Search for “{searchRecipeVal.trim()}”
+                {/* Quote the *debounced* query, matching the results and the
+                    empty-state above — the whole dropdown describes the query
+                    that actually ran, so during the debounce window the footer
+                    can't disagree with the "No matches for …" sibling. */}
+                Search for “{trimmedQuery}”
               </button>
             </>
           )}

--- a/src/hooks/useSlashFocusSearch.ts
+++ b/src/hooks/useSlashFocusSearch.ts
@@ -1,17 +1,17 @@
 import { useEffect } from 'react'
 
-// An element is "typing context" if a bare `/` should be inserted as text rather
-// than treated as the search hotkey — inputs, textareas, selects, and any
-// contenteditable surface (rich-text editors, etc.).
-function isTypingContext(el: EventTarget | null): boolean {
+// The hotkey must stand down when the user's focus is somewhere a bare `/`
+// shouldn't be stolen from: a text-entry surface (insert the `/` instead) or an
+// open modal dialog (react-modal renders `role="dialog"` + `aria-modal="true"`
+// and traps focus — a document-level keydown would otherwise escape that trap
+// and yank focus to the search input behind the overlay).
+function isGuardedContext(el: EventTarget | null): boolean {
   if (!(el instanceof HTMLElement)) return false
   const tag = el.tagName
-  return (
-    tag === 'INPUT' ||
-    tag === 'TEXTAREA' ||
-    tag === 'SELECT' ||
-    el.isContentEditable
-  )
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable) {
+    return true
+  }
+  return !!el.closest('[aria-modal="true"], [role="dialog"]')
 }
 
 // Whether an element can actually receive focus right now. Several
@@ -44,15 +44,18 @@ export function useSlashFocusSearch(): void {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       // Only a bare `/`: never with a modifier held (leave browser/OS shortcuts
-      // alone), never mid-IME-composition, and never while already typing in a
-      // field (so `/` inserts normally there).
+      // alone), never mid-IME-composition, and never while focus is in a text
+      // field or an open modal dialog (check both the event target and the
+      // active element — a keydown can target `document`/`body` when focus sits
+      // on a non-interactive dialog container).
       if (
         e.key !== '/' ||
         e.ctrlKey ||
         e.metaKey ||
         e.altKey ||
         e.isComposing ||
-        isTypingContext(e.target)
+        isGuardedContext(e.target) ||
+        isGuardedContext(document.activeElement)
       ) {
         return
       }

--- a/src/hooks/useSlashFocusSearch.ts
+++ b/src/hooks/useSlashFocusSearch.ts
@@ -1,0 +1,78 @@
+import { useEffect } from 'react'
+
+// An element is "typing context" if a bare `/` should be inserted as text rather
+// than treated as the search hotkey — inputs, textareas, selects, and any
+// contenteditable surface (rich-text editors, etc.).
+function isTypingContext(el: EventTarget | null): boolean {
+  if (!(el instanceof HTMLElement)) return false
+  const tag = el.tagName
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    el.isContentEditable
+  )
+}
+
+// Whether an element can actually receive focus right now. Several
+// `.search-recipes-input` instances can be in the DOM at once but hidden by an
+// *ancestor* rather than themselves — the desktop nav search sits in a
+// `display:none .dnav__search` on the Home hero, and the closed mobile menu is a
+// `visibility:hidden` subtree — and neither can take focus. So walk the ancestor
+// chain, not just the element's own style. `getComputedStyle` (rather than
+// `offsetParent`/`getClientRects`) keeps this meaningful under jsdom, which has
+// no layout engine: with no stylesheet applied every ancestor reads as visible,
+// so the happy path is still unit-testable.
+function isFocusableVisible(el: HTMLElement): boolean {
+  let node: HTMLElement | null = el
+  while (node) {
+    const style = window.getComputedStyle(node)
+    if (style.display === 'none' || style.visibility === 'hidden') return false
+    node = node.parentElement
+  }
+  return true
+}
+
+/**
+ * Global "press / to search" hotkey (GitHub/MDN convention). While the user
+ * isn't already typing in a field, a bare `/` focuses the page's primary recipe
+ * search — the navbar search on most pages, the page's own search on `/recipes`
+ * (where the navbar one is suppressed), or the hero/menu search elsewhere — and
+ * selects any existing text so it can be overtyped. Attach once at the app shell.
+ */
+export function useSlashFocusSearch(): void {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      // Only a bare `/`: never with a modifier held (leave browser/OS shortcuts
+      // alone), never mid-IME-composition, and never while already typing in a
+      // field (so `/` inserts normally there).
+      if (
+        e.key !== '/' ||
+        e.ctrlKey ||
+        e.metaKey ||
+        e.altKey ||
+        e.isComposing ||
+        isTypingContext(e.target)
+      ) {
+        return
+      }
+
+      // First search input that can actually take focus. The navbar renders
+      // before <main>, so on pages that keep the top-bar search it wins; the
+      // visibility filter skips the closed mobile menu's still-mounted input.
+      const target = Array.from(
+        document.querySelectorAll<HTMLInputElement>('input.search-recipes-input')
+      ).find(isFocusableVisible)
+      if (!target) return
+
+      // Suppress the `/` that would otherwise land in the field, then focus and
+      // select any existing text.
+      e.preventDefault()
+      target.focus()
+      target.select()
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [])
+}

--- a/src/test/useSlashFocusSearch.test.tsx
+++ b/src/test/useSlashFocusSearch.test.tsx
@@ -52,6 +52,28 @@ describe('useSlashFocusSearch', () => {
     expect(notPrevented).toBe(true)
   })
 
+  it('does nothing while focus is inside an open modal dialog', () => {
+    render(
+      <Harness
+        extra={
+          <div role='dialog' aria-modal='true' aria-label='A modal'>
+            <button aria-label='dialog-btn'>ok</button>
+          </div>
+        }
+      />
+    )
+    const dialogBtn = screen.getByLabelText('dialog-btn')
+    const search = screen.getByLabelText('search')
+    dialogBtn.focus()
+
+    // Focus is trapped in the dialog -> "/" must not escape it to the search.
+    const notPrevented = fireEvent.keyDown(dialogBtn, { key: '/' })
+
+    expect(search).not.toHaveFocus()
+    expect(dialogBtn).toHaveFocus()
+    expect(notPrevented).toBe(true)
+  })
+
   it('ignores "/" pressed with a modifier held', () => {
     render(<Harness />)
     const search = screen.getByLabelText('search')

--- a/src/test/useSlashFocusSearch.test.tsx
+++ b/src/test/useSlashFocusSearch.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, fireEvent, screen } from '@testing-library/react'
+import { useSlashFocusSearch } from 'src/hooks/useSlashFocusSearch'
+
+// Minimal harness: mounts the hook plus a search input (matching the real
+// `.search-recipes-input` selector). `extra` is rendered *before* it so tests
+// can inject an earlier-in-DOM input to exercise the "first visible" selection.
+function Harness({ extra }: { extra?: React.ReactNode }) {
+  useSlashFocusSearch()
+  return (
+    <div>
+      {extra}
+      <input
+        className='search-recipes-input'
+        aria-label='search'
+        defaultValue='abc'
+      />
+    </div>
+  )
+}
+
+describe('useSlashFocusSearch', () => {
+  it('focuses the search input and selects its text on bare "/"', () => {
+    render(<Harness />)
+    const input = screen.getByLabelText('search') as HTMLInputElement
+    expect(input).not.toHaveFocus()
+
+    const notPrevented = fireEvent.keyDown(document, { key: '/' })
+
+    expect(input).toHaveFocus()
+    // preventDefault ran, so the "/" never reaches the field...
+    expect(notPrevented).toBe(false)
+    // ...and existing text is selected so it can be overtyped.
+    expect(input.selectionStart).toBe(0)
+    expect(input.selectionEnd).toBe(3)
+  })
+
+  it('does nothing while the user is already typing in a field', () => {
+    render(
+      <Harness extra={<input aria-label='other' defaultValue='' />} />
+    )
+    const other = screen.getByLabelText('other')
+    const search = screen.getByLabelText('search')
+    other.focus()
+
+    // Event originates from the text field -> "/" should type normally.
+    const notPrevented = fireEvent.keyDown(other, { key: '/' })
+
+    expect(search).not.toHaveFocus()
+    expect(other).toHaveFocus()
+    expect(notPrevented).toBe(true)
+  })
+
+  it('ignores "/" pressed with a modifier held', () => {
+    render(<Harness />)
+    const search = screen.getByLabelText('search')
+
+    fireEvent.keyDown(document, { key: '/', metaKey: true })
+    fireEvent.keyDown(document, { key: '/', ctrlKey: true })
+
+    expect(search).not.toHaveFocus()
+  })
+
+  it('skips a visibility:hidden input and focuses the next visible one', () => {
+    render(
+      <Harness
+        extra={
+          <input
+            className='search-recipes-input'
+            aria-label='hidden-search'
+            style={{ visibility: 'hidden' }}
+          />
+        }
+      />
+    )
+    const hidden = screen.getByLabelText('hidden-search')
+    const visible = screen.getByLabelText('search')
+
+    fireEvent.keyDown(document, { key: '/' })
+
+    expect(hidden).not.toHaveFocus()
+    expect(visible).toHaveFocus()
+  })
+})


### PR DESCRIPTION
Wave-3 lane **C4** (`docs/BACKLOG_ROADMAP.md`) — the two `SearchRecipesInput` items, both isolated to search UI.

## 1. Autocomplete footer quotes the debounced query
The `Search for "…"` footer button quoted the **live** input (`searchRecipeVal.trim()`) while the empty-state above it quotes the **debounced** query (`trimmedQuery`). The whole dropdown — results, corrected banner, empty-state — describes the query that *actually ran*, so during the 300ms debounce window the footer could disagree with its `No matches for …` sibling (e.g. footer `"chibb"` vs empty-state `"chib"`). Footer label now uses `trimmedQuery` too, so the two can't diverge.

The submit *action* stays on the live value — it's shared with Enter and the top Search button, which must work for <3-char queries that never open a dropdown.

## 2. Press `/` to jump to the recipe search
Adds the GitHub/MDN-style `/` hotkey via a new `useSlashFocusSearch` hook attached once at the app shell (`Layout`). A bare `/` outside a text field focuses the page's primary recipe search and selects its text; modifier combos, IME composition, and keystrokes already inside an `input`/`textarea`/`select`/`contenteditable` are left untouched.

Targeting is the interesting part: several `.search-recipes-input` instances can be mounted at once, hidden by an **ancestor** rather than themselves — the desktop nav search sits in a `display:none .dnav__search` on the Home hero, and the closed mobile menu is a `visibility:hidden` subtree. So the selector walks the ancestor chain for `display:none`/`visibility:hidden` (not just the element's own style) and focuses the first *focusable-visible* one:
- most pages → the navbar search
- `/recipes` (navbar search suppressed) → the page's own search
- Home hero → the hero search (nav search is `display:none` there)

`getComputedStyle` (not `offsetParent`) keeps the check meaningful under jsdom (no layout engine), so the happy path stays unit-testable.

## Testing
- New `src/test/useSlashFocusSearch.test.tsx` (4 cases): focus + select-text, typing-context guard, modifier guard, visibility-skip.
- Gates green: `tsc --noEmit`, Vitest **560 passed / 2 skipped** (76 files), `npm run build`.
- **Runtime-verified** end-to-end in the running app (Playwright, Home + `/recipes`): `/` focuses the *visible* search (skips the `display:none` nav search, lands on the hero search), the `/` isn't inserted into the field, typing-guard holds, footer renders the settled query, and `/recipes` focuses its own search.

Frontend-only; no `server/` changes.

https://claude.ai/code/session_01JwP511UkTUgU69S9MZTJ8x