### PR TITLE
feat(reports): recipe-only "incorrect info / price" report reason (N2)

### DIFF
--- a/server/__tests__/reports.test.js
+++ b/server/__tests__/reports.test.js
@@ -232,6 +232,40 @@ describe('POST /api/reports', () => {
     expect(res.status).toBe(400)
   })
 
+  it('accepts incorrect_info on a recipe report (N2)', async () => {
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ ...validRecipeReport, reason: 'incorrect_info' })
+    expect(res.status).toBe(201)
+    expect(res.body.reason).toBe('incorrect_info')
+  })
+
+  it('rejects incorrect_info on a review report — recipe-only reason (N2)', async () => {
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({
+        targetType: 'review',
+        recipeId: 'recipe-001',
+        reportedUsername: 'baduser',
+        reason: 'incorrect_info',
+      })
+    expect(res.status).toBe(400)
+    // The reason is otherwise valid — it's the target that's wrong — so the
+    // error names the gating, not "Invalid reason".
+    expect(res.body.error).toMatch(/only applies to recipe/i)
+  })
+
+  it('rejects incorrect_info on a user report — recipe-only reason (N2)', async () => {
+    const res = await request(app)
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send({ targetType: 'user', reportedUsername: 'baduser', reason: 'incorrect_info' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/only applies to recipe/i)
+  })
+
   it('rejects over-long details', async () => {
     const res = await request(app)
       .post('/api/reports')

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -52,7 +52,12 @@ const reportLimiter = makeUserLimiter({
 // report carries `reportedUsername` alongside `recipeId`. A 'user' report
 // targets a profile directly: it carries `reportedUsername` and has no recipeId.
 const TARGET_TYPES = ['recipe', 'review', 'user']
-const REASONS = ['spam', 'inappropriate', 'offensive', 'copyright', 'dangerous', 'other']
+const REASONS = ['spam', 'inappropriate', 'offensive', 'copyright', 'dangerous', 'incorrect_info', 'other']
+// Reasons that only make sense for recipe content (wrong quantities, a bad price
+// estimate, etc.) — rejected on review/user targets so the queue can trust that
+// an `incorrect_info` report is always about a recipe. Kept in sync with the
+// client's `recipeOnly` option flag (src/Components/ReportControl).
+const RECIPE_ONLY_REASONS = ['incorrect_info']
 const RESOLUTIONS = ['resolved', 'dismissed']
 const MAX_DETAILS_LEN = 1000
 
@@ -98,6 +103,9 @@ router.post('/reports', verifyToken, requireActive, reportLimiter, asyncHandler(
   }
   if (!REASONS.includes(reason)) {
     return res.status(400).json({ error: 'Invalid reason' })
+  }
+  if (RECIPE_ONLY_REASONS.includes(reason) && targetType !== 'recipe') {
+    return res.status(400).json({ error: 'That reason only applies to recipe reports' })
   }
   if (details != null && (typeof details !== 'string' || details.length > MAX_DETAILS_LEN)) {
     return res.status(400).json({ error: `details must be a string under ${MAX_DETAILS_LEN} chars` })

--- a/src/Components/ReportControl/ReportControl.tsx
+++ b/src/Components/ReportControl/ReportControl.tsx
@@ -26,12 +26,20 @@ type ReportControlProps = {
   variant?: 'link' | 'button' | 'menu'
 }
 
-const REASON_OPTIONS: { value: ReportReason; label: string }[] = [
+// `recipeOnly` reasons (wrong quantities / price) are offered only when the
+// target is a recipe; the server rejects them on review/user targets, so the two
+// lists must agree (server/routes/reports.js: RECIPE_ONLY_REASONS).
+const REASON_OPTIONS: {
+  value: ReportReason
+  label: string
+  recipeOnly?: boolean
+}[] = [
   { value: 'spam', label: 'Spam or advertising' },
   { value: 'inappropriate', label: 'Inappropriate content' },
   { value: 'offensive', label: 'Offensive or abusive' },
   { value: 'copyright', label: 'Copyright violation' },
   { value: 'dangerous', label: 'Dangerous or unsafe' },
+  { value: 'incorrect_info', label: 'Incorrect information or price', recipeOnly: true },
   { value: 'other', label: 'Something else' },
 ]
 
@@ -50,6 +58,13 @@ const ReportControl: FC<ReportControlProps> = ({ target, variant = 'link' }) => 
     user: 'user',
   }
   const noun = NOUNS[target.targetType]
+
+  // Recipe-only reasons appear solely on recipe reports; everything else is
+  // universal. The default/reset reason ('spam') is always in this list, so the
+  // filtered set can never leave `reason` pointing at a hidden option.
+  const reasonOptions = REASON_OPTIONS.filter(
+    opt => !opt.recipeOnly || target.targetType === 'recipe'
+  )
 
   // Close the kebab dropdown on an outside click or Escape (matches the
   // SortDropdown pattern). Only wired while the menu is actually open.
@@ -132,7 +147,7 @@ const ReportControl: FC<ReportControlProps> = ({ target, variant = 'link' }) => 
           value={reason}
           onChange={e => setReason(e.target.value as ReportReason)}
         >
-          {REASON_OPTIONS.map(opt => (
+          {reasonOptions.map(opt => (
             <option key={opt.value} value={opt.value}>
               {opt.label}
             </option>

--- a/src/pages/Admin/Reports/Reports.tsx
+++ b/src/pages/Admin/Reports/Reports.tsx
@@ -338,7 +338,9 @@ const Reports: FC = () => {
                   <span className={`type-pill ${report.targetType}`}>
                     {report.targetType}
                   </span>
-                  <span className='reason-pill'>{report.reason}</span>
+                  <span className='reason-pill'>
+                    {report.reason.replace(/_/g, ' ')}
+                  </span>
                   <span className={`status-pill ${report.status}`}>
                     {report.status}
                   </span>

--- a/src/test/ReportControl.test.tsx
+++ b/src/test/ReportControl.test.tsx
@@ -64,6 +64,46 @@ describe('ReportControl', () => {
     )
   })
 
+  it('offers the recipe-only "incorrect_info" reason on a recipe report and submits it (N2)', async () => {
+    mockedUseAuth.mockReturnValue({ user: { uid: 'u1' } })
+    render(<ReportControl target={{ targetType: 'recipe', recipeId: 'r1' }} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /report this recipe/i }))
+
+    // The recipe-only option is present and selectable.
+    const option = screen.getByRole('option', { name: /incorrect information or price/i })
+    expect(option).toBeInTheDocument()
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'incorrect_info' } })
+    fireEvent.click(screen.getByRole('button', { name: /submit report/i }))
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1))
+    expect(mockedCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ targetType: 'recipe', reason: 'incorrect_info' })
+    )
+  })
+
+  it('hides the recipe-only "incorrect_info" reason on review and user reports (N2)', () => {
+    mockedUseAuth.mockReturnValue({ user: { uid: 'u1' } })
+    const { unmount } = render(
+      <ReportControl
+        target={{ targetType: 'review', recipeId: 'r1', reportedUsername: 'baduser' }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /report this review/i }))
+    expect(
+      screen.queryByRole('option', { name: /incorrect information or price/i })
+    ).not.toBeInTheDocument()
+    // A universal reason is still there.
+    expect(screen.getByRole('option', { name: /spam or advertising/i })).toBeInTheDocument()
+    unmount()
+
+    render(<ReportControl target={{ targetType: 'user', reportedUsername: 'baduser' }} />)
+    fireEvent.click(screen.getByRole('button', { name: /report this user/i }))
+    expect(
+      screen.queryByRole('option', { name: /incorrect information or price/i })
+    ).not.toBeInTheDocument()
+  })
+
   it('passes reportedUsername through for a review report', async () => {
     mockedUseAuth.mockReturnValue({ user: { uid: 'u1' } })
     render(

--- a/src/types.ts
+++ b/src/types.ts
@@ -250,6 +250,9 @@ export type ReportReason =
   | 'offensive'
   | 'copyright'
   | 'dangerous'
+  // Recipe-only: wrong ingredient amounts, bad price estimate, etc. The server
+  // rejects it on review/user targets; the UI only offers it for recipes.
+  | 'incorrect_info'
   | 'other'
 export type ReportStatus = 'open' | 'resolved' | 'dismissed'
 


### PR DESCRIPTION
## N2 — report reason "incorrect info / price"

Adds an `incorrect_info` report reason, **gated to recipe targets** (wrong ingredient quantities / bad price estimate is a recipe-content complaint, not a review/user one — the owner's call).

### Change, across the three synced lists + the admin display
- **`src/types.ts`** — new `ReportReason` union member, documented recipe-only.
- **`server/routes/reports.js`** (authoritative) — added to `REASONS`, plus a new `RECIPE_ONLY_REASONS` guard that returns **400** with a target-specific error when the reason is used on a review/user report.
- **`ReportControl.tsx`** — the option carries a `recipeOnly` flag; the rendered reason list is filtered by `target.targetType`, so it only appears on recipe reports. The default/reset reason (`spam`) is always in the filtered set, so `reason` can never point at a hidden option.
- **Admin Reports queue** — the reason pill now spaces underscores so `incorrect_info` reads as "incorrect info" (the pill rendered the raw value; every prior reason was a clean single word).

### Tests
- **Server (3):** accepts `incorrect_info` on a recipe report; rejects it on review and user reports with the gating error (not "Invalid reason").
- **Frontend (2):** the option is shown + selectable + submittable on a recipe report; hidden on review and user reports.

### Gates
`tsc` clean · Vitest (ReportControl + Reports) 14 pass · server Jest (reports) 60 pass · `npm run build` clean.

Additive union member in shared `types.ts` — rebase before merge if the board moved (roadmap rule 8a).

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK