### PR TITLE
refactor(settings): drop redundant 'Change password' subhead (F4)

### DIFF
--- a/src/pages/Settings/sections/AccountSection.tsx
+++ b/src/pages/Settings/sections/AccountSection.tsx
@@ -185,7 +185,6 @@ const AccountSection: FC = () => {
       {/* Change password — only meaningful for password-based accounts. */}
       {hasPasswordProvider && (
         <div className='sr-subsection'>
-          <h3 className='sr-subhead'>Change password</h3>
           <div className='sr-grid-2'>
             <TextField
               label='Current password'

--- a/src/test/AccountSection.test.tsx
+++ b/src/test/AccountSection.test.tsx
@@ -250,7 +250,7 @@ describe('Account & Security — federated (Google) account', () => {
 
   it('hides the change-password section', () => {
     render(<AccountSection />)
-    expect(screen.queryByText('Change password')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('New password')).not.toBeInTheDocument()
     expect(screen.queryByText('Update password')).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## F4 · change-password subhead

Removes the redundant `<h3 class='sr-subhead'>Change password</h3>` in **Settings → Account & Security** (`AccountSection.tsx:188`). Backlog item [`docs/BACKLOG.md:207`], roadmap track **F4**.

### Why
The change-password subsection is already self-describing: its fields carry their own labels (*Current password* / *New password* / *Confirm new password*) and the **Update password** button names the action. Under the governing `<h2>Account & Security</h2>` section heading (`Settings.tsx:103`), the extra `<h3>` just restated the button and added visual clutter.

The `.sr-subsection` wrapper (with its `border-top` divider) is **kept**, so the block retains its visual grouping — only the redundant label is dropped.

**`Connected accounts` keeps its subhead** on purpose: it labels a passive, display-only provider list that has no self-describing control, so its heading carries real information.

### Test
Repointed the federated-account *"hides the change-password section"* test off the now-removed heading text onto the block-unique **New password** field label, so it stays a meaningful anchor (the `Update password` button check is unchanged). The 7-test `describe('change password')` block that mounts a password-provider user and renders this exact subsection is unaffected.

### Verification
- `npx tsc --noEmit` — clean
- `npx vitest run` — **568 passed / 2 skipped** (77 files); `AccountSection` suites 25/25
- `npm run build` — clean

_No authed pixel screenshot: the block is gated behind `hasPasswordProvider`, and the Cypress `test-cypress-user` has no `password` provider (custom-token uid, empty `providerData`), so `cy.login()` can't render it without mutating shared dev-auth state. Change is a pure static-markup removal; the CSS (`.sr-subsection` divider retained) and the password-variant render tests cover it._

### Follow-up (filed, not fixed)
Minor heading asymmetry now that the password subsection has a divider but no heading while *Connected accounts* has both — inherent to the owner's "this heading is redundant" call and left as a separate visual-design decision.