### PR TITLE
R2: refactor the account page (usePaginatedLoadMore + shell hooks)

### DIFF
--- a/src/pages/Account/Account.tsx
+++ b/src/pages/Account/Account.tsx
@@ -2,12 +2,6 @@ import React, { FC, useEffect, useState } from 'react'
 import { useLocation, useNavigate, Outlet, Link } from 'react-router-dom'
 import './Account.scss'
 import { Helmet } from 'react-helmet-async'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import toast from 'react-hot-toast'
-import AuthAPI from 'src/api/auth'
-import RecipeAPI from 'src/api/recipes'
-import GamificationAPI from 'src/api/gamification'
-import { useAuth } from 'src/context/AuthContext'
 import LevelCard from 'src/pages/Account/components/LevelCard'
 import ProfileControls from 'src/pages/Account/components/ProfileControls'
 import SegmentedNav from 'src/pages/Account/components/SegmentedNav'
@@ -17,92 +11,20 @@ import {
 } from 'src/pages/Account/components/accountTabs'
 import AchievementsModal from 'src/pages/Account/components/AchievementsModal'
 import DefaultAvatar from 'src/Components/DefaultAvatar/DefaultAvatar'
-
-// Format Firebase's `creationTime` ("Tue, 22 Mar 2023 …") as "March 2023".
-const formatMemberSince = (creationTime?: string | null): string | null => {
-  if (!creationTime) return null
-  const d = new Date(creationTime)
-  if (isNaN(d.getTime())) return null
-  return d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
-}
+import { useAccountData } from 'src/pages/Account/useAccountData'
+import { useAchievementsToast } from 'src/pages/Account/useAchievementsToast'
 
 const Account: FC = () => {
-  const uid = AuthAPI.getUID()
-
   const location = useLocation()
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const [rewardsOpen, setRewardsOpen] = useState(false)
   // Fall back to the initial if the avatar URL fails to load instead of showing
   // a broken image.
   const [avatarError, setAvatarError] = useState(false)
 
-  const authRes = useAuth()
-  const user = authRes?.user
-
-  // Always fetch the real username handle (even when a Firebase displayName
-  // exists): the Share link and public profile route resolve by handle, not by
-  // display name, so we need it regardless of what we show in the header.
-  const { data } = useQuery({
-    queryKey: ['username', uid],
-    queryFn: () => AuthAPI.getUsername(),
-    enabled: !!uid,
-  })
-
-  const { data: profile } = useQuery({
-    queryKey: ['profile', uid],
-    queryFn: () => AuthAPI.getProfile(),
-    enabled: !!uid,
-  })
-
-  const { data: counts } = useQuery({
-    queryKey: ['account-counts', uid],
-    queryFn: () => RecipeAPI.getAccountCounts(),
-    enabled: !!uid,
-  })
-
-  const { data: gamification } = useQuery({
-    queryKey: ['gamification', uid],
-    queryFn: () => GamificationAPI.getGamification(),
-    enabled: !!uid,
-  })
-
-  // Celebrate any achievements earned since the user last looked, then mark them
-  // acknowledged so the toast won't fire again on the next load. Several can
-  // unlock at once (e.g. a new user's first visit), so collapse those into one
-  // summary toast rather than stacking a wall of them.
-  useEffect(() => {
-    if (!gamification || gamification.newlyUnlocked.length === 0) return
-    const byId = new Map(gamification.achievements.map(a => [a.id, a]))
-    const names = gamification.newlyUnlocked
-      .map(id => byId.get(id)?.name)
-      .filter((n): n is string => !!n)
-    if (names.length === 1) {
-      toast.success(`🏅 Achievement unlocked: ${names[0]}!`)
-    } else if (names.length > 1) {
-      toast.success(`🏅 ${names.length} achievements unlocked!`)
-    }
-    GamificationAPI.acknowledgeAchievements(gamification.newlyUnlocked)
-      .then(() =>
-        queryClient.invalidateQueries({ queryKey: ['gamification', uid] })
-      )
-      .catch(() => {
-        // Non-fatal: if the ack fails, the toast simply re-fires next load.
-      })
-  }, [gamification, uid, queryClient])
-
-  const handle = data ?? '' // the real @username, used for the share/public link
-  const displayName = user?.displayName ?? handle
-
-  const memberSince = formatMemberSince(user?.metadata?.creationTime)
-  const place = profile?.location ?? ''
-  const bio = profile?.bio ?? ''
-  // Name and username collapse to the same string today (displayName falls back
-  // to the username), so a separate `@handle` would just duplicate the title.
-  // Revisit when public profiles (Phase 5) give the handle independent meaning.
-  const metaParts = [place, memberSince ? `Since ${memberSince}` : null].filter(
-    Boolean
-  )
+  const { handle, displayName, photoURL, metaParts, bio, counts, gamification } =
+    useAccountData()
+  useAchievementsToast(gamification)
 
   useEffect(() => {
     if (location.pathname === '/account') {
@@ -114,7 +36,7 @@ const Account: FC = () => {
   }, [location.pathname, navigate])
 
   // Reset the avatar fallback when the photo changes.
-  useEffect(() => setAvatarError(false), [user?.photoURL])
+  useEffect(() => setAvatarError(false), [photoURL])
 
   return (
     <>
@@ -126,9 +48,9 @@ const Account: FC = () => {
       <div className='page account-page'>
         <header className='acct-head'>
           <div className='acct-id'>
-            {user?.photoURL && !avatarError ? (
+            {photoURL && !avatarError ? (
               <img
-                src={user.photoURL}
+                src={photoURL}
                 alt='Profile avatar'
                 className='acct-avatar'
                 onError={() => setAvatarError(true)}

--- a/src/pages/Account/SavedRecipes/SavedRecipes.tsx
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.tsx
@@ -15,6 +15,7 @@ import { useDelayedLoading } from 'src/hooks/useDelayedLoading'
 import { COLLECTION_CREATE_ERROR } from 'src/util/toastMessages'
 import { useDebounce } from 'src/hooks/useDebounce'
 import { invalidateSavedCaches } from 'src/util/invalidateSavedCaches'
+import { usePaginatedLoadMore } from 'src/pages/Account/usePaginatedLoadMore'
 import CollectionCard from './CollectionCard'
 
 type SortOption = { value: string; label: string }
@@ -36,9 +37,6 @@ const SavedRecipes: FC = () => {
   const uid = AuthAPI.getUID()
   const queryClient = useQueryClient()
 
-  const [recipes, setRecipes] = useState<RecipeType[]>([])
-  const [currPage, setCurrPage] = useState(0)
-  const [isMoreRecipes, setIsMoreRecipes] = useState(false)
   const [sort, setSort] = useState(SORT_OPTIONS[0])
 
   // null = the "All" view (the master saved list); otherwise a collection id.
@@ -53,11 +51,41 @@ const SavedRecipes: FC = () => {
   // actually drives the request, so we don't fire one per keystroke.
   const [searchInput, setSearchInput] = useState('')
   const query = useDebounce(searchInput.trim(), 300)
+
+  // The saved grid's load-more core (page cursor, accumulate, is-more,
+  // flash-guarded skeleton) lives in the shared hook; sort/collection/search are
+  // baked into the key so changing any of them refetches, paired with
+  // resetToFirstPage() at each of those change sites to jump back to page 0.
+  const {
+    items: recipes,
+    isLoading,
+    showSkeleton,
+    isMore: isMoreRecipes,
+    loadMore: handleLoadMoreRecipes,
+    reset: resetToFirstPage,
+  } = usePaginatedLoadMore<RecipeType>({
+    queryKey: page => [
+      'saved-recipes',
+      sort.value,
+      page,
+      activeCollectionId,
+      query,
+    ],
+    queryFn: page =>
+      RecipeAPI.getSavedRecipes(
+        page,
+        PER_PAGE,
+        sort.value,
+        activeCollectionId ?? undefined,
+        query || undefined
+      ).then(d => d && { items: d.recipes, totalCount: d.totalCount }),
+  })
+
   // Reset to the first page off the debounced term, not the keystroke, so a new
   // search doesn't fire a throwaway page-0 request for the old term first.
   useEffect(() => {
-    setCurrPage(0)
-  }, [query])
+    resetToFirstPage()
+  }, [query, resetToFirstPage])
 
   const { data: collections = [], isLoading: collectionsLoading } = useQuery({
     queryKey: ['collections'],
@@ -78,53 +106,27 @@ const SavedRecipes: FC = () => {
   useEffect(() => {
     if (activeCollectionId && collections.length > 0 && !activeCollection) {
       setActiveCollectionId(null)
-      setCurrPage(0)
+      resetToFirstPage()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeCollectionId, activeCollection, collections.length])
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['saved-recipes', sort.value, currPage, activeCollectionId, query],
-    queryFn: () =>
-      RecipeAPI.getSavedRecipes(
-        currPage,
-        PER_PAGE,
-        sort.value,
-        activeCollectionId ?? undefined,
-        query || undefined
-      ),
-  })
-  const showSkeleton = useDelayedLoading(isLoading)
   // Collections load on their own query; reserve their row with skeleton tiles
   // (delay-gated, same as the grid) so collections don't pop in and shove the
   // grid down.
   const showCollSkeleton = useDelayedLoading(collectionsLoading)
 
-  useEffect(() => {
-    if (!data) return
-    if (currPage === 0) {
-      setRecipes([...data.recipes])
-      setIsMoreRecipes(Number(data.totalCount) > data.recipes.length)
-    } else {
-      const updated = [...recipes, ...data.recipes]
-      setRecipes(updated)
-      setIsMoreRecipes(Number(data.totalCount) > updated.length)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data])
-
   const selectCollection = (id: string | null) => {
     setActiveCollectionId(id)
-    setCurrPage(0)
+    resetToFirstPage()
     setRenaming(false)
   }
   const changeSort = (value: string) => {
     const next = SORT_OPTIONS.find(o => o.value === value)
     if (next) setSort(next)
-    setCurrPage(0)
+    resetToFirstPage()
   }
   const onSearchChange = (v: string) => setSearchInput(v)
-  const handleLoadMoreRecipes = () => setCurrPage(prev => prev + 1)
 
   // Refresh after a membership/collection change. Counts + covers always
   // refetch. The grid must refetch too — an unsave from the popover removes a
@@ -135,8 +137,8 @@ const SavedRecipes: FC = () => {
   // render would defeat React.memo and re-render every saved card.
   const refreshAfterMutation = useCallback(() => {
     invalidateSavedCaches(queryClient, uid)
-    setCurrPage(0)
-  }, [queryClient, uid])
+    resetToFirstPage()
+  }, [queryClient, uid, resetToFirstPage])
 
   const handleCreate = async () => {
     const name = newName.trim()

--- a/src/pages/Account/UserRatings/UserRatings.tsx
+++ b/src/pages/Account/UserRatings/UserRatings.tsx
@@ -1,6 +1,5 @@
 import { ChevronDownIcon, CornerDownRightIcon, StarOutlineIcon } from 'src/Components/icons'
-import React, { FC, useEffect, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import React, { FC } from 'react'
 import RecipeAPI from 'src/api/recipes'
 import { OptionalReviewType } from 'types'
 import StarRating from 'src/Components/StarRating/StarRating'
@@ -10,7 +9,7 @@ import { timeElapsedSince } from 'src/util/timeElapsedSince'
 import Skeleton from 'react-loading-skeleton'
 import { skeletonBase as skeletonColor } from 'src/util/loadingStyles'
 import { useNavigate } from 'react-router-dom'
-import { useDelayedLoading } from 'src/hooks/useDelayedLoading'
+import { usePaginatedLoadMore } from 'src/pages/Account/usePaginatedLoadMore'
 
 type SingleReviewProps = {
   review?: OptionalReviewType
@@ -106,40 +105,23 @@ const SingleReview: FC<SingleReviewProps> = ({ review, loading }) => {
 // now; the query keeps this fixed order.)
 const SORT = 'newAdd'
 const Ratings: FC = () => {
-  const [reviews, setReviews] = useState<OptionalReviewType[]>([])
-  const [currPage, setCurrPage] = useState(0)
-  const [isMoreReviews, setIsMoreReviews] = useState(false)
-
-  const { data, isLoading } = useQuery({
-    queryKey: ['user-reviews', SORT, currPage],
-    queryFn: () => RecipeAPI.getSingleUserReviews(currPage, 5, SORT, true),
+  // `showList` stays true across the one-frame gap where the query has settled
+  // but the accumulator hasn't populated `reviews` yet, so the "no ratings"
+  // empty state can't flash before a genuine zero result.
+  const {
+    items: reviews,
+    isLoading,
+    showSkeleton,
+    isMore: isMoreReviews,
+    showList,
+    loadMore: handleLoadMoreReviews,
+  } = usePaginatedLoadMore<OptionalReviewType>({
+    queryKey: page => ['user-reviews', SORT, page],
+    queryFn: page =>
+      RecipeAPI.getSingleUserReviews(page, 5, SORT, true).then(
+        d => d && { items: d.reviews, totalCount: d.totalCount }
+      ),
   })
-  const showSkeleton = useDelayedLoading(isLoading)
-  // `reviews` is populated by the effect below one render AFTER react-query
-  // flips `isLoading` to false, so on a fast load there's a frame where the
-  // query has settled but `reviews` is still []. Gate the list on the resolved
-  // payload too (`data.reviews`) so that frame keeps showing the list instead
-  // of flashing the "no ratings" empty state.
-  const dataHasReviews = !!data && data.reviews.length > 0
-  const showList = reviews.length > 0 || isLoading || dataHasReviews
-
-  useEffect(() => {
-    if (data) {
-      if (currPage === 0) {
-        setReviews([...data.reviews])
-        setIsMoreReviews(Number(data.totalCount) > data.reviews.length)
-      } else {
-        const updated = [...reviews, ...data.reviews]
-        setReviews(updated)
-        setIsMoreReviews(Number(data.totalCount) > updated.length)
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data])
-
-  const handleLoadMoreReviews = () => {
-    setCurrPage(prev => prev + 1)
-  }
 
   return (
     <div className='user-ratings'>

--- a/src/pages/Account/UserRecipes/UserRecipes.tsx
+++ b/src/pages/Account/UserRecipes/UserRecipes.tsx
@@ -1,12 +1,11 @@
 import { BookOpenIcon, ChevronDownIcon } from 'src/Components/icons'
-import React, { FC, useState, useEffect } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import React, { FC } from 'react'
 
 import './UserRecipes.scss'
 import EmptyState from 'src/Components/EmptyState/EmptyState'
 import RecipeAPI from 'src/api/recipes'
 import { RecipeType } from 'types'
-import { useDelayedLoading } from 'src/hooks/useDelayedLoading'
+import { usePaginatedLoadMore } from 'src/pages/Account/usePaginatedLoadMore'
 import UserRecipeThumbnail from './UserRecipeThumbnail'
 
 // Default order: newest first. (The sort control was removed for now; the query
@@ -14,42 +13,23 @@ import UserRecipeThumbnail from './UserRecipeThumbnail'
 const SORT = 'new'
 
 const UserRecipes: FC = () => {
-  const [recipes, setRecipes] = useState<RecipeType[]>([])
-  const [currPage, setCurrPage] = useState(0)
-  const [isMoreRecipes, setIsMoreRecipes] = useState(false)
-
-  const { data, isLoading } = useQuery({
-    queryKey: ['created-recipes', SORT, currPage],
-    queryFn: () => RecipeAPI.getCreatedRecipes(currPage, 6, SORT),
+  // `showGrid` (the hook's showList) stays true across the one-frame gap where
+  // the query has settled but the accumulator hasn't populated yet, so the
+  // "no recipes" empty state can't flash before a genuine zero result.
+  const {
+    items: recipes,
+    isLoading,
+    showSkeleton,
+    isMore,
+    showList: showGrid,
+    loadMore,
+  } = usePaginatedLoadMore<RecipeType>({
+    queryKey: page => ['created-recipes', SORT, page],
+    queryFn: page =>
+      RecipeAPI.getCreatedRecipes(page, 6, SORT).then(
+        d => d && { items: d.recipes, totalCount: d.totalCount }
+      ),
   })
-
-  useEffect(() => {
-    if (data) {
-      if (currPage === 0) {
-        setRecipes([...data.recipes])
-        setIsMoreRecipes(Number(data.totalCount) > data.recipes.length)
-      } else {
-        const updated = [...recipes, ...data.recipes]
-        setRecipes(updated)
-        setIsMoreRecipes(Number(data.totalCount) > updated.length)
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data])
-
-  const handleLoadMoreRecipes = () => {
-    setCurrPage(prev => prev + 1)
-  }
-
-  const showSkeleton = useDelayedLoading(isLoading)
-  // `recipes` is populated by the effect above one render AFTER react-query
-  // flips `isLoading` to false, so on a fast load there's a frame where the
-  // query has settled but `recipes` is still []. Gate the grid on the resolved
-  // payload too (`data.recipes`) so that frame shows the grid, not a flash of
-  // the "no recipes" empty state. The empty state then appears only once the
-  // query has genuinely returned zero recipes.
-  const dataHasRecipes = !!data && data.recipes.length > 0
-  const showGrid = recipes.length > 0 || isLoading || dataHasRecipes
 
   return (
     <div className='user-recipes'>
@@ -75,11 +55,8 @@ const UserRecipes: FC = () => {
               </>
             )}
           </div>
-          {isMoreRecipes && recipes.length > 0 ? (
-            <button
-              className='load-more-btn'
-              onClick={handleLoadMoreRecipes}
-            >
+          {isMore && recipes.length > 0 ? (
+            <button className='load-more-btn' onClick={loadMore}>
               Load more recipes <ChevronDownIcon />
             </button>
           ) : null}

--- a/src/pages/Account/useAccountData.ts
+++ b/src/pages/Account/useAccountData.ts
@@ -1,0 +1,88 @@
+import { useQuery } from '@tanstack/react-query'
+import AuthAPI from 'src/api/auth'
+import RecipeAPI from 'src/api/recipes'
+import GamificationAPI from 'src/api/gamification'
+import { useAuth } from 'src/context/AuthContext'
+import { AccountTabCounts, Gamification } from 'types'
+
+// Format Firebase's `creationTime` ("Tue, 22 Mar 2023 …") as "March 2023".
+const formatMemberSince = (creationTime?: string | null): string | null => {
+  if (!creationTime) return null
+  const d = new Date(creationTime)
+  if (isNaN(d.getTime())) return null
+  return d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+}
+
+export type AccountData = {
+  // The real @username handle — the Share link and public profile route resolve
+  // by handle, not display name.
+  handle: string
+  displayName: string
+  photoURL: string | null | undefined
+  // Header meta line parts (location · "Since <month year>"), already filtered.
+  metaParts: string[]
+  bio: string
+  counts: AccountTabCounts | null | undefined
+  gamification: Gamification | null | undefined
+}
+
+// useAccountData — the account header's data layer: the four reads behind the
+// profile header (handle, profile, per-tab counts, gamification) plus the
+// derived display strings. Split out of Account so the page stays presentational
+// and useAchievementsToast can share the same gamification query off the
+// react-query cache.
+export function useAccountData(): AccountData {
+  const uid = AuthAPI.getUID()
+  const authRes = useAuth()
+  const user = authRes?.user
+
+  // Always fetch the real username handle (even when a Firebase displayName
+  // exists): the Share link and public profile route resolve by handle, not by
+  // display name, so we need it regardless of what we show in the header.
+  const { data: username } = useQuery({
+    queryKey: ['username', uid],
+    queryFn: () => AuthAPI.getUsername(),
+    enabled: !!uid,
+  })
+
+  const { data: profile } = useQuery({
+    queryKey: ['profile', uid],
+    queryFn: () => AuthAPI.getProfile(),
+    enabled: !!uid,
+  })
+
+  const { data: counts } = useQuery({
+    queryKey: ['account-counts', uid],
+    queryFn: () => RecipeAPI.getAccountCounts(),
+    enabled: !!uid,
+  })
+
+  const { data: gamification } = useQuery({
+    queryKey: ['gamification', uid],
+    queryFn: () => GamificationAPI.getGamification(),
+    enabled: !!uid,
+  })
+
+  const handle = username ?? '' // the real @username, used for the share/public link
+  const displayName = user?.displayName ?? handle
+  const memberSince = formatMemberSince(user?.metadata?.creationTime)
+  const place = profile?.location ?? ''
+  const bio = profile?.bio ?? ''
+  // Name and username collapse to the same string today (displayName falls back
+  // to the username), so a separate `@handle` would just duplicate the title.
+  // Revisit when public profiles (Phase 5) give the handle independent meaning.
+  const metaParts = [
+    place,
+    memberSince ? `Since ${memberSince}` : null,
+  ].filter(Boolean) as string[]
+
+  return {
+    handle,
+    displayName,
+    photoURL: user?.photoURL,
+    metaParts,
+    bio,
+    counts,
+    gamification,
+  }
+}

--- a/src/pages/Account/useAchievementsToast.ts
+++ b/src/pages/Account/useAchievementsToast.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import AuthAPI from 'src/api/auth'
+import GamificationAPI from 'src/api/gamification'
+import { Gamification } from 'types'
+
+// useAchievementsToast — celebrate any achievements earned since the user last
+// looked, then mark them acknowledged so the toast won't fire again on the next
+// load. Several can unlock at once (e.g. a new user's first visit), so collapse
+// those into one summary toast rather than stacking a wall of them.
+export function useAchievementsToast(
+  gamification: Gamification | null | undefined
+): void {
+  const uid = AuthAPI.getUID()
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    if (!gamification || gamification.newlyUnlocked.length === 0) return
+    const byId = new Map(gamification.achievements.map(a => [a.id, a]))
+    const names = gamification.newlyUnlocked
+      .map(id => byId.get(id)?.name)
+      .filter((n): n is string => !!n)
+    if (names.length === 1) {
+      toast.success(`🏅 Achievement unlocked: ${names[0]}!`)
+    } else if (names.length > 1) {
+      toast.success(`🏅 ${names.length} achievements unlocked!`)
+    }
+    GamificationAPI.acknowledgeAchievements(gamification.newlyUnlocked)
+      .then(() =>
+        queryClient.invalidateQueries({ queryKey: ['gamification', uid] })
+      )
+      .catch(() => {
+        // Non-fatal: if the ack fails, the toast simply re-fires next load.
+      })
+  }, [gamification, uid, queryClient])
+}

--- a/src/pages/Account/usePaginatedLoadMore.ts
+++ b/src/pages/Account/usePaginatedLoadMore.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useState } from 'react'
+import { QueryKey, useQuery } from '@tanstack/react-query'
+import { useDelayedLoading } from 'src/hooks/useDelayedLoading'
+
+// usePaginatedLoadMore — the shared "Load more" accumulator behind the account
+// list tabs (Saved / Ratings / Your Recipes). All three fetch a page at a time
+// from a `{ items, totalCount }` endpoint and stitch the pages into one growing
+// list, showing a "Load more" button until every item has been pulled. This hook
+// is the single copy of that state machine (page cursor, accumulate-on-append,
+// is-more, and the flash-guarded skeleton gate); the tabs supply only their
+// query key and fetcher.
+//
+// Behaviour is byte-for-byte the pre-extraction pattern: page 0 replaces (a
+// fresh sort/filter/search), later pages append; `isMore` is `totalCount >`
+// what's accumulated. The accumulate effect is keyed on `data` alone — as the
+// original tabs were — because each page increment yields a new `data` reference
+// and page 0 resets via the query key, so replace-vs-append stays correct
+// without listing `items`/`page` as deps (which would loop).
+
+// One page from a paginated endpoint: the slice for the requested page plus the
+// total across all pages (used to decide whether "Load more" should show).
+export type LoadMorePage<T> = {
+  items: T[]
+  totalCount: number
+}
+
+type UsePaginatedLoadMoreOptions<T> = {
+  // Cache key for a given page. Page-independent params (sort, filter, search)
+  // must be baked into the key so changing them refetches; callers pair that
+  // with reset() to jump back to page 0.
+  queryKey: (page: number) => QueryKey
+  // Fetch one page. Returns null on a soft-failed/absent response (matching the
+  // RecipeAPI paginated endpoints); the hook treats null as "no new items".
+  queryFn: (page: number) => Promise<LoadMorePage<T> | null>
+}
+
+export type UsePaginatedLoadMoreResult<T> = {
+  items: T[]
+  isLoading: boolean
+  // Skeleton visibility, flash-guarded via useDelayedLoading — reserve the
+  // list's height on this, not raw isLoading.
+  showSkeleton: boolean
+  isMore: boolean
+  // The current page's payload has resolved with at least one item. Bridges the
+  // one-frame gap between the query settling and the accumulate effect
+  // populating `items`, so the empty state doesn't flash on a fast load.
+  hasResolvedItems: boolean
+  // items.length > 0 || isLoading || hasResolvedItems — the standard "render the
+  // list, not the empty state" gate for the flash-guarded tabs.
+  showList: boolean
+  loadMore: () => void
+  reset: () => void
+  page: number
+}
+
+export function usePaginatedLoadMore<T>({
+  queryKey,
+  queryFn,
+}: UsePaginatedLoadMoreOptions<T>): UsePaginatedLoadMoreResult<T> {
+  const [items, setItems] = useState<T[]>([])
+  const [page, setPage] = useState(0)
+  const [isMore, setIsMore] = useState(false)
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKey(page),
+    queryFn: () => queryFn(page),
+  })
+  const showSkeleton = useDelayedLoading(isLoading)
+
+  useEffect(() => {
+    if (!data) return
+    if (page === 0) {
+      setItems([...data.items])
+      setIsMore(data.totalCount > data.items.length)
+    } else {
+      const updated = [...items, ...data.items]
+      setItems(updated)
+      setIsMore(data.totalCount > updated.length)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
+
+  const loadMore = useCallback(() => setPage(p => p + 1), [])
+  const reset = useCallback(() => setPage(0), [])
+
+  const hasResolvedItems = !!data && data.items.length > 0
+  const showList = items.length > 0 || isLoading || hasResolvedItems
+
+  return {
+    items,
+    isLoading,
+    showSkeleton,
+    isMore,
+    hasResolvedItems,
+    showList,
+    loadMore,
+    reset,
+    page,
+  }
+}

--- a/src/test/usePaginatedLoadMore.test.tsx
+++ b/src/test/usePaginatedLoadMore.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * usePaginatedLoadMore — the shared "Load more" accumulator behind the account
+ * list tabs (Saved / Ratings / Your Recipes). Exercises the page cursor, the
+ * page-0-replaces / later-pages-append accumulation, the `isMore` computation
+ * off totalCount, reset-to-page-0, and the null-payload + flash-guard contract.
+ *
+ * react-query is real (a fresh client per test, staleTime Infinity so page 0 is
+ * served from cache after a reset); the fetcher is a plain mock.
+ */
+
+import React, { FC, ReactNode } from 'react'
+import { vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  usePaginatedLoadMore,
+  LoadMorePage,
+} from 'src/pages/Account/usePaginatedLoadMore'
+
+const makeWrapper = (client: QueryClient): FC<{ children: ReactNode }> => {
+  return ({ children }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+const newClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, refetchOnWindowFocus: false },
+    },
+  })
+
+const renderLoadMore = <T,>(
+  queryFn: (page: number) => Promise<LoadMorePage<T> | null>,
+  keyPrefix = 'k'
+) =>
+  renderHook(
+    () =>
+      usePaginatedLoadMore<T>({
+        queryKey: page => [keyPrefix, page],
+        queryFn,
+      }),
+    { wrapper: makeWrapper(newClient()) }
+  )
+
+it('loads page 0 and flags more when totalCount exceeds the page', async () => {
+  const queryFn = vi.fn(async () => ({ items: ['a', 'b', 'c'], totalCount: 5 }))
+  const { result } = renderLoadMore(queryFn)
+
+  await waitFor(() => expect(result.current.items).toHaveLength(3))
+  expect(result.current.items).toEqual(['a', 'b', 'c'])
+  expect(result.current.isMore).toBe(true)
+  expect(result.current.showList).toBe(true)
+  expect(queryFn).toHaveBeenCalledWith(0)
+})
+
+it('appends later pages and clears isMore once everything is loaded', async () => {
+  const queryFn = vi.fn(async (page: number) =>
+    page === 0
+      ? { items: ['a', 'b', 'c'], totalCount: 5 }
+      : { items: ['d', 'e'], totalCount: 5 }
+  )
+  const { result } = renderLoadMore(queryFn)
+
+  await waitFor(() => expect(result.current.items).toHaveLength(3))
+  expect(result.current.isMore).toBe(true)
+
+  act(() => result.current.loadMore())
+
+  await waitFor(() => expect(result.current.items).toHaveLength(5))
+  expect(result.current.items).toEqual(['a', 'b', 'c', 'd', 'e'])
+  expect(result.current.isMore).toBe(false)
+  expect(queryFn).toHaveBeenCalledWith(1)
+})
+
+it('reset() returns to page 0 and replaces the accumulated list', async () => {
+  const queryFn = vi.fn(async (page: number) =>
+    page === 0
+      ? { items: ['a', 'b', 'c'], totalCount: 5 }
+      : { items: ['d', 'e'], totalCount: 5 }
+  )
+  const { result } = renderLoadMore(queryFn)
+
+  await waitFor(() => expect(result.current.items).toHaveLength(3))
+  act(() => result.current.loadMore())
+  await waitFor(() => expect(result.current.items).toHaveLength(5))
+
+  act(() => result.current.reset())
+
+  // Page 0 is served from cache (staleTime Infinity) and replaces the list.
+  await waitFor(() => expect(result.current.items).toHaveLength(3))
+  expect(result.current.items).toEqual(['a', 'b', 'c'])
+  expect(result.current.page).toBe(0)
+})
+
+it('treats a null payload as no items (empty-state gate, not a flash)', async () => {
+  const queryFn = vi.fn(async () => null)
+  const { result } = renderLoadMore<string>(queryFn)
+
+  await waitFor(() => expect(result.current.isLoading).toBe(false))
+  expect(result.current.items).toHaveLength(0)
+  expect(result.current.hasResolvedItems).toBe(false)
+  expect(result.current.isMore).toBe(false)
+  // items empty + settled + no resolved payload => render the empty state.
+  expect(result.current.showList).toBe(false)
+})
+
+it('a resolved-but-empty page keeps showList false (genuine empty state)', async () => {
+  const queryFn = vi.fn(async () => ({ items: [] as string[], totalCount: 0 }))
+  const { result } = renderLoadMore<string>(queryFn)
+
+  await waitFor(() => expect(result.current.isLoading).toBe(false))
+  expect(result.current.items).toHaveLength(0)
+  expect(result.current.hasResolvedItems).toBe(false)
+  expect(result.current.isMore).toBe(false)
+  expect(result.current.showList).toBe(false)
+})


### PR DESCRIPTION
## R2 · refactor the account page (Wave 5)

Behaviour-preserving structural refactor of `src/pages/Account/**`, following `docs/CONVENTIONS.md`. No user-visible change.

### What changed
1. **Extract `usePaginatedLoadMore`** (`src/pages/Account/usePaginatedLoadMore.ts`) — the load-more state machine (page cursor, page-0-replaces / later-pages-append accumulation, `isMore` off `totalCount`, flash-guarded skeleton gate) was **triplicated** across Saved / Ratings / Your-Recipes. Now one typed hook; +5 unit tests.
2. **Wire the three list tabs** onto the hook — `UserRecipes`, `UserRatings`, and `SavedRecipes`. DOM/CSS unchanged; each tab keeps its exact `showList` gate (SavedRecipes intentionally has no flash-guard) and SavedRecipes keeps its collections/search/sort chrome + the F3 `useCallback(refreshAfterMutation)` memo fix.
3. **Account shell tidy** — lifted the four header reads (username/profile/counts/gamification) + derived display strings into `useAccountData`, and the newly-unlocked achievements toast into `useAchievementsToast`. `Account.tsx` **204 → 126 lines**, now presentational.

### Scope decision
**F6** (SegmentedNav styling polish) is **closed as stale**, not implemented: the account nav was already redesigned in #136 (vertical rail) and token-normalized after; the F6 line was a vague backlog-seed added *after* that work with no concrete defect behind it. Confirmed with the owner. This PR is purely structural.

### Verification
- **tsc** clean · **Vitest** 582 passed / 2 skipped (577 baseline + 5 new hook tests) · **build** ✓ (eslint passes)
- **Runtime** (headless Chromium vs the running dev app): authed `/account` — shell + all four tabs render, active-tab tracking correct, **zero console errors**; load-more accumulation driven against the real Saved component (6 → click → 9, button hides at totalCount) + search reset-to-page-0 (→ 1 filtered, button gone) + clear-restore (→ 6, button returns). The populated path was exercised via a network stub against the real component (no dev-DB writes / no mutation of the shared Cypress user).

Net: +426 / −201 across 8 files (4 refactored, 3 new hooks, 1 test).

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK
