### PR TITLE
refactor(routes): single-source RECIPES_PATH + account sub-route constants (C2)

### DIFF
--- a/src/Components/Footer/footerData.ts
+++ b/src/Components/Footer/footerData.ts
@@ -1,4 +1,9 @@
 import pjson from '../../../package.json'
+import {
+  ACCOUNT_SAVED_RECIPES_PATH,
+  ACCOUNT_YOUR_RECIPES_PATH,
+  RECIPES_PATH,
+} from 'src/routes'
 
 // ---------------------------------------------------------------------------
 // Shared footer content — single source of truth for the footer's links, blurb,
@@ -26,7 +31,7 @@ export const footerColumns: FooterColumn[] = [
     heading: 'Discover',
     links: [
       { label: 'Home', to: '/' },
-      { label: 'All recipes', to: '/recipes' },
+      { label: 'All recipes', to: RECIPES_PATH },
       // Add a recipe is behind PrivateRoute — only show it to signed-in users so
       // logged-out visitors aren't bounced to the login wall from the footer.
       { label: 'Add a recipe', to: '/add-recipe', auth: 'in' },
@@ -40,8 +45,8 @@ export const footerColumns: FooterColumn[] = [
     links: [
       { label: 'Log in', to: '/login', auth: 'out' },
       { label: 'Sign up', to: '/signup', auth: 'out' },
-      { label: 'My recipes', to: '/account/your-recipes', auth: 'in' },
-      { label: 'Saved recipes', to: '/account/saved-recipes', auth: 'in' },
+      { label: 'My recipes', to: ACCOUNT_YOUR_RECIPES_PATH, auth: 'in' },
+      { label: 'Saved recipes', to: ACCOUNT_SAVED_RECIPES_PATH, auth: 'in' },
     ],
   },
   {

--- a/src/Components/Navbar/desktop/DesktopAccountMenu.tsx
+++ b/src/Components/Navbar/desktop/DesktopAccountMenu.tsx
@@ -3,6 +3,7 @@ import React, { FC, useEffect, useId, useRef, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { NavMenuData } from 'src/Components/Navbar/menu/types'
 import DefaultAvatar from 'src/Components/DefaultAvatar/DefaultAvatar'
+import { ACCOUNT_YOUR_RECIPES_PATH } from 'src/routes'
 
 type DesktopAccountMenuProps = Pick<
   NavMenuData,
@@ -71,7 +72,7 @@ const DesktopAccountMenu: FC<DesktopAccountMenuProps> = ({
 
   const linkItems: LinkItem[] = [
     { to: '/account', label: 'Account', Icon: UserIcon },
-    { to: '/account/your-recipes', label: 'Your recipes', Icon: RecipesMenuIcon },
+    { to: ACCOUNT_YOUR_RECIPES_PATH, label: 'Your recipes', Icon: RecipesMenuIcon },
     { to: '/settings', label: 'Settings', Icon: SettingsIcon },
     { to: '/help', label: 'Help', Icon: HelpIcon },
   ]

--- a/src/Components/Navbar/desktop/DesktopBar.tsx
+++ b/src/Components/Navbar/desktop/DesktopBar.tsx
@@ -6,6 +6,7 @@ import { skeletonBase as skeletonColor } from 'src/util/loadingStyles'
 import SearchRecipesInput from 'src/Components/SearchRecipesInput/SearchRecipesInput'
 import DesktopAccountMenu from './DesktopAccountMenu'
 import { DesktopNavProps } from './types'
+import { ACCOUNT_SAVED_RECIPES_PATH, RECIPES_PATH } from 'src/routes'
 
 
 const linkClass = ({ isActive }: { isActive: boolean }) =>
@@ -42,7 +43,7 @@ const DesktopBar: FC<DesktopNavProps> = data => {
   // `.dnav--no-search` pushes the links/actions cluster to the right so the bar
   // doesn't leave a gap — same treatment the Home hero uses (DesktopNav.scss).
   const { pathname } = useLocation()
-  const showSearch = pathname !== '/recipes'
+  const showSearch = pathname !== RECIPES_PATH
 
   return (
     <div className={`dnav dnav--quiet${showSearch ? '' : ' dnav--no-search'}`}>
@@ -55,7 +56,7 @@ const DesktopBar: FC<DesktopNavProps> = data => {
       <nav className='dnav__links' aria-label='Primary'>
         {/* aria-label keeps the name when the label collapses to an icon below
             1000px (the icon SVG carries no accessible name on its own). */}
-        <NavLink to='/recipes' className={linkClass} aria-label='Recipes'>
+        <NavLink to={RECIPES_PATH} className={linkClass} aria-label='Recipes'>
           <RecipesMenuIcon className='dnav__link-icon' />
           <span className='dnav__link-label'>Recipes</span>
         </NavLink>
@@ -81,7 +82,7 @@ const DesktopBar: FC<DesktopNavProps> = data => {
         ) : isLoggedIn ? (
           <>
             <NavLink
-              to='/account/saved-recipes'
+              to={ACCOUNT_SAVED_RECIPES_PATH}
               aria-label='Saved recipes'
               className={({ isActive }) =>
                 isActive ? 'dnav__icon-link is-active' : 'dnav__icon-link'

--- a/src/Components/Navbar/menu/NavMenu.tsx
+++ b/src/Components/Navbar/menu/NavMenu.tsx
@@ -7,6 +7,7 @@ import AccountCard from './AccountCard'
 import SearchRecipesInput from 'src/Components/SearchRecipesInput/SearchRecipesInput'
 import { getNavGroups } from './navItems'
 import { NavMenuProps } from './types'
+import { RECIPES_PATH } from 'src/routes'
 
 /**
  * Mobile navigation menu (≤725px): full-screen panel with a subtle brand
@@ -17,7 +18,7 @@ const NavMenu: FC<NavMenuProps> = ({ open, onClose, ...menu }) => {
   // The /recipes browse page has its own search, so don't duplicate it in the
   // menu there. Kept on every other route (incl. single-recipe /recipes/:id).
   const { pathname } = useLocation()
-  const showSearch = pathname !== '/recipes'
+  const showSearch = pathname !== RECIPES_PATH
 
   return (
   <MenuShell open={open} onClose={onClose}>

--- a/src/Components/Navbar/menu/navItems.ts
+++ b/src/Components/Navbar/menu/navItems.ts
@@ -1,10 +1,11 @@
 import { HelpIcon, HomeIcon, PlusCircleIcon, RecipesMenuIcon, UserIcon } from 'src/Components/icons'
 import { NavItem, NavGroup } from './types'
+import { RECIPES_PATH } from 'src/routes'
 
 /** Browse links — always shown (logged in or out). */
 const browseItems: NavItem[] = [
   { label: 'Home', to: '/', icon: HomeIcon },
-  { label: 'Recipes', to: '/recipes', icon: RecipesMenuIcon },
+  { label: 'Recipes', to: RECIPES_PATH, icon: RecipesMenuIcon },
 ]
 
 /** Create links — logged-in only. */

--- a/src/pages/Account/Account.tsx
+++ b/src/pages/Account/Account.tsx
@@ -13,7 +13,7 @@ import ProfileControls from 'src/pages/Account/components/ProfileControls'
 import SegmentedNav from 'src/pages/Account/components/SegmentedNav'
 import {
   accountTabs,
-  activeAccountTabIndex,
+  activeAccountTab,
 } from 'src/pages/Account/components/accountTabs'
 import AchievementsModal from 'src/pages/Account/components/AchievementsModal'
 import DefaultAvatar from 'src/Components/DefaultAvatar/DefaultAvatar'
@@ -185,7 +185,7 @@ const Account: FC = () => {
                 from the same accountTabs source as SegmentedNav's highlight, so
                 the heading and the active tab always name the same route. */}
             <h2 className='sr-only'>
-              {accountTabs[activeAccountTabIndex(location.pathname)].srHeading}
+              {activeAccountTab(location.pathname).srHeading}
             </h2>
             <Outlet />
           </div>

--- a/src/pages/Account/components/accountTabs.tsx
+++ b/src/pages/Account/components/accountTabs.tsx
@@ -1,6 +1,12 @@
 import { BookOpenIcon, BookmarkIcon, FileTextIcon, StarOutlineIcon } from 'src/Components/icons'
 import React, { ReactNode } from 'react'
 import { AccountTabCounts } from 'types'
+import {
+  ACCOUNT_DRAFTS_PATH,
+  ACCOUNT_RATINGS_PATH,
+  ACCOUNT_SAVED_RECIPES_PATH,
+  ACCOUNT_YOUR_RECIPES_PATH,
+} from 'src/routes'
 
 // The single source of truth for the account sub-routes. Both SegmentedNav (the
 // rail/tab-bar switcher) and Account (the visually-hidden per-panel <h2>) derive
@@ -28,14 +34,14 @@ export const accountTabs: AccountTab[] = [
     label: 'Saved',
     srHeading: 'Saved recipes',
     icon: <BookmarkIcon />,
-    to: '/account/saved-recipes',
+    to: ACCOUNT_SAVED_RECIPES_PATH,
   },
   {
     key: 'ratings',
     label: 'Ratings',
     srHeading: 'Your ratings',
     icon: <StarOutlineIcon />,
-    to: '/account/ratings',
+    to: ACCOUNT_RATINGS_PATH,
   },
   {
     key: 'recipes',
@@ -43,14 +49,14 @@ export const accountTabs: AccountTab[] = [
     short: 'Recipes',
     srHeading: 'Recipes you created',
     icon: <BookOpenIcon />,
-    to: '/account/your-recipes',
+    to: ACCOUNT_YOUR_RECIPES_PATH,
   },
   {
     key: 'drafts',
     label: 'Drafts',
     srHeading: 'Your drafts',
     icon: <FileTextIcon />,
-    to: '/account/drafts',
+    to: ACCOUNT_DRAFTS_PATH,
   },
 ]
 
@@ -66,3 +72,9 @@ export const activeAccountTabIndex = (pathname: string): number =>
         : pathname.startsWith(t.to)
     )
   )
+
+// The active tab itself, for callers that want the tab object rather than its
+// index (e.g. Account's SR heading). SegmentedNav still uses the index for its
+// `i === activeIndex` highlight, so both are exported.
+export const activeAccountTab = (pathname: string): AccountTab =>
+  accountTabs[activeAccountTabIndex(pathname)]

--- a/src/pages/AddRecipe/DraftResumeBanner.tsx
+++ b/src/pages/AddRecipe/DraftResumeBanner.tsx
@@ -3,6 +3,7 @@ import React, { FC, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import DraftAPI from 'src/api/drafts'
+import { ACCOUNT_DRAFTS_PATH } from 'src/routes'
 import './DraftResumeBanner.scss'
 
 // Shown at the top of the create-recipe page when the user already has saved
@@ -44,7 +45,7 @@ const DraftResumeBanner: FC = () => {
         >
           Resume
         </button>
-        <Link to='/account/drafts' className='view-all'>
+        <Link to={ACCOUNT_DRAFTS_PATH} className='view-all'>
           View all drafts
         </Link>
         <button

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -12,6 +12,7 @@ import SearchRecipesInput from 'src/Components/SearchRecipesInput/SearchRecipesI
 import SortDropdown from 'src/Components/SortDropdown/SortDropdown'
 import RecipeAPI from 'src/api/recipes'
 import { SITE_URL, DEFAULT_OG_IMAGE } from 'src/util/seo'
+import { RECIPES_PATH } from 'src/routes'
 import { dietLabelsOptions } from 'src/recipeData/dietLabels'
 import cuisinesList from 'src/recipeData/cuisinesList'
 import mealTypesList from 'src/recipeData/mealTypesList'
@@ -75,7 +76,7 @@ const Recipes: FC = () => {
     d.length ? params.set('dietTags', d.join(',')) : params.delete('dietTags')
     c ? params.set('cuisine', c) : params.delete('cuisine')
     m.length ? params.set('mealTypes', m.join(',')) : params.delete('mealTypes')
-    navigate(`/recipes?${params.toString()}`)
+    navigate(`${RECIPES_PATH}?${params.toString()}`)
   }
 
   const changeSort = (value: string) => {
@@ -101,21 +102,27 @@ const Recipes: FC = () => {
     setMeals(next)
     syncUrl({ meals: next })
   }
-  const clearFilters = () => {
+  // Reset just the filter selections (diets/cuisine/meals). Shared by the in-list
+  // "Clear filters" button (which re-syncs the URL, preserving the search term)
+  // and the empty-state "Browse all" reset (which drops the search term too), so
+  // the two affordances can't drift on which filters they clear.
+  const resetFilters = () => {
     setDiets([])
     setCuisine('')
     setMeals([])
+  }
+  const clearFilters = () => {
+    resetFilters()
     syncUrl({ diets: [], cuisine: '', meals: [] })
   }
   // Full reset escape-hatch for the empty state: drop the search term AND every
   // filter, landing on the unfiltered catalog. `syncUrl`/`clearFilters` both
-  // preserve `q`, so we reset the local state and navigate to a bare /recipes.
+  // preserve `q`, so navigating to a bare RECIPES_PATH (no query string) is what
+  // additionally clears the search term.
   const browseAll = () => {
     setSort('popular')
-    setDiets([])
-    setCuisine('')
-    setMeals([])
-    navigate('/recipes')
+    resetFilters()
+    navigate(RECIPES_PATH)
   }
 
   const { data, isFetching, isError, fetchNextPage, hasNextPage } =

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,14 +1,20 @@
-// Central route-path constants. The single source of truth for route strings that
-// appear in more than one place — nav links, redirects, and the `pathname === …`
-// search-suppression checks — so renaming a route can't silently drift copies out
-// of sync: every consumer resolves through TypeScript instead of a bare literal.
+// Central route-path constants — the source of truth for route strings shared
+// across the nav/footer/browse surface, so renaming a route can't silently drift
+// those copies out of sync: consumers resolve through TypeScript, not a bare
+// literal.
 //
-// Scope note: only route strings duplicated across files live here. Single-use
-// route literals stay inline at their one call site (nothing to drift from).
+// Scope note: migration is intentionally partial. The account sub-routes below are
+// fully centralized (every consumer points here). RECIPES_PATH covers only the
+// nav/footer/browse surface touched by this change — other `'/recipes'` links
+// (Home, About, PublicProfile, SingleRecipe, SavedRecipes, UserRatings, …) still
+// use the inline literal and will migrate as their files are next touched. Until
+// then this const is authoritative for its consumers, NOT for every `/recipes`
+// reference app-wide.
 
-/** The browse/catalog page. Referenced by the navbar link, the two navbar
- *  search-suppression checks (`pathname === RECIPES_PATH`), and the Recipes
- *  page's own "browse all" reset. */
+/** The browse/catalog page. Referenced here by the navbar link, the two navbar
+ *  search-suppression checks (`pathname === RECIPES_PATH`), the footer, and the
+ *  Recipes page's own "browse all" reset — see the scope note above re: the
+ *  `'/recipes'` literals elsewhere not yet routed through this const. */
 export const RECIPES_PATH = '/recipes'
 
 // Account sub-routes. `accountTabs` (src/pages/Account/components/accountTabs.tsx)

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,21 @@
+// Central route-path constants. The single source of truth for route strings that
+// appear in more than one place — nav links, redirects, and the `pathname === …`
+// search-suppression checks — so renaming a route can't silently drift copies out
+// of sync: every consumer resolves through TypeScript instead of a bare literal.
+//
+// Scope note: only route strings duplicated across files live here. Single-use
+// route literals stay inline at their one call site (nothing to drift from).
+
+/** The browse/catalog page. Referenced by the navbar link, the two navbar
+ *  search-suppression checks (`pathname === RECIPES_PATH`), and the Recipes
+ *  page's own "browse all" reset. */
+export const RECIPES_PATH = '/recipes'
+
+// Account sub-routes. `accountTabs` (src/pages/Account/components/accountTabs.tsx)
+// consumes these for its tab `to` fields, and the app-wide nav links (DesktopBar,
+// DesktopAccountMenu, the footer, and DraftResumeBanner) point at the same
+// constants — so the account-page tab strip and the global nav can't drift apart.
+export const ACCOUNT_SAVED_RECIPES_PATH = '/account/saved-recipes'
+export const ACCOUNT_RATINGS_PATH = '/account/ratings'
+export const ACCOUNT_YOUR_RECIPES_PATH = '/account/your-recipes'
+export const ACCOUNT_DRAFTS_PATH = '/account/drafts'


### PR DESCRIPTION
## C2 · route-constant single-sourcing

Backlog track **C2** (Wave 3) — [`docs/BACKLOG_ROADMAP.md`](../blob/development/docs/BACKLOG_ROADMAP.md), items at `docs/BACKLOG.md:609` & `:651`. Frontend-only; no `server/` changes.

### What & why
Route strings that appear in more than one place were bare literals, so a rename would silently drift copies apart with no compile error (e.g. the `pathname === '/recipes'` search-suppression checks vs. the `/recipes` nav link). Introduces **`src/routes.ts`** as the single source of truth; every consumer now resolves through TypeScript.

**`RECIPES_PATH` (`'/recipes'`)** — migrated within C2's declared surface:
- `navItems.ts` (mobile nav link), `DesktopBar.tsx` (link + suppression check), `NavMenu.tsx` (suppression check), `footerData.ts` (footer link)
- `Recipes.tsx` — `syncUrl` + `browseAll` navigations

**Four `ACCOUNT_*_PATH` consts** — `accountTabs` consumes them for its tab `.to` fields, and the app-wide nav links point at the same constants so the account tab strip and the global nav can't drift:
- `DesktopBar.tsx` (saved-recipes), `DesktopAccountMenu.tsx` (your-recipes), `footerData.ts` (my/saved), `DraftResumeBanner.tsx` (drafts)

### Two judgment calls (BACKLOG left both open)
1. **`browseAll` → `clearFilters`:** rather than literally calling `clearFilters()` inside `browseAll` (which would double-navigate — `clearFilters`'s `syncUrl` pushes `/recipes?q=…`, then `browseAll`'s bare navigate pushes `/recipes` — an extra history entry + refetch), I extracted a shared **`resetFilters()`** setter block both use. Genuinely DRY, behavior-preserving.
2. **Account routes:** BACKLOG offered "point consumers at `accountTabs[].to`" **or** "pull the paths into a tiny shared `routes` constant the tab list also consumes." Chose the latter — a leaf `src/routes.ts` both sides consume — to avoid a `Components/* → pages/Account/*` layering inversion.

Also added **`activeAccountTab(pathname)`** alongside `activeAccountTabIndex` (kept — SegmentedNav needs the index); Account's SR heading now reads the cleaner helper.

### Scope guard
`RECIPES_PATH` migrated **only** within C2's collision surface. Left untouched (other lanes / follow-up): `SingleRecipe.tsx` (**C3**), `SearchRecipesInput.tsx` (**C4**), the `App.tsx` route definition, and the ~10 other page-level `/recipes` links — noted as a future adopt-everywhere sweep.

### Verification
- **Gates:** `tsc --noEmit` clean · Vitest **557 passed / 2 skipped** (75 files) · `npm run build` clean.
- **Behavior coverage (jsdom):** `browseAll`/`clearFilters` exercised by `Recipes.test.tsx` (incl. "Browse all recipes → bare /recipes, refetch with `query:''`, `diets:[]`"); `activeAccountTab` by `Account.test.tsx` (23 tests across all four account routes); nav structure by `navItems`/`DesktopNav`/`NavMenu` tests.
- Dev server (client :3005 / API :4003): no Vite resolve errors; `/recipes` + `/account/saved-recipes` serve 200.