### PR TITLE
feat(auth): make Login/Signup brand mark a home link (N3)

### DIFF
--- a/src/Components/Form/FormStyles.scss
+++ b/src/Components/Form/FormStyles.scss
@@ -57,6 +57,20 @@
     background: linear-gradient(135deg, #2ec0c8, s.$secondary);
     box-shadow: s.$shadow-teal;
     margin-bottom: 1rem;
+
+    // Now a home link (these pages render outside <Layout>, so the mark is the
+    // only route back to home): strip the anchor underline, keep the tile flat
+    // (chrome doesn't lift) with a gentle brightness affordance, add a ring.
+    text-decoration: none;
+    transition: filter 0.15s ease;
+
+    &:hover {
+      filter: brightness(1.06);
+    }
+
+    &:focus-visible {
+      @include s.focus-glow(s.$secondary, 0.2);
+    }
   }
 
   .form {

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -36,7 +36,9 @@ const Login: FC = () => {
       </Helmet>
       <main className='login-page form-format'>
         <div className='form-container'>
-          <div className='brand-mark'>P</div>
+          <Link to='/' className='brand-mark' aria-label='Prepify home'>
+            P
+          </Link>
           <form onSubmit={handleEmailAndPasswordFormSubmit} className='form'>
             <h1 className='title'>Welcome back</h1>
             <div aria-live='polite'>

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -46,7 +46,9 @@ const Signup: FC = () => {
       </Helmet>
       <main className='signup-page form-format'>
         <div className='form-container'>
-          <div className='brand-mark'>P</div>
+          <Link to='/' className='brand-mark' aria-label='Prepify home'>
+            P
+          </Link>
           <form onSubmit={handleEmailAndPasswordFormSubmit} className='form'>
             <h1 className='title'>Create your account</h1>
             <div aria-live='polite'>


### PR DESCRIPTION
## N3 · auth-page home links (Wave 6)

The Login and Signup pages render **outside `<Layout>`** (no navbar), so their "P" brand mark was a dead-end `<div>` with no route back to home. This wraps the mark in `<Link to='/'>` on both pages so it navigates home, with an `aria-label` for the icon-only link.

### Changes
- `Login.tsx` / `Signup.tsx`: `<div className='brand-mark'>P</div>` → `<Link to='/' className='brand-mark' aria-label='Prepify home'>P</Link>`
- `FormStyles.scss` `.brand-mark`: strip the anchor underline; keep the tile **flat** (chrome doesn't lift) with a subtle `brightness(1.06)` hover affordance + a `focus-glow` ring on `:focus-visible`. Visual is otherwise unchanged.

### Verification (runtime, headless Playwright)
- Clicking the mark on `/login` and `/signup` navigates to `/`.
- Keyboard: Tab focuses the link (accessible name "Prepify home"), Enter activates → `/`; `:focus-visible` ring renders.
- Hover applies `brightness(1.06)`; `text-decoration-line: none` (no underline regression).
- Gates during implementation: `tsc` clean · Vitest 617 passed / 2 skipped · `build` clean (no server changes).

Board: BACKLOG_ROADMAP.md N3. Disjoint from the in-flight N2 lane.