### PR TITLE
refactor(scss): single-source the field-focus glow via @mixin focus-glow (C5)

### DIFF
--- a/docs/scss-conventions.md
+++ b/docs/scss-conventions.md
@@ -115,9 +115,13 @@ tile).
 Text inputs, textareas, and the Settings controls also cast a soft **coloured
 halo** while focused (paired with a `border-color` shift) — the `box-shadow: 0 0
 0 3px rgba(accent, …)` you see on a focused field. That is **not** the a11y
-`outline()` ring and the two coexist: `outline()` is the keyboard-focus
-indicator (`:focus-visible`), the glow is the "this field is active" affordance
-(`:focus` / `:focus-within`, so it shows on click too). Both are legitimate.
+`outline()` ring: `outline()` is the blue `outline-style: auto` ring, the glow is
+a coloured `box-shadow`. They usually coexist — the glow most often sits on
+`:focus` / `:focus-within` (so it shows on click too), while `outline()` handles
+`:focus-visible`. But on a few fields (the textarea, the `md` input, the signup
+checkbox) the glow *is* the `:focus-visible` indicator, doubling as the keyboard
+focus ring (WCAG 2.4.7) where a bespoke control drops `outline`. Both are
+legitimate.
 
 The glow comes from **`@include focus-glow($color, $opacity)`** in `helpers.scss`.
 The geometry (`0 0 0 3px`) is fixed — the mixin *is* the one definition — while

--- a/docs/scss-conventions.md
+++ b/docs/scss-conventions.md
@@ -110,6 +110,24 @@ coloured ring (an orange 2px ring on a card is drift, not a variant). Use
 `outline-offset` when a control needs the ring inset (a row) or nudged out (a
 tile).
 
+### The field-focus glow is a separate signal — `@include focus-glow()`
+
+Text inputs, textareas, and the Settings controls also cast a soft **coloured
+halo** while focused (paired with a `border-color` shift) — the `box-shadow: 0 0
+0 3px rgba(accent, …)` you see on a focused field. That is **not** the a11y
+`outline()` ring and the two coexist: `outline()` is the keyboard-focus
+indicator (`:focus-visible`), the glow is the "this field is active" affordance
+(`:focus` / `:focus-within`, so it shows on click too). Both are legitimate.
+
+The glow comes from **`@include focus-glow($color, $opacity)`** in `helpers.scss`.
+The geometry (`0 0 0 3px`) is fixed — the mixin *is* the one definition — while
+the tint follows the field's accent: teal `$secondary` at `0.15` is the default
+(`@include s.focus-glow;`), with `$primary` (the `/recipes` search), `$error-red`
+(invalid), and a success green (valid) as the branded/validation variants. **Don't
+hand-roll `box-shadow: 0 0 0 3px …` on a focused field** — reach for the mixin so
+the spread stays single-sourced. Opacity still varies slightly per surface
+(`0.12`–`0.25`); that spread is preserved, not yet normalised.
+
 ---
 
 ## To document later

--- a/src/Components/Form/FormInput.scss
+++ b/src/Components/Form/FormInput.scss
@@ -71,7 +71,7 @@
 
         &:focus {
           border-color: s.$secondary;
-          box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.15);
+          @include s.focus-glow;
         }
         &::placeholder {
           color: s.$tertiary-text;
@@ -132,7 +132,7 @@
         // md variant's teal ring (WCAG 2.4.7).
         &:focus-visible {
           border-color: s.$secondary;
-          box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.15);
+          @include s.focus-glow;
         }
       }
     }

--- a/src/Components/Form/FormStyles.scss
+++ b/src/Components/Form/FormStyles.scss
@@ -137,7 +137,7 @@
           }
           &:focus-visible {
             outline: none;
-            box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.2);
+            @include s.focus-glow(s.$secondary, 0.2);
           }
         }
       }

--- a/src/helpers.scss
+++ b/src/helpers.scss
@@ -183,8 +183,9 @@ $max-width: 1400px;
 // Out of scope, kept bespoke (NOT on this ramp) — directional or multi-layer
 // shadows where the ramp geometry would be wrong: the two-layer add-ingredient
 // bar (index.scss), the horizontal off-canvas drawer (Recipes.scss), and the two
-// upward sticky-bar shadows (AccountStatusBanner / AddRecipeSummaryBar). Focus
-// rings (`box-shadow: 0 0 0 3px …`) are a separate concern, left for a later pass.
+// upward sticky-bar shadows (AccountStatusBanner / AddRecipeSummaryBar). The
+// coloured field-focus glows (`box-shadow: 0 0 0 3px …`) are their own concern —
+// they live in the `@mixin focus-glow()` below, not on this neutral ramp.
 $elevation-1: 0 1px 3px rgba($primary-text, 0.14); //   hairline — toggle knobs, faint insets
 $elevation-2: 0 2px 8px rgba($primary-text, 0.12); //   small — sticky nav, badges, chips
 $elevation-3: 0 6px 18px rgba($primary-text, 0.1); //   resting cards (RecipeCard, Home, panels)
@@ -275,6 +276,24 @@ $bp-nav-up: 726px;
 }
 @mixin between($min, $max) {
   @media screen and (min-width: $min) and (max-width: $max) { @content; }
+}
+
+// ── Focus affordances ────────────────────────────────────────────────────────
+// Two distinct focus signals, deliberately kept separate:
+//
+//   @mixin outline()    — the accessibility keyboard-focus ring (blue, outline-
+//                         style: auto), shown on :focus-visible. One ring on every
+//                         control; see "Focus rings" in docs/scss-conventions.md.
+//   @mixin focus-glow() — the soft coloured halo a *form field* casts while
+//                         focused (paired with a border-colour shift), on :focus /
+//                         :focus-within. Fixed 3px spread; the tint follows the
+//                         field's accent — teal $secondary by default, or $primary
+//                         / $error-red / a success green for branded & validation
+//                         states. It's :focus (mouse + keyboard) not :focus-visible
+//                         — an active input should always show it. Documented in
+//                         docs/scss-conventions.md.
+@mixin focus-glow($color: $secondary, $opacity: 0.15) {
+  box-shadow: 0 0 0 3px rgba($color, $opacity);
 }
 
 @mixin outline() {

--- a/src/helpers.scss
+++ b/src/helpers.scss
@@ -285,13 +285,13 @@ $bp-nav-up: 726px;
 //                         style: auto), shown on :focus-visible. One ring on every
 //                         control; see "Focus rings" in docs/scss-conventions.md.
 //   @mixin focus-glow() — the soft coloured halo a *form field* casts while
-//                         focused (paired with a border-colour shift), on :focus /
-//                         :focus-within. Fixed 3px spread; the tint follows the
+//                         focused (paired with a border-colour shift), typically on
+//                         :focus / :focus-within — and as the :focus-visible ring
+//                         where a field's glow doubles as its keyboard indicator
+//                         (WCAG 2.4.7). Fixed 3px spread; the tint follows the
 //                         field's accent — teal $secondary by default, or $primary
 //                         / $error-red / a success green for branded & validation
-//                         states. It's :focus (mouse + keyboard) not :focus-visible
-//                         — an active input should always show it. Documented in
-//                         docs/scss-conventions.md.
+//                         states. Documented in docs/scss-conventions.md.
 @mixin focus-glow($color: $secondary, $opacity: 0.15) {
   box-shadow: 0 0 0 3px rgba($color, $opacity);
 }

--- a/src/pages/AddRecipe/RecipeFormTextArea.scss
+++ b/src/pages/AddRecipe/RecipeFormTextArea.scss
@@ -37,7 +37,7 @@
       // replacement; restore a visible one (teal, matching FormInput). WCAG 2.4.7.
       &:focus-visible {
         border-color: s.$secondary;
-        box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.15);
+        @include s.focus-glow;
       }
     }
     .small-textarea {

--- a/src/pages/CreateUsername/CreateUsername.scss
+++ b/src/pages/CreateUsername/CreateUsername.scss
@@ -66,7 +66,7 @@
 
     &:focus {
       border-color: s.$secondary;
-      box-shadow: 0 0 0 3px rgba(0, 173, 181, 0.15);
+      @include s.focus-glow;
     }
     &::placeholder {
       color: s.$tertiary-text;

--- a/src/pages/Help/Help.scss
+++ b/src/pages/Help/Help.scss
@@ -91,14 +91,14 @@
         border-color: s.$secondary;
         color: s.$secondary-accessible;
         background: rgba(s.$secondary, 0.07);
-        box-shadow: 0 0 0 3px rgba(s.$secondary, 0.12);
+        @include s.focus-glow(s.$secondary, 0.12);
         .chip-icon {
           color: s.$secondary;
         }
       }
       &:focus-visible {
         outline: none;
-        box-shadow: 0 0 0 3px rgba(s.$secondary, 0.25);
+        @include s.focus-glow(s.$secondary, 0.25);
       }
     }
   }
@@ -129,7 +129,7 @@
 
         &:focus {
           border-color: s.$secondary;
-          box-shadow: 0 0 0 3px rgba(s.$secondary, 0.15);
+          @include s.focus-glow;
         }
         &::placeholder {
           color: s.$tertiary-text;

--- a/src/pages/Recipes/Recipes.scss
+++ b/src/pages/Recipes/Recipes.scss
@@ -51,7 +51,7 @@
         }
         &:focus {
           border-color: s.$primary;
-          box-shadow: 0 0 0 3px rgba(s.$primary, 0.12);
+          @include s.focus-glow(s.$primary, 0.12);
         }
       }
       .search-recipes-btn {

--- a/src/pages/Settings/components/controls.scss
+++ b/src/pages/Settings/components/controls.scss
@@ -79,7 +79,7 @@
     &:focus {
       outline: none;
       border-color: s.$secondary;
-      box-shadow: 0 0 0 3px rgba(s.$secondary, 0.16);
+      @include s.focus-glow(s.$secondary, 0.16);
     }
   }
   .sr-textarea {
@@ -123,13 +123,13 @@
   &.has-error input {
     border-color: s.$error-red;
     &:focus {
-      box-shadow: 0 0 0 3px rgba(s.$error-red, 0.15);
+      @include s.focus-glow(s.$error-red, 0.15);
     }
   }
   &.has-success input {
     border-color: #29a155;
     &:focus {
-      box-shadow: 0 0 0 3px rgba(#29a155, 0.18);
+      @include s.focus-glow(#29a155, 0.18);
     }
   }
   &.is-disabled input {


### PR DESCRIPTION
## C5 · focus-ring tokens (Wave 3, SCSS loner)

Collapses the repeated field-focus **glow** onto one mixin. 12 focused-field halos across 7 component stylesheets each hand-rolled `box-shadow: 0 0 0 3px rgba(accent, …)` — the same fixed 3px geometry, several with the teal accent as a raw `rgba(0, 173, 181, …)` literal instead of `$secondary`.

### What changed
- **New `@mixin focus-glow($color: $secondary, $opacity: 0.15)`** in `helpers.scss` (grouped with `@mixin outline()`), the single definition of the `0 0 0 3px` ring geometry.
- **All 12 rings routed through it**, each keeping its **exact colour + opacity** — raw `rgba(0,173,181,…)` teal literals now resolve via `$secondary`; `$primary` / `$error-red` / success-green variants pass their accent explicitly.
- Documented the split in `docs/scss-conventions.md` (new field-glow subsection) and repointed the stale helpers.scss "focus rings left for a later pass" comment at the mixin.

### Not the a11y ring
`focus-glow` is deliberately **distinct from `@mixin outline()`** (the blue `#4d90fe` `:focus-visible` keyboard ring). The glow is the ":focus / :focus-within, this field is active" affordance; the two coexist. This lane does **not** touch `outline()`.

### Zero visual change — verified
Each call preserves its original colour+opacity, so the compiled CSS is **byte-identical**. Confirmed against the production build — all 12 rings emit the same hex+alpha:
`#00adb51f` (teal/.12), `#00adb526` ×5 (teal/.15), `#00adb529` (teal/.16), `#00adb533` (teal/.2), `#00adb540` (teal/.25), `#29a1552e` (green/.18), `#c5303f26` (error/.15), `#ff57221f` (primary/.12).

### Gates
- `npx tsc --noEmit` — clean
- `npm run build` — clean (SCSS compiles through the mixin)
- `npm test` (Vitest) — **557 passed / 2 skipped** (75 files)
- No `server/` changes → no Jest.

### Scope notes
- **Opacity preserved, not normalised.** The teal glows still vary slightly per surface (.12–.25); that's an intentional-vs-drift design call left as a follow-up, noted in the conventions doc — this PR is a pure de-dup.
- **Out of scope (observed, not touched):** `controls.scss` `.has-success` uses a bare `#29a155` for both its border-colour *and* glow (≠ the `$success-green` token, and a third green `#0a7d2c` for the hint) — a colour-token dedup, separate from the focus-ring concern. The glow keeps `#29a155` to stay coherent with its paired border.

Backlog item: **C5 · focus-ring tokens** (also reconciles the now-focus-rings-only "remaining hardcoded values" sub-item).

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ