### PR TITLE
feat(admin): ingredient-enrichment telemetry + N1 price-outlier guard (N6)

### DIFF
--- a/docs/BACKLOG_ROADMAP.md
+++ b/docs/BACKLOG_ROADMAP.md
@@ -98,7 +98,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **6** | **N3 · auth-page home links** | brand-mark `<div>` → `<Link to='/'>` on Login + Signup (BACKLOG UX) | `[ ]` | `src/pages/Login/`, `src/pages/Signup/` | tiny |
 | **6** | **N4 · SingleRecipe lane** ⚠ lane | author-byline + reviewer-name → `/u/:username` links; servings-pill spacing/glyph visual check (BACKLOG UX + pixel batch a) | `[ ]` | `src/pages/SingleRecipe/**` (incl. `Reviews/RecipeReview.tsx`) | reviewer-name half overlaps RELEASE_PLAN §D overhaul — see rule 8; screenshot the pill before touching it |
 | **6** | **N5 · polish sweep** | skip-link overscroll fix (A11y); RecipeNotFound copy/search; /recipes search-btn offset; footer bug-btn decision (pixel batch b, c) | `[ ]` | `Layout.scss`, `RecipeNotFound/*`, `Recipes.scss`, `Footer.scss` | disjoint smalls, one worktree; RecipeNotFound wording needs the owner's voice — draft options |
-| **6** | **N6 · ingredient-miss telemetry** (+ N1 outlier guard) | persist enrichment misses + admin list (BACKLOG Features, admin); **folds in N1's price-outlier flag** | `[~]` `worktree-feat+n6-ingredient-telemetry` (2026-07-08) | `server/routes/ingredients.js`, `server/routes/admin.js`, `src/pages/Admin/**` | new `ingredientMisses` collection; write stays best-effort. N1's guard rides this surface as a second event type (flag, not clamp) |
+| **6** | **N6 · ingredient-miss telemetry** (+ N1 outlier guard) | persist enrichment misses + admin list (BACKLOG Features, admin); **folds in N1's price-outlier flag** | `[P]` [#255](https://github.com/jclind/prepify/pull/255) (2026-07-08) | `server/routes/ingredients.js`, `server/routes/admin.js`, `src/pages/Admin/**` | new `ingredientMisses` collection; write stays best-effort. N1's guard rides this surface as a second event type (flag, not clamp) |
 | **6** | **N7 · ops: storage-bucket env** | set `FIREBASE_STORAGE_BUCKET` (prod+dev) + real empty-env skip (BACKLOG Tech debt) | `[ ]` | server envs (owner) + `server/util/firebaseStorage.js` | env half is owner-gated; code half is a 3-line early-return |
 | **—** | **Deferred / post-1.0 / owner** | see [that section](#deferred--post-10--owner-off-the-active-board) | `[blocked]`/`[dropped]` | — | prerendering, Edamam, theming, brand-orange, DB relocation, ideas |
 
@@ -1469,3 +1469,19 @@ Append-only; newest at the bottom. Mirror each merge into the item's box in [`BA
   updated: option-B is now this lane; the re-enrich backfill (option A) stays owner/proxy-gated. Disjoint from
   every other N-lane (owns `ingredients.js`/`admin.js`/`src/pages/Admin`). Verified `development` in sync with
   origin before claiming and no in-flight worktree on these files.
+- **2026-07-08** — **N6 implemented** in `worktree-feat+n6-ingredient-telemetry` → PR
+  [#255](https://github.com/jclind/prepify/pull/255) opened (`[P]`). `POST /api/ingredients/parse` now writes
+  best-effort telemetry into a new **`ingredientMisses`** collection — `miss` (a clean Spoonacular miss, which
+  was `console.warn`-only) and, folding in **N1**'s guard, `price_outlier` (an enriched row whose
+  `totalPriceUSACents` clears a **$15/row ceiling** — the "$10 parfait" class, e.g. `1 cup strawberries` =
+  $25.34 on dev). Upsert keyed `${type}:${normalized}` with a `$inc` counter + `firstSeen`/`lastSeen`; the
+  write is `try/catch`'d so a telemetry/DB failure never affects the parse response, and the route finally
+  gets the `getDB()` handle it lacked. **Flag, not clamp** — the returned/stored price is untouched (clamping
+  would mangle legitimately expensive rows like a pound of saffron); the guard is pure observability. Surfaced
+  read-only via `GET /admin/ingredients` (admin-gated, count-desc, `type` filter) + a new **Admin › Ingredients**
+  page mirroring the Audit list (type tabs, pagination). Tests: server integration (real app + real Mongo) 9
+  cases — parse writes `miss`/`price_outlier`/nothing + increments; admin auth/list/filter — and frontend
+  component 3 cases (render both types + formatted $25.34, filter refetch, empty state). Gates: `tsc` clean,
+  Vitest 617, Jest 772, `npm run build` clean; live dev server route-mount confirmed (401 parity with
+  `/admin/audit`), nodemon reloaded cleanly. **N1's re-enrich backfill (option A) stays owner/proxy-gated** —
+  out of this PR's scope (the hosted v2 proxy was erroring during the N1 investigation).

--- a/server/__tests__/ingredient-telemetry.test.js
+++ b/server/__tests__/ingredient-telemetry.test.js
@@ -1,0 +1,176 @@
+/**
+ * Ingredient-enrichment telemetry (N6 + N1 outlier guard).
+ *
+ * Covers the two halves that share the `ingredientMisses` collection:
+ *   - POST /api/ingredients/parse writes a best-effort telemetry doc — `miss`
+ *     on a clean enrichment miss, `price_outlier` when an enriched row's price
+ *     clears the outlier ceiling ($15) — and increments a per-key counter.
+ *   - GET /api/admin/ingredients lists them read-only, admin-gated, filterable
+ *     by type, sorted by count desc.
+ *
+ * The parser is mocked (no real proxy calls); the DB is the shared in-memory
+ * replica set from setup.js.
+ */
+
+jest.mock('@jclind/ingredient-parser', () => ({
+  ingredientParser: jest.fn(),
+}))
+
+const request = require('supertest')
+const admin = require('firebase-admin') // auto-mocked
+const app = require('../app')
+const { ingredientParser } = require('@jclind/ingredient-parser')
+const { getDB } = require('../db')
+
+const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
+
+// Build a v2 ingredientParser result with a given price (cents). `null` price
+// omits it entirely (partial enrichment); `undefined` data models a clean miss.
+const v2Result = (cents) => ({
+  parsed: { original: 'x' },
+  data: {
+    name: 'strawberries',
+    category: 'Produce',
+    image: 'https://spoonacular.com/cdn/ingredients_100x100/strawberries.png',
+    possibleUnits: ['cup', 'g'],
+    nutrition: null,
+    price: cents == null ? null : { cents, basis: 'gram' },
+  },
+})
+
+const miss = () => ({ parsed: { original: 'x' }, data: null })
+
+beforeEach(() => {
+  ingredientParser.mockReset()
+})
+
+afterEach(async () => {
+  admin.__resetClaims()
+  await getDB().collection('ingredientMisses').deleteMany({})
+})
+
+describe('POST /api/ingredients/parse — telemetry writes', () => {
+  it('records a `miss` doc on a clean enrichment miss', async () => {
+    ingredientParser.mockResolvedValue(miss())
+    const res = await request(app)
+      .post('/api/ingredients/parse')
+      .set(AUTH_HEADER)
+      .send({ ingredientString: '1 cup zzqxnonexistent, fresh' })
+    // Response is unaffected — telemetry never changes the parse contract.
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ingredientData: null })
+
+    const docs = await getDB().collection('ingredientMisses').find({}).toArray()
+    expect(docs).toHaveLength(1)
+    expect(docs[0]).toMatchObject({
+      _id: 'miss:1 cup zzqxnonexistent', // comma-clause dropped, lowercased
+      type: 'miss',
+      normalized: '1 cup zzqxnonexistent',
+      raw: '1 cup zzqxnonexistent, fresh',
+      count: 1,
+    })
+    expect(docs[0].firstSeen).toBeInstanceOf(Date)
+    expect(docs[0].lastSeen).toBeInstanceOf(Date)
+  })
+
+  it('records a `price_outlier` doc when an enriched price clears the ceiling', async () => {
+    ingredientParser.mockResolvedValue(v2Result(2533.86)) // → $25.34, the parfait class
+    const res = await request(app)
+      .post('/api/ingredients/parse')
+      .set(AUTH_HEADER)
+      .send({ ingredientString: '1 cup strawberries' })
+    // The price still flows through to the client unchanged — flag, not clamp.
+    expect(res.status).toBe(200)
+    expect(res.body.ingredientData.totalPriceUSACents).toBe(2534)
+
+    const doc = await getDB()
+      .collection('ingredientMisses')
+      .findOne({ _id: 'price_outlier:1 cup strawberries' })
+    expect(doc).toMatchObject({
+      type: 'price_outlier',
+      normalized: '1 cup strawberries',
+      name: 'strawberries',
+      priceCents: 2534,
+      count: 1,
+    })
+  })
+
+  it('records nothing for a normal, plausibly-priced ingredient', async () => {
+    ingredientParser.mockResolvedValue(v2Result(160.88)) // $1.61 — fine
+    const res = await request(app)
+      .post('/api/ingredients/parse')
+      .set(AUTH_HEADER)
+      .send({ ingredientString: '1 cup granola' })
+    expect(res.status).toBe(200)
+    const count = await getDB().collection('ingredientMisses').countDocuments({})
+    expect(count).toBe(0)
+  })
+
+  it('records nothing when an enriched ingredient has no price at all', async () => {
+    ingredientParser.mockResolvedValue(v2Result(null))
+    await request(app)
+      .post('/api/ingredients/parse')
+      .set(AUTH_HEADER)
+      .send({ ingredientString: 'pinch of salt' })
+    const count = await getDB().collection('ingredientMisses').countDocuments({})
+    expect(count).toBe(0)
+  })
+
+  it('increments the counter (not a new doc) on a repeat of the same string', async () => {
+    ingredientParser.mockResolvedValue(miss())
+    for (let i = 0; i < 3; i++) {
+      await request(app)
+        .post('/api/ingredients/parse')
+        .set(AUTH_HEADER)
+        .send({ ingredientString: 'made up thing' })
+    }
+    const docs = await getDB().collection('ingredientMisses').find({}).toArray()
+    expect(docs).toHaveLength(1)
+    expect(docs[0].count).toBe(3)
+  })
+})
+
+describe('GET /api/admin/ingredients', () => {
+  const seedTelemetry = () =>
+    getDB()
+      .collection('ingredientMisses')
+      .insertMany([
+        { _id: 'miss:a', type: 'miss', normalized: 'a', raw: 'a', count: 5, firstSeen: new Date(), lastSeen: new Date() },
+        { _id: 'miss:b', type: 'miss', normalized: 'b', raw: 'b', count: 1, firstSeen: new Date(), lastSeen: new Date() },
+        { _id: 'price_outlier:c', type: 'price_outlier', normalized: 'c', raw: 'c', name: 'c', priceCents: 2000, count: 9, firstSeen: new Date(), lastSeen: new Date() },
+      ])
+
+  it('requires admin (403 without the claim)', async () => {
+    const res = await request(app).get('/api/admin/ingredients').set(AUTH_HEADER)
+    expect(res.status).toBe(403)
+  })
+
+  it('lists all telemetry sorted by count desc', async () => {
+    admin.__setClaims({ admin: true })
+    await seedTelemetry()
+    const res = await request(app).get('/api/admin/ingredients').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.totalCount).toBe(3)
+    expect(res.body.items.map((i) => i.count)).toEqual([9, 5, 1]) // count desc
+  })
+
+  it('filters by type', async () => {
+    admin.__setClaims({ admin: true })
+    await seedTelemetry()
+    const res = await request(app)
+      .get('/api/admin/ingredients?type=price_outlier')
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.totalCount).toBe(1)
+    expect(res.body.items[0]).toMatchObject({ type: 'price_outlier', priceCents: 2000 })
+  })
+
+  it('ignores an unknown type filter (lists everything)', async () => {
+    admin.__setClaims({ admin: true })
+    await seedTelemetry()
+    const res = await request(app)
+      .get('/api/admin/ingredients?type=bogus')
+      .set(AUTH_HEADER)
+    expect(res.body.totalCount).toBe(3)
+  })
+})

--- a/server/db.js
+++ b/server/db.js
@@ -187,6 +187,19 @@ async function ensureIndexes() {
   } catch (err) {
     console.error('Failed to create indexes on auditLog:', err.message)
   }
+
+  // Ingredient-enrichment telemetry (N6). GET /admin/ingredients sorts by count
+  // desc (tie-broken by lastSeen) and optionally filters by `type`. The bare
+  // {count,lastSeen} index serves the default "All" tab; the type-led compound
+  // serves the filtered tabs filter-then-sort by one index rather than an
+  // in-memory sort (mirrors the auditLog bare + compound split above).
+  try {
+    const ingredientMisses = db.collection('ingredientMisses')
+    await ingredientMisses.createIndex({ count: -1, lastSeen: -1 })
+    await ingredientMisses.createIndex({ type: 1, count: -1, lastSeen: -1 })
+  } catch (err) {
+    console.error('Failed to create indexes on ingredientMisses:', err.message)
+  }
 }
 
 async function closeDB() {

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -458,4 +458,34 @@ router.get('/admin/analytics', verifyToken, requireAdmin, asyncHandler(async (re
   })
 }))
 
+// GET /admin/ingredients?type=&page=&perPage= — read-only ingredient-enrichment
+// telemetry (N6). Lists the `ingredientMisses` docs written best-effort by
+// POST /api/ingredients/parse: `miss` (no Spoonacular match) and `price_outlier`
+// (enriched to an implausible per-row price — the N1 "$10 parfait" class).
+// Sorted by count desc so the most-frequent problems surface first. `type`
+// filters to one event kind; omitted lists both.
+const INGREDIENT_MISS_TYPES = ['miss', 'price_outlier']
+router.get('/admin/ingredients', verifyToken, requireAdmin, asyncHandler(async (req, res) => {
+  const db = getDB()
+  const { type } = req.query
+  const page = Math.max(parseInt(req.query.page) || 1, 1)
+  const perPage = Math.min(parseInt(req.query.perPage) || DEFAULT_PER_PAGE, MAX_PER_PAGE)
+
+  const filter = {}
+  if (typeof type === 'string' && INGREDIENT_MISS_TYPES.includes(type)) filter.type = type
+
+  const [items, totalCount] = await Promise.all([
+    db
+      .collection('ingredientMisses')
+      .find(filter)
+      .sort({ count: -1, lastSeen: -1 })
+      .skip((page - 1) * perPage)
+      .limit(perPage)
+      .toArray(),
+    db.collection('ingredientMisses').countDocuments(filter),
+  ])
+
+  res.json({ items, totalCount })
+}))
+
 module.exports = router

--- a/server/routes/ingredients.js
+++ b/server/routes/ingredients.js
@@ -4,8 +4,63 @@ const { verifyToken } = require('../middleware/auth')
 const { makeUserLimiter } = require('../middleware/writeLimiter')
 const { GENERIC_500_MESSAGE } = require('../util/respondServerError')
 const { asyncHandler } = require('../util/asyncHandler')
+const { getDB } = require('../db')
 
 const router = Router()
+
+// Per-ingredient price above which an *enriched* row is almost certainly a bad
+// proxy gram-estimate rather than a real cost — a single home-recipe ingredient
+// rarely exceeds this (a pound of premium meat/seafood tops out ~$12–15). Above
+// it we record a `price_outlier` telemetry event for admin review. FLAG ONLY:
+// the stored price is left untouched (clamping would mangle a legitimately
+// expensive row like a pound of saffron). Surfaced by N1's "$10 parfait"
+// investigation, where `1 cup strawberries` enriched to $25.34. Tune here.
+const PRICE_OUTLIER_CENTS = 1500
+
+// Normalize an ingredient string into a stable telemetry key: lowercase, drop a
+// trailing comma-clause ("…strawberries, fresh or frozen" → "…strawberries"),
+// collapse internal whitespace, trim, and cap length so a pathological input
+// can't mint a huge _id. Quantity/unit are kept (they drive the price, so a
+// per-quantity key is what a price_outlier wants).
+function normalizeIngredientKey(str) {
+  return String(str)
+    .toLowerCase()
+    .split(',')[0]
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 200)
+}
+
+// Best-effort enrichment-quality telemetry. Upserts a per-(type, key) counter
+// into `ingredientMisses` so admins can see which strings miss enrichment
+// (`miss`) and which enrich to implausible prices (`price_outlier`) — the N6
+// telemetry surface, with N1's price guard folded in as a second event type.
+// Wrapped so a telemetry/DB failure NEVER affects the parse response (the route
+// soft-fails on its own); the write is awaited only so it's deterministic under
+// test — errors are swallowed here, so awaiting can't reject the handler.
+async function recordIngredientTelemetry(type, ingredientString, extra = {}) {
+  try {
+    const normalized = normalizeIngredientKey(ingredientString)
+    if (!normalized) return
+    const now = new Date()
+    await getDB()
+      .collection('ingredientMisses')
+      .updateOne(
+        { _id: `${type}:${normalized}` },
+        {
+          $set: { type, normalized, raw: ingredientString, lastSeen: now, ...extra },
+          $inc: { count: 1 },
+          $setOnInsert: { firstSeen: now },
+        },
+        { upsert: true }
+      )
+  } catch (err) {
+    console.error(
+      '[ingredients/parse] telemetry write failed',
+      JSON.stringify({ type, message: err && err.message })
+    )
+  }
+}
 
 // Every call can spend paid Spoonacular quota (via the parser's proxy), so this
 // route gets its own tight per-user limit — an independent bucket from the
@@ -72,12 +127,25 @@ router.post('/parse', verifyToken, parseLimiter, asyncHandler(async (req, res) =
 
     // Soft-fail by design: a clean lookup miss (no Spoonacular match) returns 200
     // with `ingredientData: null`. Log it so we can see which strings miss in
-    // prod and decide whether to seed the proxy cache.
+    // prod and decide whether to seed the proxy cache, and persist it for the
+    // admin telemetry list (N6).
     if (!ingredientData) {
       console.warn(
         '[ingredients/parse] enrichment miss',
         JSON.stringify({ ingredientString })
       )
+      await recordIngredientTelemetry('miss', ingredientString)
+    } else if (
+      typeof ingredientData.totalPriceUSACents === 'number' &&
+      ingredientData.totalPriceUSACents >= PRICE_OUTLIER_CENTS
+    ) {
+      // Enriched, but to an implausible price — record it for admin review so a
+      // bad proxy gram-estimate (the N1 "$10 parfait" class) is visible. The
+      // price still flows through to the client unchanged; this is observability.
+      await recordIngredientTelemetry('price_outlier', ingredientString, {
+        name: ingredientData.name,
+        priceCents: ingredientData.totalPriceUSACents,
+      })
     }
     return res.json({ ingredientData })
   } catch (err) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,9 @@ const BugReports = lazyRoute(
   () => import('src/pages/Admin/BugReports/BugReports')
 )
 const Users = lazyRoute(() => import('src/pages/Admin/Users/Users'))
+const Ingredients = lazyRoute(
+  () => import('src/pages/Admin/Ingredients/Ingredients')
+)
 const Audit = lazyRoute(() => import('src/pages/Admin/Audit/Audit'))
 
 // Account area. PublicProfile is a direct-landing surface (shared profile
@@ -388,6 +391,14 @@ const App: FC = () => {
                   element={
                     <Lazy>
                       <Users />
+                    </Lazy>
+                  }
+                />
+                <Route
+                  path='ingredients'
+                  element={
+                    <Lazy>
+                      <Ingredients />
                     </Lazy>
                   }
                 />

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -6,6 +6,8 @@ import {
   AuditAction,
   AuditTargetType,
   AnalyticsResponse,
+  IngredientMissType,
+  IngredientMissesResponse,
 } from 'types'
 import { http } from 'src/api/http-common'
 
@@ -78,6 +80,21 @@ class AdminAPIClass {
     perPage?: number
   }): Promise<AuditResponse> {
     const result = await http.get<AuditResponse>('api/admin/audit', { params })
+    return result.data
+  }
+
+  // Read-only ingredient-enrichment telemetry (N6): strings that missed
+  // enrichment or enriched to an implausible price. `type` filters to one event
+  // kind; omitted lists both. Sorted server-side by count desc.
+  async listIngredientMisses(params?: {
+    type?: IngredientMissType
+    page?: number
+    perPage?: number
+  }): Promise<IngredientMissesResponse> {
+    const result = await http.get<IngredientMissesResponse>(
+      'api/admin/ingredients',
+      { params }
+    )
     return result.data
   }
 

--- a/src/pages/Admin/AdminLayout.tsx
+++ b/src/pages/Admin/AdminLayout.tsx
@@ -11,6 +11,7 @@ const ADMIN_NAV = [
   { to: '/admin/reports', label: 'Reports' },
   { to: '/admin/bug-reports', label: 'Bug reports' },
   { to: '/admin/users', label: 'Users' },
+  { to: '/admin/ingredients', label: 'Ingredients' },
   { to: '/admin/audit', label: 'Audit log' },
 ]
 

--- a/src/pages/Admin/Ingredients/Ingredients.scss
+++ b/src/pages/Admin/Ingredients/Ingredients.scss
@@ -1,0 +1,182 @@
+@use '../../../helpers.scss' as s;
+
+.admin-ingredients {
+  max-width: 820px;
+
+  .admin-ingredients-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+
+    h1 {
+      margin: 0;
+      font-size: s.$text-2xl;
+    }
+
+    .total-count {
+      font-size: s.$text-sm;
+      font-weight: 600;
+      color: s.$admin-slate-600;
+      background: s.$admin-slate-100;
+      padding: 0.2rem 0.55rem;
+      border-radius: s.$radius-pill;
+    }
+  }
+
+  .admin-ingredients-intro {
+    margin: 0 0 1.5rem;
+    font-size: s.$text-sm;
+    color: s.$admin-slate-500;
+    max-width: 60ch;
+  }
+
+  .ingredients-filters {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+
+    .type-tabs {
+      display: flex;
+      gap: 0.4rem;
+      flex-wrap: wrap;
+
+      .tab {
+        border: 1px solid s.$admin-slate-300;
+        background: s.$white;
+        color: s.$admin-slate-600;
+        padding: 0.35rem 0.8rem;
+        border-radius: s.$radius-pill;
+        font-size: s.$text-sm;
+        cursor: pointer;
+        transition: color s.$hover-timing, background-color s.$hover-timing,
+          border-color s.$hover-timing;
+
+        &:hover {
+          border-color: s.$admin-slate-400;
+        }
+
+        &.active {
+          background: s.$admin-chrome;
+          border-color: s.$admin-chrome;
+          color: s.$white;
+        }
+      }
+    }
+  }
+
+  .ingredients-state {
+    color: s.$admin-slate-500;
+    font-size: s.$text-base;
+
+    &.error {
+      color: s.$admin-danger-text;
+    }
+  }
+
+  .ingredients-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .ingredient-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.85rem 0;
+    border-bottom: 1px solid s.$admin-slate-200;
+
+    .ingredient-body {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .ingredient-line {
+      margin: 0;
+      display: flex;
+      align-items: baseline;
+      gap: 0.55rem;
+      flex-wrap: wrap;
+      font-size: s.$text-base;
+      color: s.$admin-slate-900;
+    }
+
+    .type-pill {
+      font-size: s.$text-fine;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      padding: 0.15rem 0.5rem;
+      border-radius: s.$radius-pill;
+      flex-shrink: 0;
+
+      &.miss {
+        color: s.$admin-slate-700;
+        background: s.$admin-slate-100;
+      }
+
+      &.price_outlier {
+        color: s.$admin-warn-text;
+        background: s.$admin-warn-bg;
+      }
+    }
+
+    .ingredient-raw {
+      word-break: break-word;
+    }
+
+    .ingredient-detail {
+      margin: 0.3rem 0 0;
+      font-size: s.$text-sm;
+      color: s.$admin-slate-600;
+
+      .price {
+        color: s.$admin-warn-text;
+      }
+    }
+
+    .ingredient-time {
+      margin: 0.25rem 0 0;
+      font-size: s.$text-fine;
+      color: s.$admin-slate-400;
+    }
+
+    .ingredient-count {
+      flex-shrink: 0;
+      font-size: s.$text-sm;
+      font-weight: 700;
+      color: s.$admin-slate-600;
+      background: s.$admin-slate-100;
+      padding: 0.2rem 0.55rem;
+      border-radius: s.$radius-pill;
+    }
+  }
+
+  .ingredients-pager {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 1.5rem;
+    font-size: s.$text-sm;
+    color: s.$admin-slate-600;
+
+    button {
+      border: 1px solid s.$admin-slate-300;
+      background: s.$white;
+      color: s.$admin-slate-700;
+      padding: 0.4rem 0.9rem;
+      border-radius: s.$radius-md;
+      cursor: pointer;
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+    }
+  }
+}

--- a/src/pages/Admin/Ingredients/Ingredients.tsx
+++ b/src/pages/Admin/Ingredients/Ingredients.tsx
@@ -1,0 +1,138 @@
+import React, { FC, useState } from 'react'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
+import { IngredientMissItem, IngredientMissType } from 'types'
+import AdminAPI from 'src/api/admin'
+import './Ingredients.scss'
+
+type TypeFilter = IngredientMissType | 'all'
+
+const PER_PAGE = 25
+
+const TYPE_TABS: { value: TypeFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'miss', label: 'Enrichment misses' },
+  { value: 'price_outlier', label: 'Price outliers' },
+]
+
+const TYPE_LABEL: Record<IngredientMissType, string> = {
+  miss: 'miss',
+  price_outlier: 'price outlier',
+}
+
+const fmtPrice = (cents?: number) =>
+  typeof cents === 'number' ? `$${(cents / 100).toFixed(2)}` : null
+
+// Read-only view of the `ingredientMisses` telemetry (N6): ingredient strings
+// that missed enrichment, and — folded in from N1 — those that enriched to an
+// implausible per-row price (the "$10 parfait" class). Sorted server-side by
+// count desc so the most-frequent problems lead. No actions: this is a signal
+// for seeding the proxy cache / auditing bad estimates, not a moderation queue.
+const Ingredients: FC = () => {
+  const [type, setType] = useState<TypeFilter>('all')
+  const [page, setPage] = useState(1)
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['admin-ingredients', type, page],
+    queryFn: () =>
+      AdminAPI.listIngredientMisses({
+        type: type === 'all' ? undefined : type,
+        page,
+        perPage: PER_PAGE,
+      }),
+    placeholderData: keepPreviousData,
+  })
+
+  const totalPages = data ? Math.max(Math.ceil(data.totalCount / PER_PAGE), 1) : 1
+
+  const changeType = (value: TypeFilter) => {
+    setType(value)
+    setPage(1)
+  }
+
+  return (
+    <div className='admin-ingredients'>
+      <header className='admin-ingredients-head'>
+        <h1>Ingredient telemetry</h1>
+        {data && <span className='total-count'>{data.totalCount} tracked</span>}
+      </header>
+
+      <p className='admin-ingredients-intro'>
+        Strings that missed enrichment or enriched to an implausible price,
+        captured best-effort at parse time. Most-frequent first — use it to seed
+        the proxy cache or spot bad price estimates.
+      </p>
+
+      <div className='ingredients-filters'>
+        <div className='type-tabs'>
+          {TYPE_TABS.map(tab => (
+            <button
+              key={tab.value}
+              className={type === tab.value ? 'tab active' : 'tab'}
+              onClick={() => changeType(tab.value)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isPending ? (
+        <p className='ingredients-state'>Loading ingredient telemetry…</p>
+      ) : isError ? (
+        <p className='ingredients-state error'>
+          Failed to load ingredient telemetry.
+        </p>
+      ) : data.items.length === 0 ? (
+        <p className='ingredients-state'>No matching ingredient telemetry.</p>
+      ) : (
+        <>
+          <ul className='ingredients-list'>
+            {data.items.map((item: IngredientMissItem) => (
+              <li key={item._id} className='ingredient-row'>
+                <div className='ingredient-body'>
+                  <p className='ingredient-line'>
+                    <span className={`type-pill ${item.type}`}>
+                      {TYPE_LABEL[item.type]}
+                    </span>
+                    <span className='ingredient-raw'>{item.raw}</span>
+                  </p>
+                  {item.type === 'price_outlier' && (
+                    <p className='ingredient-detail'>
+                      matched <strong>{item.name || '—'}</strong> at{' '}
+                      <strong className='price'>{fmtPrice(item.priceCents)}</strong>
+                    </p>
+                  )}
+                  <p className='ingredient-time'>
+                    last seen {new Date(item.lastSeen).toLocaleString()}
+                  </p>
+                </div>
+                <span className='ingredient-count' title='times seen'>
+                  ×{item.count}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          {totalPages > 1 && (
+            <div className='ingredients-pager'>
+              <button disabled={page <= 1} onClick={() => setPage(p => p - 1)}>
+                Prev
+              </button>
+              <span>
+                Page {page} of {totalPages}
+              </span>
+              <button
+                disabled={page >= totalPages}
+                onClick={() => setPage(p => p + 1)}
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+export default Ingredients

--- a/src/test/AdminIngredients.test.tsx
+++ b/src/test/AdminIngredients.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Admin Ingredients (enrichment telemetry) page: renders `miss` and
+ * `price_outlier` rows from AdminAPI.listIngredientMisses and filters by type.
+ * The API is mocked; react-query/router are real.
+ */
+
+import React from 'react'
+import { vi, Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import Ingredients from 'src/pages/Admin/Ingredients/Ingredients'
+import AdminAPI from 'src/api/admin'
+
+vi.mock('src/api/admin', () => ({
+  __esModule: true,
+  default: { listIngredientMisses: vi.fn() },
+}))
+
+const mockedList = AdminAPI.listIngredientMisses as unknown as Mock
+
+const missItem = {
+  _id: 'miss:1 cup zzqx',
+  type: 'miss' as const,
+  normalized: '1 cup zzqx',
+  raw: '1 cup zzqx, fresh',
+  count: 4,
+  firstSeen: new Date('2026-06-01T12:00:00Z').toISOString(),
+  lastSeen: new Date('2026-06-02T12:00:00Z').toISOString(),
+}
+
+const outlierItem = {
+  _id: 'price_outlier:1 cup strawberries',
+  type: 'price_outlier' as const,
+  normalized: '1 cup strawberries',
+  raw: '1 cup strawberries',
+  name: 'strawberries',
+  priceCents: 2534,
+  count: 2,
+  firstSeen: new Date('2026-06-01T12:00:00Z').toISOString(),
+  lastSeen: new Date('2026-06-02T12:00:00Z').toISOString(),
+}
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+    >
+      <MemoryRouter>
+        <Ingredients />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+
+afterEach(() => vi.clearAllMocks())
+
+describe('Admin Ingredients telemetry page', () => {
+  it('renders a miss row and a price-outlier row with its formatted price', async () => {
+    mockedList.mockResolvedValue({ items: [outlierItem, missItem], totalCount: 2 })
+    renderPage()
+
+    expect(await screen.findByText('1 cup strawberries')).toBeInTheDocument()
+    expect(screen.getByText('1 cup zzqx, fresh')).toBeInTheDocument()
+    // The outlier's matched name + formatted price ($25.34 from 2534 cents).
+    expect(screen.getByText('strawberries')).toBeInTheDocument()
+    expect(screen.getByText('$25.34')).toBeInTheDocument()
+    // Occurrence counts render as ×N.
+    expect(screen.getByText('×4')).toBeInTheDocument()
+  })
+
+  it('filters by type and refetches', async () => {
+    mockedList.mockResolvedValue({ items: [outlierItem], totalCount: 1 })
+    renderPage()
+    await screen.findByText('1 cup strawberries')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Price outliers' }))
+
+    await waitFor(() =>
+      expect(mockedList).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'price_outlier', page: 1 })
+      )
+    )
+  })
+
+  it('shows an empty state when there is no telemetry', async () => {
+    mockedList.mockResolvedValue({ items: [], totalCount: 0 })
+    renderPage()
+    expect(
+      await screen.findByText(/no matching ingredient telemetry/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -445,6 +445,29 @@ export interface AuditResponse {
   totalCount: number
 }
 
+// Ingredient-enrichment telemetry (N6 + N1 outlier guard). Mirrors the
+// `ingredientMisses` docs written best-effort by POST /api/ingredients/parse
+// and listed read-only by GET /admin/ingredients.
+export type IngredientMissType = 'miss' | 'price_outlier'
+
+export interface IngredientMissItem {
+  _id: string
+  type: IngredientMissType
+  normalized: string
+  raw: string
+  count: number
+  firstSeen: string
+  lastSeen: string
+  // price_outlier only: the matched ingredient name + the offending price (cents).
+  name?: string
+  priceCents?: number
+}
+
+export interface IngredientMissesResponse {
+  items: IngredientMissItem[]
+  totalCount: number
+}
+
 // Admin analytics dashboard (P3b). Mirrors GET /admin/analytics in
 // server/routes/admin.js.
 export interface AnalyticsTotals {


### PR DESCRIPTION
## What & why

**Wave 6 · N6** (ingredient-miss telemetry) with **N1's price-outlier guard folded in** (per the owner's call after the [N1 investigation](../blob/development/docs/BACKLOG_ROADMAP.md) attributed the "\$10 parfait" to a bad *proxy price-estimate*, not a parse or division bug).

Enrichment misses were previously only `console.warn`'d and the `/parse` route had no DB handle — no persistence, no admin surface. This adds both, and rides the same surface for N1's guard as a second event type.

## Changes

**Server**
- `POST /api/ingredients/parse` now writes best-effort telemetry into a new **`ingredientMisses`** collection:
  - `miss` — a clean Spoonacular miss (no match)
  - `price_outlier` — an enriched row whose `totalPriceUSACents` clears a **\$15/row ceiling** (the N1 "\$10 parfait" class; `1 cup strawberries` enriched to \$25.34 on dev)
  - Upsert keyed by `${type}:${normalized}` with a `$inc` counter + `firstSeen`/`lastSeen`.
- **Flag, not clamp** — the stored/returned price is untouched (clamping would mangle legitimately expensive rows like a pound of saffron); the guard is pure observability.
- Write is `try/catch`'d so a telemetry/DB failure **never** affects the parse response. The route finally gets its `getDB()` handle.
- `GET /api/admin/ingredients` — read-only, admin-gated, sorted by `count` desc, `type` filter.

**Frontend**
- New **Admin › Ingredients** page (`/admin/ingredients`) mirroring the Audit list — type tabs (All / Misses / Price outliers), pagination, formatted price on outliers.
- `AdminAPI.listIngredientMisses`, nav item, lazy route, `types.ts` additions.

## Tests
- **Server** (`ingredient-telemetry.test.js`, 9 cases) — real Express app + real Mongo: parse writes `miss`/`price_outlier`/nothing and increments the counter; admin route auth (403), list sort, type filter, unknown-filter fallthrough.
- **Frontend** (`AdminIngredients.test.tsx`, 3 cases) — renders both event types + formatted \$25.34, filter refetch, empty state.

## Verification
- Gates green: `tsc` clean · Vitest **617** · Jest **772** · `npm run build` clean.
- Live dev server: route mounts (401 unauth, parity with `/admin/audit`); nodemon reloaded cleanly (Connected to MongoDB, port 4001). The parse→telemetry write path is exercised end-to-end by the supertest integration tests against a real Mongo (rather than a manual token-authed curl).

## Follow-up (not in this PR)
N1's **re-enrich backfill** (fix-option A) stays owner/proxy-gated — the hosted v2 proxy was erroring during the N1 investigation, so healing stale v1 prices catalog-wide is a separate ops run.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK