### PR TITLE
C3 · SingleRecipe lane: escape </script> in JSON-LD

### DIFF
--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -36,7 +36,7 @@ import { closestFraction } from 'src/util/formatQuantity'
 import { IngredientsType, InstructionsType, RecipeType, ReviewType } from 'types'
 import RecipeAPI from 'src/api/recipes'
 import AuthAPI from 'src/api/auth'
-import { buildRecipeJsonLd } from 'src/pages/SingleRecipe/buildRecipeJsonLd'
+import { serializeRecipeJsonLd } from 'src/pages/SingleRecipe/buildRecipeJsonLd'
 
 type LocalStorageRecipeType = { recipeId: string; numServings: number }
 
@@ -152,7 +152,9 @@ const SingleRecipe: FC = () => {
 
   const pageUrl =
     typeof window !== 'undefined' ? window.location.href : ''
-  const recipeJsonLd = currRecipe ? buildRecipeJsonLd(currRecipe, pageUrl) : null
+  // Pre-serialized (and `</script>`-escaped) so the raw string can go straight into
+  // the ld+json script tag below — see serializeRecipeJsonLd for why the escape matters.
+  const recipeJsonLd = currRecipe ? serializeRecipeJsonLd(currRecipe, pageUrl) : null
 
   // Social/meta values for this recipe. Canonical is built from the production
   // origin (not window.location, which is localhost in dev) so crawlers resolve it.
@@ -279,9 +281,7 @@ const SingleRecipe: FC = () => {
           <meta name='twitter:image' content={recipeOgImage} />
         )}
         {recipeJsonLd && (
-          <script type='application/ld+json'>
-            {JSON.stringify(recipeJsonLd)}
-          </script>
+          <script type='application/ld+json'>{recipeJsonLd}</script>
         )}
       </Helmet>
 

--- a/src/pages/SingleRecipe/buildRecipeJsonLd.ts
+++ b/src/pages/SingleRecipe/buildRecipeJsonLd.ts
@@ -80,3 +80,17 @@ export const buildRecipeJsonLd = (
 
   return jsonLd
 }
+
+// Serialize the JSON-LD object for embedding in a `<script type="application/ld+json">`
+// tag. `JSON.stringify` alone leaves a literal `</script>` from a user-controlled field
+// (title/description/instructions) intact, which under SSR/prerender would close the
+// script element early and render the rest of that field as HTML. Replacing every `<`
+// with its backslash-u-003c unicode escape — still a valid JSON string, decoded back to
+// `<` by any JSON-LD parser — neutralizes that. Harmless under today's CSR (React inserts the child
+// as a text node, so `</script>` never re-parses), but escape it now rather than leave a
+// latent hole for the prerender change to trip on.
+export const serializeRecipeJsonLd = (
+  recipe: RecipeType,
+  pageUrl: string
+): string =>
+  JSON.stringify(buildRecipeJsonLd(recipe, pageUrl)).replace(/</g, '\\u003c')

--- a/src/test/buildRecipeJsonLd.test.ts
+++ b/src/test/buildRecipeJsonLd.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { RecipeType } from 'types'
+import {
+  buildRecipeJsonLd,
+  serializeRecipeJsonLd,
+} from 'src/pages/SingleRecipe/buildRecipeJsonLd'
+
+// A complete, valid recipe. Individual tests override just the field under test.
+const baseRecipe: RecipeType = {
+  _id: 'recipe-1',
+  userId: 'author-uid',
+  title: 'Chicken Tacos',
+  prepTime: 15,
+  cookTime: 15,
+  servings: 4,
+  fridgeLife: 3,
+  freezerLife: 14,
+  description: 'Tasty tacos',
+  ingredients: [],
+  instructions: [],
+  recipeImage: 'https://example.com/tacos.jpg',
+  nutritionData: null,
+  totalTime: 30,
+  authorUsername: 'chef',
+  rating: { rateCount: 0, rateValue: 0 },
+  createdAt: '2024-01-01',
+  editedAt: null,
+  servingPrice: 200,
+  cuisine: 'Mexican',
+  mealTypes: ['dinner'],
+  nutritionLabels: null,
+  views: 10,
+  numTimesSaved: 2,
+  numTimesMade: 5,
+}
+
+const PAGE_URL = 'https://prepify.app/recipes/recipe-1'
+
+describe('buildRecipeJsonLd', () => {
+  it('emits the core schema.org/Recipe fields', () => {
+    const ld = buildRecipeJsonLd(baseRecipe, PAGE_URL)
+    expect(ld['@context']).toBe('https://schema.org')
+    expect(ld['@type']).toBe('Recipe')
+    expect(ld.name).toBe('Chicken Tacos')
+    expect(ld.description).toBe('Tasty tacos')
+    expect(ld.mainEntityOfPage).toBe(PAGE_URL)
+    expect(ld.prepTime).toBe('PT15M')
+    expect(ld.cookTime).toBe('PT15M')
+    expect(ld.totalTime).toBe('PT30M')
+    expect(ld.recipeYield).toBe('4 servings')
+    expect(ld.author).toEqual({ '@type': 'Person', name: 'chef' })
+  })
+
+  it('omits fields that are missing or zero (sparse recipe stays valid)', () => {
+    const sparse = {
+      ...baseRecipe,
+      cookTime: null,
+      totalTime: 0,
+      servings: 0,
+      rating: { rateCount: 0, rateValue: 0 },
+    }
+    const ld = buildRecipeJsonLd(sparse, PAGE_URL)
+    expect('cookTime' in ld).toBe(false)
+    expect('totalTime' in ld).toBe(false)
+    expect('recipeYield' in ld).toBe(false)
+    expect('aggregateRating' in ld).toBe(false)
+  })
+
+  it('includes aggregateRating only when there is at least one rating', () => {
+    const rated = { ...baseRecipe, rating: { rateCount: 12, rateValue: 4.3333 } }
+    const ld = buildRecipeJsonLd(rated, PAGE_URL)
+    expect(ld.aggregateRating).toEqual({
+      '@type': 'AggregateRating',
+      ratingValue: 4.33,
+      ratingCount: 12,
+      bestRating: 5,
+      worstRating: 1,
+    })
+  })
+})
+
+describe('serializeRecipeJsonLd', () => {
+  it('produces the same object as buildRecipeJsonLd when parsed back', () => {
+    const parsed = JSON.parse(serializeRecipeJsonLd(baseRecipe, PAGE_URL))
+    expect(parsed).toEqual(buildRecipeJsonLd(baseRecipe, PAGE_URL))
+  })
+
+  // The core of the C3 hardening: a user-controlled field carrying a literal
+  // </script> must not survive as raw text in the serialized output, or it would
+  // close the ld+json <script> element the moment this is rendered to markup
+  // (SSR/prerender). It must still round-trip back to the exact original string.
+  it('escapes a </script> breakout in the title but keeps it recoverable', () => {
+    const malicious = {
+      ...baseRecipe,
+      title: 'Tacos</script><script>alert(1)</script>',
+    }
+    const out = serializeRecipeJsonLd(malicious, PAGE_URL)
+
+    // No literal `<` (hence no `</script>`) survives in the emitted string.
+    expect(out).not.toContain('<')
+    expect(out).not.toContain('</script>')
+    // The escape is present instead...
+    expect(out).toContain('\\u003c')
+    // ...and JSON-LD consumers still recover the original title verbatim.
+    expect(JSON.parse(out).name).toBe(
+      'Tacos</script><script>alert(1)</script>'
+    )
+  })
+
+  it('escapes < wherever it appears (description + instruction steps too)', () => {
+    const malicious = {
+      ...baseRecipe,
+      description: 'Best <b>tacos</b> ever',
+      instructions: [
+        { content: 'Mix </script> then bake', index: 0, id: 'i1' },
+      ],
+    }
+    const out = serializeRecipeJsonLd(malicious, PAGE_URL)
+    expect(out).not.toContain('<')
+    const parsed = JSON.parse(out)
+    expect(parsed.description).toBe('Best <b>tacos</b> ever')
+    expect(parsed.recipeInstructions[0].text).toBe('Mix </script> then bake')
+  })
+})


### PR DESCRIPTION
## C3 · SingleRecipe lane

Third Wave-3 lane (the SingleRecipe ⚠ solo lane). Frontend-only, no `server/` changes.

### ① JSON-LD `</script>` escaping — the fix

`buildRecipeJsonLd` assembles the schema.org/Recipe object from user-controlled fields (`title`/`description`/`instructions`) and `SingleRecipe.tsx` injected it via `{JSON.stringify(recipeJsonLd)}` into a `<script type="application/ld+json">`. A literal `</script>` in any of those fields:

- is **inert today** — under CSR, React sets the child as a text node, so `</script>` never re-parses;
- becomes a **real breakout** the instant SSR/prerender serializes this subtree to HTML (roadmap rule 6: escaping's natural home is the prerender PR, but it's a harmless one-liner now and one less thing that PR must remember).

New `serializeRecipeJsonLd()` stringifies then replaces every `<` with its `<` unicode escape — still a valid JSON string, decoded back to `<` by any JSON-LD consumer — and the component renders the pre-escaped string directly.

**Tests** (`src/test/buildRecipeJsonLd.test.ts`, +6): escape + JSON round-trip for a malicious title, description, and instruction step (asserts no raw `<` survives, `<` is present, and the original text is recoverable), plus core `buildRecipeJsonLd` output (fields, sparse-omission, aggregateRating gating).

### ② "CLS controls-block reserve" — intentionally a no-op

Investigation found `RecipeControls` **renders only for the recipe owner** (`if (!isUsersRecipe) return null`), so the "controls-block CLS" only ever affected an owner viewing their own recipe. Every **non-owner**-visible control on the page is *already* CLS-reserved:

| Element | Reserve | Location |
|---|---|---|
| Action bar (Save/Rate/Print) | exact-dimension skeletons | `SingleRecipe.tsx:461` |
| Servings stepper | placeholder | `SingleRecipe.tsx:496` |
| Ratings & Reviews | full skeleton from frame 1 | `SingleRecipe.tsx:638` |
| Report kebab (`.sr-controls`) | `min-height: 30px` | `SingleRecipe.scss:26` |
| Made-row | empty when logged-out; renders frame 1 otherwise | `MadeRecipeBtn.tsx:69` |

Any *speculative* reserve for the owner banner can't know ownership until the fetch resolves, so it would regress a larger segment (logged-out SEO traffic, or logged-in users browsing others' recipes) to fix the rarest case. **Per an explicit product call, the owner-only shift is left unreserved** and the non-owner path (already tailored) stands. No code change for this item.

### Verification
- `npx tsc --noEmit` clean · `npx vitest run` **563 passed / 2 skipped** (76 files) · `npm run build` clean.
- **Runtime** (headless Chrome against the running dev app): the live recipe page renders a valid, parseable ld+json `<script>` (`@type: Recipe`, correct name, ingredients + aggregateRating, no raw `</script>`). The existing `SingleRecipe.test.tsx` also exercises the new serialize→script path in integration.

Hero `srcset` stays deferred to **I1**.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK