### PR TITLE
feat(recipe): link author byline to /u/:username + Lucide servings-pill glyphs (N4)

### DIFF
--- a/src/Components/icons/index.ts
+++ b/src/Components/icons/index.ts
@@ -83,6 +83,7 @@ export {
   LuLock as LockIcon,
   LuLogOut as LogOutIcon,
   LuMapPin as MapPinIcon,
+  LuMinus as MinusIcon,
   LuEllipsis as MoreIcon,
   LuChartPie as PieChartIcon,
   LuPizza as PizzaIcon,

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -322,7 +322,7 @@ $soft-radius: 16px;
         &:hover { background: s.$primary; color: s.$white; }
       }
       .serv-input {
-        width: 28px;
+        width: 25px;
         height: 32px;
         box-sizing: border-box;
         border: none;
@@ -331,6 +331,11 @@ $soft-radius: 16px;
         font-weight: 700;
         font-size: s.$text-base;
         color: s.$primary-text;
+        // A hair narrower than the original 28px tightens the "N serv"
+        // pairing (the centred digit no longer floats mid-box), while the
+        // left margin keeps the − button off the number — the padding the
+        // wider box used to give for free.
+        margin-left: 0.15rem;
         padding: 0;
         // Was outline:none with no replacement — restore a visible keyboard
         // focus ring (matches the +/- step buttons beside it). WCAG 2.4.7.
@@ -338,7 +343,8 @@ $soft-radius: 16px;
           @include s.outline();
         }
       }
-      .serv-unit { font-size: s.$text-sm; color: s.$secondary-text; margin: 0 0.35rem 0 0.05rem; }
+      // Right margin gives the + button the same breathing room as the − side.
+      .serv-unit { font-size: s.$text-sm; color: s.$secondary-text; margin: 0 0.4rem 0 0; }
     }
     .ing-list {
       list-style: none;

--- a/src/pages/SingleRecipe/SingleRecipe.scss
+++ b/src/pages/SingleRecipe/SingleRecipe.scss
@@ -117,12 +117,24 @@ $soft-radius: 16px;
     }
     .author-row {
       margin-top: auto;
-      display: flex;
+      // Inline-flex + align-self so the link's hit area hugs the byline
+      // (avatar + text) rather than stretching the full column width.
+      display: inline-flex;
+      align-self: flex-start;
       align-items: center;
       gap: 0.5rem;
       font-size: s.$text-sm;
       color: s.$tertiary-text;
+      text-decoration: none;
       strong { color: s.$primary-text; font-weight: 700; }
+      // Underline only the handle on hover/focus — the profile affordance,
+      // without lifting or recolouring the whole chrome row.
+      &:hover strong,
+      &:focus-visible strong { text-decoration: underline; }
+      &:focus-visible {
+        @include s.outline();
+        border-radius: s.$radius-sm;
+      }
       .avatar {
         width: 28px;
         height: 28px;

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon, CheckCircleIcon, ClockIcon, GroupAddIcon, ShoppingBasketIcon, StarFilledIcon, StarOutlineIcon, TagIcon } from 'src/Components/icons'
+import { ArrowLeftIcon, CheckCircleIcon, ClockIcon, GroupAddIcon, MinusIcon, PlusIcon, ShoppingBasketIcon, StarFilledIcon, StarOutlineIcon, TagIcon } from 'src/Components/icons'
 import React, { FC, useState, useEffect, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useParams, Link } from 'react-router-dom'
@@ -531,7 +531,7 @@ const SingleRecipe: FC = () => {
                       aria-label='Decrease servings'
                       onClick={() => changeServings((servingSize || 1) - 1)}
                     >
-                      −
+                      <MinusIcon aria-hidden />
                     </button>
                     <input
                       type='tel'
@@ -555,7 +555,7 @@ const SingleRecipe: FC = () => {
                       aria-label='Increase servings'
                       onClick={() => changeServings((servingSize || 0) + 1)}
                     >
-                      +
+                      <PlusIcon aria-hidden />
                     </button>
                   </div>
                 )}

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -401,7 +401,11 @@ const SingleRecipe: FC = () => {
                 <p className='description'>{currRecipe?.description}</p>
               )}
               {currRecipe && (
-                <div className='author-row'>
+                <Link
+                  to={`/u/${currRecipe.authorUsername}`}
+                  className='author-row'
+                  aria-label={`View @${currRecipe.authorUsername}'s profile`}
+                >
                   <DefaultAvatar
                     seed={currRecipe.authorUsername}
                     className='avatar'
@@ -413,7 +417,7 @@ const SingleRecipe: FC = () => {
                       <> · {formatMonthYear(currRecipe.createdAt)}</>
                     )}
                   </span>
-                </div>
+                </Link>
               )}
             </div>
           </header>

--- a/src/test/SingleRecipe.test.tsx
+++ b/src/test/SingleRecipe.test.tsx
@@ -129,6 +129,16 @@ describe('SingleRecipe page', () => {
     await screen.findByText('Chicken Tacos')
   })
 
+  it('links the author byline to the author profile at /u/:username', async () => {
+    mockGetRecipe.mockResolvedValue(baseRecipe)
+    renderSingleRecipe()
+    await screen.findByText('Chicken Tacos')
+    const authorLink = screen.getByRole('link', { name: "View @chef's profile" })
+    expect(authorLink).toHaveAttribute('href', '/u/chef')
+    // the handle + avatar live inside the single clickable byline
+    expect(authorLink).toHaveTextContent('@chef')
+  })
+
   it('shows RecipeNotFound when API response has no title', async () => {
     mockGetRecipe.mockResolvedValue({ _id: 'recipe-1' })
     renderSingleRecipe()


### PR DESCRIPTION
## N4 · SingleRecipe lane

Two of the three N4 items (the third yields to §D — see below).

### 1. Author byline → profile link
The recipe author byline (`SingleRecipe.tsx`) was a plain `<div>` with a bare `<strong>@{authorUsername}</strong>`, while the admin pages already link handles to `/u/:username`. Now the **whole byline** (avatar + `@username` + date) is one `<Link to="/u/:username">`:
- reuses the existing `.author-row` class on the anchor — `inline-flex` + `align-self:flex-start` so the hit area hugs the byline, not the full column;
- link resets (inherited colour, no default underline), an underline-on-hover/focus affordance **on the handle only** (no chrome lift), and the standard `@mixin outline()` keyboard focus ring;
- `aria-label="View @<handle>'s profile"` for the icon-only avatar.

### 2. Servings-pill `−`/`+` → Lucide icons (pixel batch a)
The step buttons rendered raw `−`/`+` **text glyphs**, so vertical centering rode on font optical metrics (the flagged nit). Swapped for house-family Lucide `MinusIcon`/`PlusIcon` (new `LuMinus` export in the icons barrel), which flex-center crisply in the 32px buttons. Buttons keep their `aria-label`s; icons are `aria-hidden` → labels + increment behaviour unchanged.

### Out of scope (rule 8b)
The **reviewer-name** link (`Reviews/RecipeReview.tsx`) yields to the RELEASE_PLAN §D Ratings & Reviews overhaul, which rewrites that file end-to-end.

## Verification
- `tsc` clean · Vitest **620 passed / 2 skipped** (incl. the icon single-source guard) · `npm run build` clean
- Runtime-verified on the dev-infra worktree app: rendered DOM confirms `<a class="author-row" aria-label="View @aaa's profile" href="/u/aaa">`; `/u/:username` route resolves (not a dead link); pill screenshotted before/after
- +1 regression test: byline links to `/u/:username`

🤖 Generated with [Claude Code](https://claude.com/claude-code)