### PR TITLE
fix(storage): skip profile-photo cleanup when FIREBASE_STORAGE_BUCKET unset (N7)

### DIFF
--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -830,6 +830,17 @@ describe('POST /deleteAccount', () => {
   describe('cascade (D2/D4/D5/D6)', () => {
     const KEEPER_UID = 'keeper-uid'
 
+    // deleteProfilePhoto now skips when FIREBASE_STORAGE_BUCKET is unset (N7), so
+    // set it here to exercise the D5 profile-photo deletion path; restore after.
+    const ORIGINAL_BUCKET = process.env.FIREBASE_STORAGE_BUCKET
+    beforeAll(() => {
+      process.env.FIREBASE_STORAGE_BUCKET = 'test-bucket'
+    })
+    afterAll(() => {
+      if (ORIGINAL_BUCKET === undefined) delete process.env.FIREBASE_STORAGE_BUCKET
+      else process.env.FIREBASE_STORAGE_BUCKET = ORIGINAL_BUCKET
+    })
+
     const seedCascade = async () => {
       const db = getDB()
       await seedUser(TEST_UID, 'goner')

--- a/server/__tests__/firebaseStorage.test.js
+++ b/server/__tests__/firebaseStorage.test.js
@@ -1,5 +1,9 @@
 const admin = require('firebase-admin') // auto-mocked
-const { parseStorageUrl, deleteRecipeImage } = require('../util/firebaseStorage')
+const {
+  parseStorageUrl,
+  deleteRecipeImage,
+  deleteProfilePhoto,
+} = require('../util/firebaseStorage')
 
 describe('parseStorageUrl', () => {
   it('extracts bucket and decoded path from a Firebase download URL', () => {
@@ -52,5 +56,61 @@ describe('deleteRecipeImage', () => {
     const url =
       'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ftuscan.jpg?alt=media&token=abc'
     await expect(deleteRecipeImage(url)).resolves.toBe(false)
+  })
+})
+
+describe('deleteProfilePhoto', () => {
+  // Save/restore the env the SUT reads so a real FIREBASE_STORAGE_BUCKET (from a
+  // loaded .env) can't leak into these cases and each test controls it explicitly.
+  const ORIGINAL_BUCKET = process.env.FIREBASE_STORAGE_BUCKET
+
+  beforeEach(() => {
+    admin.__deleteFile.mockClear()
+    admin.__storageInstance.bucket.mockClear()
+  })
+  afterEach(() => {
+    if (ORIGINAL_BUCKET === undefined) delete process.env.FIREBASE_STORAGE_BUCKET
+    else process.env.FIREBASE_STORAGE_BUCKET = ORIGINAL_BUCKET
+  })
+
+  it('deletes profilePhotos/{uid} from the named bucket and returns true', async () => {
+    process.env.FIREBASE_STORAGE_BUCKET = 'test-bucket'
+    await expect(deleteProfilePhoto('test-uid')).resolves.toBe(true)
+    // Bucket named explicitly (Admin has no default bucket), path is by uid.
+    expect(admin.__storageInstance.bucket).toHaveBeenCalledWith('test-bucket')
+    const results = admin.__storageInstance.bucket.mock.results
+    const fileMock = results[results.length - 1].value.file
+    expect(fileMock).toHaveBeenCalledWith('profilePhotos/test-uid')
+    expect(admin.__deleteFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('SKIPS cleanup (returns false, no storage call) when FIREBASE_STORAGE_BUCKET is unset', async () => {
+    // The N7 fix: with the env unset, we must NOT call the argless
+    // getStorage().bucket() (which throws "Bucket name not specified" in prod);
+    // we skip per the `.env.example` "leave empty to skip" contract.
+    delete process.env.FIREBASE_STORAGE_BUCKET
+    await expect(deleteProfilePhoto('test-uid')).resolves.toBe(false)
+    expect(admin.__storageInstance.bucket).not.toHaveBeenCalled()
+    expect(admin.__deleteFile).not.toHaveBeenCalled()
+  })
+
+  it('SKIPS cleanup when FIREBASE_STORAGE_BUCKET is the empty string', async () => {
+    process.env.FIREBASE_STORAGE_BUCKET = ''
+    await expect(deleteProfilePhoto('test-uid')).resolves.toBe(false)
+    expect(admin.__storageInstance.bucket).not.toHaveBeenCalled()
+  })
+
+  it('returns false without touching storage for a missing/invalid uid', async () => {
+    process.env.FIREBASE_STORAGE_BUCKET = 'test-bucket'
+    await expect(deleteProfilePhoto('')).resolves.toBe(false)
+    await expect(deleteProfilePhoto(null)).resolves.toBe(false)
+    await expect(deleteProfilePhoto(undefined)).resolves.toBe(false)
+    expect(admin.__storageInstance.bucket).not.toHaveBeenCalled()
+  })
+
+  it('swallows storage errors and returns false', async () => {
+    process.env.FIREBASE_STORAGE_BUCKET = 'test-bucket'
+    admin.__deleteFile.mockRejectedValueOnce(new Error('boom'))
+    await expect(deleteProfilePhoto('test-uid')).resolves.toBe(false)
   })
 })

--- a/server/util/firebaseStorage.js
+++ b/server/util/firebaseStorage.js
@@ -34,19 +34,20 @@ async function deleteRecipeImage(url) {
 // back) the account deletion it accompanies. Returns true only when a file was
 // actually deleted.
 //
-// The Admin SDK isn't initialized with a default storageBucket, so we name the
-// bucket explicitly from FIREBASE_STORAGE_BUCKET when set, else fall back to the
-// default bucket (which is what the test mock exercises). If neither resolves,
-// the attempt simply fails and is swallowed.
+// The Admin SDK isn't initialized with a default storageBucket, so we can only
+// name the bucket explicitly from FIREBASE_STORAGE_BUCKET. When it's unset we
+// SKIP the cleanup (return false) rather than calling the argless
+// getStorage().bucket(), which throws "Bucket name not specified" — that throw
+// was previously swallowed, logging a spurious error on every account deletion
+// and orphaning the avatar. Skipping matches the `.env.example` contract
+// ("leave empty to skip profile-photo cleanup — an orphaned avatar is tolerated").
 async function deleteProfilePhoto(uid) {
   if (!uid || typeof uid !== 'string') return false
+  const bucketName = process.env.FIREBASE_STORAGE_BUCKET
+  if (!bucketName) return false
   const path = `profilePhotos/${uid}`
   try {
-    const bucketName = process.env.FIREBASE_STORAGE_BUCKET
-    const bucket = bucketName
-      ? getStorage().bucket(bucketName)
-      : getStorage().bucket()
-    await bucket.file(path).delete()
+    await getStorage().bucket(bucketName).file(path).delete()
     return true
   } catch (err) {
     console.error('Failed to delete profile photo from storage:', err.message)


### PR DESCRIPTION
## N7 — storage-bucket env / real empty-env skip (code half)

Wave 6 backlog track **N7**. Ships the **code half only**; the ops half (set `FIREBASE_STORAGE_BUCKET` in the prod + dev server envs) stays owner-gated.

### The bug
`deleteProfilePhoto` (`server/util/firebaseStorage.js`) — called best-effort in the account-deletion cascade (`routes/auth.js:550`) — fell back to the **argless** `getStorage().bucket()` when `FIREBASE_STORAGE_BUCKET` was unset. But Admin init passes no default `storageBucket` (`middleware/auth.js`), so that fallback throws **"Bucket name not specified"**. The throw was caught and swallowed, which meant:

- a spurious `console.error` on **every** account deletion, and
- the departing user's avatar (`profilePhotos/{uid}`) **silently orphaned**.

User deletion itself was never broken (the cascade is best-effort try/catch), and the report that surfaced this (6-18 "Bucket name not specified") was never a data-integrity issue — just noise + an orphan.

### The fix
Early-return `false` when `FIREBASE_STORAGE_BUCKET` is empty/unset, **before** touching Storage — so behaviour matches the documented `.env.example` contract:

> Leave empty to skip profile-photo cleanup (best-effort — an orphaned avatar is tolerated).

Setting the env (the owner ops half) turns cleanup back on with **no further code change** — the named-bucket path is unchanged.

### Tests
- `firebaseStorage.test.js`: new `deleteProfilePhoto` block — named-bucket delete (asserts bucket name + `profilePhotos/{uid}` path), skip-when-unset (no Storage call), skip-when-empty-string, invalid/missing uid, and error-swallow.
- `auth.test.js`: the D5 cascade block now sets `FIREBASE_STORAGE_BUCKET` (scoped `beforeAll`/`afterAll`) so the profile-photo deletion path is still exercised after the skip change.
- Server Jest **780/780** green.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK