### PR TITLE
feat(images): uid-key recipe-image uploads + owner-scoped storage.rules (I2)

### DIFF
--- a/docs/IMAGE_PIPELINE.md
+++ b/docs/IMAGE_PIPELINE.md
@@ -1,9 +1,16 @@
-# Recipe image pipeline — responsive variants (BACKLOG I1)
+# Recipe image pipeline — responsive variants (I1) + uid re-key (I2)
 
-How Prepify serves right-sized recipe images, and the **owner-run** steps to turn
-it on. Companion to the code: `src/util/recipeImageVariants.ts` (URL derivation),
-`extensions/storage-resize-images.env` (the extension config), and the `srcset`
-wiring in `RecipeCard.tsx` + `SingleRecipe.tsx`.
+How Prepify serves right-sized recipe images, and the **owner-run** steps to turn it
+on and to roll out the uid-scoped Storage keying. Companion to the code:
+`src/util/recipeImageVariants.ts` (URL derivation), `extensions/storage-resize-images.env`
+(the extension config), the `srcset` wiring in `RecipeCard.tsx` + `SingleRecipe.tsx`,
+and — for I2 — `src/api/recipes.ts` (`uploadRecipeImage`) + `storage.rules`.
+
+Two owner-run rollouts live here: **I1** (install the resize extension + backfill +
+flip the `srcset` flag — "Runbook — enabling it") and **I2** (deploy the uid-scoped
+rules + migrate existing objects — "Runbook — I2 uid re-key rollout"). They're
+independent but touch the same objects, so the I2 migration section notes where they
+interlock (re-run the I1 backfill after moving originals).
 
 ## What it does
 
@@ -115,6 +122,82 @@ serving originals. The extension + variants can stay in place (harmless, unused)
 
 ---
 
+## Runbook — I2 uid re-key rollout (owner)
+
+I2 changed two coupled things that must go live **together**: the frontend now
+uploads to `recipeImages/{uid}/{uuid}` (was `recipeImages/{filename}`), and
+`storage.rules` now (a) allows owner-scoped writes to that uid path and (b) **denies**
+writes to the old flat path. The merged code is inert on the current deployment until
+the rules are deployed — verified live: a new-frontend upload to the uid path returns
+**403 `storage/unauthorized`** under the still-deployed flat rules.
+
+### ⚠ Ordering — rules and frontend ship together
+
+Each half breaks the *other* half's uploads if it lands alone:
+
+| live rules ↓ / live frontend → | old frontend (flat write) | new frontend (uid write) |
+|---|---|---|
+| **old rules** (deployed today) | ✅ works | ❌ 403 — uid path unmatched |
+| **new rules** (this PR) | ❌ 403 — flat write denied | ✅ works |
+
+So deploy `storage.rules` **and** the client in the same window. At beta traffic a
+brief (seconds–minutes) window where image *uploads* fail is acceptable — reads are
+unaffected and only the create/edit-recipe image step is touched. For
+**zero-downtime**, first deploy a transitional rules file that allows writes to
+*both* paths (keep the old flat `allow write: if request.auth != null && …` block
+beside the new uid-scoped one), cut the frontend over, then deploy this PR's final
+rules (flat writes denied) once no old clients remain.
+
+### 1. Deploy the rules
+
+```bash
+firebase use prepify-dev-58579        # dev first
+firebase deploy --only storage         # applies storage.rules
+# smoke-test an upload on dev (step 3), then repeat for prod:
+firebase use <prod-project>
+firebase deploy --only storage
+```
+
+### 2. Migrate existing objects (flat → uid path)
+
+Existing images live at `recipeImages/{filename}`; their download URLs are stored in
+`recipes.recipeImage`. Until migrated, the **legacy read-only rule keeps them
+rendering** (`match /recipeImages/{imageId} { allow read: if true }`), so this can run
+lazily *after* the deploy. Write a one-off script modelled on the read-first ops
+scripts in `server/scripts/` (e.g. `reconcileRatingAggregates.js` — dry-run by
+default, `--apply` to write). Per recipe whose `recipeImage` is still a flat path:
+
+1. Parse the bucket + object path from the stored URL with
+   `server/util/firebaseStorage.js` `parseStorageUrl` — it decodes the full path and
+   surfaces the bucket, which matters because the catalog is **mixed-bucket** (some
+   URLs point at `prepify-9b974`, others at the dev/prod buckets). **Copy within the
+   same bucket.**
+2. Resolve the owner **uid** from `recipes.userId` (the field `addRecipe` stamps;
+   fall back to `authorUsername` → `usernames` lookup for any legacy doc missing it).
+3. `bucket.file(oldPath).copy('recipeImages/${uid}/${uuid}')` via the Admin SDK
+   (bypasses rules), then `getDownloadURL` on the new object.
+4. Update the recipe's `recipeImage` to the new URL. **Idempotent:** skip recipes
+   whose `recipeImage` already decodes to a `recipeImages/{uid}/…` path.
+5. Once verified, optionally delete the old flat object (or leave it for a later
+   purge sweep — flat writes are denied, but the object stays public-read).
+
+Then re-run the **I1 backfill** (§ "Backfill existing images") so the moved originals
+get their `{uid}/`-directory variants (any variants generated at the old flat path
+are now orphaned — regenerating at the new path is simplest).
+
+### 3. Verify + finish
+
+- Create a recipe with a photo through the deployed app; confirm the upload `200`s to
+  `recipeImages/{uid}/{uuid}` (devtools **Network**, or
+  `gsutil ls 'gs://<bucket>/recipeImages/**'`).
+- Spot-check that a **pre-migration** recipe still renders (legacy read rule) and a
+  **post-migration** one serves from the uid path.
+- **Optional final tighten:** once every object is migrated *and* I1 variants are
+  backfilled, drop the legacy `match /recipeImages/{imageId}` block so `recipeImages/*`
+  is uid-scoped end to end.
+
+---
+
 ## Notes & follow-ups
 
 - **Hero `srcset` (C3 carry-over).** The SingleRecipe hero `srcset` that C3 deferred
@@ -133,4 +216,5 @@ serving originals. The extension + variants can stay in place (harmless, unused)
   land in the same `{uid}/` directory as their original (the derivation helper splits
   on the last `/`, so the deeper path just works; the two-segment read rule covers the
   variants). `INCLUDE_PATH_LIST=/recipeImages` is a leading-segment match, so it still
-  catches the nested originals with no change.
+  catches the nested originals with no change. **Rolling it out** (deploy rules +
+  migrate objects) is the "Runbook — I2 uid re-key rollout" section above.

--- a/docs/IMAGE_PIPELINE.md
+++ b/docs/IMAGE_PIPELINE.md
@@ -7,16 +7,20 @@ wiring in `RecipeCard.tsx` + `SingleRecipe.tsx`.
 
 ## What it does
 
-Recipe photos upload full-resolution to Firebase Storage (`recipeImages/<name>`).
-The Firebase **Resize Images** extension (`storage-resize-images`) generates three
-WebP width variants next to each original on upload:
+Recipe photos upload full-resolution to Firebase Storage, keyed by owner uid at
+`recipeImages/{uid}/{uuid}` (BACKLOG I2). The Firebase **Resize Images** extension
+(`storage-resize-images`) generates three WebP width variants next to each original
+on upload — in the **same `{uid}/` directory**, so they inherit the owner prefix:
 
 ```
-recipeImages/photo.jpg           (original, kept)
-recipeImages/photo_400x400.webp  (variants, generated)
-recipeImages/photo_800x800.webp
-recipeImages/photo_1600x1600.webp
+recipeImages/{uid}/{uuid}            (original, kept)
+recipeImages/{uid}/{uuid}_400x400.webp   (variants, generated)
+recipeImages/{uid}/{uuid}_800x800.webp
+recipeImages/{uid}/{uuid}_1600x1600.webp
 ```
+
+(The extension's `INCLUDE_PATH_LIST=/recipeImages` is a leading-segment match, so it
+covers this nested path exactly as it did the old flat `recipeImages/{name}` key.)
 
 The browse-grid card and the single-recipe hero then render a `srcset` over those
 variants, so a phone downloads a ~40 KB WebP instead of the ~190 KB original — the
@@ -75,7 +79,7 @@ This is the one assumption the frontend can't self-check. After the extension is
 live, upload a test recipe image (or re-upload one), then list the bucket:
 
 ```bash
-gsutil ls 'gs://<bucket>/recipeImages/' | grep _400x400
+gsutil ls 'gs://<bucket>/recipeImages/**' | grep _400x400
 ```
 
 Confirm the generated name is **`<stem>_400x400.webp`** (extension stripped), e.g.
@@ -123,6 +127,10 @@ serving originals. The extension + variants can stay in place (harmless, unused)
   report preview still render the original — intentionally out of scope (the board
   scoped I1 to the card + hero, the LCP surfaces). They can adopt `recipeImageSrcSet`
   later with no infra change.
-- **Pairs with I2.** I2 (uid-keyed `recipeImages/{uid}/{uuid}` + owner-scoped rules)
-  changes the object path. If I2 lands after this, keep resized variants in the same
-  directory as their original so the derivation + read rule still hold.
+- **Pairs with I2 (landed).** I2 re-keyed uploads to `recipeImages/{uid}/{uuid}` and
+  tightened `storage.rules` to owner-scoped writes (`request.auth.uid == uid`). The
+  resize config was kept compatible: `RESIZED_IMAGES_PATH` stays empty so variants
+  land in the same `{uid}/` directory as their original (the derivation helper splits
+  on the last `/`, so the deeper path just works; the two-segment read rule covers the
+  variants). `INCLUDE_PATH_LIST=/recipeImages` is a leading-segment match, so it still
+  catches the nested originals with no change.

--- a/docs/IMAGE_PIPELINE.md
+++ b/docs/IMAGE_PIPELINE.md
@@ -89,11 +89,16 @@ live, upload a test recipe image (or re-upload one), then list the bucket:
 gsutil ls 'gs://<bucket>/recipeImages/**' | grep _400x400
 ```
 
-Confirm the generated name is **`<stem>_400x400.webp`** (extension stripped), e.g.
-`photo_400x400.webp` — **not** `photo.jpg_400x400.webp`. The helper assumes the
-stripped form. If your version keeps the original extension, that's a one-line fix
-in `recipeImageVariantUrl()` (build the stem without stripping `.jpg`); the
-`RECIPE_IMAGE_VARIANT_WIDTHS` array and everything else stay the same.
+Since I2, originals upload **without a file extension** — the object is
+`recipeImages/{uid}/{uuid}` (a bare uuid, no `.jpg`). So confirm the generated
+name is **`{uuid}_400x400.webp`**, e.g. an original
+`recipeImages/ab12…/9f3c1d2e-…` yields `9f3c1d2e-…_400x400.webp`. The helper
+splits the stem on the last `.`, so with no extension in the source name the
+whole uuid is the stem — exactly what it expects. (If your extension version
+instead names variants off the *content type* and injects an extension, e.g.
+`9f3c1d2e-….jpeg_400x400.webp`, that's a one-line fix in
+`recipeImageVariantUrl()`; the `RECIPE_IMAGE_VARIANT_WIDTHS` array and everything
+else stay the same.)
 
 ### 3. Backfill existing images
 
@@ -113,7 +118,8 @@ VITE_IMAGE_VARIANTS_ENABLED=true
 ```
 
 Then spot-check in the browser devtools **Network** tab: card/hero requests should
-now be `*_800x800.webp` (or the DPR-appropriate width), not the original `.jpg`.
+now be `*_800x800.webp` (or the DPR-appropriate width), not the extensionless
+original object.
 
 ### Rollback
 

--- a/extensions/storage-resize-images.env
+++ b/extensions/storage-resize-images.env
@@ -22,12 +22,13 @@ IMAGE_TYPE=webp
 # frontend drops to if a variant is ever missing.
 DELETE_ORIGINAL_FILE=false
 
-# Empty => variants land in the SAME directory as the original, e.g.
-#   recipeImages/photo.jpg  ->  recipeImages/photo_400x400.webp
-# This matters for security rules: same-directory variants are still a single
-# path segment under recipeImages/, so the existing `match /recipeImages/{imageId}
+# Empty => variants land in the SAME directory as the original. With I2's uid
+# keying the originals live at recipeImages/{uid}/{uuid}, so:
+#   recipeImages/{uid}/{uuid}  ->  recipeImages/{uid}/{uuid}_400x400.webp
+# This matters for security rules: same-directory variants sit under the SAME
+# {uid}/ prefix as the original, so the `match /recipeImages/{uid}/{imageId}
 # { allow read: if true }` rule covers them with NO storage.rules change. A
-# subfolder here (e.g. "resized") would be a 2-segment path the rule misses.
+# subfolder here (e.g. "resized") would add a path segment the rule misses.
 RESIZED_IMAGES_PATH=
 
 # Reads use token-less Firebase media URLs, which are authorized by the

--- a/server/__tests__/firebaseStorage.test.js
+++ b/server/__tests__/firebaseStorage.test.js
@@ -11,6 +11,19 @@ describe('parseStorageUrl', () => {
     })
   })
 
+  it('extracts the full nested path for uid-keyed images (I2 re-key)', () => {
+    // After I2, uploads land at recipeImages/{uid}/{uuid} — the whole slash-bearing
+    // object path is percent-encoded as one URL segment, so decoding it must yield
+    // the full nested path (not just the last segment) or server-side
+    // deletion/moderation would target the wrong object.
+    const url =
+      'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Fuser-abc%2F123e4567-e89b-12d3-a456-426614174000?alt=media&token=xyz'
+    expect(parseStorageUrl(url)).toEqual({
+      bucket: 'test-bucket',
+      path: 'recipeImages/user-abc/123e4567-e89b-12d3-a456-426614174000',
+    })
+  })
+
   it('returns null for empty, non-string, or non-Firebase values', () => {
     expect(parseStorageUrl('')).toBeNull()
     expect(parseStorageUrl(null)).toBeNull()

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -183,9 +183,25 @@ class RecipeAPIClass {
         setProgress(70)
         return 'https://cypress.test/fake-recipe-image.jpg'
       }
+      // Key the object by owner uid + a random uuid: `recipeImages/{uid}/{uuid}`
+      // (BACKLOG I2). The old `recipeImages/{imageFile.name}` key let two users'
+      // `photo.jpg` collide and — because the path carried no uid — meant
+      // storage.rules could only auth-gate writes, not scope them to the owner.
+      // The uid prefix lets the rule enforce `request.auth.uid == uid` (mirroring
+      // profilePhotos/{uid}); the uuid makes the object collision-proof so we no
+      // longer need the original filename. No extension is needed — Firebase sets
+      // the content type from the File, and the I1 variant helper derives the
+      // srcset stem from the object path regardless of extension.
+      const uid = AuthAPI.getUID()
+      if (!uid) {
+        // Defensive: both addRecipe/editRecipe run behind auth, and the tightened
+        // storage.rules would reject a uid-less write anyway — fail closed rather
+        // than fall back to an unscoped path.
+        throw new Error('Must be signed in to upload a recipe image')
+      }
       const storage = getStorage()
 
-      const recipeImagesRef = ref(storage, `recipeImages/${imageFile.name}`)
+      const recipeImagesRef = ref(storage, `recipeImages/${uid}/${uuidv4()}`)
       setProgress(40)
       await uploadBytes(recipeImagesRef, imageFile)
       setProgress(50)

--- a/src/test/RecipesApi.test.ts
+++ b/src/test/RecipesApi.test.ts
@@ -34,6 +34,8 @@ vi.mock('src/api/http-common', () => ({
 
 // Import after mocks are in place.
 import RecipeAPI from 'src/api/recipes'
+import AuthAPI from 'src/api/auth'
+import { ref, uploadBytes } from 'firebase/storage'
 import type { RecipeEditFormType, RecipeFormType, RecipeType } from 'types'
 
 const makeFormData = (): RecipeFormType => ({
@@ -312,5 +314,46 @@ describe('RecipeAPI.editRecipe', () => {
       () => {}
     )
     expect(result).toEqual({ status: 'error', message: 'Forbidden' })
+  })
+})
+
+describe('RecipeAPI.uploadRecipeImage — uid-keyed Storage path (I2)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.mocked(ref).mockClear()
+    vi.mocked(uploadBytes).mockClear()
+    vi.mocked(AuthAPI.getUID).mockReturnValue('test-uid')
+  })
+
+  it('keys the upload at recipeImages/{uid}/{uuid}, never the raw filename', async () => {
+    // The suite runs with VITE_CYPRESS='true' (the fake-URL short-circuit); stub it
+    // off so the real, mocked-SDK upload path runs and we can inspect the ref path.
+    vi.stubEnv('VITE_CYPRESS', 'false')
+    const file = new File([''], 'photo.jpg', { type: 'image/jpeg' })
+
+    const url = await RecipeAPI.uploadRecipeImage(file, () => {})
+
+    // getDownloadURL mock => the stored original URL is returned unchanged.
+    expect(url).toBe('https://fake.cdn/image.jpg')
+    // ref(storage, path): the object path is scoped to the owner uid + a uuid, so
+    // two users' "photo.jpg" can't collide and storage.rules can scope by uid.
+    const objectPath = vi.mocked(ref).mock.calls[0][1]
+    expect(objectPath).toMatch(
+      /^recipeImages\/test-uid\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    )
+    expect(objectPath).not.toContain('photo.jpg')
+    expect(uploadBytes).toHaveBeenCalledOnce()
+  })
+
+  it('fails closed (throws, no upload) when there is no authenticated uid', async () => {
+    vi.stubEnv('VITE_CYPRESS', 'false')
+    vi.mocked(AuthAPI.getUID).mockReturnValueOnce(null)
+    const file = new File([''], 'photo.jpg', { type: 'image/jpeg' })
+
+    await expect(RecipeAPI.uploadRecipeImage(file, () => {})).rejects.toThrow(
+      /signed in/i
+    )
+    // Never reaches the SDK — no unscoped/uid-less object is written.
+    expect(ref).not.toHaveBeenCalled()
   })
 })

--- a/src/util/recipeImageVariants.ts
+++ b/src/util/recipeImageVariants.ts
@@ -73,9 +73,12 @@ export function recipeImageVariantUrl(
     return null // malformed percent-encoding
   }
 
-  // Split dir / filename / extension so the variant sits beside the original
-  // with the extension swapped, matching the extension's naming:
-  //   recipeImages/photo.jpg  ->  recipeImages/photo_400x400.webp
+  // Split dir / filename / extension so the variant sits beside the original,
+  // matching the extension's naming. Since I2 originals are keyed by a bare uuid
+  // with no extension, so the stem is the whole filename:
+  //   recipeImages/{uid}/{uuid}  ->  recipeImages/{uid}/{uuid}_400x400.webp
+  // (The last-dot split still handles a legacy extensioned name too, e.g.
+  //   recipeImages/photo.jpg  ->  recipeImages/photo_400x400.webp.)
   const slash = objectPath.lastIndexOf('/')
   const dir = slash === -1 ? '' : objectPath.slice(0, slash + 1)
   const file = slash === -1 ? objectPath : objectPath.slice(slash + 1)

--- a/storage.rules
+++ b/storage.rules
@@ -20,15 +20,31 @@ service firebase.storage {
                    && request.resource.contentType.matches('image/.*');
     }
 
-    // Recipe images: stored at recipeImages/{filename} (api/recipes.ts) — the
-    // path is keyed by filename, not uid, so ownership can't be enforced here.
-    // Require auth + size + image type as defense-in-depth (the previous gap was
-    // an open bucket). See BACKLOG: key recipe images by uid to allow scoping.
-    match /recipeImages/{imageId} {
+    // Recipe images (I2): stored at recipeImages/{uid}/{uuid} (api/recipes.ts), so
+    // — like profilePhotos/{uid} above — we can enforce that a user only writes
+    // under their OWN uid prefix. The I1 "Resize Images" extension writes its WxH
+    // variants into this same {uid}/ directory; the {imageId} wildcard covers them
+    // for public read, and the extension writes via the Admin SDK so it bypasses
+    // the owner-write check below.
+    match /recipeImages/{uid}/{imageId} {
       allow read: if true;
       allow write: if request.auth != null
+                   && request.auth.uid == uid
                    && request.resource.size < 5 * 1024 * 1024
                    && request.resource.contentType.matches('image/.*');
+    }
+
+    // Legacy recipe images (pre-I2): keyed by bare filename at recipeImages/{file},
+    // one segment under recipeImages/ (so disjoint from the uid-scoped match above,
+    // whose objects are two segments deep). Kept publicly READABLE so existing
+    // recipes keep rendering until these objects are migrated to the uid-scoped
+    // path, but writes are DENIED — nothing writes here anymore (uploads re-keyed),
+    // and denying closes the old "any signed-in user can overwrite any recipe
+    // image" gap for the flat path too. The server Admin SDK bypasses rules, so the
+    // owner-run migration is unaffected.
+    match /recipeImages/{imageId} {
+      allow read: if true;
+      allow write: if false;
     }
 
     // Everything else is denied. The specific matches above grant access for


### PR DESCRIPTION
## I2 · uid-key recipe images (Wave 4)

Recipe-image uploads landed at `recipeImages/{imageFile.name}` (`src/api/recipes.ts`), keyed by the **raw filename**, so:
- **(a)** two users uploading `photo.jpg` collided/overwrote each other, and
- **(b)** because the path carried no uid, `storage.rules` could only *auth-gate* writes — any signed-in user could overwrite/delete **any** recipe image.

This re-keys uploads to `recipeImages/{uid}/{uuid}` and tightens the Storage rule to owner-scoped writes (`request.auth.uid == uid`), mirroring the proven `profilePhotos/{uid}` pattern.

### Changes
- **`src/api/recipes.ts`** — `uploadRecipeImage` keys objects at `recipeImages/${uid}/${uuidv4()}` (uid from `AuthAPI.getUID()`, uuid for collision-safety); **fails closed** (throws) if there's no uid rather than falling back to an unscoped path. No file extension needed — Firebase sets `contentType` from the `File`, and the I1 variant helper derives the srcset stem from the path regardless of depth/extension. (Both `AuthAPI`/`uuidv4` were already imported.)
- **`storage.rules`** —
  - new `match /recipeImages/{uid}/{imageId}`: public read; write requires `request.auth.uid == uid` + 5 MB cap + `image/*`. Covers the I1 resize **variants** (same `{uid}/` dir) for read; the extension writes via Admin SDK so it bypasses the owner check.
  - legacy `match /recipeImages/{imageId}` (one segment, disjoint): kept publicly **readable** so un-migrated images still render, but **write denied** — nothing writes there anymore, and this closes the old overwrite gap for the flat path too.
- **I1 reconciliation** — `RESIZED_IMAGES_PATH` stays empty (variants co-located under `{uid}/`); `INCLUDE_PATH_LIST=/recipeImages` is a leading-segment match that still catches the nested originals. Server `parseStorageUrl` decodes the whole `/o/<encoded>` segment, so moderation/delete are depth-agnostic (**no server change**). Config/doc comments updated (`extensions/storage-resize-images.env`, `docs/IMAGE_PIPELINE.md`).

### Tests & verification
- `src/test/RecipesApi.test.ts` — asserts the exact uid-keyed `ref` path (`recipeImages/{uid}/{uuid}`, never the filename) and the fail-closed no-uid throw.
- `server/__tests__/firebaseStorage.test.js` — nested-path extraction regression.
- Gates: `tsc` clean · Vitest **579 passed / 2 skipped** · `npm run build` clean · server Jest green.
- **Rules exercised under the Firebase Storage rules emulator — 11/11:** owner write ✅, cross-uid write deny ✅, anon write deny ✅, oversize deny ✅, non-image deny ✅, legacy flat write deny ✅, public read on original + `_400x400.webp` variant + legacy ✅, `profilePhotos` owner-scoping regression ✅.

### Owner-gated (ships inert, like I1)
The deployed dev rules are still the old flat ones, so this is safe to merge but takes effect only after:
1. `firebase deploy --only storage` (dev, then prod).
2. Migrate existing filename-keyed objects to the uid path (ops step; server Admin SDK bypasses rules).

### Off-board note (pre-existing, not fixed here)
`deleteRecipeImage` removes only the original object, so a deleted recipe orphans its I1 resize variants — latent since I1 (independent of this re-key).