### PR TITLE
I1: responsive recipe-image variants (Firebase Resize Images + srcset)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ VITE_FIREBASE_PROJECT_ID=<your-firebase-project-id>
 VITE_FIREBASE_STORAGE_BUCKET=<your-firebase-storage-bucket>
 VITE_API_URL=http://localhost:4000
 VITE_CYPRESS=false
+# Responsive recipe-image variants (BACKLOG I1). Leave false/unset until the
+# Firebase "Resize Images" extension is installed AND existing images are
+# backfilled — see docs/IMAGE_PIPELINE.md. Off ⇒ the original image is served as
+# today (no srcset, no variant requests); on ⇒ cards + hero emit a WebP srcset.
+VITE_IMAGE_VARIANTS_ENABLED=false
 # Sentry client error monitoring. Leave empty to disable entirely — the app
 # no-ops (no init, no reporting) without a DSN, so local dev/CI stay quiet.
 VITE_SENTRY_DSN=

--- a/docs/IMAGE_PIPELINE.md
+++ b/docs/IMAGE_PIPELINE.md
@@ -1,0 +1,128 @@
+# Recipe image pipeline — responsive variants (BACKLOG I1)
+
+How Prepify serves right-sized recipe images, and the **owner-run** steps to turn
+it on. Companion to the code: `src/util/recipeImageVariants.ts` (URL derivation),
+`extensions/storage-resize-images.env` (the extension config), and the `srcset`
+wiring in `RecipeCard.tsx` + `SingleRecipe.tsx`.
+
+## What it does
+
+Recipe photos upload full-resolution to Firebase Storage (`recipeImages/<name>`).
+The Firebase **Resize Images** extension (`storage-resize-images`) generates three
+WebP width variants next to each original on upload:
+
+```
+recipeImages/photo.jpg           (original, kept)
+recipeImages/photo_400x400.webp  (variants, generated)
+recipeImages/photo_800x800.webp
+recipeImages/photo_1600x1600.webp
+```
+
+The browse-grid card and the single-recipe hero then render a `srcset` over those
+variants, so a phone downloads a ~40 KB WebP instead of the ~190 KB original — the
+biggest remaining mobile-LCP lever after code-splitting.
+
+### How the frontend builds variant URLs
+
+`recipeImageVariantUrl()` takes the **stored original URL** and rewrites it to the
+variant path, **deriving the bucket from the URL itself** (the catalog spans more
+than one Storage bucket, so nothing is hardcoded). The variant URL is
+**token-less** — it relies on the bucket's public-read rule
+(`allow read: if true`), so it needs no per-object download token (each resized
+object has its own token we couldn't derive anyway). Verified: token-less
+`?alt=media` reads return `200` under the current rules.
+
+### Two safety nets (why this is safe to ship before install)
+
+1. **Feature flag `VITE_IMAGE_VARIANTS_ENABLED`** (default off). Until it's on, the
+   components render **only the original** — no `srcset`, no variant requests, zero
+   behaviour change. This is why the frontend merged ahead of the install.
+2. **Per-image error fallback.** Even with the flag on, the original stays the
+   `<img src>`; if a variant 404s (a legacy/un-backfilled image, or the brief
+   window after an upload before the extension runs) the component drops `srcset`
+   and shows the original. No broken images, ever.
+
+So the merged code is inert until you (a) install the extension, (b) backfill, and
+(c) flip the flag.
+
+---
+
+## Runbook — enabling it (owner)
+
+> Requires the **Blaze** (pay-as-you-go) plan — the extension runs Cloud
+> Functions. Real cost at Prepify's catalog size is a few cents/month; the
+> exposure is theoretical runaway billing, so keep a budget alert on.
+
+Do this **once per Firebase project** — dev (`prepify-dev-58579`) first, then prod.
+
+### 1. Install the extension
+
+The committed manifest (`firebase.json` + `extensions/storage-resize-images.env`)
+pins the config, so a plain deploy applies it:
+
+```bash
+firebase use prepify-dev-58579          # then repeat the whole flow for prod
+firebase deploy --only extensions        # reads firebase.json + the .env manifest
+```
+
+If the CLI reports a newer version than `@0.3.5`, take it and update the pin in
+`firebase.json`. (Alternatively `firebase ext:install firebase/storage-resize-images`
+walks the params interactively — the committed `.env` lists the exact answers.)
+
+### 2. ⚠ VERIFY the variant naming matches the helper
+
+This is the one assumption the frontend can't self-check. After the extension is
+live, upload a test recipe image (or re-upload one), then list the bucket:
+
+```bash
+gsutil ls 'gs://<bucket>/recipeImages/' | grep _400x400
+```
+
+Confirm the generated name is **`<stem>_400x400.webp`** (extension stripped), e.g.
+`photo_400x400.webp` — **not** `photo.jpg_400x400.webp`. The helper assumes the
+stripped form. If your version keeps the original extension, that's a one-line fix
+in `recipeImageVariantUrl()` (build the stem without stripping `.jpg`); the
+`RECIPE_IMAGE_VARIANT_WIDTHS` array and everything else stay the same.
+
+### 3. Backfill existing images
+
+New uploads are resized automatically. For images already in the bucket, run the
+extension's backfill (the install flow offers "process existing images?", or use
+the extension's `backfill` task). Note the **mixed-bucket** caveat: each install
+only processes its own project's default bucket, so images whose stored URL points
+at a *different* bucket won't have variants until that project is also set up — the
+error fallback (safety net #2) covers them in the meantime.
+
+### 4. Flip the flag on
+
+Set the frontend build env and redeploy the client (Netlify):
+
+```
+VITE_IMAGE_VARIANTS_ENABLED=true
+```
+
+Then spot-check in the browser devtools **Network** tab: card/hero requests should
+now be `*_800x800.webp` (or the DPR-appropriate width), not the original `.jpg`.
+
+### Rollback
+
+Set `VITE_IMAGE_VARIANTS_ENABLED=false` and redeploy the client — instantly back to
+serving originals. The extension + variants can stay in place (harmless, unused).
+
+---
+
+## Notes & follow-ups
+
+- **Hero `srcset` (C3 carry-over).** The SingleRecipe hero `srcset` that C3 deferred
+  to I1 ships here — this is that item.
+- **`sizes` accuracy.** Card `(max-width: 700px) 90vw, 300px`; hero
+  `(max-width: 820px) 100vw, 400px` (the hero is a fixed 400px grid column ≥820px).
+  These only steer variant *selection*, so approximate is fine; tune against real
+  devices if desired.
+- **Other image surfaces.** Home cards, the autocomplete thumb, and the admin
+  report preview still render the original — intentionally out of scope (the board
+  scoped I1 to the card + hero, the LCP surfaces). They can adopt `recipeImageSrcSet`
+  later with no infra change.
+- **Pairs with I2.** I2 (uid-keyed `recipeImages/{uid}/{uuid}` + owner-scoped rules)
+  changes the object path. If I2 lands after this, keep resized variants in the same
+  directory as their original so the derivation + read rule still hold.

--- a/extensions/storage-resize-images.env
+++ b/extensions/storage-resize-images.env
@@ -1,0 +1,42 @@
+# Firebase "Resize Images" extension params (BACKLOG I1).
+# Runbook: docs/IMAGE_PIPELINE.md. Extension: firebase/storage-resize-images@0.3.5.
+#
+# This manifest is SHARED across the dev + prod projects — IMG_BUCKET is left
+# unset so it falls back to each project's own default bucket (${STORAGE_BUCKET}).
+# Deploy with:  firebase use <project> && firebase deploy --only extensions
+
+# Only resize recipe images. Profile photos (profilePhotos/{uid}) are left alone.
+INCLUDE_PATH_LIST=/recipeImages
+
+# Three width variants. Each WIDTHxHEIGHT is a bounding box (aspect ratio
+# preserved; for the typical landscape recipe photo the WIDTH is the binding
+# dimension, so it matches the srcset `w` descriptor). These widths are the
+# single source of truth mirrored by RECIPE_IMAGE_VARIANT_WIDTHS in
+# src/util/recipeImageVariants.ts — change them together.
+IMG_SIZES=400x400,800x800,1600x1600
+
+# Emit WebP (materially smaller than JPEG/PNG at equal quality — the LCP win).
+IMAGE_TYPE=webp
+
+# Keep the full-resolution original: it stays the <img src> and the fallback the
+# frontend drops to if a variant is ever missing.
+DELETE_ORIGINAL_FILE=false
+
+# Empty => variants land in the SAME directory as the original, e.g.
+#   recipeImages/photo.jpg  ->  recipeImages/photo_400x400.webp
+# This matters for security rules: same-directory variants are still a single
+# path segment under recipeImages/, so the existing `match /recipeImages/{imageId}
+# { allow read: if true }` rule covers them with NO storage.rules change. A
+# subfolder here (e.g. "resized") would be a 2-segment path the rule misses.
+RESIZED_IMAGES_PATH=
+
+# Reads use token-less Firebase media URLs, which are authorized by the
+# public-read Storage rule — so no GCS object-level public ACL is needed.
+MAKE_PUBLIC=false
+
+# The variant filename encodes its size and never changes content, so cache hard.
+CACHE_CONTROL_HEADER=public, max-age=604800, immutable
+
+# 1024 MB is the default; bump to 2048 if very large uploads OOM the resizer
+# (the 5 MB upload cap in storage.rules makes this unlikely). See runbook.
+FUNCTION_MEMORY=1024

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,8 @@
 {
   "storage": {
     "rules": "storage.rules"
+  },
+  "extensions": {
+    "storage-resize-images": "firebase/storage-resize-images@0.3.5"
   }
 }

--- a/src/Components/RecipeCard/RecipeCard.tsx
+++ b/src/Components/RecipeCard/RecipeCard.tsx
@@ -9,6 +9,7 @@ import SaveControl from 'src/Components/AddToCollection/SaveControl'
 import { formatRating } from 'src/util/formatRating'
 import { formatPrice } from 'src/util/formatPrice'
 import { minToHrMin } from 'src/util/minToHrMin'
+import { recipeImageSrcSet } from 'src/util/recipeImageVariants'
 import { RecipeType } from 'types'
 import './RecipeCard.scss'
 
@@ -54,6 +55,10 @@ const RecipeCard: FC<RecipeCardProps> = ({ recipe, loading, onMutated }) => {
   // Hold a skeleton over the thumb until the image actually decodes (onLoad), so
   // a card never shows an empty box painting in top-down. Reset if the URL changes.
   const [imgLoaded, setImgLoaded] = useState(false)
+  // If a resized variant 404s (legacy/un-backfilled image, or the brief window
+  // after upload before the extension runs), drop srcset and retry the original
+  // — only give up to the placeholder if the original itself then fails.
+  const [variantFailed, setVariantFailed] = useState(false)
 
   if (loading || !recipe) {
     return (
@@ -82,6 +87,12 @@ const RecipeCard: FC<RecipeCardProps> = ({ recipe, loading, onMutated }) => {
     recipe.servingPrice != null
       ? `${formatPrice(recipe.servingPrice)}/serving`
       : null
+  // Responsive variants for the thumb (no-op until VITE_IMAGE_VARIANTS_ENABLED);
+  // cleared once a variant has failed so the retry uses the original only.
+  const imgSrcSet = variantFailed
+    ? undefined
+    : recipeImageSrcSet(recipe.recipeImage)
+
   const hm = minToHrMin(recipe.totalTime)
   const time = !hm
     ? `${recipe.totalTime} min`
@@ -102,6 +113,8 @@ const RecipeCard: FC<RecipeCardProps> = ({ recipe, loading, onMutated }) => {
             <>
               <img
                 src={recipe.recipeImage}
+                srcSet={imgSrcSet}
+                sizes={imgSrcSet ? '(max-width: 700px) 90vw, 300px' : undefined}
                 alt=''
                 loading='lazy'
                 decoding='async'
@@ -118,7 +131,9 @@ const RecipeCard: FC<RecipeCardProps> = ({ recipe, loading, onMutated }) => {
                 }}
                 className={imgLoaded ? 'is-loaded' : ''}
                 onLoad={() => setImgLoaded(true)}
-                onError={() => setImgError(true)}
+                onError={() =>
+                  imgSrcSet ? setVariantFailed(true) : setImgError(true)
+                }
               />
               {!imgLoaded && (
                 <Skeleton

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -32,6 +32,7 @@ import { formatRating } from 'src/util/formatRating'
 import { formatMonthYear } from 'src/util/formatDate'
 import { formatPrice } from 'src/util/formatPrice'
 import { closestFraction } from 'src/util/formatQuantity'
+import { recipeImageSrcSet } from 'src/util/recipeImageVariants'
 
 import { IngredientsType, InstructionsType, RecipeType, ReviewType } from 'types'
 import RecipeAPI from 'src/api/recipes'
@@ -86,9 +87,17 @@ const SingleRecipe: FC = () => {
   // instant `loading` flips and you watch the image paint in top-down over an
   // empty box. Reset when the image URL changes (navigating between recipes).
   const [heroLoaded, setHeroLoaded] = useState(false)
+  // Drop to the original if a resized hero variant 404s (legacy/un-backfilled
+  // image, or the post-upload window before the extension runs). Reset with
+  // heroLoaded when navigating to another recipe.
+  const [heroVariantFailed, setHeroVariantFailed] = useState(false)
   useEffect(() => {
     setHeroLoaded(false)
+    setHeroVariantFailed(false)
   }, [currRecipe?.recipeImage])
+  const heroSrcSet = heroVariantFailed
+    ? undefined
+    : recipeImageSrcSet(currRecipe?.recipeImage)
   const printedRef = useRef<HTMLDivElement>(null)
 
   const updateRecipeLocalStorage = (recipeId: string, numServings: number) => {
@@ -321,6 +330,8 @@ const SingleRecipe: FC = () => {
               {currRecipe?.recipeImage && (
                 <img
                   src={currRecipe.recipeImage}
+                  srcSet={heroSrcSet}
+                  sizes={heroSrcSet ? '(max-width: 820px) 100vw, 400px' : undefined}
                   alt={currRecipe.title}
                   title={currRecipe.title}
                   loading='eager'
@@ -336,6 +347,7 @@ const SingleRecipe: FC = () => {
                     }
                   }}
                   onLoad={() => setHeroLoaded(true)}
+                  onError={() => heroSrcSet && setHeroVariantFailed(true)}
                   className={heroLoaded ? 'is-loaded' : ''}
                 />
               )}

--- a/src/test/recipeImageVariants.test.ts
+++ b/src/test/recipeImageVariants.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  recipeImageVariantUrl,
+  recipeImageSrcSet,
+} from 'src/util/recipeImageVariants'
+
+// A real-shape Firebase Storage download URL (legacy prod bucket, with token).
+const ORIGINAL =
+  'https://firebasestorage.googleapis.com/v0/b/prepify-9b974.appspot.com/o/recipeImages%2FCinnamon-Raisin-Granola-4.jpg?alt=media&token=9fa71bb6-04ef-4923-9015-73d90abce7e9'
+
+describe('recipeImageVariantUrl', () => {
+  it('swaps in the _WxW.webp variant beside the original and drops the token', () => {
+    expect(recipeImageVariantUrl(ORIGINAL, 400)).toBe(
+      'https://firebasestorage.googleapis.com/v0/b/prepify-9b974.appspot.com/o/recipeImages%2FCinnamon-Raisin-Granola-4_400x400.webp?alt=media'
+    )
+  })
+
+  it('is bucket-agnostic — derives the bucket from the stored URL', () => {
+    const devUrl = ORIGINAL.replace(
+      'prepify-9b974.appspot.com',
+      'prepify-dev-58579.firebasestorage.app'
+    )
+    const variant = recipeImageVariantUrl(devUrl, 800)
+    expect(variant).toContain('/b/prepify-dev-58579.firebasestorage.app/o/')
+    expect(variant).toContain('_800x800.webp')
+  })
+
+  it('produces a round-trippable, token-less object path', () => {
+    const variant = recipeImageVariantUrl(ORIGINAL, 1600)!
+    const encoded = variant.match(/\/o\/([^?]+)/)![1]
+    expect(decodeURIComponent(encoded)).toBe(
+      'recipeImages/Cinnamon-Raisin-Granola-4_1600x1600.webp'
+    )
+    expect(variant).not.toContain('token=')
+  })
+
+  it('works when the original has no token', () => {
+    const noToken =
+      'https://firebasestorage.googleapis.com/v0/b/b1/o/recipeImages%2Fp.jpg?alt=media'
+    expect(recipeImageVariantUrl(noToken, 400)).toBe(
+      'https://firebasestorage.googleapis.com/v0/b/b1/o/recipeImages%2Fp_400x400.webp?alt=media'
+    )
+  })
+
+  it('handles a filename with no extension', () => {
+    const url =
+      'https://firebasestorage.googleapis.com/v0/b/b1/o/recipeImages%2Fphoto?alt=media'
+    expect(recipeImageVariantUrl(url, 400)).toBe(
+      'https://firebasestorage.googleapis.com/v0/b/b1/o/recipeImages%2Fphoto_400x400.webp?alt=media'
+    )
+  })
+
+  it('returns null for empty / non-Firebase / dotfile URLs', () => {
+    expect(recipeImageVariantUrl('', 400)).toBeNull()
+    expect(recipeImageVariantUrl(null, 400)).toBeNull()
+    expect(recipeImageVariantUrl(undefined, 400)).toBeNull()
+    // Cypress E2E bridge returns this fake URL — must not be transformed.
+    expect(
+      recipeImageVariantUrl('https://cypress.test/fake-recipe-image.jpg', 400)
+    ).toBeNull()
+    expect(recipeImageVariantUrl('https://example.com/img.jpg', 400)).toBeNull()
+    // Dotfile with no stem (e.g. an object literally named ".jpg").
+    expect(
+      recipeImageVariantUrl(
+        'https://firebasestorage.googleapis.com/v0/b/b1/o/recipeImages%2F.jpg?alt=media',
+        400
+      )
+    ).toBeNull()
+  })
+})
+
+describe('recipeImageSrcSet (feature-flag gating)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('returns undefined when the flag is off (the default)', () => {
+    // Imported at top of file with VITE_IMAGE_VARIANTS_ENABLED unset ⇒ disabled.
+    expect(recipeImageSrcSet(ORIGINAL)).toBeUndefined()
+  })
+
+  it('composes a full srcset over every width when the flag is on', async () => {
+    vi.resetModules()
+    vi.stubEnv('VITE_IMAGE_VARIANTS_ENABLED', 'true')
+    const mod = await import('src/util/recipeImageVariants')
+
+    const srcset = mod.recipeImageSrcSet(ORIGINAL)
+    expect(srcset).toBeDefined()
+    for (const w of mod.RECIPE_IMAGE_VARIANT_WIDTHS) {
+      expect(srcset).toContain(`_${w}x${w}.webp?alt=media ${w}w`)
+    }
+    expect(srcset!.split(',').length).toBe(
+      mod.RECIPE_IMAGE_VARIANT_WIDTHS.length
+    )
+  })
+
+  it('returns undefined (even with the flag on) when the URL yields no variants', async () => {
+    vi.resetModules()
+    vi.stubEnv('VITE_IMAGE_VARIANTS_ENABLED', 'true')
+    const mod = await import('src/util/recipeImageVariants')
+
+    expect(mod.recipeImageSrcSet('https://cypress.test/fake.jpg')).toBeUndefined()
+    expect(mod.recipeImageSrcSet('')).toBeUndefined()
+    expect(mod.recipeImageSrcSet(null)).toBeUndefined()
+  })
+})

--- a/src/util/recipeImageVariants.ts
+++ b/src/util/recipeImageVariants.ts
@@ -1,0 +1,104 @@
+/**
+ * Responsive-image helpers for recipe photos (BACKLOG I1).
+ *
+ * Recipe images are uploaded full-resolution to Firebase Storage. The Firebase
+ * "Resize Images" extension (`storage-resize-images`) generates fixed-width WebP
+ * variants next to each original — see `docs/IMAGE_PIPELINE.md` for the install +
+ * backfill runbook. This module turns a stored original-image URL into a
+ * `srcset` over those variants so cards and the hero download an appropriately
+ * sized image instead of the full original (the main mobile-LCP lever).
+ *
+ * Two independent safety nets keep this from ever showing a broken image:
+ *   1. `VITE_IMAGE_VARIANTS_ENABLED` gates srcset emission entirely. Until the
+ *      extension is installed AND existing images are backfilled, it stays off
+ *      and every consumer renders only the original `src` — zero 404s, zero
+ *      behaviour change from before I1. (This is why the frontend can ship and
+ *      merge ahead of the owner-gated extension install.)
+ *   2. Even with the flag on, consumers keep the original as the `<img src>` and
+ *      fall back to it on a variant load error — covering legacy/un-backfilled
+ *      images (the catalog spans more than one Storage bucket) and the brief
+ *      window after an upload before the extension finishes generating variants.
+ */
+
+// Variant bounding-box widths, ascending. Each value is BOTH the extension's
+// configured box width (`IMG_SIZES = "400x400,800x800,1600x1600"`) and the
+// srcset `w` descriptor. This array is the single source of truth for the
+// variant naming built below — keep it in lockstep with the extension config
+// documented in `docs/IMAGE_PIPELINE.md`.
+export const RECIPE_IMAGE_VARIANT_WIDTHS = [400, 800, 1600] as const
+
+// Output format the extension is configured to emit (`IMAGE_TYPE=webp`).
+const VARIANT_EXTENSION = 'webp'
+
+/**
+ * Feature flag. The extension must be installed AND existing images backfilled
+ * before variants exist, so this defaults off (unset ⇒ disabled). The owner
+ * flips it on after running the install/backfill in `docs/IMAGE_PIPELINE.md`.
+ */
+export const IMAGE_VARIANTS_ENABLED =
+  import.meta.env.VITE_IMAGE_VARIANTS_ENABLED === 'true'
+
+// A Firebase Storage download URL looks like:
+//   https://firebasestorage.googleapis.com/v0/b/<bucket>/o/<enc-path>?alt=media&token=…
+// where <enc-path> is the object path with every "/" encoded as "%2F". Capture
+// the "…/o/" prefix (group 1) and the encoded path up to the query (group 2).
+const FIREBASE_STORAGE_URL =
+  /^(https:\/\/firebasestorage\.googleapis\.com\/v0\/b\/[^/]+\/o\/)([^?]+)/
+
+/**
+ * Build the resized-variant URL for `width` from a stored original URL, or
+ * `null` if `url` isn't a recognizable Firebase Storage object URL (empty, a
+ * legacy/other host, the Cypress fake URL, …).
+ *
+ * The variant URL is **token-less**: it relies on the bucket's public-read
+ * Storage rule (`allow read: if true`), so it needs no per-object download token
+ * — which matters because each resized object has its own token we can't derive
+ * from the original's. (Verified: token-less reads return 200 under the current
+ * rules.) Deriving from the stored URL string keeps this bucket-agnostic, so it
+ * works across the mixed-bucket catalog.
+ */
+export function recipeImageVariantUrl(
+  url: string | undefined | null,
+  width: number
+): string | null {
+  if (!url) return null
+  const match = url.match(FIREBASE_STORAGE_URL)
+  if (!match) return null
+  const [, base, encodedPath] = match
+
+  let objectPath: string
+  try {
+    objectPath = decodeURIComponent(encodedPath)
+  } catch {
+    return null // malformed percent-encoding
+  }
+
+  // Split dir / filename / extension so the variant sits beside the original
+  // with the extension swapped, matching the extension's naming:
+  //   recipeImages/photo.jpg  ->  recipeImages/photo_400x400.webp
+  const slash = objectPath.lastIndexOf('/')
+  const dir = slash === -1 ? '' : objectPath.slice(0, slash + 1)
+  const file = slash === -1 ? objectPath : objectPath.slice(slash + 1)
+  const dot = file.lastIndexOf('.')
+  const stem = dot === -1 ? file : file.slice(0, dot)
+  if (!stem) return null // dotfile with no stem, e.g. ".jpg"
+
+  const variantPath = `${dir}${stem}_${width}x${width}.${VARIANT_EXTENSION}`
+  return `${base}${encodeURIComponent(variantPath)}?alt=media`
+}
+
+/**
+ * A `srcset` string over all width variants for a stored original URL, or
+ * `undefined` when variants are disabled or the URL yields none — so it drops
+ * straight onto `<img srcSet={...}>` (undefined omits the attribute).
+ */
+export function recipeImageSrcSet(
+  url: string | undefined | null
+): string | undefined {
+  if (!IMAGE_VARIANTS_ENABLED) return undefined
+  const set = RECIPE_IMAGE_VARIANT_WIDTHS.map(w => {
+    const variant = recipeImageVariantUrl(url, w)
+    return variant ? `${variant} ${w}w` : null
+  }).filter((v): v is string => v !== null)
+  return set.length ? set.join(', ') : undefined
+}


### PR DESCRIPTION
Wave-4 lane **I1** — serve right-sized WebP variants for the browse-grid card and the single-recipe hero (the main mobile-LCP lever) instead of the full-resolution original. Owner-chosen approach: the **Firebase Resize Images extension**.

## Two halves

**A — generate variants (owner-gated install).** `firebase.json` + `extensions/storage-resize-images.env` pin `firebase/storage-resize-images@0.3.5`, configured for 400/800/1600 WebP variants beside each original under `recipeImages/`:
- `INCLUDE_PATH_LIST=/recipeImages` scopes it to recipe photos (profile photos untouched).
- Same-directory output keeps variants a single path segment under `recipeImages/`, so the existing `allow read: if true` rule covers them — **no `storage.rules` change**.
- Original kept (`DELETE_ORIGINAL_FILE=false`) as the fallback source.
- `docs/IMAGE_PIPELINE.md` is the install + backfill + flag-flip runbook, including the one owner **VERIFY** step (confirm the variant filename matches the helper) and the mixed-bucket caveat.

**B — consume variants (this PR's runtime change).**
- `src/util/recipeImageVariants.ts` derives **token-less** variant URLs from the stored original, **bucket-agnostic** (the catalog spans more than one Storage bucket). Token-less reads are authorized by the existing public-read rule — verified `200` — sidestepping the per-variant download-token problem.
- `RecipeCard` + `SingleRecipe` hero emit `srcset`/`sizes`, each with an `onError` fallback to the original so a missing variant never renders broken.

## Safe to merge before the install

1. **`VITE_IMAGE_VARIANTS_ENABLED`** gates srcset emission (default **off** ⇒ zero behaviour change, no variant requests). The frontend merges ahead of the Blaze-gated extension install; the owner flips it on after install + backfill.
2. **`onError` fallback** covers legacy/un-backfilled images and the brief post-upload window.

## Verification

- **Gates:** `tsc` clean · Vitest **577 pass / 2 skip** (+9 new helper tests) · `build` clean.
- **Runtime (headless Chrome vs the running app):**
  - flag **off** → no `srcset`, **0** variant requests, all images load (identical to pre-I1).
  - flag **on** → `srcset` emitted (**11** variant requests), variants `404` (well-formed, token-less, correct bucket — confirmed via `curl`), `onError` falls back so **every image still loads** (no broken images).
- Happy-path rendering (variants present) is the owner's post-install VERIFY step in the runbook.

Also closes **C3**'s deferred hero `srcset`. Pairs with **I2** (see runbook note).

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK