### PR TITLE
fix(auth): strip admin stamps from exportMyData own recipes/drafts

### DIFF
--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -694,6 +694,52 @@ describe('GET /exportMyData', () => {
       expect(recipe).not.toHaveProperty(field)
     }
   })
+
+  it("strips admin moderation stamps from the user's OWN recipes and drafts", async () => {
+    await seedUser(TEST_UID, 'exporter')
+    const db = getDB()
+    const STAMPS = {
+      moderatedBy: 'admin-uid-1',
+      moderatedAt: '2026-01-01',
+      featuredBy: 'admin-uid-2',
+      featuredAt: '2026-01-02',
+      publishUpdatedBy: 'admin-uid-3',
+      publishUpdatedAt: '2026-01-03',
+    }
+    // The user authored these, and an admin later moderated/featured them, so the
+    // raw docs carry admin Firebase uids. `description` is a user-authored field
+    // that is NOT in publicRecipeProjection — it must survive, proving the export
+    // uses an exclusion projection (full body minus stamps), not the card whitelist.
+    await db.collection('recipes').insertOne({
+      _id: 'own-1',
+      userId: TEST_UID,
+      title: 'My Stew',
+      description: 'a private note the whitelist would drop',
+      ...STAMPS,
+    })
+    await db.collection('recipeDrafts').insertOne({
+      _id: 'draft-1',
+      userId: TEST_UID,
+      title: 'My Draft',
+      description: 'draft note',
+      ...STAMPS,
+    })
+
+    const res = await request(app).get('/api/exportMyData').set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    const [ownRecipe] = res.body.recipes
+    const [ownDraft] = res.body.drafts
+    // Full authored body is preserved (including non-whitelist fields)...
+    expect(ownRecipe.title).toBe('My Stew')
+    expect(ownRecipe.description).toBe('a private note the whitelist would drop')
+    expect(ownDraft.title).toBe('My Draft')
+    // ...but none of the six admin-uid stamps ride along on either.
+    for (const field of Object.keys(STAMPS)) {
+      expect(ownRecipe).not.toHaveProperty(field)
+      expect(ownDraft).not.toHaveProperty(field)
+    }
+  })
 })
 
 // ─── POST /deleteAccount ─────────────────────────────────────────────────────

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -14,7 +14,10 @@ const { deleteRecipeImage, deleteProfilePhoto } = require('../util/firebaseStora
 const recipeRating = require('../util/recipeRating')
 const { recipeIdInQuery } = require('../util/recipeIdQuery')
 const { RECIPE_VISIBLE } = require('../util/moderation')
-const { publicRecipeProjection } = require('../util/recipeFields')
+const {
+  publicRecipeProjection,
+  recipeInternalStampsExclusion,
+} = require('../util/recipeFields')
 const { moderateText } = require('../util/textModeration')
 const { moderateImage } = require('../util/imageModeration')
 const { respondBlocked } = require('../util/automod')
@@ -340,11 +343,24 @@ router.get('/exportMyData', verifyToken, asyncHandler(async (req, res) => {
   const usernameDoc = await db.collection('usernames').findOne({ _id: uid })
   const username = usernameDoc?.username || null
 
+  // The user's OWN recipes/drafts are exported as full high-fidelity bodies —
+  // but strip the internal admin moderation stamps (RECIPE_INTERNAL_STAMPS) that
+  // any admin action left on them, so the downloaded JSON never carries admin
+  // Firebase uids. An exclusion projection (drop only those 6 keys) rather than
+  // the public card whitelist: this is the author's own content, so keep
+  // everything else. (Saved recipes below go through publicRecipeProjection —
+  // those are OTHER users' recipes, read as a non-owner would.)
   const [profile, userRecipeData, recipes, drafts, ratings] = await Promise.all([
     db.collection('userProfiles').findOne({ _id: uid }),
     db.collection('userRecipeData').findOne({ _id: uid }),
-    db.collection('recipes').find({ userId: uid }).toArray(),
-    db.collection('recipeDrafts').find({ userId: uid }).toArray(),
+    db
+      .collection('recipes')
+      .find({ userId: uid }, { projection: recipeInternalStampsExclusion })
+      .toArray(),
+    db
+      .collection('recipeDrafts')
+      .find({ userId: uid }, { projection: recipeInternalStampsExclusion })
+      .toArray(),
     db.collection('ratings').find({ userId: uid }).toArray(),
   ])
 

--- a/server/util/recipeFields.js
+++ b/server/util/recipeFields.js
@@ -42,13 +42,27 @@ const CREATABLE_RECIPE_FIELDS = [
   'editedAt',
 ]
 
+// The internal moderation/curation stamps an admin action writes onto a recipe.
+// They carry admin Firebase uids + curation metadata that no client reads, so
+// they must never reach a non-admin caller. Named here as the single source of
+// truth for both the public whitelist below (which structurally excludes them)
+// and the owner-export exclusion (which keeps the full authored body but strips
+// exactly these) — so the two can't drift.
+const RECIPE_INTERNAL_STAMPS = [
+  'moderatedBy',
+  'moderatedAt',
+  'featuredBy',
+  'featuredAt',
+  'publishUpdatedBy',
+  'publishUpdatedAt',
+]
+
 // The recipe fields safe to return on PUBLIC (unauthenticated / non-admin)
 // responses. This is exactly the shape the client's `RecipeType` consumes; the
-// internal moderation/curation stamps are deliberately excluded because no
-// client reads them and they carry admin Firebase uids + curation metadata:
-//   moderatedBy, moderatedAt, featuredBy, featuredAt, publishUpdatedBy, publishUpdatedAt
-// A whitelist (not a blacklist of those six) so a future internal stamp added to
-// the doc can't silently leak — it stays out of public responses until added
+// internal moderation/curation stamps (RECIPE_INTERNAL_STAMPS) are deliberately
+// excluded because no client reads them and they carry admin Firebase uids.
+// A whitelist (not a blacklist of those stamps) so a future internal stamp added
+// to the doc can't silently leak — it stays out of public responses until added
 // here on purpose. Built on CREATABLE_RECIPE_FIELDS so new user-content fields
 // propagate automatically, matching the drafts/edit whitelists above.
 const PUBLIC_RECIPE_FIELDS = [
@@ -98,6 +112,14 @@ const toProjection = (fields) => Object.fromEntries(fields.map((f) => [f, 1]))
 const publicRecipeProjection = toProjection(PUBLIC_RECIPE_FIELDS)
 const publicRecipeCardProjection = toProjection(PUBLIC_RECIPE_CARD_FIELDS)
 
+// An EXCLUSION projection ({ field: 0 }) that drops only the internal admin
+// stamps, leaving every other (user-authored) field intact. Used for the
+// owner's export of their OWN recipes/drafts, where — unlike a public read — the
+// full high-fidelity body is wanted, just not the admin-uid moderation metadata.
+const recipeInternalStampsExclusion = Object.fromEntries(
+  RECIPE_INTERNAL_STAMPS.map((f) => [f, 0])
+)
+
 // Copy only the whitelisted keys that are present in `body`. Absent keys are
 // left out (callers merge via $set), so a field the client doesn't send is
 // untouched rather than overwritten.
@@ -115,7 +137,9 @@ module.exports = {
   CREATABLE_RECIPE_FIELDS,
   PUBLIC_RECIPE_FIELDS,
   PUBLIC_RECIPE_CARD_FIELDS,
+  RECIPE_INTERNAL_STAMPS,
   publicRecipeProjection,
   publicRecipeCardProjection,
+  recipeInternalStampsExclusion,
   pickFields,
 }


### PR DESCRIPTION
## What

`GET /exportMyData` returned the owner's **own** `recipes`/`drafts` as raw Mongo docs (`find({ userId: uid }).toArray()`, no projection). Any of the user's own recipes an admin ever moderated/featured therefore carried the six internal admin stamps — `moderatedBy`/`moderatedAt`, `featuredBy`/`featuredAt`, `publishUpdatedBy`/`publishUpdatedAt` (**admin Firebase uids**) — straight into the JSON the non-admin owner downloads.

This is the **last unprojected account read** in the #397/#446 recipe-projection leak class. The **saved-recipe** half of this same endpoint was already sealed by #229 (S2) via `publicRecipeProjection`; this closes the owner's-own-content half. (BACKLOG.md item, filed 2026-07-03 in the S2 review; Low severity — audience is only the recipe's own author, via an explicit export, and the PII is internal admin uids.)

## How

A data export should stay **higher-fidelity** than a public card, so rather than the card whitelist this uses an **exclusion projection** that drops *only* the six stamps and keeps the full user-authored body.

- `server/util/recipeFields.js` — added a shared `RECIPE_INTERNAL_STAMPS` constant naming the six stamps once (also documents what the public whitelist structurally excludes, so the two can't drift), plus a `recipeInternalStampsExclusion` (`{ field: 0 }`) derived from it.
- `server/routes/auth.js` — applied the exclusion projection to both the `recipes` and `recipeDrafts` finds in `exportMyData`. Saved recipes are untouched (they're other users' recipes, still read through `publicRecipeProjection`).

## Verification

- Extended the auth Jest suite with an own-recipes/drafts regression test: seeds all six stamps **plus** a non-whitelist `description` field, asserts the stamps are gone from both `recipes` and `drafts` while the authored body (incl. `description`) survives — proving exclusion-not-whitelist.
- Full server Jest suite green: **32 suites / 749 tests**.
- Server boots with the new wiring (`Connected to MongoDB`) and the endpoint routes (401 unauth).

## Notes

- Read-only endpoint; no behaviour change for the saved-recipe path.
- Drafts are pre-publish so rarely carry these stamps, but the exclusion is applied there too for consistency/defence-in-depth (dropping absent keys is a no-op).

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK