### PR TITLE
perf(recipes): index-back autocomplete fuzzy fallback with a $text tier (I3)

### DIFF
--- a/server/__tests__/recipeTitleMatch.test.js
+++ b/server/__tests__/recipeTitleMatch.test.js
@@ -4,6 +4,7 @@ const {
   ratio,
   titleScore,
   fuzzyRankTitles,
+  toTextSearch,
   FUZZY_THRESHOLD,
 } = require('../util/recipeTitleMatch')
 
@@ -103,5 +104,28 @@ describe('fuzzyRankTitles', () => {
 
   it('returns [] when nothing clears the threshold', () => {
     expect(fuzzyRankTitles('zzzqwerty', candidates)).toEqual([])
+  })
+})
+
+describe('toTextSearch', () => {
+  it('lowercases and collapses to an OR-of-terms string', () => {
+    expect(toTextSearch('  Chicken   Soup ')).toBe('chicken soup')
+  })
+
+  it('strips leading dashes so a term is never negated', () => {
+    // Raw "-apple" would negate apple in a $text query; sanitized it just searches it.
+    expect(toTextSearch('-apple')).toBe('apple')
+    expect(toTextSearch('soup -chicken')).toBe('soup chicken')
+  })
+
+  it('strips double quotes so nothing forces phrase mode', () => {
+    expect(toTextSearch('"apple pie"')).toBe('apple pie')
+  })
+
+  it('returns empty string when nothing searchable remains', () => {
+    expect(toTextSearch('')).toBe('')
+    expect(toTextSearch('  ')).toBe('')
+    expect(toTextSearch('"')).toBe('')
+    expect(toTextSearch('-')).toBe('')
   })
 })

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -1383,6 +1383,36 @@ describe('GET /searchAutoCompleteRecipes', () => {
     const res = await request(server).get('/api/searchAutoCompleteRecipes?title=apple')
     expect(res.body.map((r) => r.title)).not.toContain('Banana Bread')
   })
+
+  it('surfaces a stemmed word match via the $text tier (index-backed)', async () => {
+    await seedRecipes([{ _id: 'ac-grill', title: 'Grilled Salmon' }])
+    // "grilling" is not a substring of "Grilled Salmon" (tier 1 misses) and its
+    // fuzzy score is below threshold (0.625 < 0.7, tier 3 misses) — only the
+    // $text tier, which stems grilling→grill ← grilled, can surface it.
+    const res = await request(server).get('/api/searchAutoCompleteRecipes?title=grilling')
+    expect(res.status).toBe(200)
+    expect(res.body.map((r) => r.title)).toContain('Grilled Salmon')
+  })
+
+  it('degrades gracefully (no 500) when the title text index is absent', async () => {
+    await seedRecipes([{ _id: 'ac-grill2', title: 'Grilled Salmon' }])
+    const recipes = getDB().collection('recipes')
+    const textIndex = (await recipes.indexes()).find((i) => i.textIndexVersion)
+    await recipes.dropIndex(textIndex.name)
+    try {
+      // With no text index the $text tier throws internally; the route must catch
+      // it and fall through to the (here empty) fuzzy tier rather than 500.
+      const res = await request(server).get('/api/searchAutoCompleteRecipes?title=grilling')
+      expect(res.status).toBe(200)
+      expect(res.body.map((r) => r.title)).not.toContain('Grilled Salmon')
+    } finally {
+      // Restore the index so the rest of the suite keeps its $text tier.
+      await recipes.createIndex({ title: 'text' })
+    }
+    // And with it restored, the same query surfaces the match again.
+    const res = await request(server).get('/api/searchAutoCompleteRecipes?title=grilling')
+    expect(res.body.map((r) => r.title)).toContain('Grilled Salmon')
+  })
 })
 
 // ─── GET /getTrendingRecipes ──────────────────────────────────────────────────

--- a/server/db.js
+++ b/server/db.js
@@ -105,6 +105,23 @@ async function ensureIndexes() {
     console.error('Failed to create browse-popular index on recipes:', err.message)
   }
 
+  // Backs the title autocomplete (GET /searchAutoCompleteRecipes). Its
+  // correctly-spelled path runs `$text: { $search }` against this index, so that
+  // path scales to any catalog size and matches query words in any order/position
+  // instead of scanning a capped in-memory candidate set on every under-filled
+  // query. The in-process Levenshtein fuzzy fallback still handles misspellings
+  // ($text is word/stem-tokenised and can't match typos), but only runs when the
+  // exact + $text tiers don't fill the results. A collection can hold only one
+  // text index; `title` is the only autocompleted field. Lives in startup (not
+  // scripts/createModerationIndexes.js) for the same reason as the browse index
+  // above: the querying code must never hit an unindexed collection post-deploy —
+  // and the route guards a missing index by degrading to the fuzzy scan anyway.
+  try {
+    await db.collection('recipes').createIndex({ title: 'text' })
+  } catch (err) {
+    console.error('Failed to create title text index on recipes:', err.message)
+  }
+
   // Backs GET /api/getSingleUserReviews (a user's ratings) and the ratings count
   // in GET /api/getAccountCounts, both of which filter ratings by username.
   try {

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -8,7 +8,7 @@ const { recipeIdQuery, recipeIdInQuery } = require('../util/recipeIdQuery')
 const { MIN_SIGNAL, selectForYou, tasteScore, weightedSample } = require('../util/forYou')
 const { loadInteractions, buildSeenProfile } = require('../util/tasteContext')
 const { RECIPE_VISIBLE, RECIPE_OWNER_VISIBLE } = require('../util/moderation')
-const { fuzzyRankTitles } = require('../util/recipeTitleMatch')
+const { fuzzyRankTitles, toTextSearch } = require('../util/recipeTitleMatch')
 const { recordAudit } = require('../util/auditLog')
 const { notifyInBackground, notifyRecipeHidden } = require('../util/email')
 const { validateRequiredRecipeFields, validateRecipeBounds } = require('../util/recipeLimits')
@@ -186,12 +186,20 @@ router.get('/recipes/facets', asyncHandler(async (req, res) => {
 
 // GET /searchAutoCompleteRecipes — quick title search for autocomplete.
 //
-// Typo-tolerant: a literal case-insensitive substring match runs first (fast,
-// covers the common case and preserves the original ordering/behaviour). When
-// that returns fewer than AUTOCOMPLETE_LIMIT hits, a fuzzy fallback ranks the
-// remaining visible titles by approximate similarity and fills the open slots,
-// so "chikcen" still surfaces "...Chicken..." results. Scoped to this endpoint
-// only — the main /recipes grid search is unchanged.
+// Three tiers fill up to AUTOCOMPLETE_LIMIT slots, best-behaviour first, each
+// deduped against the ones before it:
+//   1. Exact-ish substring — a literal case-insensitive `$regex` match (fast,
+//      precise, preserves the original ordering/behaviour for the common case).
+//   2. `$text` word/stem match — index-backed via the `{ title: 'text' }` index,
+//      so it scales to any catalog size (no capped in-memory scan) and matches
+//      the query words in any order/position, e.g. "soup chicken" surfaces
+//      "Chicken Noodle Soup" which the adjacent-substring pass above misses.
+//   3. Fuzzy Levenshtein fallback — ranks a capped candidate scan so a typo like
+//      "chikcen" still surfaces "...Chicken...". `$text` is word/stem-tokenised
+//      and can't match misspellings, so this tier catches what tiers 1-2 can't;
+//      it now only runs when they leave slots open (typically just typo queries),
+//      keeping the correctly-spelled hot path off the capped scan entirely.
+// Scoped to this endpoint only — the main /recipes grid search is unchanged.
 const AUTOCOMPLETE_LIMIT = 8
 const AUTOCOMPLETE_PROJECTION = {
   _id: 1,
@@ -212,7 +220,21 @@ router.get('/searchAutoCompleteRecipes', asyncHandler(async (req, res) => {
   const title = typeof req.query.title === 'string' ? req.query.title.trim() : ''
   if (!title) return res.json([])
 
-  // 1. Exact-ish substring match (original behaviour).
+  // Accumulate up to AUTOCOMPLETE_LIMIT unique results across the tiers below,
+  // preserving insertion order (tier 1 first) and skipping any _id already added.
+  const results = []
+  const seen = new Set()
+  const addUnique = (docs) => {
+    for (const doc of docs) {
+      if (results.length >= AUTOCOMPLETE_LIMIT) break
+      const id = String(doc._id)
+      if (seen.has(id)) continue
+      seen.add(id)
+      results.push(doc)
+    }
+  }
+
+  // Tier 1 — exact-ish substring match (original behaviour: precise, ordered).
   const exact = await db
     .collection('recipes')
     .find(
@@ -221,13 +243,41 @@ router.get('/searchAutoCompleteRecipes', asyncHandler(async (req, res) => {
     )
     .limit(AUTOCOMPLETE_LIMIT)
     .toArray()
+  addUnique(exact)
+  if (results.length >= AUTOCOMPLETE_LIMIT) return res.json(results)
 
-  if (exact.length >= AUTOCOMPLETE_LIMIT) return res.json(exact)
+  // Tier 2 — index-backed `$text` word/stem match. Fills remaining slots ordered
+  // by relevance (textScore). Guarded: if the text index isn't there yet (build
+  // deferred/failed at startup — see ensureIndexes) a `$text` query throws, so we
+  // log and fall through to the fuzzy tier rather than 500 the endpoint.
+  const textSearch = toTextSearch(title)
+  if (textSearch) {
+    try {
+      const textDocs = await db
+        .collection('recipes')
+        .find(
+          { $text: { $search: textSearch }, ...RECIPE_VISIBLE },
+          {
+            projection: {
+              ...AUTOCOMPLETE_PROJECTION,
+              _score: { $meta: 'textScore' },
+            },
+          }
+        )
+        .sort({ _score: { $meta: 'textScore' } })
+        .limit(AUTOCOMPLETE_LIMIT)
+        .toArray()
+      // Drop the internal _score before it reaches the client.
+      addUnique(textDocs.map(({ _score, ...doc }) => doc))
+    } catch (err) {
+      console.error('[autocomplete] $text search unavailable:', err.message)
+    }
+  }
+  if (results.length >= AUTOCOMPLETE_LIMIT) return res.json(results)
 
-  // 2. Fuzzy fallback fills the remaining slots with near-misses. Pull a capped
-  // set of lightweight {_id, title} candidates, rank them, then hydrate only the
-  // winners with the full projection (preserving the ranked order).
-  const seen = new Set(exact.map((r) => String(r._id)))
+  // Tier 3 — fuzzy Levenshtein fallback for misspellings. Pull a capped set of
+  // lightweight {_id, title} candidates, rank them, then hydrate only the winners
+  // with the full projection (preserving the ranked order).
   const candidates = await db
     .collection('recipes')
     .find({ ...RECIPE_VISIBLE }, { projection: { _id: 1, title: 1 } })
@@ -237,23 +287,21 @@ router.get('/searchAutoCompleteRecipes', asyncHandler(async (req, res) => {
   const ranked = fuzzyRankTitles(
     title,
     candidates.filter((c) => !seen.has(String(c._id))),
-    { limit: AUTOCOMPLETE_LIMIT - exact.length }
+    { limit: AUTOCOMPLETE_LIMIT - results.length }
   )
-  if (!ranked.length) return res.json(exact)
+  if (ranked.length) {
+    const fuzzyDocs = await db
+      .collection('recipes')
+      .find(
+        { _id: { $in: ranked.map((r) => r._id) }, ...RECIPE_VISIBLE },
+        { projection: AUTOCOMPLETE_PROJECTION }
+      )
+      .toArray()
+    const byId = new Map(fuzzyDocs.map((d) => [String(d._id), d]))
+    addUnique(ranked.map((r) => byId.get(String(r._id))).filter(Boolean))
+  }
 
-  const fuzzyDocs = await db
-    .collection('recipes')
-    .find(
-      { _id: { $in: ranked.map((r) => r._id) }, ...RECIPE_VISIBLE },
-      { projection: AUTOCOMPLETE_PROJECTION }
-    )
-    .toArray()
-  const byId = new Map(fuzzyDocs.map((d) => [String(d._id), d]))
-  const fuzzyOrdered = ranked
-    .map((r) => byId.get(String(r._id)))
-    .filter(Boolean)
-
-  res.json([...exact, ...fuzzyOrdered])
+  res.json(results)
 }))
 
 // GET /getTrendingRecipes

--- a/server/util/recipeTitleMatch.js
+++ b/server/util/recipeTitleMatch.js
@@ -123,11 +123,30 @@ function fuzzyRankTitles(
     .slice(0, limit)
 }
 
+/**
+ * Build a MongoDB `$text` search string from a raw autocomplete query.
+ *
+ * `$text` gives `"…"` (phrase) and a leading `-` (term negation) operator
+ * meaning, so a user typing them would silently change the query — a leading
+ * `-apple` would EXCLUDE apple rather than search for it. Strip those operator
+ * characters and normalize to a plain space-separated OR-of-terms over the
+ * title text index. Returns '' when nothing searchable remains.
+ */
+function toTextSearch(query) {
+  return normalize(query)
+    .replace(/"/g, ' ') // no phrase mode
+    .split(' ')
+    .map((w) => w.replace(/^-+/, '')) // no per-term negation
+    .filter(Boolean)
+    .join(' ')
+}
+
 module.exports = {
   normalize,
   levenshtein,
   ratio,
   titleScore,
   fuzzyRankTitles,
+  toTextSearch,
   FUZZY_THRESHOLD,
 }


### PR DESCRIPTION
**Track:** I3 · autocomplete title index (Wave 4)

## What & why

`GET /searchAutoCompleteRecipes` already had an in-process Levenshtein fuzzy fallback (`fuzzyRankTitles`, landed #167). The board's I3 was the **scalability** half that was still open: every under-filled query (exact substring < 8 hits) ran a capped **1000-doc candidate COLLSCAN** to feed the fuzzy ranker — unindexed, and silently blind to near-misses past the first 1000 docs as the catalog grows. There was **no `$text` index** on `recipes.title`.

## Change

Add a `{ title: 'text' }` index (`server/db.js` `ensureIndexes`) and insert an **index-backed `$text` tier** between the exact-substring pass and the fuzzy fallback:

| Tier | Pass | Notes |
|---|---|---|
| 1 | exact substring (`$regex`) | precise, ordered — **unchanged** |
| 2 | `$text` word/stem match | **new**, index-backed, scales; matches query words in **any order/position** and **stems** |
| 3 | fuzzy Levenshtein | **unchanged**; now only runs for actual misspellings, so the correctly-spelled hot path no longer hits the capped scan |

- **Owner call:** Mongo `$text` over Atlas Search (low urgency at current catalog size).
- `$text` operator chars (leading `-`, quotes) are stripped via a new `toTextSearch()` sanitizer so user input can't flip the query into a negation/phrase.
- The `$text` tier is **guarded** (`try/catch`): a missing/late index degrades to the fuzzy scan instead of 500-ing.
- `RECIPE_VISIBLE` preserved in every tier (hidden recipes stay excluded).

> Note: `$text` is word/stem-tokenised, so it can't match typos — that's exactly why the Levenshtein tier stays as the final fallback. Real fuzzy-at-scale (Atlas Search `fuzzy`) remains the deferred option.

## Verification

- **Server Jest: 747 passed** (32 suites). New: `toTextSearch` unit cases; route tests for the stemmed `$text` match (chosen below the fuzzy threshold so it isolates tier 2) and graceful degradation when the text index is absent.
- **Runtime (live dev API), all tiers:** `basil salmon` → *Grilled Salmon with Tomatoes & Basil* (out-of-order, substring can't); `grilling` → same (stemmed); `chikcen`/`medaterranean` → chicken/Mediterranean (fuzzy); `tuscan` → precise substring; `-salmon` → still finds salmon (sanitized). No `_score` leak in payloads.

Server-only; no frontend changes.

https://claude.ai/code/session_01FkVneix7zcbFNjq1KrisxZ