### PR TITLE
feat(reviews): §D PR-A server — reviewer avatars, rating breakdown, editReview body

### DIFF
--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -321,7 +321,7 @@ All routes live in `server/routes/reviews.js`, mounted at `/api` (server/app.js)
   - `400 {error:'Rating must be between 1 and 5'}`
 - **Response:** `200 {rated: true}`. Plus `401` (verifyToken), `403 {error, code, reason}` (requireActive), `429 {error, code:'RATE_LIMITED'}`.
 - **Client:** `src/api/recipes.ts:435` → `RecipeAPI.addRating(recipeId, rating)` — used by `src/pages/SingleRecipe/DataSections/RatingsAndReviews/Ratings/Ratings.tsx:44`. Returns `null` without calling if not signed in.
-- **Notes:** Upsert via `upsertWithDupRetry` on the unique `{userId, recipeId}` index (concurrent double-submit → E11000 retried as plain update). On insert, review fields are defaulted to `''`. Recomputes and persists the recipe's aggregate `rating: {rateCount, rateValue}` via `recomputeRecipeRating` (server/util/recipeRating.js), which excludes moderation-hidden docs and non-numeric ratings.
+- **Notes:** Upsert via `upsertWithDupRetry` on the unique `{userId, recipeId}` index (concurrent double-submit → E11000 retried as plain update). On insert, review fields are defaulted to `''`. Recomputes and persists the recipe's aggregate `rating: {rateCount, rateValue, breakdown}` via `recomputeRecipeRating` (server/util/recipeRating.js), which excludes moderation-hidden docs and non-numeric ratings. `breakdown` (added §D PR-A) is a `{1..5: number}` per-star histogram of the counted ratings (each bucketed by nearest whole star, buckets sum to `rateCount`); new recipes seed it all-zero, and the one-off backfill is `server/scripts/reconcileRatingAggregates.js --apply`.
 
 ### POST /api/newReview
 - **Handler:** `server/routes/reviews.js:66`
@@ -346,14 +346,14 @@ All routes live in `server/routes/reviews.js`, mounted at `/api` (server/app.js)
 ### POST /api/editReview
 - **Handler:** `server/routes/reviews.js:127`
 - **Middleware:** `verifyToken` → `requireActive` → `reviewWriteLimiter`
-- **Request:** query `recipeId` (string, required), `text` (string, required; empty string allowed — only `null`/non-string rejected). No body.
+- **Request:** JSON body `{recipeId: string, text: string}` (both required; empty `text` allowed — only `null`/non-string rejected). The pre-§D query form (`?recipeId=&text=`) is still accepted as a **backward-compat fallback**; the body wins when both are present. The query form corrupts text containing `&`/`#`/`%`/`+` and is slated for removal one release after the frontend switches to the body (PR-B).
   - `400 {error:'recipeId and text are required'}`
   - `400 {error:'Review cannot exceed 2000 characters'}`
   - `422 {error, code:'CONTENT_BLOCKED'}` — same `moderateText` gate as /newReview
   - `403 {error:'Review not found or not authorized'}` — update matched 0 docs (non-author can never match, since the filter is `{userId: req.uid, recipeId}`)
 - **Response:** `200 {edited: true}`. Plus `401/403/429`.
 - **Client:** `src/api/recipes.ts:456` → `RecipeAPI.editReview(recipeId, text)` — used by `src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.tsx:59`.
-- **Notes:** Updates `reviewText` + `reviewLastUpdated` only. Asymmetric with /newReview: create takes JSON body `reviewText`, edit takes query param `text`.
+- **Notes:** Updates `reviewText` + `reviewLastUpdated` only. As of §D PR-A both create and edit accept a JSON body (`newReview`→`reviewText`, `editReview`→`text`); the field-name difference remains but the transport is now aligned.
 
 ### DELETE /api/deleteReview
 - **Handler:** `server/routes/reviews.js:156`
@@ -375,9 +375,9 @@ All routes live in `server/routes/reviews.js`, mounted at `/api` (server/app.js)
 - **Handler:** `server/routes/reviews.js:229`
 - **Middleware:** `optionalAuth` (anonymous-friendly)
 - **Request:** query `recipeId` (string, required — `400 {error:'recipeId is required'}`), `page` (int, default 0), `reviewsPerPage` (int, default 5, capped at `MAX_PER_PAGE` = 50, reviews.js:18), `filter` (`'new'` → sort `reviewCreatedAt` desc, `'top'` → sort `rating` desc, anything else → natural order).
-- **Response:** `200 {reviews: [...], totalCount: number}` — each review is the raw ratings doc (only docs with non-empty `reviewText` and not `moderationHidden` via `REVIEW_VISIBLE`, server/util/moderation.js:33) plus a derived `isCurrentUser: boolean`.
+- **Response:** `200 {reviews: [...], totalCount: number}` — each review is the raw ratings doc (only docs with non-empty `reviewText` and not `moderationHidden` via `REVIEW_VISIBLE`, server/util/moderation.js:33) plus a derived `isCurrentUser: boolean` and, added in §D PR-A, the author's `photoURL: string | null` and `displayName: string | null`.
 - **Client:** `src/api/recipes.ts:470` → `RecipeAPI.getReviews(recipeId, filter, page, reviewsPerPage)` — used by `src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewsContainer.tsx:40` (react-query).
-- **Notes:** `isCurrentUser` is derived from the *verified* token uid (`req.uid`) matching the doc's `userId` — never from any client-supplied identity. Raw docs are spread as-is, so authors' `userId` (Firebase uid) and denormalized `username` are visible to anonymous callers.
+- **Notes:** `isCurrentUser` is derived from the *verified* token uid (`req.uid`) matching the doc's `userId` — never from any client-supplied identity. `photoURL`/`displayName` are resolved from Firebase Auth via a single deduped, batched `getAuth().getUsers()` keyed on the docs' stable `userId` (the rating doc stores neither); the lookup is failure-tolerant (a transient Admin-SDK error or a deleted/not-found reviewer yields `null` for both fields and never fails the list) — same degrade-gracefully pattern as `getPublicProfile`. Legacy docs lacking a `userId` skip the lookup entirely. Raw docs are spread as-is, so authors' `userId` (Firebase uid) and denormalized `username` are visible to anonymous callers.
 
 ### GET /api/getSingleUserReviews
 - **Handler:** `server/routes/reviews.js:257`
@@ -403,7 +403,7 @@ All routes live in `server/routes/reviews.js`, mounted at `/api` (server/app.js)
 
 - ~~**`getReviews` client sends a `username` query param the server never reads**~~ **[fixed with this regeneration]** — the client awaited `AuthAPI.getUsername()` and appended `username=...` (literally `username=null` when signed out), but the handler destructures only `recipeId, page, reviewsPerPage, filter` (reviews.js:231) and derives `isCurrentUser` from the verified token uid. The dead param and its extra username round-trip are removed from `RecipeAPI.getReviews`.
 - ~~**`editReview` interpolates raw review text into the URL query string without encoding**~~ **[fixed with this regeneration]** — the client built `` `api/editReview?recipeId=${recipeId}&text=${text}` `` with no encoding, so any `&`, `#`, `%`, or `+` in the edited text truncated or corrupted what the server received. `RecipeAPI.editReview` now passes both values via axios `params`, which URL-encodes them. (The remaining asymmetry — create sends body `reviewText`, edit sends query `text` — stands, below.)
-- **Create/edit contract asymmetry** — same field travels as body `reviewText` on create (reviews.js:68) but query `text` on edit (reviews.js:128).
+- **Create/edit field-name asymmetry** — the review text is body `reviewText` on create (reviews.js:68) but body `text` on edit (reviews.js:128). As of §D PR-A both accept a JSON body (edit also still honors the legacy `?text=` query form as a fallback), so the transport is aligned; only the field name differs.
 - **Missing-doc status inconsistency between the two delete routes** — `/deleteReview` returns `403` (reviews.js:167) while `/removeRating` returns `404` (reviews.js:203) for the identical "you have no doc for this recipe" case. Both client methods ignore the body, so nothing breaks, but the contract is inconsistent.
 - **`getSingleUserReviews` is a public any-username endpoint whose only client caller queries the caller's own handle** — the route takes arbitrary `username` with no auth, but `src/api/recipes.ts:487` hardwires `AuthAPI.getUsername()`. The public-profile surface does not use this endpoint (no other call sites in `src/`), so the arbitrary-username capability is currently reachable only by direct request.
 - **Raw ratings docs leak internal fields to anonymous callers** — `/getReviews` (reviews.js:248-251) and `/getSingleUserReviews` spread the stored doc verbatim, exposing each author's Firebase `userId`, Mongo `_id`, and (on moderated-then-restored docs) `moderatedBy`/`moderatedAt`. Nothing secret-critical, but there is no projection layer.

--- a/server/__mocks__/firebase-admin.js
+++ b/server/__mocks__/firebase-admin.js
@@ -25,6 +25,8 @@ function toFbUser(u) {
     uid: u.uid,
     email: u.email || null,
     customClaims: u.admin ? { admin: true } : u.customClaims || null,
+    photoURL: u.photoURL || null,
+    displayName: u.displayName || null,
   }
 }
 function notFound() {
@@ -54,13 +56,25 @@ const getUserByEmail = jest.fn().mockImplementation(async email => {
   if (!u) throw notFound()
   return toFbUser(u)
 })
+// Batched lookup used by GET /getReviews to resolve reviewer avatar/displayName.
+// Mirrors the Admin SDK shape: takes [{ uid }], returns { users, notFound }.
+const getUsers = jest.fn().mockImplementation(async identifiers => {
+  const found = []
+  const notFoundList = []
+  for (const id of identifiers) {
+    const u = users.find(x => x.uid === id.uid)
+    if (u) found.push(toFbUser(u))
+    else notFoundList.push(id)
+  }
+  return { users: found, notFound: notFoundList }
+})
 // Used by POST /deleteAccount. Resolves by default; tests assert the uid it was
 // called with via admin.__deleteUser.
 const deleteUser = jest.fn().mockResolvedValue(undefined)
 // Used by POST /updatePhoto to set the moderated photoURL. Resolves by default;
 // tests assert the (uid, props) it was called with via admin.__updateUser.
 const updateUser = jest.fn().mockResolvedValue(undefined)
-const authInstance = { verifyIdToken, getUser, getUserByEmail, deleteUser, updateUser }
+const authInstance = { verifyIdToken, getUser, getUsers, getUserByEmail, deleteUser, updateUser }
 
 // Storage chain used by util/firebaseStorage. deleteFile is exported so tests
 // can assert (or override) image-deletion behavior.
@@ -76,6 +90,7 @@ const admin = {
   __deleteFile: deleteFile,
   __verifyIdToken: verifyIdToken,
   __getUser: getUser,
+  __getUsers: getUsers,
   __deleteUser: deleteUser,
   __updateUser: updateUser,
   __setClaims: claims => {

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -899,7 +899,11 @@ describe('POST /deleteAccount', () => {
       // goner's review of 'kept' is gone; only keeper(4) remains.
       expect(await db.collection('ratings').countDocuments({ recipeId: 'kept' })).toBe(1)
       const kept = await db.collection('recipes').findOne({ _id: 'kept' })
-      expect(kept.rating).toEqual({ rateCount: 1, rateValue: 4 })
+      expect(kept.rating).toEqual({
+        rateCount: 1,
+        rateValue: 4,
+        breakdown: { 1: 0, 2: 0, 3: 0, 4: 1, 5: 0 },
+      })
     })
 
     it('deletes the departing user\'s recipe images and profile photo from Storage (D5)', async () => {

--- a/server/__tests__/recipeRating.test.js
+++ b/server/__tests__/recipeRating.test.js
@@ -41,15 +41,40 @@ describe('computeRecipeRating (pure read)', () => {
     ], { rateCount: 0, rateValue: 0 })
 
     const agg = await computeRecipeRating(getDB(), RECIPE_ID)
-    expect(agg).toEqual({ rateCount: 2, rateValue: 4.5 })
+    // Only the two visible numeric docs (4 and '5') count toward the histogram.
+    expect(agg).toEqual({
+      rateCount: 2,
+      rateValue: 4.5,
+      breakdown: { 1: 0, 2: 0, 3: 0, 4: 1, 5: 1 },
+    })
   })
 
-  it('returns a zero aggregate for a recipe with no ratings', async () => {
+  it('returns a zero aggregate (all-zero breakdown) for a recipe with no ratings', async () => {
     await seed([], { rateCount: 0, rateValue: 0 })
     expect(await computeRecipeRating(getDB(), RECIPE_ID)).toEqual({
       rateCount: 0,
       rateValue: 0,
+      breakdown: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
     })
+  })
+
+  it('buckets each visible rating into its nearest whole star (clamped 1–5)', async () => {
+    await seed([
+      { recipeId: RECIPE_ID, userId: 'a', rating: 1 },
+      { recipeId: RECIPE_ID, userId: 'b', rating: 4 },
+      { recipeId: RECIPE_ID, userId: 'c', rating: '4' }, // legacy string → 4
+      { recipeId: RECIPE_ID, userId: 'd', rating: 4.4 }, // rounds down → 4
+      { recipeId: RECIPE_ID, userId: 'e', rating: 4.6 }, // rounds up → 5
+      { recipeId: RECIPE_ID, userId: 'f', rating: 3, moderationHidden: true }, // hidden → excluded
+      { recipeId: RECIPE_ID, userId: 'g', rating: null }, // review-only → ignored
+    ], { rateCount: 0, rateValue: 0 })
+
+    const agg = await computeRecipeRating(getDB(), RECIPE_ID)
+    expect(agg.rateCount).toBe(5)
+    expect(agg.breakdown).toEqual({ 1: 1, 2: 0, 3: 0, 4: 3, 5: 1 })
+    // The buckets sum to rateCount by construction.
+    const summed = Object.values(agg.breakdown).reduce((a, b) => a + b, 0)
+    expect(summed).toBe(agg.rateCount)
   })
 
   it('does NOT write — the stored aggregate is left untouched', async () => {
@@ -74,9 +99,30 @@ describe('recomputeRecipeRating (persisting)', () => {
     })
 
     const returned = await recomputeRecipeRating(getDB(), RECIPE_ID)
-    expect(returned).toEqual({ rateCount: 1, rateValue: 4 })
+    expect(returned).toEqual({
+      rateCount: 1,
+      rateValue: 4,
+      breakdown: { 1: 0, 2: 0, 3: 0, 4: 1, 5: 0 },
+    })
 
     const recipe = await getDB().collection('recipes').findOne({ _id: RECIPE_ID })
-    expect(recipe.rating).toEqual({ rateCount: 1, rateValue: 4 })
+    expect(recipe.rating).toEqual({
+      rateCount: 1,
+      rateValue: 4,
+      breakdown: { 1: 0, 2: 0, 3: 0, 4: 1, 5: 0 },
+    })
+  })
+
+  it('persists a refreshed breakdown when a recipe predates the field', async () => {
+    // A recipe rated before §D shipped: correct rateCount/rateValue, NO breakdown.
+    await seed([
+      { recipeId: RECIPE_ID, userId: 'a', rating: 5 },
+      { recipeId: RECIPE_ID, userId: 'b', rating: 5 },
+    ], { rateCount: 2, rateValue: 5 })
+
+    await recomputeRecipeRating(getDB(), RECIPE_ID)
+
+    const recipe = await getDB().collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.rating.breakdown).toEqual({ 1: 0, 2: 0, 3: 0, 4: 0, 5: 2 })
   })
 })

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -508,7 +508,11 @@ describe('POST /addRecipe', () => {
     const stored = await getDB().collection('recipes').findOne({ _id: new ObjectId(res.body._id) })
     expect(stored.status).toBeUndefined()
     expect(stored.featured).toBeUndefined()
-    expect(stored.rating).toEqual({ rateCount: 0, rateValue: 0 })
+    expect(stored.rating).toEqual({
+      rateCount: 0,
+      rateValue: 0,
+      breakdown: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
+    })
   })
 
   describe('input bounds (defense-in-depth)', () => {

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -25,6 +25,10 @@ const request = require('supertest')
 const app = require('../app')
 const { getDB } = require('../db')
 const { getAuth } = require('firebase-admin/auth')
+// The shared mock (server/__mocks__/firebase-admin.js) exposes the batched
+// getUsers() handle + the users-registry setters used by the /getReviews
+// avatar-enrichment tests below.
+const admin = require('firebase-admin')
 const { seedRating } = require('./helpers/seed')
 
 const TEST_UID = 'test-uid'
@@ -50,10 +54,14 @@ beforeEach(async () => {
     recipeImage: 'https://example.com/review-test.jpg',
     rating: { rateCount: 0, rateValue: 0 },
   })
-  // Reset to default: verifyToken resolves req.uid = TEST_UID
+  // Reset to default: verifyToken resolves req.uid = TEST_UID. getUsers delegates
+  // to the shared registry mock so /getReviews avatar enrichment works (the local
+  // stub would otherwise omit it, since this beforeEach replaces the whole auth
+  // instance getAuth() returns).
   getAuth.mockReset()
   getAuth.mockImplementation(() => ({
     verifyIdToken: jest.fn().mockResolvedValue({ uid: TEST_UID }),
+    getUsers: admin.__getUsers,
   }))
 })
 
@@ -209,6 +217,37 @@ describe('POST /editReview', () => {
       .collection('ratings')
       .findOne({ username: TEST_USERNAME, recipeId: RECIPE_ID })
     expect(doc.reviewText).toBe('Updated review')
+  })
+
+  it('accepts the params in a JSON body (the new client transport)', async () => {
+    // The body form avoids the query-string corruption of &, #, %, + in review
+    // text; verify a body with such characters round-trips intact.
+    const tricky = 'Loved it — 100% & then #2 too + more'
+    const res = await request(app)
+      .post('/api/editReview')
+      .set(AUTH_HEADER)
+      .send({ recipeId: RECIPE_ID, text: tricky })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ edited: true })
+
+    const doc = await getDB()
+      .collection('ratings')
+      .findOne({ userId: TEST_UID, recipeId: RECIPE_ID })
+    expect(doc.reviewText).toBe(tricky)
+  })
+
+  it('prefers the body over the query string when both are present', async () => {
+    const res = await request(app)
+      .post(`/api/editReview?recipeId=${RECIPE_ID}&text=from-query`)
+      .set(AUTH_HEADER)
+      .send({ recipeId: RECIPE_ID, text: 'from-body' })
+
+    expect(res.status).toBe(200)
+    const doc = await getDB()
+      .collection('ratings')
+      .findOne({ userId: TEST_UID, recipeId: RECIPE_ID })
+    expect(doc.reviewText).toBe('from-body')
   })
 
   // Audit §4 item 4: edited review text must be bounded too.
@@ -731,6 +770,96 @@ describe('GET /getReviews', () => {
     expect(res.status).toBe(200)
     expect(res.body.reviews).toHaveLength(2)
     expect(res.body.totalCount).toBe(3)
+  })
+
+  // ── avatar + display-name enrichment (§D) ──────────────────────────────────
+  describe('reviewer identity enrichment', () => {
+    // __setUsers mutates shared mock state; restore the default registry after
+    // each so it can't leak into sibling tests.
+    afterEach(() => admin.__resetUsers())
+
+    it('enriches each review with the author’s photoURL and displayName', async () => {
+      admin.__setUsers([
+        { uid: 'rev-uid-1', photoURL: 'https://cdn/avatar-1.jpg', displayName: 'Reviewer One' },
+      ])
+      await seedRating({
+        userId: 'rev-uid-1',
+        username: 'reviewerone',
+        recipeId: RECIPE_ID,
+        rating: 5,
+        reviewText: 'Great recipe',
+        reviewCreatedAt: '1000',
+      })
+
+      const res = await request(app).get(`/api/getReviews?recipeId=${RECIPE_ID}`)
+      expect(res.status).toBe(200)
+      expect(res.body.reviews[0].photoURL).toBe('https://cdn/avatar-1.jpg')
+      expect(res.body.reviews[0].displayName).toBe('Reviewer One')
+    })
+
+    it('returns null photoURL/displayName when the reviewer has no Auth record', async () => {
+      // Deleted / never-existed Auth user: getUsers finds nobody for the uid.
+      admin.__setUsers([])
+      await seedRating({
+        userId: 'ghost-uid',
+        username: 'ghost',
+        recipeId: RECIPE_ID,
+        rating: 4,
+        reviewText: 'Left before deleting account',
+        reviewCreatedAt: '1000',
+      })
+
+      const res = await request(app).get(`/api/getReviews?recipeId=${RECIPE_ID}`)
+      expect(res.status).toBe(200)
+      expect(res.body.reviews[0].photoURL).toBeNull()
+      expect(res.body.reviews[0].displayName).toBeNull()
+    })
+
+    it('still returns the reviews (null identity) when the Auth batch lookup throws', async () => {
+      admin.__getUsers.mockRejectedValueOnce(new Error('admin sdk unavailable'))
+      await seedRating({
+        userId: 'rev-uid-1',
+        username: 'reviewerone',
+        recipeId: RECIPE_ID,
+        rating: 5,
+        reviewText: 'Great recipe',
+        reviewCreatedAt: '1000',
+      })
+
+      const res = await request(app).get(`/api/getReviews?recipeId=${RECIPE_ID}`)
+      expect(res.status).toBe(200)
+      expect(res.body.reviews).toHaveLength(1)
+      expect(res.body.reviews[0].photoURL).toBeNull()
+      expect(res.body.reviews[0].displayName).toBeNull()
+    })
+
+    it('resolves the whole page in a single deduped getUsers call', async () => {
+      admin.__setUsers([
+        { uid: 'u1', photoURL: 'p1', displayName: 'D1' },
+        { uid: 'u2', photoURL: 'p2', displayName: 'D2' },
+      ])
+      await seedRating({ userId: 'u1', username: 'u1name', recipeId: RECIPE_ID, rating: 5, reviewText: 'A', reviewCreatedAt: '1000' })
+      await seedRating({ userId: 'u2', username: 'u2name', recipeId: RECIPE_ID, rating: 4, reviewText: 'B', reviewCreatedAt: '2000' })
+      admin.__getUsers.mockClear()
+
+      const res = await request(app).get(`/api/getReviews?recipeId=${RECIPE_ID}`)
+      expect(res.status).toBe(200)
+      expect(admin.__getUsers).toHaveBeenCalledTimes(1)
+      const identifiers = admin.__getUsers.mock.calls[0][0]
+      expect(identifiers).toHaveLength(2)
+      expect(identifiers.map((i) => i.uid).sort()).toEqual(['u1', 'u2'])
+    })
+
+    it('does not call getUsers when no review on the page carries a uid', async () => {
+      // Legacy docs written before the uid backfill have only a username.
+      await seedRating({ username: 'legacy', recipeId: RECIPE_ID, rating: 3, reviewText: 'Old review', reviewCreatedAt: '1000' })
+      admin.__getUsers.mockClear()
+
+      const res = await request(app).get(`/api/getReviews?recipeId=${RECIPE_ID}`)
+      expect(res.status).toBe(200)
+      expect(res.body.reviews[0].photoURL).toBeNull()
+      expect(admin.__getUsers).not.toHaveBeenCalled()
+    })
   })
 })
 

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -547,7 +547,7 @@ router.post('/addRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncH
     ...pickFields(body, CREATABLE_RECIPE_FIELDS),
     _id: newId,
     userId: uid,
-    rating: { rateCount: 0, rateValue: 0 },
+    rating: { rateCount: 0, rateValue: 0, breakdown: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 } },
     numTimesSaved: 0,
     numTimesMade: 0,
     views: 0,

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -41,7 +41,9 @@ async function resolveReviewerIdentities(reviews) {
     }
   } catch (err) {
     // Transient Admin SDK failure — return what we have (empty); callers default
-    // the fields to null so the reviews still render.
+    // the fields to null so the reviews still render. Log it so a real outage
+    // (avatars silently vanishing page-wide) surfaces instead of being invisible.
+    console.warn('resolveReviewerIdentities: getUsers batch failed, reviews will render without avatars:', err?.message || err)
   }
   return byUid
 }

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -1,4 +1,5 @@
 const { Router } = require('express')
+const { getAuth } = require('firebase-admin/auth')
 const { asyncHandler } = require('../util/asyncHandler')
 const { getDB } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
@@ -16,6 +17,34 @@ const router = Router()
 
 // Hard ceiling on client-requested page sizes (audit §4.5); mirrors recipes.js.
 const MAX_PER_PAGE = 50
+
+// Resolve reviewer avatar + display name for a page of reviews (§D). photoURL and
+// displayName live on the Firebase Auth record, not the rating doc, so batch-fetch
+// them keyed on the doc's stable uid (never a client-supplied value). One deduped
+// getUsers() call covers the page (≤ MAX_PER_PAGE < the SDK's 100-identifier cap).
+// Degrade gracefully like publicProfile: a failed batch or a not-found/deleted
+// reviewer yields null fields (the client falls back to DefaultAvatar + @username)
+// and NEVER fails the list. Returns a Map<uid, { photoURL, displayName }>.
+async function resolveReviewerIdentities(reviews) {
+  const byUid = new Map()
+  const uids = [...new Set(reviews.map((r) => r.userId).filter(Boolean))]
+  // getUsers() throws on an empty identifier array — skip the call when a page
+  // has no resolvable uids (e.g. legacy docs written before the uid backfill).
+  if (uids.length === 0) return byUid
+  try {
+    const { users } = await getAuth().getUsers(uids.map((uid) => ({ uid })))
+    for (const u of users) {
+      byUid.set(u.uid, {
+        photoURL: u.photoURL || null,
+        displayName: u.displayName || null,
+      })
+    }
+  } catch (err) {
+    // Transient Admin SDK failure — return what we have (empty); callers default
+    // the fields to null so the reviews still render.
+  }
+  return byUid
+}
 
 // POST /addRating
 router.post('/addRating', verifyToken, requireActive, reviewWriteLimiter, asyncHandler(async (req, res) => {
@@ -124,8 +153,13 @@ router.get('/checkIfReviewed', verifyToken, asyncHandler(async (req, res) => {
 }))
 
 // POST /editReview
+// Params come from the JSON body; the query-string form (?recipeId=&text=) is a
+// backward-compat fallback for the pre-§D client and can be dropped one release
+// after the frontend switches to the body (the query form corrupts review text
+// containing &, #, % or +). Body takes precedence when both are present.
 router.post('/editReview', verifyToken, requireActive, reviewWriteLimiter, asyncHandler(async (req, res) => {
-  const { recipeId, text } = req.query
+  const recipeId = req.body?.recipeId ?? req.query.recipeId
+  const text = req.body?.text ?? req.query.text
   const db = getDB()
   if (!recipeId || typeof recipeId !== 'string' || text == null || typeof text !== 'string') {
     return res.status(400).json({ error: 'recipeId and text are required' })
@@ -245,10 +279,18 @@ router.get('/getReviews', optionalAuth, asyncHandler(async (req, res) => {
     db.collection('ratings').countDocuments(query),
   ])
 
-  const reviews = rawReviews.map((r) => ({
-    ...r,
-    isCurrentUser: req.uid != null && r.userId === req.uid,
-  }))
+  // Enrich each review with the author's avatar + display name (§D). Batched,
+  // deduped, and failure-tolerant — see resolveReviewerIdentities.
+  const identities = await resolveReviewerIdentities(rawReviews)
+  const reviews = rawReviews.map((r) => {
+    const identity = identities.get(r.userId)
+    return {
+      ...r,
+      isCurrentUser: req.uid != null && r.userId === req.uid,
+      photoURL: identity ? identity.photoURL : null,
+      displayName: identity ? identity.displayName : null,
+    }
+  })
 
   res.json({ reviews, totalCount })
 }))

--- a/server/scripts/reconcileRatingAggregates.js
+++ b/server/scripts/reconcileRatingAggregates.js
@@ -1,10 +1,12 @@
 /**
  * S6 — one-off catalog-wide rating-aggregate reconciliation.
  *
- * Each recipe carries a denormalized `rating: { rateCount, rateValue }` that the
- * server recomputes (util/recipeRating.js `recomputeRecipeRating`) on every
- * rating add/edit/delete and on every moderation hide/restore. The denormalized
- * value can nonetheless DRIFT from the source-of-truth `ratings` docs:
+ * Each recipe carries a denormalized `rating: { rateCount, rateValue, breakdown }`
+ * that the server recomputes (util/recipeRating.js `recomputeRecipeRating`) on
+ * every rating add/edit/delete and on every moderation hide/restore. The
+ * denormalized value can nonetheless DRIFT from the source-of-truth `ratings` docs:
+ *   - recipes rated before the per-star `breakdown` field shipped (§D) — running
+ *     this with --apply is the one-off backfill that populates it everywhere,
  *   - legacy / pre-recompute data written before the recompute-on-every-change
  *     rule shipped (PR #150),
  *   - a past silent best-effort recompute failure (the deleteAccount path was
@@ -53,14 +55,32 @@ const EPS = 1e-9
 // the summary counts are always exact and the cap is announced (no silent trim).
 const MAX_LISTED = 100
 
+// The per-star histogram (§D) is part of the aggregate, so a recipe whose stored
+// rateCount/rateValue are correct but which predates `breakdown` (or has a drifted
+// one) must still be flagged and healed — this doubles as the breakdown backfill.
+// A missing stored breakdown compares unequal to the recomputed five-bucket object,
+// so it's correctly caught. Buckets are integers: exact comparison.
+function breakdownEqual(a, b) {
+  if (!a || !b) return false
+  for (let s = 1; s <= 5; s++) {
+    if ((Number(a[s]) || 0) !== (Number(b[s]) || 0)) return false
+  }
+  return true
+}
+
 function ratingsEqual(a, b) {
-  return a.rateCount === b.rateCount && Math.abs(a.rateValue - b.rateValue) < EPS
+  return (
+    a.rateCount === b.rateCount &&
+    Math.abs(a.rateValue - b.rateValue) < EPS &&
+    breakdownEqual(a.breakdown, b.breakdown)
+  )
 }
 
 // The stored aggregate can be absent (legacy recipes predating the field),
 // partial, or string-typed. Normalize to numbers so the comparison and the
 // printout are well-defined; a missing/!finite field reads as NaN and will not
-// equal any real recomputed value, so it is correctly flagged.
+// equal any real recomputed value, so it is correctly flagged. `breakdown` is
+// passed through as-is for breakdownEqual (which tolerates absent/partial).
 function readStored(rating) {
   const rateCount = Number(rating && rating.rateCount)
   const rateValue = Number(rating && rating.rateValue)
@@ -68,14 +88,20 @@ function readStored(rating) {
     present: !!rating && rating.rateCount != null && rating.rateValue != null,
     rateCount,
     rateValue,
+    breakdown: rating && rating.breakdown,
   }
+}
+
+function fmtBreakdown(breakdown) {
+  if (!breakdown) return 'breakdown (absent)'
+  return `breakdown [${[1, 2, 3, 4, 5].map((s) => Number(breakdown[s]) || 0).join('/')}]`
 }
 
 function fmt(agg) {
   if (agg.present === false) return '(absent)'
   const c = Number.isFinite(agg.rateCount) ? agg.rateCount : '?'
   const v = Number.isFinite(agg.rateValue) ? Number(agg.rateValue.toFixed(4)) : '?'
-  return `{ rateCount: ${c}, rateValue: ${v} }`
+  return `{ rateCount: ${c}, rateValue: ${v}, ${fmtBreakdown(agg.breakdown)} }`
 }
 
 async function main() {

--- a/server/util/recipeRating.js
+++ b/server/util/recipeRating.js
@@ -29,7 +29,17 @@ async function computeRecipeRating(db, recipeId) {
   const rateValue = rateCount
     ? ratings.reduce((sum, r) => sum + parseFloat(r.rating), 0) / rateCount
     : 0
-  return { rateCount, rateValue }
+  // Per-star histogram for the reviews-summary UI (§D). Bucket each rating by its
+  // nearest whole star — clamped to 1–5 so a fractional/out-of-range legacy value
+  // can't land outside the five buckets — and always return all five keys, so the
+  // client renders empty bars without null-guarding each one. The buckets sum to
+  // rateCount by construction.
+  const breakdown = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+  for (const r of ratings) {
+    const star = Math.min(5, Math.max(1, Math.round(parseFloat(r.rating))))
+    breakdown[star] += 1
+  }
+  return { rateCount, rateValue, breakdown }
 }
 
 // Recompute and persist a recipe's aggregate rating from its ratings docs,


### PR DESCRIPTION
Server-only groundwork for the **§D Ratings & Reviews overhaul** (RELEASE_PLAN.md release blocker). First of the sequenced PRs; frontend types/client (PR-B) and the redesign (PR-C) follow. Scope doc: `docs/REVIEWS_OVERHAUL_SCOPE.md` (on `development`).

All three changes are **additive and backward-compatible** — the current frontend keeps working unchanged (it just ignores the new fields).

## What's in this PR

**1. Reviewer avatars on `GET /getReviews`** (fold-in A; Q4)
Each returned review now carries `photoURL: string | null` and `displayName: string | null`, resolved from Firebase Auth via a **single deduped, batched `getAuth().getUsers()`** keyed on the doc's stable `userId`. Failure-tolerant like `getPublicProfile`: a transient Admin-SDK error or a deleted/not-found reviewer yields `null` for both fields and never fails the list; legacy docs without a `userId` skip the lookup entirely.

**2. Per-star rating breakdown** (Q1)
The recipe aggregate `rating` gains a `breakdown` `{1..5}` histogram, computed alongside `rateCount`/`rateValue` in `recipeRating.js` (each rating bucketed by nearest whole star; buckets sum to `rateCount`). New recipes seed it all-zero. `reconcileRatingAggregates.js` now compares `breakdown` too, so **`node server/scripts/reconcileRatingAggregates.js --apply` is the one-off backfill** — dry-run verified against dev (13 recipes, all correctly flagged for backfill). Not yet applied to any environment (owner-gated).

**3. `POST /editReview` accepts a JSON body** `{recipeId, text}`
Fixes the query-string encoding bug (raw `&`/`#`/`%`/`+` in review text was truncated/corrupted). The legacy `?text=` query form stays as a **one-release fallback**; the body wins when both are present. PR-B switches the client to the body, after which the query form can be dropped.

## Testing
- **Server Jest: 789 passing** (35 suites). New coverage: identity enrichment (happy path / not-found → null / batch throws → null / single-deduped-call / no-uid-skips), `editReview` body + body-wins-over-query, breakdown bucketing + predates-field backfill. Updated the recompute/create rating-shape assertions in `recipes.test.js` + `auth.test.js`; `firebase-admin` mock gains `getUsers`.
- **Runtime-verified** against the dev DB + real Firebase Auth: `getReviews` returned live `displayName` for users who have one, `null` for those who don't, and skipped a legacy `userId: null` doc without error.
- No frontend files touched → frontend gates unaffected.

## Follow-ups (not this PR)
- Run the `--apply` backfill at deploy/cutover time.
- PR-B: `ReviewType`/`OptionalReviewType` gain `photoURL`/`displayName`/`userId`, `rating: number|null`, recipe `rating.breakdown`; client `editReview` → body; StarRating a11y.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK