### PR TITLE
chore: F5 housekeeping one-liners (comment/doc drift + util rename)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,9 @@ Prepify is a recipe website built with React/TypeScript frontend and an Express 
 
 - `src/pages/` - Route components (Home, Recipes, AddRecipe, Account, etc.)
 - `src/Components/` - Reusable UI components (Layout, Navbar, RecipeThumbnail, Form, etc.)
-- `src/context/` - React Context providers (AuthContext is active; RecipeContext is commented out/migrated)
+- `src/context/` - React Context providers (AuthContext is active; RecipeContext has been removed/migrated)
 - `src/api/` - API client modules
-- `src/util/` - Utility functions (calculateServingPrice, validateIngredientQuantityStr, etc.)
+- `src/util/` - Utility functions (calculateServingPrice, formatQuantity, etc.)
 - `src/recipeData/` - Static data (cuisinesList, dietLabels, mealTypesList)
 - `src/test/` - Vitest test suite with jsdom environment
 
@@ -118,7 +118,7 @@ npx cypress open       # Open Cypress test runner
 
 ## Important Notes
 
-- RecipeContext in `src/context/RecipeContext.tsx` is commented out - recipe operations are called directly via `RecipeAPI` class
+- RecipeContext has been removed (the former `src/context/RecipeContext.tsx` no longer exists) - recipe operations are called directly via `RecipeAPI` class
 - Firebase Admin SDK is on **v14** and uses the **modular API** (`firebase-admin/app`, `firebase-admin/auth`, `firebase-admin/storage`) — v14 removed the legacy `admin.*` namespace. Init is guarded with `if (!getApps().length)` (from `firebase-admin/app`) to prevent double initialization (`server/middleware/auth.js`). The frontend's Cypress config (`cypress.config.ts`) also runs Admin v14 for E2E token minting. Both `package.json`s carry an `overrides` pinning `uuid` to `^11.1.1` in the Admin dependency subtree — the `@google-cloud/storage` chain otherwise pulls a `uuid@9` with a moderate CVE and there's no fixed storage release yet; drop the override once one ships.
 - MongoDB connections use connection pooling with maxPoolSize: 10
 - The main server exposes a `/health` endpoint for health checks

--- a/scripts/generate-brand-assets.mjs
+++ b/scripts/generate-brand-assets.mjs
@@ -3,7 +3,7 @@
 //
 //   npm run gen:brand
 //
-// Fonts: scripts/fonts/Montserrat-{Bold,SemiBold,Italic}.ttf (SIL OFL, see OFL.txt).
+// Fonts: scripts/fonts/Montserrat-{Bold,SemiBold,MediumItalic}.ttf (SIL OFL, see OFL.txt).
 // Requires the @resvg/resvg-js devDependency.
 //
 // NOTE: the social link-preview card (public/images/og-card.png) is a

--- a/src/Components/IngredientItemText/IngredientItemText.tsx
+++ b/src/Components/IngredientItemText/IngredientItemText.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { closestFraction } from 'src/util/validateIngredientQuantityStr'
+import { closestFraction } from 'src/util/formatQuantity'
 import './IngredientItemText.scss'
 
 type IngredientItemTextProps = {

--- a/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.tsx
+++ b/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react'
 import './PrintableRecipe.scss'
 
 import { capitalize } from 'src/util/capitalize'
-import { closestFraction } from 'src/util/validateIngredientQuantityStr'
+import { closestFraction } from 'src/util/formatQuantity'
 import { formatRating } from 'src/util/formatRating'
 import { formatMonthYear } from 'src/util/formatDate'
 import { formatPrice } from 'src/util/formatPrice'

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -31,7 +31,7 @@ import { capitalize } from 'src/util/capitalize'
 import { formatRating } from 'src/util/formatRating'
 import { formatMonthYear } from 'src/util/formatDate'
 import { formatPrice } from 'src/util/formatPrice'
-import { closestFraction } from 'src/util/validateIngredientQuantityStr'
+import { closestFraction } from 'src/util/formatQuantity'
 
 import { IngredientsType, InstructionsType, RecipeType, ReviewType } from 'types'
 import RecipeAPI from 'src/api/recipes'

--- a/src/test/closestFraction.test.ts
+++ b/src/test/closestFraction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { closestFraction } from 'src/util/validateIngredientQuantityStr'
+import { closestFraction } from 'src/util/formatQuantity'
 
 // closestFraction renders a decimal ingredient quantity as the nearest "nice"
 // cooking fraction for display (the recipe page + printable view + ingredient

--- a/src/util/formatQuantity.ts
+++ b/src/util/formatQuantity.ts
@@ -2,8 +2,8 @@
 // for display (e.g. 1.5 → "1 1/2", 0.33 → "1/3"). The old in-app quantity
 // *validation* this file was named for is gone — ingredient parsing now happens
 // via @jclind/ingredient-parser — so the only surviving export is this display
-// helper. (Filename kept to avoid churning import sites; a rename to e.g.
-// formatQuantity.ts is a safe follow-up.)
+// helper, and the file was renamed from validateIngredientQuantityStr.ts to
+// match.
 export const closestFraction = (num: number): string => {
   const fractions = [
     { num: 1, den: 8 },

--- a/src/util/updateIngredients.ts
+++ b/src/util/updateIngredients.ts
@@ -1,5 +1,5 @@
 import { IngredientData, ParsedIngredient, IngredientsType } from 'types'
-// import { evalNum } from './validateIngredientQuantityStr'
+// import { evalNum } from './formatQuantity'
 
 // const mixedToDecimal = (str: string): number => {
 //   const split: string[] = str.split(' ')


### PR DESCRIPTION
## F5 · Housekeeping one-liners

Three low-risk drift fixes from the backlog (domain: `scripts/`, `CLAUDE.md`, `src/util/`):

1. **Brand-asset comment** — `scripts/generate-brand-assets.mjs:6` named `Montserrat-Italic.ttf`, but the script loads `Montserrat-MediumItalic.ttf` (line 28) and that's the file that exists in `scripts/fonts/`. Comment now matches reality.
2. **CLAUDE.md RecipeContext drift** — updated two references that said `RecipeContext` was "commented out" to "has been removed" (`src/context/` now contains only `AuthContext.tsx`); also fixed the `src/util/` example list.
3. **Util rename** — `src/util/validateIngredientQuantityStr.ts` → `src/util/formatQuantity.ts` (the file's only surviving export is the `closestFraction` display helper; the old validation it was named for is gone). Repointed all 4 importers + 1 commented ref.

### Verification
- Runtime-verified: drove 3 live recipe pages, confirmed `closestFraction` renders both whole (`8 ounce`, `1 cup`) and fractional (`1/2 cup`, `1 1/2 cup`, `1/4 cup`) quantities with zero console errors.
- Code review (local, high-effort): no bugs — all importers repoint, old file gone, no stale source refs, both doc-claims confirmed true against disk.
- Gates green: tsc, Vitest (556 pass / 2 skip), build.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK