### PR TITLE
R1: refactor the create-recipe page (useRecipeForm + FormField) + C1 cluster

### DIFF
--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -16,8 +16,7 @@ import MealTypeSelector from 'src/pages/AddRecipe/MealTypeSelector/MealTypeSelec
 import DietSelector from 'src/pages/AddRecipe/DietSelector/DietSelector'
 import { TITLE_MAX_LENGTH, DESCRIPTION_MAX_LENGTH } from 'src/util/recipeLimits'
 import styles from 'src/_exports.module.scss'
-import AddRecipeFormError from 'src/pages/AddRecipe/AddRecipeFormError'
-import SectionHeader from 'src/pages/AddRecipe/SectionHeader'
+import FormField from 'src/pages/AddRecipe/FormField'
 import AddRecipeSummaryBar from 'src/pages/AddRecipe/AddRecipeSummaryBar'
 import { Helmet } from 'react-helmet-async'
 import DraftSaveStatus from 'src/pages/AddRecipe/DraftSaveStatus'
@@ -101,11 +100,13 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
         {!isEditMode && !draftId && <DraftResumeBanner />}
         <div className='container'>
           <div className='container-inner' ref={addRecipeFormRef}>
-            <div className='title input-field'>
-              <SectionHeader label='Title' required />
-              {errors.title && (
-                <AddRecipeFormError error={errors.title} id='error-title' />
-              )}
+            <FormField
+              className='title'
+              label='Title'
+              required
+              error={errors.title}
+              errorId='error-title'
+            >
               <FormInput
                 size='compact'
                 placeholder='Add a title to your recipe.'
@@ -115,12 +116,14 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
                 invalid={!!errors.title}
                 describedBy={errors.title ? 'error-title' : undefined}
               />
-            </div>
-            <div className='image-picker input-field'>
-              <SectionHeader label='Select Image' required />
-              {errors.image && (
-                <AddRecipeFormError error={errors.image} id='error-image' />
-              )}
+            </FormField>
+            <FormField
+              className='image-picker'
+              label='Select Image'
+              required
+              error={errors.image}
+              errorId='error-image'
+            >
               {resumedFromDraft && !recipeImage && (
                 <p className='draft-image-hint'>
                   <InfoIcon className='icon' />
@@ -133,15 +136,14 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
                 initialPreviewUrl={existingImageUrl}
                 onRemove={() => setExistingImageUrl(undefined)}
               />
-            </div>
-            <div className='description input-field'>
-              <SectionHeader label='Description' required />
-              {errors.description && (
-                <AddRecipeFormError
-                  error={errors.description}
-                  id='error-description'
-                />
-              )}
+            </FormField>
+            <FormField
+              className='description'
+              label='Description'
+              required
+              error={errors.description}
+              errorId='error-description'
+            >
               <RecipeFormTextArea
                 placeholder='Add a description to your recipe'
                 val={description}
@@ -150,85 +152,86 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
                 invalid={!!errors.description}
                 describedBy={errors.description ? 'error-description' : undefined}
               />
-            </div>
-            <div className='servings input-field'>
-              <SectionHeader label='Servings' required />
-              {errors.servings && (
-                <AddRecipeFormError error={errors.servings} id='error-servings' />
-              )}
+            </FormField>
+            <FormField
+              className='servings'
+              label='Servings'
+              required
+              error={errors.servings}
+              errorId='error-servings'
+            >
               <ServingsInput
                 servings={servings}
                 setServings={setServings}
                 invalid={!!errors.servings}
                 describedBy={errors.servings ? 'error-servings' : undefined}
               />
-            </div>
-            <div className='prep-time input-field'>
-              <SectionHeader label='Prep Time' required />
-              {errors.prepTime && (
-                <AddRecipeFormError error={errors.prepTime} id='error-prepTime' />
-              )}
+            </FormField>
+            <FormField
+              className='prep-time'
+              label='Prep Time'
+              required
+              error={errors.prepTime}
+              errorId='error-prepTime'
+            >
               <TimeInput
                 label={'How long will your recipe take to prepare?'}
                 val={prepTime}
                 setVal={setPrepTime}
               />
-            </div>
-            <div className='cook-time input-field'>
-              <SectionHeader label='Cook Time' />
+            </FormField>
+            <FormField className='cook-time' label='Cook Time'>
               <TimeInput
                 label={'How long will your recipe take to cook?'}
                 val={cookTime}
                 setVal={setCookTime}
               />
-            </div>
-            <div className='ingredients input-field'>
-              <SectionHeader label='Ingredients' required />
-              {errors.ingredients && (
-                <AddRecipeFormError
-                  error={errors.ingredients}
-                  id='error-ingredients'
-                />
-              )}
+            </FormField>
+            <FormField
+              className='ingredients'
+              label='Ingredients'
+              required
+              error={errors.ingredients}
+              errorId='error-ingredients'
+            >
               <IngredientsContainer
                 ingredients={ingredients}
                 setIngredients={setIngredients}
               />
-            </div>
-            <div className='instructions input-field'>
-              <SectionHeader label='Instructions' required />
-              {errors.instructions && (
-                <AddRecipeFormError
-                  error={errors.instructions}
-                  id='error-instructions'
-                />
-              )}
+            </FormField>
+            <FormField
+              className='instructions'
+              label='Instructions'
+              required
+              error={errors.instructions}
+              errorId='error-instructions'
+            >
               <InstructionsContainer
                 instructions={instructions}
                 setInstructions={setInstructions}
               />
-            </div>
-            <div className='cuisine input-field'>
-              <SectionHeader label='Cuisine' />
+            </FormField>
+            <FormField className='cuisine' label='Cuisine'>
               <CuisineSelector cuisine={cuisine} setCuisine={setCuisine} />
-            </div>
-            <div className='course input-field'>
-              <SectionHeader label='Course' required />
-              {errors.mealType && (
-                <AddRecipeFormError error={errors.mealType} id='error-mealType' />
-              )}
+            </FormField>
+            <FormField
+              className='course'
+              label='Course'
+              required
+              error={errors.mealType}
+              errorId='error-mealType'
+            >
               <MealTypeSelector
                 mealTypes={mealTypes}
                 setMealTypes={setMealTypes}
               />
-            </div>
-            <div className='diet input-field'>
-              <SectionHeader label='Diet' />
+            </FormField>
+            <FormField className='diet' label='Diet'>
               <DietSelector
                 nutritionLabels={nutritionLabels}
                 setNutritionLabels={setNutritionLabels}
               />
-            </div>
+            </FormField>
           </div>
         </div>
         <AddRecipeSummaryBar

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -27,13 +27,11 @@ import MealTypeSelector from 'src/pages/AddRecipe/MealTypeSelector/MealTypeSelec
 import DietSelector from 'src/pages/AddRecipe/DietSelector/DietSelector'
 import { hrMinToMin } from 'src/util/hrMinToMin'
 import { minToHrMin } from 'src/util/minToHrMin'
+import { TITLE_MAX_LENGTH, DESCRIPTION_MAX_LENGTH } from 'src/util/recipeLimits'
 import {
-  TITLE_MAX_LENGTH,
-  DESCRIPTION_MAX_LENGTH,
-  INSTRUCTION_MAX_LENGTH,
-  MAX_INGREDIENTS,
-  MAX_INSTRUCTIONS,
-} from 'src/util/recipeLimits'
+  validateRecipeForm,
+  isRecipeFormValid,
+} from 'src/pages/AddRecipe/recipeFormValidation'
 import RecipeAPI from 'src/api/recipes'
 import styles from 'src/_exports.module.scss'
 import AddRecipeFormError from 'src/pages/AddRecipe/AddRecipeFormError'
@@ -265,38 +263,19 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
   }, [draftId])
 
   const validate = (assignErrors: boolean = false) => {
-    let newErrors: Partial<AddRecipeErrorType> = {}
-
-    if (!title) {
-      newErrors.title = 'Title is required'
-    } else if (title.length > TITLE_MAX_LENGTH) {
-      newErrors.title = `Title cannot exceed ${TITLE_MAX_LENGTH} characters`
-    }
-
-    // In edit mode a recipe with no newly-picked file is still valid as long as
-    // it has its existing stored image.
-    if (!recipeImage && !existingImageUrl) newErrors.image = 'Image is required'
-    if (!description) {
-      newErrors.description = 'Description is required'
-    } else if (description.length > DESCRIPTION_MAX_LENGTH) {
-      newErrors.description = `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`
-    }
-    if (!servings) newErrors.servings = 'Servings amount is required'
-    if (!prepTime) newErrors.prepTime = 'Prep time is required'
-    if (ingredients.length <= 0) {
-      newErrors.ingredients = 'Recipe must contain ingredients'
-    } else if (ingredients.length > MAX_INGREDIENTS) {
-      newErrors.ingredients = `A recipe cannot have more than ${MAX_INGREDIENTS} ingredients`
-    }
-    if (instructions.length <= 0) {
-      newErrors.instructions = 'Instructions are required'
-    } else if (instructions.length > MAX_INSTRUCTIONS) {
-      newErrors.instructions = `A recipe cannot have more than ${MAX_INSTRUCTIONS} instructions`
-    }
-    if (mealTypes.length <= 0) newErrors.mealType = 'Meal type required'
-
+    const newErrors = validateRecipeForm({
+      title,
+      recipeImage,
+      existingImageUrl,
+      description,
+      servings,
+      prepTime,
+      ingredients,
+      instructions,
+      mealTypes,
+    })
     assignErrors && setErrors(newErrors)
-    return Object.keys(newErrors).length === 0
+    return isRecipeFormValid(newErrors)
   }
   useEffect(() => {
     // Once the user has attempted a submit, keep the displayed errors in sync as

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -86,6 +86,9 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
           name='description'
           content='Create your own healthy recipe on Prepify'
         />
+        {/* The create/edit form is an authted app page, never something to
+            index — matches the noindex on Account/Settings/CreateUsername. */}
+        <meta name='robots' content='noindex' />
       </Helmet>
       <div className='add-recipe-page page'>
         <LoadingBar

--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -1,18 +1,7 @@
 import { InfoIcon } from 'src/Components/icons'
-import React, { FC, useEffect, useMemo, useRef, useState } from 'react'
-import axios from 'axios'
-import { useNavigate, useSearchParams } from 'react-router-dom'
-import { useQueryClient } from '@tanstack/react-query'
-import {
-  AddRecipeErrorType,
-  IngredientsType,
-  InstructionsType,
-  RecipeDraftContent,
-  RecipeDraftType,
-  RecipeEditFormType,
-  RecipeFormType,
-  RecipeType,
-} from 'types'
+import React, { FC } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { RecipeType } from 'types'
 import LoadingBar from 'react-top-loading-bar'
 import FormInput from 'src/Components/Form/FormInput'
 import ImagePicker from 'src/pages/AddRecipe/ImagePicker/ImagePicker'
@@ -25,355 +14,62 @@ import InstructionsContainer from 'src/pages/AddRecipe/Instructions/Instructions
 import CuisineSelector from 'src/pages/AddRecipe/CuisineSelector/CuisineSelector'
 import MealTypeSelector from 'src/pages/AddRecipe/MealTypeSelector/MealTypeSelector'
 import DietSelector from 'src/pages/AddRecipe/DietSelector/DietSelector'
-import { hrMinToMin } from 'src/util/hrMinToMin'
-import { minToHrMin } from 'src/util/minToHrMin'
 import { TITLE_MAX_LENGTH, DESCRIPTION_MAX_LENGTH } from 'src/util/recipeLimits'
-import {
-  validateRecipeForm,
-  isRecipeFormValid,
-} from 'src/pages/AddRecipe/recipeFormValidation'
-import RecipeAPI from 'src/api/recipes'
 import styles from 'src/_exports.module.scss'
 import AddRecipeFormError from 'src/pages/AddRecipe/AddRecipeFormError'
 import SectionHeader from 'src/pages/AddRecipe/SectionHeader'
 import AddRecipeSummaryBar from 'src/pages/AddRecipe/AddRecipeSummaryBar'
 import { Helmet } from 'react-helmet-async'
-import { toast } from 'react-hot-toast'
-import DraftAPI from 'src/api/drafts'
-import { useDraftAutosave } from 'src/pages/AddRecipe/useDraftAutosave'
 import DraftSaveStatus from 'src/pages/AddRecipe/DraftSaveStatus'
 import DraftResumeBanner from 'src/pages/AddRecipe/DraftResumeBanner'
-
-type TimeVal = { hours: number; minutes: number } | null
-
-// Same auth-expiry message on both the update and publish paths below.
-const SESSION_EXPIRED =
-  'Your session has expired — please sign in again and retry.'
-
-// Shown when a recipe saves but is held by automated moderation for an admin to
-// review before it appears publicly. Longer-lived than a normal toast (and not
-// styled as an error — nothing went wrong) so the owner doesn't miss it.
-const notifyPendingReview = () =>
-  toast(
-    'Your recipe was submitted and is pending review. It will appear publicly once approved.',
-    { icon: '⏳', duration: 7000 }
-  )
+import { useRecipeForm } from 'src/pages/AddRecipe/useRecipeForm'
 
 // When `initialRecipe` is supplied the form runs in edit mode: every field is
 // pre-populated from the existing recipe and submitting updates it (preserving
-// ratings/saves) instead of creating a new one.
+// ratings/saves) instead of creating a new one. All form state, validation,
+// draft autosave and submit orchestration live in useRecipeForm; this component
+// is the presentation layer.
 type AddRecipeProps = { initialRecipe?: RecipeType }
 
 const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
-  const isEditMode = !!initialRecipe
-
-  const [addRecipeLoading, setAddRecipeLoading] = useState(false)
-  const [loadingProgress, setLoadingProgress] = useState(0)
-  const addRecipeFormRef = useRef<HTMLDivElement>(null)
-  const [title, setTitle] = useState(initialRecipe?.title ?? '')
-  const [recipeImage, setRecipeImage] = useState<File | undefined>()
-  // Edit mode only: the recipe's current image URL, kept when the user doesn't
-  // pick a new file. Cleared if they remove the image (forcing a new pick).
-  const [existingImageUrl, setExistingImageUrl] = useState<string | undefined>(
-    initialRecipe?.recipeImage
-  )
-  const [description, setDescription] = useState(initialRecipe?.description ?? '')
-  const [servings, setServings] = useState<number | ''>(
-    initialRecipe?.servings ?? ''
-  )
-  const [prepTime, setPrepTime] = useState<TimeVal>(
-    initialRecipe ? minToHrMin(initialRecipe.prepTime) : null
-  )
-  const [cookTime, setCookTime] = useState<TimeVal>(
-    initialRecipe ? minToHrMin(initialRecipe.cookTime) : null
-  )
-  const [fridgeLife, setFridgeLife] = useState<number>(
-    initialRecipe?.fridgeLife ?? 0
-  )
-  const [freezerLife, setFreezerLife] = useState<number>(
-    initialRecipe?.freezerLife ?? 0
-  )
-  const [ingredients, setIngredients] = useState<IngredientsType[]>(
-    initialRecipe?.ingredients ?? []
-  )
-  const [instructions, setInstructions] = useState<InstructionsType[]>(
-    initialRecipe?.instructions ?? []
-  )
-  const [cuisine, setCuisine] = useState(initialRecipe?.cuisine ?? '')
-  const [mealTypes, setMealTypes] = useState<string[]>(
-    initialRecipe?.mealTypes ?? []
-  )
-  // Author-selected diet tags (optional). In edit mode this pre-fills from the
-  // recipe's existing nutritionLabels — including ones Edamam set on older
-  // recipes — so the author can keep or correct them.
-  const [nutritionLabels, setNutritionLabels] = useState<string[]>(
-    initialRecipe?.nutritionLabels ?? []
-  )
-  const [errors, setErrors] = useState<Partial<AddRecipeErrorType>>({})
-
-  const [isFormValid, setIsFormValid] = useState(false)
-  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
-
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
-
-  // ─── Draft autosave (create flow only) ──────────────────────────────────────
-  // Edit mode never touches drafts. In create mode the form is autosaved to a
-  // server-side draft so unfinished recipes survive a refresh or navigating
-  // away. The image is intentionally not part of a draft — it's re-picked on
-  // resume (publish validation still requires one).
-  const [searchParams, setSearchParams] = useSearchParams()
-  const urlDraftId = isEditMode ? null : searchParams.get('draftId')
-  const [draftId, setDraftId] = useState<string | null>(urlDraftId)
-  // "Hydrated" gates autosave: true for a fresh create, briefly false while a
-  // resumed draft loads into the fields.
-  const [hydrated, setHydrated] = useState(!urlDraftId)
-  // Draft ids whose content is already on screen — either just loaded here, or
-  // just created by autosave. The hydration effect skips these so our own URL
-  // updates (and a resume of the draft we're already editing) don't trigger a
-  // redundant reload.
-  const ownedDraftsRef = useRef<Set<string>>(new Set())
-  // True once a draft was resumed (loaded from the server) this session, used to
-  // remind the user to re-add the image — drafts don't persist it. Not set for
-  // drafts created in the current session (the user never had an image to lose).
-  const [resumedFromDraft, setResumedFromDraft] = useState(false)
-
-  // Load the draft named in the URL whenever it points at one we haven't loaded
-  // yet. Runs on mount for `?draftId=…`, and again when the resume banner
-  // navigates to a draft while this page is already mounted — same route, so no
-  // remount happens on its own and a mount-only effect would never re-fire.
-  useEffect(() => {
-    if (isEditMode || !urlDraftId || ownedDraftsRef.current.has(urlDraftId)) return
-    let cancelled = false
-    setHydrated(false)
-    DraftAPI.getDraft(urlDraftId)
-      .then(draft => {
-        if (cancelled) return
-        ownedDraftsRef.current.add(urlDraftId)
-        if (draft) {
-          setDraftId(urlDraftId)
-          setTitle(draft.title ?? '')
-          setDescription(draft.description ?? '')
-          setServings(draft.servings ?? '')
-          setPrepTime(draft.prepTime != null ? minToHrMin(draft.prepTime) : null)
-          setCookTime(draft.cookTime != null ? minToHrMin(draft.cookTime) : null)
-          setFridgeLife(draft.fridgeLife ?? 0)
-          setFreezerLife(draft.freezerLife ?? 0)
-          setIngredients(draft.ingredients ?? [])
-          setInstructions(draft.instructions ?? [])
-          setCuisine(draft.cuisine ?? '')
-          setMealTypes(draft.mealTypes ?? [])
-          setNutritionLabels(draft.nutritionLabels ?? [])
-          setResumedFromDraft(true)
-        }
-        setHydrated(true)
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return
-        const status = axios.isAxiosError(err) ? err.response?.status : undefined
-        if (status === 404 || status === 403) {
-          // The draft is genuinely gone or not the caller's. Drop only the
-          // draftId param (preserving any other query params) and let the user
-          // start a fresh draft.
-          toast.error("Couldn't load that draft — starting a new one.")
-          setDraftId(null)
-          const next = new URLSearchParams(searchParams)
-          next.delete('draftId')
-          setSearchParams(next, { replace: true })
-          setHydrated(true)
-        } else {
-          // Transient failure (network/5xx) on a draft that likely still
-          // exists. Leave autosave disabled (hydrated stays false) so we don't
-          // create a duplicate or overwrite the unloaded draft with a partial
-          // form; ask the user to retry.
-          toast.error('Could not load your draft. Refresh to try again.')
-        }
-      })
-    return () => {
-      cancelled = true
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [urlDraftId])
-
-  // Serializable draft content mirrored from form state. Times are stored as
-  // minutes (matching the recipe shape); empty values are omitted.
-  const draftContent: RecipeDraftContent = useMemo(
-    () => ({
-      title,
-      description,
-      // Send explicit null (not undefined) when empty so clearing a field is
-      // persisted rather than silently dropped from the payload — see
-      // RecipeDraftContent.
-      servings: servings === '' ? null : Number(servings),
-      prepTime: prepTime ? hrMinToMin(prepTime) : null,
-      cookTime: cookTime ? hrMinToMin(cookTime) : null,
-      fridgeLife,
-      freezerLife,
-      ingredients,
-      instructions,
-      cuisine,
-      mealTypes,
-      nutritionLabels,
-    }),
-    [
-      title,
-      description,
-      servings,
-      prepTime,
-      cookTime,
-      fridgeLife,
-      freezerLife,
-      ingredients,
-      instructions,
-      cuisine,
-      mealTypes,
-      nutritionLabels,
-    ]
-  )
-
-  // A brand-new draft is only created once the recipe has a title. This gates
-  // out throwaway drafts from a stray keystroke (keeping the Drafts list and the
-  // per-user draft count clean); updating an existing draft is unaffected.
-  const canCreateDraft = !!title.trim()
-
-  const { status: draftStatus, clearDraft } = useDraftAutosave({
-    content: draftContent,
-    enabled: !isEditMode && hydrated,
-    canCreate: canCreateDraft,
-    draftId,
-    onDraftCreated: (draft: RecipeDraftType) => {
-      // Mark as owned before the URL sync below points the URL at it, so the
-      // hydration effect doesn't reload the draft we just created.
-      ownedDraftsRef.current.add(draft._id)
-      setDraftId(draft._id)
-      queryClient.invalidateQueries({ queryKey: ['drafts'] })
-    },
-    onLimitReached: (message: string) => toast.error(message),
-  })
-
-  // Reflect the active draft id in the URL (replace) so a refresh resumes the
-  // same draft rather than starting a second one.
-  useEffect(() => {
-    if (isEditMode || !draftId) return
-    if (searchParams.get('draftId') === draftId) return
-    const next = new URLSearchParams(searchParams)
-    next.set('draftId', draftId)
-    setSearchParams(next, { replace: true })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [draftId])
-
-  const validate = (assignErrors: boolean = false) => {
-    const newErrors = validateRecipeForm({
-      title,
-      recipeImage,
-      existingImageUrl,
-      description,
-      servings,
-      prepTime,
-      ingredients,
-      instructions,
-      mealTypes,
-    })
-    assignErrors && setErrors(newErrors)
-    return isRecipeFormValid(newErrors)
-  }
-  useEffect(() => {
-    // Once the user has attempted a submit, keep the displayed errors in sync as
-    // fields are fixed (assignErrors=true) so a corrected field clears its message
-    // immediately instead of lingering until the next submit click. Before the
-    // first attempt we only compute validity, never surface errors.
-    if (validate(hasAttemptedSubmit)) setIsFormValid(true)
-    else setIsFormValid(false)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
+  const {
+    isEditMode,
     title,
     recipeImage,
     existingImageUrl,
     description,
     servings,
     prepTime,
+    cookTime,
     ingredients,
     instructions,
+    cuisine,
     mealTypes,
-    hasAttemptedSubmit,
-  ])
-  const handleSubmit = async () => {
-    if (addRecipeLoading) return
-    setHasAttemptedSubmit(true)
-    if (!validate(true)) {
-      addRecipeFormRef?.current && addRecipeFormRef.current.scrollTo(0, 0)
-      return
-    }
-
-    setAddRecipeLoading(true)
-    // Shared form-state → payload mapping; the two branches differ only in the
-    // image field (optional on edit, required on create) and which API they call.
-    const formData = {
-      title,
-      prepTime: hrMinToMin(prepTime),
-      cookTime: hrMinToMin(cookTime),
-      servings: Number(servings),
-      fridgeLife,
-      freezerLife,
-      description,
-      ingredients,
-      instructions,
-      cuisine,
-      mealTypes,
-      nutritionLabels,
-    }
-    if (isEditMode && initialRecipe) {
-      const editData: RecipeEditFormType = { ...formData, recipeImage }
-      const result = await RecipeAPI.editRecipe(
-        initialRecipe._id,
-        editData,
-        initialRecipe,
-        setLoadingProgress
-      )
-      if (result.status === 'auth-error') {
-        toast.error(SESSION_EXPIRED)
-      } else if (result.status === 'success') {
-        // Write the server's updated recipe straight into the cache rather than
-        // invalidating: invalidation would refetch GET /getRecipe (which bumps
-        // the public view counter) and briefly flash stale data. The created
-        // list still needs a refetch to reorder/relabel.
-        queryClient.setQueryData(['recipe', initialRecipe._id], result.recipe)
-        queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
-        // A medium-confidence moderation hold saves the edit but withholds it from
-        // public reads until an admin clears it; tell the owner instead of the
-        // usual "updated" so a silently-hidden recipe isn't a surprise.
-        if (result.recipe.status === 'pending_review') {
-          notifyPendingReview()
-        } else {
-          toast.success('Recipe updated.')
-        }
-        navigate(`/recipes/${initialRecipe._id}`)
-      } else {
-        toast.error(result.message)
-      }
-    } else {
-      const recipeData: RecipeFormType = { ...formData, recipeImage: recipeImage! }
-      const result = await RecipeAPI.addRecipe(recipeData, setLoadingProgress)
-      if (result.status === 'auth-error') {
-        toast.error(SESSION_EXPIRED)
-      } else if (result.status === 'success') {
-        // Recipe is saved — remove the now-redundant draft (and stop autosave
-        // from recreating it on unmount) before navigating away.
-        await clearDraft()
-        queryClient.invalidateQueries({ queryKey: ['drafts'] })
-        if (result.pendingReview) {
-          notifyPendingReview()
-        } else {
-          toast.success('Recipe published.')
-        }
-        navigate(`/recipes/${result.id}`)
-      } else {
-        toast.error(result.message)
-      }
-    }
-    setAddRecipeLoading(false)
-    setLoadingProgress(100)
-  }
+    nutritionLabels,
+    setTitle,
+    setRecipeImage,
+    setExistingImageUrl,
+    setDescription,
+    setServings,
+    setPrepTime,
+    setCookTime,
+    setIngredients,
+    setInstructions,
+    setCuisine,
+    setMealTypes,
+    setNutritionLabels,
+    errors,
+    isFormValid,
+    addRecipeLoading,
+    loadingProgress,
+    setLoadingProgress,
+    draftStatus,
+    draftId,
+    resumedFromDraft,
+    addRecipeFormRef,
+    handleSubmit,
+  } = useRecipeForm(initialRecipe)
 
   return (
     <>

--- a/src/pages/AddRecipe/FormField.tsx
+++ b/src/pages/AddRecipe/FormField.tsx
@@ -1,0 +1,37 @@
+import React, { FC, ReactNode } from 'react'
+import SectionHeader from 'src/pages/AddRecipe/SectionHeader'
+import AddRecipeFormError from 'src/pages/AddRecipe/AddRecipeFormError'
+
+type FormFieldProps = {
+  // Section-specific wrapper class (e.g. 'title', 'image-picker'); the shared
+  // 'input-field' class is always appended so layout/spacing stays uniform.
+  className: string
+  label: string
+  required?: boolean
+  // When set, the field's error message is rendered (as an announced alert)
+  // between the header and the control, linked to the input via `errorId`.
+  error?: string
+  errorId?: string
+  children: ReactNode
+}
+
+// One create-recipe form row: an orange section header + an optional inline
+// error + the field's control. Collapses the header/error/wrapper boilerplate
+// that every field in AddRecipe repeated verbatim; markup is identical to the
+// former inline blocks so CSS and the field tests are unaffected.
+const FormField: FC<FormFieldProps> = ({
+  className,
+  label,
+  required = false,
+  error,
+  errorId,
+  children,
+}) => (
+  <div className={`${className} input-field`}>
+    <SectionHeader label={label} required={required} />
+    {error && <AddRecipeFormError error={error} id={errorId} />}
+    {children}
+  </div>
+)
+
+export default FormField

--- a/src/pages/AddRecipe/TimeInput/TimeInput.tsx
+++ b/src/pages/AddRecipe/TimeInput/TimeInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import FormInput from 'src/Components/Form/FormInput'
 import './TimeInput.scss'
 
@@ -19,6 +19,11 @@ interface TimeInputProps {
 const TimeInput: React.FC<TimeInputProps> = ({ label, val, setVal }) => {
   const [minutes, setMinutes] = useState<number | ''>('')
   const [hours, setHours] = useState<number | ''>('')
+  // True once the user has typed in either field. Distinguishes a genuine
+  // clear-both-fields (which must propagate null to the parent) from the initial
+  // pre-hydration render — where both fields are also empty, but the parent still
+  // holds the value we're about to load in, so clearing then would wipe it.
+  const hasUserEdited = useRef(false)
 
   useEffect(() => {
     // Hydrate from the parent's { hours, minutes } value (edit / draft-resume).
@@ -43,6 +48,7 @@ const TimeInput: React.FC<TimeInputProps> = ({ label, val, setVal }) => {
         inputVal >= 0 &&
         inputVal <= 99)
     ) {
+      hasUserEdited.current = true
       setHours(inputVal)
     }
   }
@@ -54,12 +60,22 @@ const TimeInput: React.FC<TimeInputProps> = ({ label, val, setVal }) => {
         inputVal >= 0 &&
         inputVal <= 59)
     ) {
+      hasUserEdited.current = true
       setMinutes(inputVal)
     }
   }
 
   useEffect(() => {
-    if (minutes || hours) setVal({ hours: hours || 0, minutes: minutes || 0 })
+    if (minutes || hours) {
+      setVal({ hours: hours || 0, minutes: minutes || 0 })
+    } else if (hasUserEdited.current) {
+      // Both fields cleared by the user: propagate the cleared state so the
+      // parent drops the stale pre-clear time instead of silently keeping it
+      // (previously this branch never fired — `if (minutes || hours)` skipped the
+      // all-empty case — so clearing a time on edit left the old value in place
+      // and the required-field guard still passed against it).
+      setVal(null)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [minutes, hours])
 

--- a/src/pages/AddRecipe/recipeFormValidation.ts
+++ b/src/pages/AddRecipe/recipeFormValidation.ts
@@ -1,0 +1,78 @@
+import { AddRecipeErrorType, IngredientsType, InstructionsType } from 'types'
+import {
+  TITLE_MAX_LENGTH,
+  DESCRIPTION_MAX_LENGTH,
+  MAX_INGREDIENTS,
+  MAX_INSTRUCTIONS,
+} from 'src/util/recipeLimits'
+
+export type TimeVal = { hours: number; minutes: number } | null
+
+export type RecipeFormErrors = Partial<AddRecipeErrorType>
+
+// The slice of the recipe-form state the validator reads. A structural subset of
+// the full form state (see useRecipeForm) so this module carries no dependency on
+// the hook — the hook's state is assignable to this shape.
+export type ValidatableRecipeForm = {
+  title: string
+  recipeImage: File | undefined
+  // Edit mode: a recipe with no newly-picked file is still valid if it kept its
+  // existing stored image.
+  existingImageUrl: string | undefined
+  description: string
+  servings: number | ''
+  prepTime: TimeVal
+  ingredients: IngredientsType[]
+  instructions: InstructionsType[]
+  mealTypes: string[]
+}
+
+// Pure validation: derive the field-error map from the current form values.
+// Extracted from AddRecipe so both the live "keep errors in sync as fields are
+// fixed" effect and unit tests can share one source of truth. Behaviour is
+// identical to the former in-component validate() — same messages, same rules
+// (cook time, cuisine and diet stay optional and are intentionally absent here).
+export function validateRecipeForm(
+  form: ValidatableRecipeForm
+): RecipeFormErrors {
+  const errors: RecipeFormErrors = {}
+
+  if (!form.title) {
+    errors.title = 'Title is required'
+  } else if (form.title.length > TITLE_MAX_LENGTH) {
+    errors.title = `Title cannot exceed ${TITLE_MAX_LENGTH} characters`
+  }
+
+  if (!form.recipeImage && !form.existingImageUrl) {
+    errors.image = 'Image is required'
+  }
+
+  if (!form.description) {
+    errors.description = 'Description is required'
+  } else if (form.description.length > DESCRIPTION_MAX_LENGTH) {
+    errors.description = `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`
+  }
+
+  if (!form.servings) errors.servings = 'Servings amount is required'
+  if (!form.prepTime) errors.prepTime = 'Prep time is required'
+
+  if (form.ingredients.length <= 0) {
+    errors.ingredients = 'Recipe must contain ingredients'
+  } else if (form.ingredients.length > MAX_INGREDIENTS) {
+    errors.ingredients = `A recipe cannot have more than ${MAX_INGREDIENTS} ingredients`
+  }
+
+  if (form.instructions.length <= 0) {
+    errors.instructions = 'Instructions are required'
+  } else if (form.instructions.length > MAX_INSTRUCTIONS) {
+    errors.instructions = `A recipe cannot have more than ${MAX_INSTRUCTIONS} instructions`
+  }
+
+  if (form.mealTypes.length <= 0) errors.mealType = 'Meal type required'
+
+  return errors
+}
+
+// The form is submittable when no field produced an error.
+export const isRecipeFormValid = (errors: RecipeFormErrors): boolean =>
+  Object.keys(errors).length === 0

--- a/src/pages/AddRecipe/useRecipeForm.ts
+++ b/src/pages/AddRecipe/useRecipeForm.ts
@@ -1,0 +1,498 @@
+import React, {
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
+import axios from 'axios'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'react-hot-toast'
+import {
+  AddRecipeErrorType,
+  IngredientsType,
+  InstructionsType,
+  RecipeDraftContent,
+  RecipeDraftType,
+  RecipeEditFormType,
+  RecipeFormType,
+  RecipeType,
+} from 'types'
+import { hrMinToMin } from 'src/util/hrMinToMin'
+import { minToHrMin } from 'src/util/minToHrMin'
+import RecipeAPI from 'src/api/recipes'
+import DraftAPI from 'src/api/drafts'
+import { useDraftAutosave, DraftStatus } from 'src/pages/AddRecipe/useDraftAutosave'
+import {
+  validateRecipeForm,
+  isRecipeFormValid,
+  TimeVal,
+} from 'src/pages/AddRecipe/recipeFormValidation'
+
+export type { TimeVal }
+
+// Same auth-expiry message on both the update and publish paths below.
+const SESSION_EXPIRED =
+  'Your session has expired — please sign in again and retry.'
+
+// Shown when a recipe saves but is held by automated moderation for an admin to
+// review before it appears publicly. Longer-lived than a normal toast (and not
+// styled as an error — nothing went wrong) so the owner doesn't miss it.
+const notifyPendingReview = () =>
+  toast(
+    'Your recipe was submitted and is pending review. It will appear publicly once approved.',
+    { icon: '⏳', duration: 7000 }
+  )
+
+// ─── Form-field state (useReducer) ──────────────────────────────────────────
+// The recipe payload the user is building. Ancillary UI/status state (loading,
+// errors, draft bookkeeping) stays as useState below — the reducer owns only the
+// fields that make up the recipe/draft body.
+export type RecipeFormState = {
+  title: string
+  recipeImage: File | undefined
+  // Edit mode only: the recipe's current image URL, kept when the user doesn't
+  // pick a new file. Cleared if they remove the image (forcing a new pick).
+  existingImageUrl: string | undefined
+  description: string
+  servings: number | ''
+  prepTime: TimeVal
+  cookTime: TimeVal
+  fridgeLife: number
+  freezerLife: number
+  ingredients: IngredientsType[]
+  instructions: InstructionsType[]
+  cuisine: string
+  mealTypes: string[]
+  nutritionLabels: string[]
+}
+
+type SetFieldAction = {
+  [K in keyof RecipeFormState]: {
+    type: 'SET_FIELD'
+    key: K
+    value: React.SetStateAction<RecipeFormState[K]>
+  }
+}[keyof RecipeFormState]
+
+type RecipeFormAction =
+  | SetFieldAction
+  | { type: 'HYDRATE'; values: Partial<RecipeFormState> }
+
+function recipeFormReducer(
+  state: RecipeFormState,
+  action: RecipeFormAction
+): RecipeFormState {
+  switch (action.type) {
+    case 'SET_FIELD': {
+      const key = action.key
+      const prev = state[key]
+      // Support both a direct value and the useState-style updater function, so
+      // child setters keep their React.Dispatch<SetStateAction<T>> contract
+      // (IngredientsContainer/InstructionsContainer rely on functional updates).
+      const next =
+        typeof action.value === 'function'
+          ? (
+              action.value as (
+                p: RecipeFormState[typeof key]
+              ) => RecipeFormState[typeof key]
+            )(prev)
+          : action.value
+      return { ...state, [key]: next }
+    }
+    case 'HYDRATE':
+      return { ...state, ...action.values }
+    default:
+      return state
+  }
+}
+
+function initFormState(initialRecipe?: RecipeType): RecipeFormState {
+  return {
+    title: initialRecipe?.title ?? '',
+    recipeImage: undefined,
+    existingImageUrl: initialRecipe?.recipeImage,
+    description: initialRecipe?.description ?? '',
+    servings: initialRecipe?.servings ?? '',
+    prepTime: initialRecipe ? minToHrMin(initialRecipe.prepTime) : null,
+    cookTime: initialRecipe ? minToHrMin(initialRecipe.cookTime) : null,
+    fridgeLife: initialRecipe?.fridgeLife ?? 0,
+    freezerLife: initialRecipe?.freezerLife ?? 0,
+    ingredients: initialRecipe?.ingredients ?? [],
+    instructions: initialRecipe?.instructions ?? [],
+    cuisine: initialRecipe?.cuisine ?? '',
+    mealTypes: initialRecipe?.mealTypes ?? [],
+    // Author-selected diet tags (optional). In edit mode this pre-fills from the
+    // recipe's existing nutritionLabels — including ones Edamam set on older
+    // recipes — so the author can keep or correct them.
+    nutritionLabels: initialRecipe?.nutritionLabels ?? [],
+  }
+}
+
+// When `initialRecipe` is supplied the form runs in edit mode: every field is
+// pre-populated from the existing recipe and submitting updates it (preserving
+// ratings/saves) instead of creating a new one.
+export function useRecipeForm(initialRecipe?: RecipeType) {
+  const isEditMode = !!initialRecipe
+
+  const [state, dispatch] = useReducer(
+    recipeFormReducer,
+    initialRecipe,
+    initFormState
+  )
+  const {
+    title,
+    recipeImage,
+    existingImageUrl,
+    description,
+    servings,
+    prepTime,
+    cookTime,
+    fridgeLife,
+    freezerLife,
+    ingredients,
+    instructions,
+    cuisine,
+    mealTypes,
+    nutritionLabels,
+  } = state
+
+  // Stable per-field setters that preserve the useState dispatch contract, so
+  // child components (and their React.memo boundaries) see an unchanging setter
+  // reference. `dispatch` is stable, so these are built once.
+  const setters = useMemo(() => {
+    const make =
+      <K extends keyof RecipeFormState>(
+        key: K
+      ): React.Dispatch<React.SetStateAction<RecipeFormState[K]>> =>
+      value =>
+        dispatch({ type: 'SET_FIELD', key, value } as RecipeFormAction)
+    return {
+      setTitle: make('title'),
+      setRecipeImage: make('recipeImage'),
+      setExistingImageUrl: make('existingImageUrl'),
+      setDescription: make('description'),
+      setServings: make('servings'),
+      setPrepTime: make('prepTime'),
+      setCookTime: make('cookTime'),
+      setFridgeLife: make('fridgeLife'),
+      setFreezerLife: make('freezerLife'),
+      setIngredients: make('ingredients'),
+      setInstructions: make('instructions'),
+      setCuisine: make('cuisine'),
+      setMealTypes: make('mealTypes'),
+      setNutritionLabels: make('nutritionLabels'),
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const [addRecipeLoading, setAddRecipeLoading] = useState(false)
+  const [loadingProgress, setLoadingProgress] = useState(0)
+  const addRecipeFormRef = useRef<HTMLDivElement>(null)
+  const [errors, setErrors] = useState<Partial<AddRecipeErrorType>>({})
+  const [isFormValid, setIsFormValid] = useState(false)
+  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
+
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  // ─── Draft autosave (create flow only) ────────────────────────────────────
+  // Edit mode never touches drafts. In create mode the form is autosaved to a
+  // server-side draft so unfinished recipes survive a refresh or navigating
+  // away. The image is intentionally not part of a draft — it's re-picked on
+  // resume (publish validation still requires one).
+  const [searchParams, setSearchParams] = useSearchParams()
+  const urlDraftId = isEditMode ? null : searchParams.get('draftId')
+  const [draftId, setDraftId] = useState<string | null>(urlDraftId)
+  // "Hydrated" gates autosave: true for a fresh create, briefly false while a
+  // resumed draft loads into the fields.
+  const [hydrated, setHydrated] = useState(!urlDraftId)
+  // Draft ids whose content is already on screen — either just loaded here, or
+  // just created by autosave. The hydration effect skips these so our own URL
+  // updates (and a resume of the draft we're already editing) don't trigger a
+  // redundant reload.
+  const ownedDraftsRef = useRef<Set<string>>(new Set())
+  // True once a draft was resumed (loaded from the server) this session, used to
+  // remind the user to re-add the image — drafts don't persist it. Not set for
+  // drafts created in the current session (the user never had an image to lose).
+  const [resumedFromDraft, setResumedFromDraft] = useState(false)
+
+  // Load the draft named in the URL whenever it points at one we haven't loaded
+  // yet. Runs on mount for `?draftId=…`, and again when the resume banner
+  // navigates to a draft while this page is already mounted — same route, so no
+  // remount happens on its own and a mount-only effect would never re-fire.
+  useEffect(() => {
+    if (isEditMode || !urlDraftId || ownedDraftsRef.current.has(urlDraftId)) return
+    let cancelled = false
+    setHydrated(false)
+    DraftAPI.getDraft(urlDraftId)
+      .then(draft => {
+        if (cancelled) return
+        ownedDraftsRef.current.add(urlDraftId)
+        if (draft) {
+          setDraftId(urlDraftId)
+          dispatch({
+            type: 'HYDRATE',
+            values: {
+              title: draft.title ?? '',
+              description: draft.description ?? '',
+              servings: draft.servings ?? '',
+              prepTime: draft.prepTime != null ? minToHrMin(draft.prepTime) : null,
+              cookTime: draft.cookTime != null ? minToHrMin(draft.cookTime) : null,
+              fridgeLife: draft.fridgeLife ?? 0,
+              freezerLife: draft.freezerLife ?? 0,
+              ingredients: draft.ingredients ?? [],
+              instructions: draft.instructions ?? [],
+              cuisine: draft.cuisine ?? '',
+              mealTypes: draft.mealTypes ?? [],
+              nutritionLabels: draft.nutritionLabels ?? [],
+            },
+          })
+          setResumedFromDraft(true)
+        }
+        setHydrated(true)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        const status = axios.isAxiosError(err) ? err.response?.status : undefined
+        if (status === 404 || status === 403) {
+          // The draft is genuinely gone or not the caller's. Drop only the
+          // draftId param (preserving any other query params) and let the user
+          // start a fresh draft.
+          toast.error("Couldn't load that draft — starting a new one.")
+          setDraftId(null)
+          const next = new URLSearchParams(searchParams)
+          next.delete('draftId')
+          setSearchParams(next, { replace: true })
+          setHydrated(true)
+        } else {
+          // Transient failure (network/5xx) on a draft that likely still
+          // exists. Leave autosave disabled (hydrated stays false) so we don't
+          // create a duplicate or overwrite the unloaded draft with a partial
+          // form; ask the user to retry.
+          toast.error('Could not load your draft. Refresh to try again.')
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlDraftId])
+
+  // Serializable draft content mirrored from form state. Times are stored as
+  // minutes (matching the recipe shape); empty values are omitted.
+  const draftContent: RecipeDraftContent = useMemo(
+    () => ({
+      title,
+      description,
+      // Send explicit null (not undefined) when empty so clearing a field is
+      // persisted rather than silently dropped from the payload — see
+      // RecipeDraftContent.
+      servings: servings === '' ? null : Number(servings),
+      prepTime: prepTime ? hrMinToMin(prepTime) : null,
+      cookTime: cookTime ? hrMinToMin(cookTime) : null,
+      fridgeLife,
+      freezerLife,
+      ingredients,
+      instructions,
+      cuisine,
+      mealTypes,
+      nutritionLabels,
+    }),
+    [
+      title,
+      description,
+      servings,
+      prepTime,
+      cookTime,
+      fridgeLife,
+      freezerLife,
+      ingredients,
+      instructions,
+      cuisine,
+      mealTypes,
+      nutritionLabels,
+    ]
+  )
+
+  // A brand-new draft is only created once the recipe has a title. This gates
+  // out throwaway drafts from a stray keystroke (keeping the Drafts list and the
+  // per-user draft count clean); updating an existing draft is unaffected.
+  const canCreateDraft = !!title.trim()
+
+  const { status: draftStatus, clearDraft } = useDraftAutosave({
+    content: draftContent,
+    enabled: !isEditMode && hydrated,
+    canCreate: canCreateDraft,
+    draftId,
+    onDraftCreated: (draft: RecipeDraftType) => {
+      // Mark as owned before the URL sync below points the URL at it, so the
+      // hydration effect doesn't reload the draft we just created.
+      ownedDraftsRef.current.add(draft._id)
+      setDraftId(draft._id)
+      queryClient.invalidateQueries({ queryKey: ['drafts'] })
+    },
+    onLimitReached: (message: string) => toast.error(message),
+  })
+
+  // Reflect the active draft id in the URL (replace) so a refresh resumes the
+  // same draft rather than starting a second one.
+  useEffect(() => {
+    if (isEditMode || !draftId) return
+    if (searchParams.get('draftId') === draftId) return
+    const next = new URLSearchParams(searchParams)
+    next.set('draftId', draftId)
+    setSearchParams(next, { replace: true })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftId])
+
+  const validate = (assignErrors: boolean = false) => {
+    const newErrors = validateRecipeForm({
+      title,
+      recipeImage,
+      existingImageUrl,
+      description,
+      servings,
+      prepTime,
+      ingredients,
+      instructions,
+      mealTypes,
+    })
+    assignErrors && setErrors(newErrors)
+    return isRecipeFormValid(newErrors)
+  }
+  useEffect(() => {
+    // Once the user has attempted a submit, keep the displayed errors in sync as
+    // fields are fixed (assignErrors=true) so a corrected field clears its message
+    // immediately instead of lingering until the next submit click. Before the
+    // first attempt we only compute validity, never surface errors.
+    if (validate(hasAttemptedSubmit)) setIsFormValid(true)
+    else setIsFormValid(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    title,
+    recipeImage,
+    existingImageUrl,
+    description,
+    servings,
+    prepTime,
+    ingredients,
+    instructions,
+    mealTypes,
+    hasAttemptedSubmit,
+  ])
+
+  const handleSubmit = async () => {
+    if (addRecipeLoading) return
+    setHasAttemptedSubmit(true)
+    if (!validate(true)) {
+      addRecipeFormRef?.current && addRecipeFormRef.current.scrollTo(0, 0)
+      return
+    }
+
+    setAddRecipeLoading(true)
+    // Shared form-state → payload mapping; the two branches differ only in the
+    // image field (optional on edit, required on create) and which API they call.
+    const formData = {
+      title,
+      prepTime: hrMinToMin(prepTime),
+      cookTime: hrMinToMin(cookTime),
+      servings: Number(servings),
+      fridgeLife,
+      freezerLife,
+      description,
+      ingredients,
+      instructions,
+      cuisine,
+      mealTypes,
+      nutritionLabels,
+    }
+    if (isEditMode && initialRecipe) {
+      const editData: RecipeEditFormType = { ...formData, recipeImage }
+      const result = await RecipeAPI.editRecipe(
+        initialRecipe._id,
+        editData,
+        initialRecipe,
+        setLoadingProgress
+      )
+      if (result.status === 'auth-error') {
+        toast.error(SESSION_EXPIRED)
+      } else if (result.status === 'success') {
+        // Write the server's updated recipe straight into the cache rather than
+        // invalidating: invalidation would refetch GET /getRecipe (which bumps
+        // the public view counter) and briefly flash stale data. The created
+        // list still needs a refetch to reorder/relabel.
+        queryClient.setQueryData(['recipe', initialRecipe._id], result.recipe)
+        queryClient.invalidateQueries({ queryKey: ['created-recipes'] })
+        // A medium-confidence moderation hold saves the edit but withholds it from
+        // public reads until an admin clears it; tell the owner instead of the
+        // usual "updated" so a silently-hidden recipe isn't a surprise.
+        if (result.recipe.status === 'pending_review') {
+          notifyPendingReview()
+        } else {
+          toast.success('Recipe updated.')
+        }
+        navigate(`/recipes/${initialRecipe._id}`)
+      } else {
+        toast.error(result.message)
+      }
+    } else {
+      const recipeData: RecipeFormType = { ...formData, recipeImage: recipeImage! }
+      const result = await RecipeAPI.addRecipe(recipeData, setLoadingProgress)
+      if (result.status === 'auth-error') {
+        toast.error(SESSION_EXPIRED)
+      } else if (result.status === 'success') {
+        // Recipe is saved — remove the now-redundant draft (and stop autosave
+        // from recreating it on unmount) before navigating away.
+        await clearDraft()
+        queryClient.invalidateQueries({ queryKey: ['drafts'] })
+        if (result.pendingReview) {
+          notifyPendingReview()
+        } else {
+          toast.success('Recipe published.')
+        }
+        navigate(`/recipes/${result.id}`)
+      } else {
+        toast.error(result.message)
+      }
+    }
+    setAddRecipeLoading(false)
+    setLoadingProgress(100)
+  }
+
+  return {
+    isEditMode,
+    // field values
+    title,
+    recipeImage,
+    existingImageUrl,
+    description,
+    servings,
+    prepTime,
+    cookTime,
+    fridgeLife,
+    freezerLife,
+    ingredients,
+    instructions,
+    cuisine,
+    mealTypes,
+    nutritionLabels,
+    // setters
+    ...setters,
+    // status / derived
+    errors,
+    isFormValid,
+    addRecipeLoading,
+    loadingProgress,
+    setLoadingProgress,
+    draftStatus,
+    draftId,
+    resumedFromDraft,
+    addRecipeFormRef,
+    // handlers
+    handleSubmit,
+  }
+}
+
+export type { DraftStatus }

--- a/src/test/CuisineSelector.test.tsx
+++ b/src/test/CuisineSelector.test.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react'
+import { vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import CuisineSelector from 'src/pages/AddRecipe/CuisineSelector/CuisineSelector'
+
+// Swap the real react-select for a controllable double exposing the props
+// CuisineSelector wires up (single-select: `value` is one option or null), so the
+// test drives CuisineSelector's own value<->option mapping, not react-select.
+vi.mock('react-select', () => ({
+  default: ({ value, onChange, options, placeholder }: any) => (
+    <div>
+      <span data-testid='placeholder'>{placeholder}</span>
+      {/* The friendly label react-select would show for the current value. */}
+      <span data-testid='selected'>{value ? value.label : ''}</span>
+      {options.slice(0, 5).map((opt: any) => (
+        <button
+          key={opt.value}
+          data-testid={`opt-${opt.value}`}
+          // Single-select hands back exactly the chosen option.
+          onClick={() => onChange(opt, { action: 'select-option' })}
+        >
+          {opt.label}
+        </button>
+      ))}
+      <button
+        data-testid='clear'
+        onClick={() => onChange(null, { action: 'clear' })}
+      >
+        clear
+      </button>
+    </div>
+  ),
+}))
+
+// Stateful host: selections flow back through setCuisine and re-render value.
+const Harness = ({ initial = '' }: { initial?: string }) => {
+  const [cuisine, setCuisine] = useState(initial)
+  return (
+    <>
+      <span data-testid='cuisine'>{cuisine}</span>
+      <CuisineSelector cuisine={cuisine} setCuisine={setCuisine} />
+    </>
+  )
+}
+
+describe('CuisineSelector', () => {
+  it('renders the cuisine placeholder', () => {
+    render(<Harness />)
+    expect(screen.getByTestId('placeholder')).toHaveTextContent(
+      'Select a cuisine...'
+    )
+  })
+
+  it('pre-fills the option for an existing stored value (edit mode)', () => {
+    render(<Harness initial='American' />)
+    expect(screen.getByTestId('selected')).toHaveTextContent('American')
+  })
+
+  it('matches a stored value case-insensitively', () => {
+    // getCuisineByString lower-cases both sides, so a legacy 'american' still
+    // resolves to the 'American' option instead of showing nothing.
+    render(<Harness initial='american' />)
+    expect(screen.getByTestId('selected')).toHaveTextContent('American')
+  })
+
+  it('shows nothing for a stored value with no matching option', () => {
+    render(<Harness initial='Klingon' />)
+    expect(screen.getByTestId('selected')).toHaveTextContent('')
+  })
+
+  it('stores the selected option value', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    await user.click(screen.getByTestId('opt-African'))
+    expect(screen.getByTestId('cuisine')).toHaveTextContent('African')
+  })
+
+  it('resets to an empty string when cleared', async () => {
+    const user = userEvent.setup()
+    render(<Harness initial='American' />)
+    expect(screen.getByTestId('cuisine')).toHaveTextContent('American')
+    // The null branch of handleChange must yield '' (not crash / not undefined).
+    await user.click(screen.getByTestId('clear'))
+    expect(screen.getByTestId('cuisine')).toHaveTextContent('')
+  })
+})

--- a/src/test/MealTypeSelector.test.tsx
+++ b/src/test/MealTypeSelector.test.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react'
+import { vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MealTypeSelector from 'src/pages/AddRecipe/MealTypeSelector/MealTypeSelector'
+
+// Controllable react-select double (isMulti: `value` is an option array), so the
+// test exercises MealTypeSelector's own value<->option mapping rather than the
+// real widget.
+vi.mock('react-select', () => ({
+  default: ({ value, onChange, options, placeholder, 'aria-label': ariaLabel }: any) => (
+    <div>
+      <span data-testid='placeholder'>{placeholder}</span>
+      <span data-testid='aria-label'>{ariaLabel}</span>
+      <span data-testid='selected'>
+        {(value ?? []).map((o: any) => o.label).join(',')}
+      </span>
+      {options.map((opt: any) => (
+        <button
+          key={opt.value}
+          data-testid={`opt-${opt.value}`}
+          // isMulti: append the chosen option and hand back the full array.
+          onClick={() => onChange([...(value ?? []), opt], { action: 'select-option' })}
+        >
+          {opt.label}
+        </button>
+      ))}
+      <button
+        data-testid='clear'
+        onClick={() => onChange(null, { action: 'clear' })}
+      >
+        clear
+      </button>
+    </div>
+  ),
+}))
+
+// Stateful host: selections flow back through setMealTypes and re-render value.
+const Harness = ({ initial = [] as string[] }) => {
+  const [mealTypes, setMealTypes] = useState<string[]>(initial)
+  return (
+    <>
+      <span data-testid='meal-types'>{mealTypes.join(',')}</span>
+      <MealTypeSelector mealTypes={mealTypes} setMealTypes={setMealTypes} />
+    </>
+  )
+}
+
+describe('MealTypeSelector', () => {
+  it('renders the meal-type placeholder (not a copy-pasted cuisine one)', () => {
+    render(<Harness />)
+    expect(screen.getByTestId('placeholder')).toHaveTextContent(
+      'Select meal type(s)...'
+    )
+  })
+
+  it('labels the control as Course for screen readers', () => {
+    render(<Harness />)
+    expect(screen.getByTestId('aria-label')).toHaveTextContent('Course')
+  })
+
+  it('pre-fills options for existing stored values (edit mode)', () => {
+    render(<Harness initial={['Breakfast', 'Dinner']} />)
+    expect(screen.getByTestId('selected')).toHaveTextContent('Breakfast,Dinner')
+  })
+
+  it('drops stored values with no matching option', () => {
+    render(<Harness initial={['Dinner', 'Brunch']} />)
+    // getMealTypesByString filters to known options, so 'Brunch' is ignored.
+    expect(screen.getByTestId('selected')).toHaveTextContent('Dinner')
+  })
+
+  it('stores option values (not labels) and accumulates multiple selections', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    await user.click(screen.getByTestId('opt-Breakfast'))
+    await user.click(screen.getByTestId('opt-Lunch'))
+    expect(screen.getByTestId('meal-types')).toHaveTextContent('Breakfast,Lunch')
+  })
+
+  it('resets to an empty selection when cleared', async () => {
+    const user = userEvent.setup()
+    render(<Harness initial={['Dinner']} />)
+    expect(screen.getByTestId('meal-types')).toHaveTextContent('Dinner')
+    // The null-newValue branch of handleChange must yield [], not crash.
+    await user.click(screen.getByTestId('clear'))
+    expect(screen.getByTestId('meal-types')).toHaveTextContent('')
+  })
+})

--- a/src/test/TimeInput.test.tsx
+++ b/src/test/TimeInput.test.tsx
@@ -88,3 +88,34 @@ describe('TimeInput hydration', () => {
     expect(minutes.value).toBe('')
   })
 })
+
+// Regression: clearing BOTH fields (on edit) must push null up so the parent
+// drops the old time. Previously the writeback effect only fired for a truthy
+// value (`if (minutes || hours)`), so emptying both left the parent holding the
+// stale pre-clear time and the "prep time required" guard kept passing.
+describe('TimeInput clear-both-fields', () => {
+  it('emits null once the user empties both fields', () => {
+    const setVal = vi.fn()
+    render(<TimeInput label='Prep time' val={{ hours: 2, minutes: 15 }} setVal={setVal} />)
+    const [hours, minutes] = screen.getAllByPlaceholderText('0') as HTMLInputElement[]
+    // Sanity: hydrated from the object.
+    expect(hours.value).toBe('2')
+    expect(minutes.value).toBe('15')
+
+    change(hours, '')
+    change(minutes, '')
+
+    expect(hours.value).toBe('')
+    expect(minutes.value).toBe('')
+    // The final emission is an explicit null (not the stale {2,15}).
+    expect(setVal.mock.calls.at(-1)![0]).toBeNull()
+  })
+
+  it('does not emit null on the initial pre-hydration render (no clobber)', () => {
+    const setVal = vi.fn()
+    // Fields start empty while the parent already holds a value; the hydration
+    // pass must not be mistaken for a user clear.
+    render(<TimeInput label='Prep time' val={{ hours: 1, minutes: 30 }} setVal={setVal} />)
+    expect(setVal).not.toHaveBeenCalledWith(null)
+  })
+})

--- a/src/test/recipeFormValidation.test.ts
+++ b/src/test/recipeFormValidation.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateRecipeForm,
+  isRecipeFormValid,
+  ValidatableRecipeForm,
+} from 'src/pages/AddRecipe/recipeFormValidation'
+import {
+  TITLE_MAX_LENGTH,
+  DESCRIPTION_MAX_LENGTH,
+  MAX_INGREDIENTS,
+  MAX_INSTRUCTIONS,
+} from 'src/util/recipeLimits'
+import { IngredientsType, InstructionsType } from 'types'
+
+const ingredient = (id: string): IngredientsType => ({
+  id,
+  parsedIngredient: {
+    ingredient: 'Flour',
+    quantity: 1,
+    unit: 'cup',
+    comment: null,
+    originalIngredientString: '1 cup Flour',
+  },
+  ingredientData: null,
+})
+
+const instruction = (id: string, index: number): InstructionsType => ({
+  id,
+  content: 'Mix',
+  index,
+})
+
+// A fully-valid form; individual tests clone + break one field.
+const validForm = (): ValidatableRecipeForm => ({
+  title: 'My Great Recipe',
+  recipeImage: new File([''], 'photo.jpg', { type: 'image/jpeg' }),
+  existingImageUrl: undefined,
+  description: 'A delicious recipe',
+  servings: 4,
+  prepTime: { hours: 0, minutes: 30 },
+  ingredients: [ingredient('i1')],
+  instructions: [instruction('s1', 1)],
+  mealTypes: ['dinner'],
+})
+
+describe('validateRecipeForm', () => {
+  it('returns no errors for a fully-valid form', () => {
+    const errors = validateRecipeForm(validForm())
+    expect(errors).toEqual({})
+    expect(isRecipeFormValid(errors)).toBe(true)
+  })
+
+  it('flags every required field on a fully-empty form', () => {
+    const errors = validateRecipeForm({
+      title: '',
+      recipeImage: undefined,
+      existingImageUrl: undefined,
+      description: '',
+      servings: '',
+      prepTime: null,
+      ingredients: [],
+      instructions: [],
+      mealTypes: [],
+    })
+    expect(errors.title).toBe('Title is required')
+    expect(errors.image).toBe('Image is required')
+    expect(errors.description).toBe('Description is required')
+    expect(errors.servings).toBe('Servings amount is required')
+    expect(errors.prepTime).toBe('Prep time is required')
+    expect(errors.ingredients).toBe('Recipe must contain ingredients')
+    expect(errors.instructions).toBe('Instructions are required')
+    expect(errors.mealType).toBe('Meal type required')
+    expect(isRecipeFormValid(errors)).toBe(false)
+  })
+
+  it('accepts a stored image (edit mode) with no newly-picked file', () => {
+    const errors = validateRecipeForm({
+      ...validForm(),
+      recipeImage: undefined,
+      existingImageUrl: 'https://example.com/stored.jpg',
+    })
+    expect(errors.image).toBeUndefined()
+  })
+
+  it('caps the title length', () => {
+    const ok = validateRecipeForm({ ...validForm(), title: 'A'.repeat(TITLE_MAX_LENGTH) })
+    expect(ok.title).toBeUndefined()
+    const tooLong = validateRecipeForm({
+      ...validForm(),
+      title: 'A'.repeat(TITLE_MAX_LENGTH + 1),
+    })
+    expect(tooLong.title).toBe(`Title cannot exceed ${TITLE_MAX_LENGTH} characters`)
+  })
+
+  it('caps the description length', () => {
+    const tooLong = validateRecipeForm({
+      ...validForm(),
+      description: 'A'.repeat(DESCRIPTION_MAX_LENGTH + 1),
+    })
+    expect(tooLong.description).toBe(
+      `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`
+    )
+  })
+
+  it('caps ingredient and instruction counts', () => {
+    const errors = validateRecipeForm({
+      ...validForm(),
+      ingredients: Array.from({ length: MAX_INGREDIENTS + 1 }, (_, i) =>
+        ingredient(`i${i}`)
+      ),
+      instructions: Array.from({ length: MAX_INSTRUCTIONS + 1 }, (_, i) =>
+        instruction(`s${i}`, i + 1)
+      ),
+    })
+    expect(errors.ingredients).toBe(
+      `A recipe cannot have more than ${MAX_INGREDIENTS} ingredients`
+    )
+    expect(errors.instructions).toBe(
+      `A recipe cannot have more than ${MAX_INSTRUCTIONS} instructions`
+    )
+  })
+
+  it('treats servings of 0 / "" as missing', () => {
+    expect(validateRecipeForm({ ...validForm(), servings: '' }).servings).toBe(
+      'Servings amount is required'
+    )
+    expect(validateRecipeForm({ ...validForm(), servings: 0 }).servings).toBe(
+      'Servings amount is required'
+    )
+  })
+
+  it('requires prep time, but a truthy {0,0} object (zero total) passes', () => {
+    expect(validateRecipeForm({ ...validForm(), prepTime: null }).prepTime).toBe(
+      'Prep time is required'
+    )
+    expect(
+      validateRecipeForm({ ...validForm(), prepTime: { hours: 0, minutes: 0 } }).prepTime
+    ).toBeUndefined()
+  })
+})

--- a/src/test/updateIngredients.test.ts
+++ b/src/test/updateIngredients.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { updateIngredients } from 'src/util/updateIngredients'
+import {
+  IngredientsType,
+  ParsedIngredient,
+  IngredientData,
+  LabelType,
+} from 'types'
+
+const parsed = (quantity: number | null): ParsedIngredient => ({
+  quantity,
+  unit: 'cup',
+  unitPlural: 'cups',
+  symbol: null,
+  ingredient: 'Flour',
+  originalIngredientString: `${quantity ?? ''} cups Flour`,
+  minQty: null,
+  maxQty: null,
+  comment: null,
+})
+
+const data = (totalPriceUSACents?: number): IngredientData => ({
+  name: 'Flour',
+  totalPriceUSACents,
+})
+
+const item = (
+  quantity: number | null,
+  price?: number
+): IngredientsType => ({
+  id: 'i1',
+  parsedIngredient: parsed(quantity),
+  ingredientData: price === undefined ? null : data(price),
+})
+
+const label: LabelType = { id: 'l1', label: 'For the sauce' }
+
+// Helper: narrow to the parsed-ingredient variant for assertions.
+const asItem = (i: IngredientsType) => {
+  if (!('parsedIngredient' in i)) throw new Error('expected an ingredient, got a label')
+  return i
+}
+
+describe('updateIngredients', () => {
+  it('scales quantity and price up when servings double', () => {
+    const [out] = updateIngredients([item(2, 100)], 2, 4)
+    const scaled = asItem(out)
+    expect(scaled.parsedIngredient.quantity).toBe(4)
+    expect(scaled.ingredientData?.totalPriceUSACents).toBe(200)
+  })
+
+  it('scales down when servings are reduced', () => {
+    const [out] = updateIngredients([item(4, 200)], 4, 2)
+    const scaled = asItem(out)
+    expect(scaled.parsedIngredient.quantity).toBe(2)
+    expect(scaled.ingredientData?.totalPriceUSACents).toBe(100)
+  })
+
+  it('scales quantity even when there is no price data', () => {
+    const [out] = updateIngredients([item(3)], 3, 6)
+    const scaled = asItem(out)
+    expect(scaled.parsedIngredient.quantity).toBe(6)
+    expect(scaled.ingredientData).toBeNull()
+  })
+
+  it('leaves a null/zero quantity untouched (nothing to scale)', () => {
+    const [out] = updateIngredients([item(null, 100)], 2, 4)
+    const scaled = asItem(out)
+    expect(scaled.parsedIngredient.quantity).toBeNull()
+    // Price still scales independently of quantity.
+    expect(scaled.ingredientData?.totalPriceUSACents).toBe(200)
+  })
+
+  it('passes label entries through unchanged', () => {
+    const [out] = updateIngredients([label], 2, 4)
+    expect(out).toEqual(label)
+  })
+
+  it('does not mutate the input ingredients (works on clones)', () => {
+    const input = [item(2, 100)]
+    updateIngredients(input, 2, 4)
+    const original = asItem(input[0])
+    expect(original.parsedIngredient.quantity).toBe(2)
+    expect(original.ingredientData?.totalPriceUSACents).toBe(100)
+  })
+
+  it('rounds the scaled price to cents (toFixed(2) semantics)', () => {
+    // 100 * (1/3) = 33.333… -> "33.33" -> 33.33
+    const [out] = updateIngredients([item(3, 100)], 3, 1)
+    const scaled = asItem(out)
+    expect(scaled.ingredientData?.totalPriceUSACents).toBeCloseTo(33.33, 2)
+  })
+})

--- a/src/util/updateIngredients.ts
+++ b/src/util/updateIngredients.ts
@@ -1,35 +1,8 @@
 import { IngredientData, ParsedIngredient, IngredientsType } from 'types'
-// import { evalNum } from './formatQuantity'
 
-// const mixedToDecimal = (str: string): number => {
-//   const split: string[] = str.split(' ')
-
-//   const decimal = split.reduce((prev, curr) => {
-//     return evalNum(prev) + evalNum(curr)
-//   }, 0)
-
-//   return decimal || 0
-// }
-// const decimalToFraction = (num: number) => {
-//   const fracs = [
-//     { frac: '0', num: 0 },
-//     { frac: '1/8', num: 0.125 },
-//     { frac: '1/4', num: 0.25 },
-//     { frac: '1/3', num: 0.333 },
-//     { frac: '3/8', num: 0.375 },
-//     { frac: '1/2', num: 0.5 },
-//     { frac: '5/8', num: 0.625 },
-//     { frac: '2/3', num: 0.666 },
-//     { frac: '3/4', num: 0.75 },
-//     { frac: '7/8', num: 0.875 },
-//   ]
-
-//   const closest = fracs.sort(
-//     (a, b) => Math.abs(num - a.num) - Math.abs(num - b.num)
-//   )[0]
-//   return closest.frac
-// }
-
+// Rescale a recipe's ingredient quantities and per-ingredient prices from
+// `originalServings` to `newServings` (used by the SingleRecipe servings
+// stepper). Labels (entries without a parsedIngredient) pass through unchanged.
 export const updateIngredients = (
   ingredients: IngredientsType[],
   originalServings: number,


### PR DESCRIPTION
Refactors the create-recipe page (**R1**, Wave 5) — decomposing the 579-line `AddRecipe.tsx` god component and folding in the live **C1** cluster, per the owner-chosen scope (moderate: hook + section components, one lane, sequenced commits). Follows `docs/CONVENTIONS.md` (R0).

## Structural refactor (behavior-preserving)
1. **`recipeFormValidation.ts`** — pure `validateRecipeForm(state) -> errors` + `isRecipeFormValid`, extracted from the in-component `validate()`. Same messages/rules (cook time, cuisine, diet stay optional). +8 unit tests.
2. **`useRecipeForm.ts`** — all form logic moved out of the component into a hook. Field state is a typed `useReducer` whose `SET_FIELD` supports the useState updater-fn form, so child setters keep their `React.Dispatch<SetStateAction<T>>` contract (Ingredients/Instructions containers rely on functional updates). The hook owns the draft hydration + URL-sync + validation effects, the draft-autosave wiring, and `handleSubmit`. Ancillary UI/status state stays as `useState`.
3. **`FormField.tsx`** — collapses the repeated `<div className='X input-field'>` + `SectionHeader` + inline error + control scaffold into one wrapper. Emitted DOM (classes, header, error, aria) is byte-identical, so CSS + tests are untouched.

Net: `AddRecipe.tsx` **579 → 257 lines**, now purely presentational.

## C1 cluster (folded in)
- **TimeInput clear-both-fields fix** — clearing both hour+minute fields now propagates `null` (was silently kept stale on edit; the `if (minutes || hours)` writeback never fired for the all-empty case). Gated behind a `hasUserEdited` ref so the pre-hydration render can't be mistaken for a user clear. +2 regression tests. (Closes the follow-up filed off F1.)
- **`/add-recipe` noindex** — added `<meta name='robots' content='noindex'>`, matching Account/Settings/CreateUsername/Admin/404.
- **Cuisine/MealType selector unit tests** — +12 tests (placeholder incl. the fixed meal-type copy, value↔option mapping, unknown-value drop, accumulate, clear), mirroring `DietSelector.test`.
- **`updateIngredients` test + dead-code** — +7 tests (up/down scaling, no-price/null-quantity, label passthrough, no-mutate, cent rounding); removed the long-dead commented `mixedToDecimal`/`decimalToFraction` block (the function itself is live — used by the SingleRecipe servings stepper).

## Deferred (filed, not fixed)
The remaining C1 visual items — **dropdown/FormInput visual uniformity** and **group-label styling** — are subjective brand/design calls. The dropdowns' orange focus/hover was a deliberate recent fix in `recipeSelectStyles.ts`, while FormInputs use teal `$secondary` focus per the C5 convention; converging them changes brand-orange → teal, which is owner-owned brand territory. Left for a design pass rather than decided here.

## Verification
- `tsc --noEmit` clean; `npm run build` clean.
- Vitest **597 pass / 2 skip** (+29 new tests) — incl. the 25-case `AddRecipe` suite that mounts the real component → `useRecipeForm` (real reducer/validation/effects) and the draft-resume flows.
- The authed real-component create flow (`addRecipe.cy.ts`, 13 tests) runs as a required CI check; every DOM/class hook it selects (`.prep-time`, `.course`, `.cuisine`, `.instructions`, `.submit-btn`, all placeholders) is preserved by the `FormField` refactor (statically verified).

https://claude.ai/code/session_01JwP511UkTUgU69S9MZTJ8x