### PR TITLE
feat(reviews): §D PR-B frontend — avatars, StarRating a11y, editReview body (stacked on #266)

### DIFF
--- a/src/Components/StarRating/StarRating.tsx
+++ b/src/Components/StarRating/StarRating.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useId, useState } from 'react'
+import React, { FC, useId, useRef, useState } from 'react'
 
 type StarRatingProps = {
   rating: number
@@ -7,6 +7,7 @@ type StarRatingProps = {
   spacing?: number
   interactive?: boolean
   onChange?: (val: number) => void
+  ariaLabel?: string
 }
 
 // Renders a single star filled left-to-right by `fill` (0–1) using a
@@ -48,23 +49,61 @@ const StarRating: FC<StarRatingProps> = ({
   spacing = 2,
   interactive = false,
   onChange,
+  ariaLabel = 'Rating',
 }) => {
   const [hovered, setHovered] = useState(0)
   // useId can contain ':' which is awkward inside url(#...) fragment refs.
   const baseId = useId().replace(/:/g, '')
-  // While hovering, preview the whole-star value under the cursor; otherwise
-  // show the actual (possibly fractional) rating.
+  // While hovering/focusing, preview the whole-star value under the
+  // cursor/focus; otherwise show the actual (possibly fractional) rating.
   const displayRating = hovered || rating
+  // Refs to each star button, indexed 0-4 (star i lives at starRefs[i - 1]),
+  // used to move DOM focus when arrow-key navigation changes the selection.
+  const starRefs = useRef<Array<HTMLButtonElement | null>>([])
+
+  const moveSelection = (next: number) => {
+    onChange?.(next)
+    starRefs.current[next - 1]?.focus()
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        e.preventDefault()
+        moveSelection(Math.min((rating || 0) + 1, 5))
+        break
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        e.preventDefault()
+        moveSelection(Math.max((rating || 0) - 1, 1))
+        break
+      case 'Home':
+        e.preventDefault()
+        moveSelection(1)
+        break
+      case 'End':
+        e.preventDefault()
+        moveSelection(5)
+        break
+      default:
+        break
+    }
+  }
 
   return (
     // Display-only stars convey their value once via an img role on the row, so
     // the individual stars below render as plain <span>s (not <button>s). A
     // focusable <button> inside the row's `role="img"` is a nested-interactive
     // a11y failure, and the stars carry no name of their own.
+    //
+    // Interactive stars are modeled as a WAI-ARIA radiogroup: the row carries
+    // role="radiogroup" and each star is role="radio", with a roving tabindex
+    // so the group is a single tab stop and arrow keys move the selection.
     <div
       style={{ display: 'inline-flex', gap: spacing }}
-      role={interactive ? undefined : 'img'}
-      aria-label={interactive ? undefined : `Rated ${rating} out of 5`}
+      role={interactive ? 'radiogroup' : 'img'}
+      aria-label={interactive ? ariaLabel : `Rated ${rating} out of 5`}
     >
       {[1, 2, 3, 4, 5].map(i => {
         const star = (
@@ -85,10 +124,19 @@ const StarRating: FC<StarRatingProps> = ({
         return (
           <button
             key={i}
+            ref={el => {
+              starRefs.current[i - 1] = el
+            }}
             type='button'
+            role='radio'
+            aria-checked={i === rating}
+            tabIndex={i === (rating || 1) ? 0 : -1}
             onClick={() => onChange?.(i)}
+            onKeyDown={handleKeyDown}
             onMouseEnter={() => setHovered(i)}
             onMouseLeave={() => setHovered(0)}
+            onFocus={() => setHovered(i)}
+            onBlur={() => setHovered(0)}
             style={{
               background: 'none',
               border: 'none',

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -457,8 +457,10 @@ class RecipeAPIClass {
   }
   async editReview(recipeId: string, text: string): Promise<AxiosResponse | null> {
     if (!AuthAPI.getUID()) return null
-    // params (not string interpolation) so `&`/`#`/`%` in the review text survive the query string
-    return await http.post('api/editReview', null, { params: { recipeId, text } })
+    // recipeId/text go in the JSON body (the axios instance defaults
+    // Content-Type: application/json) — the server reads the body first,
+    // falling back to query params for older clients.
+    return await http.post('api/editReview', { recipeId, text })
   }
   async deleteReview(recipeId: string): Promise<AxiosResponse | null> {
     if (!AuthAPI.getUID()) return null
@@ -474,7 +476,7 @@ class RecipeAPIClass {
     filter = 'new',
     page: number,
     reviewsPerPage = 5
-  ) {
+  ): Promise<{ reviews: ReviewType[]; totalCount: number }> {
     const result = await http.get(
       `api/getReviews?recipeId=${recipeId}&page=${page}&reviewsPerPage=${reviewsPerPage}&filter=${filter}`
     )

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Ratings/Ratings.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Ratings/Ratings.tsx
@@ -1,5 +1,5 @@
 import { StarOutlineIcon } from 'src/Components/icons'
-import React, { FC } from 'react'
+import React, { FC, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
@@ -25,6 +25,12 @@ const Ratings: FC<RatingsProps> = ({
 }) => {
   const queryClient = useQueryClient()
   const uid = AuthAPI.getUID()
+  // Monotonic id of the most recent rating change. Keyboard nav (arrow-key
+  // hold / OS key-repeat) can fire several changeRating calls before any
+  // resolves, so responses may land out of order. We only let a request touch
+  // the UI if it's still the latest — otherwise a slow earlier request's
+  // failure would revert to a stale value the user already moved past.
+  const latestReqRef = useRef(0)
 
   // After a rating change, refresh the recipe aggregate (the displayed
   // "Average Rating") and the user's own rating so both reflect the server
@@ -39,15 +45,20 @@ const Ratings: FC<RatingsProps> = ({
     // rejects (e.g. a suspended account hitting requireActive, or a network
     // failure) so the UI never shows a rating that wasn't actually saved.
     const prev = rating
+    const reqId = ++latestReqRef.current
     setRating(e)
     try {
       await RecipeAPI.addRating(recipeId, e)
     } catch (err) {
+      // Superseded by a newer change — leave that one's value in place.
+      if (latestReqRef.current !== reqId) return
       setRating(prev)
       toast.error('Could not save your rating. Please try again.')
       return
     }
-    refreshRatingViews()
+    // Only the latest change should refetch; a stale success would pull the
+    // aggregate mid-flight and fight the newer optimistic value.
+    if (latestReqRef.current === reqId) refreshRatingViews()
   }
 
   const handleRemoveRating = async () => {

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.scss
@@ -11,6 +11,17 @@
     padding-bottom: 0;
     margin-bottom: 0.5rem;
 
+    // Small reviewer avatar in front of the name/stars. PR-C owns further
+    // restyling; this is a modest, functional size for now.
+    .avatar {
+      flex-shrink: 0;
+      height: 34px;
+      width: 34px;
+      border-radius: s.$radius-circle;
+      object-fit: cover;
+      margin-right: 0.15rem;
+    }
+
     // username + stars on the same line
     .name-content {
       display: flex;

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.tsx
@@ -22,6 +22,7 @@ import { ReviewType } from 'types'
 import RecipeAPI from 'src/api/recipes'
 import ReviewOptions from 'src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewOptions'
 import { formatDate } from 'src/util/formatDate'
+import DefaultAvatar from 'src/Components/DefaultAvatar/DefaultAvatar'
 
 type RecipeReviewProps = {
   review: ReviewType
@@ -37,6 +38,7 @@ const RecipeReview: FC<RecipeReviewProps> = ({
   const [rating, setRating] = useState(0)
   const [date, setDate] = useState('')
   const [username, setUsername] = useState('')
+  const [imgFailed, setImgFailed] = useState(false)
 
   const [reviewText, setReviewText] = useState(review.reviewText)
 
@@ -73,6 +75,16 @@ const RecipeReview: FC<RecipeReviewProps> = ({
 
   const renderReviewHeader = () => (
     <div className='head'>
+      {review.photoURL && !imgFailed ? (
+        <img
+          className='avatar'
+          src={review.photoURL}
+          alt=''
+          onError={() => setImgFailed(true)}
+        />
+      ) : (
+        <DefaultAvatar className='avatar' seed={username} ariaHidden />
+      )}
       <div className='name-content'>
         <div className='name'>{username ? `@${username}` : ''}</div>
         <div className='rating'>

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewCardSkeleton.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewCardSkeleton.tsx
@@ -13,6 +13,15 @@ const ReviewCardSkeleton: FC<{ count?: number }> = ({ count = 2 }) => (
     {Array.from({ length: count }).map((_, i) => (
       <div className='recipe-review' key={i} aria-hidden='true'>
         <div className='head'>
+          <Skeleton
+            circle
+            inline
+            baseColor={skeletonColor}
+            className='avatar'
+            containerClassName='avatar'
+            height={34}
+            width={34}
+          />
           <div className='name-content'>
             <div className='name'>
               <Skeleton inline baseColor={skeletonColor} width={110} />

--- a/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewCardSkeleton.tsx
+++ b/src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/ReviewCardSkeleton.tsx
@@ -17,7 +17,6 @@ const ReviewCardSkeleton: FC<{ count?: number }> = ({ count = 2 }) => (
             circle
             inline
             baseColor={skeletonColor}
-            className='avatar'
             containerClassName='avatar'
             height={34}
             width={34}

--- a/src/test/RatingsAndReviews.test.tsx
+++ b/src/test/RatingsAndReviews.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { vi } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -460,5 +460,43 @@ describe('RecipeReview', () => {
 
     await waitFor(() => expect(mockDeleteReview).toHaveBeenCalledWith('recipe-1'))
     await waitFor(() => expect(setCurrUserReview).toHaveBeenCalledWith(null))
+  })
+
+  // ─── Reviewer avatar (photoURL vs. DefaultAvatar fallback) ─────────────────
+
+  it('renders an <img> avatar when the review has a photoURL', () => {
+    const review = {
+      ...baseReview,
+      photoURL: 'https://example.com/a.jpg',
+      displayName: 'Photo User',
+    }
+    const { container } = renderRecipeReview({ review })
+    const img = container.querySelector('img.avatar')
+    expect(img).not.toBeNull()
+    expect(img).toHaveAttribute('src', 'https://example.com/a.jpg')
+    expect(container.querySelector('.default-avatar')).toBeNull()
+  })
+
+  it('falls back to DefaultAvatar when the <img> avatar fails to load', () => {
+    const review = {
+      ...baseReview,
+      photoURL: 'https://example.com/broken.jpg',
+      displayName: 'Photo User',
+    }
+    const { container } = renderRecipeReview({ review })
+    const img = container.querySelector('img.avatar') as HTMLImageElement
+    expect(img).not.toBeNull()
+
+    fireEvent.error(img)
+
+    expect(container.querySelector('img.avatar')).toBeNull()
+    expect(container.querySelector('.default-avatar')).not.toBeNull()
+  })
+
+  it('renders DefaultAvatar (no <img> avatar) when photoURL is null', () => {
+    const review = { ...baseReview, photoURL: null, displayName: null }
+    const { container } = renderRecipeReview({ review })
+    expect(container.querySelector('img.avatar')).toBeNull()
+    expect(container.querySelector('.default-avatar')).not.toBeNull()
   })
 })

--- a/src/test/StarRating.test.tsx
+++ b/src/test/StarRating.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import StarRating from 'src/Components/StarRating/StarRating'
+
+// ─── StarRating — interactive keyboard a11y (WAI-ARIA radiogroup) ────────────
+
+describe('StarRating (interactive radiogroup)', () => {
+  it('renders a radiogroup container and five radio stars', () => {
+    render(<StarRating interactive rating={3} onChange={vi.fn()} />)
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument()
+    expect(screen.getAllByRole('radio')).toHaveLength(5)
+  })
+
+  it('aria-checked is true only on the star matching rating', () => {
+    render(<StarRating interactive rating={3} onChange={vi.fn()} />)
+    const radios = screen.getAllByRole('radio')
+    radios.forEach((radio, idx) => {
+      const starNumber = idx + 1
+      expect(radio).toHaveAttribute('aria-checked', String(starNumber === 3))
+    })
+  })
+
+  it('roving tabindex: only the star at rating is a tab stop', () => {
+    render(<StarRating interactive rating={3} onChange={vi.fn()} />)
+    const radios = screen.getAllByRole('radio')
+    radios.forEach((radio, idx) => {
+      const starNumber = idx + 1
+      expect(radio).toHaveAttribute('tabIndex', starNumber === 3 ? '0' : '-1')
+    })
+  })
+
+  it('roving tabindex falls back to star 1 when rating is 0', () => {
+    render(<StarRating interactive rating={0} onChange={vi.fn()} />)
+    const radios = screen.getAllByRole('radio')
+    radios.forEach((radio, idx) => {
+      const starNumber = idx + 1
+      expect(radio).toHaveAttribute('tabIndex', starNumber === 1 ? '0' : '-1')
+    })
+  })
+
+  it('ArrowRight moves selection forward by one', () => {
+    const onChange = vi.fn()
+    render(<StarRating interactive rating={3} onChange={onChange} />)
+    const radios = screen.getAllByRole('radio')
+    fireEvent.keyDown(radios[2], { key: 'ArrowRight' })
+    expect(onChange).toHaveBeenCalledWith(4)
+  })
+
+  it('ArrowLeft moves selection back by one', () => {
+    const onChange = vi.fn()
+    render(<StarRating interactive rating={3} onChange={onChange} />)
+    const radios = screen.getAllByRole('radio')
+    fireEvent.keyDown(radios[2], { key: 'ArrowLeft' })
+    expect(onChange).toHaveBeenCalledWith(2)
+  })
+
+  it('Home jumps to the first star', () => {
+    const onChange = vi.fn()
+    render(<StarRating interactive rating={3} onChange={onChange} />)
+    const radios = screen.getAllByRole('radio')
+    fireEvent.keyDown(radios[2], { key: 'Home' })
+    expect(onChange).toHaveBeenCalledWith(1)
+  })
+
+  it('End jumps to the last star', () => {
+    const onChange = vi.fn()
+    render(<StarRating interactive rating={3} onChange={onChange} />)
+    const radios = screen.getAllByRole('radio')
+    fireEvent.keyDown(radios[2], { key: 'End' })
+    expect(onChange).toHaveBeenCalledWith(5)
+  })
+
+  it('ArrowRight at rating=5 stays clamped at 5', () => {
+    const onChange = vi.fn()
+    render(<StarRating interactive rating={5} onChange={onChange} />)
+    const radios = screen.getAllByRole('radio')
+    fireEvent.keyDown(radios[4], { key: 'ArrowRight' })
+    expect(onChange).toHaveBeenCalledWith(5)
+  })
+
+  it('ArrowLeft at rating=1 stays clamped at 1', () => {
+    const onChange = vi.fn()
+    render(<StarRating interactive rating={1} onChange={onChange} />)
+    const radios = screen.getAllByRole('radio')
+    fireEvent.keyDown(radios[0], { key: 'ArrowLeft' })
+    expect(onChange).toHaveBeenCalledWith(1)
+  })
+
+  it('display mode (non-interactive) renders role="img" with no radio roles', () => {
+    render(<StarRating rating={4} />)
+    const img = screen.getByRole('img')
+    expect(img).toHaveAttribute('aria-label', 'Rated 4 out of 5')
+    expect(screen.queryByRole('radiogroup')).toBeNull()
+    expect(screen.queryAllByRole('radio')).toHaveLength(0)
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,13 @@ export interface IngredientData {
   id?: number
 }
 
+export type RatingBreakdown = { '1': number; '2': number; '3': number; '4': number; '5': number }
+export type RatingAggregate = {
+  rateCount: number
+  rateValue: number
+  breakdown?: RatingBreakdown
+}
+
 export type RecipeType = {
   _id: string
   // Firebase uid of the author. Stamped server-side and returned by GET
@@ -69,10 +76,7 @@ export type RecipeType = {
   nutritionData: NutritionDataType | null
   totalTime: number
   authorUsername: string
-  rating: {
-    rateCount: number
-    rateValue: number
-  }
+  rating: RatingAggregate
   createdAt: string
   editedAt: null | string
   servingPrice: number | null
@@ -203,10 +207,7 @@ export interface RecipeSearchResponseType {
   title: string
   recipeImage: string
   totalTime: number
-  rating: {
-    rateCount: number
-    rateValue: number
-  }
+  rating: RatingAggregate
   servingPrice: number
   nutritionLabels: string[]
   servings: number
@@ -232,6 +233,8 @@ export type ReviewType = {
   reviewCreatedAt: string
   reviewLastUpdated: string
   reviewText: string
+  photoURL: string | null
+  displayName: string | null
 }
 
 export interface NewReviewType {


### PR DESCRIPTION
## §D Reviews overhaul — PR-B (frontend plumbing)

**Stacked on #266 (PR-A server).** Base branch is `worktree-feat+reviews-overhaul-pr-a-server`, so this diff is frontend-only — merge #266 first, then this retargets to `development` automatically. Consumes the server contract PR-A added: reviewer avatars/`displayName` on `getReviews`, per-star `breakdown` on the rating aggregate, and `editReview` reading a JSON body.

### What's in it
- **Types (`src/types.ts`)** — extracted the duplicated inline `rating: {rateCount, rateValue}` literal into a shared `RatingAggregate` (with optional `breakdown: RatingBreakdown`); added `photoURL`/`displayName` to `ReviewType`.
- **`editReview` (`src/api/recipes.ts`)** — send `recipeId`/`text` as a JSON body instead of query params (server reads body-first, query fallback for older clients); annotated `getReviews` return type.
- **Reviewer avatars (`RecipeReview.tsx` + `.scss`)** — render `photoURL` with an `onError` → `DefaultAvatar` fallback (mirrors `AccountCard`); skeleton parity in `ReviewCardSkeleton`.
- **`StarRating` a11y** — interactive variant is now a WAI-ARIA radiogroup: `role=radiogroup`/`radio`, `aria-checked`, roving tabindex, Arrow/Home/End keys, focus-mirrors-hover preview.
- **Follow-up fixes (`22dd12b`, from a local review)** — skeleton avatar margin no longer double-applied; `Ratings.changeRating` optimistic revert is now concurrency-safe (monotonic request id) so rapid arrow-key repeats can't revert to a stale rating.

### Verification
- 639 vitest pass incl. new `StarRating.test.tsx` (keyboard a11y) + `RatingsAndReviews.test.tsx` avatar branches; `tsc --noEmit` clean.
- Runtime-verified end-to-end (headless drive): real `<img>` vs `DefaultAvatar` both branches, keyboard nav with aria-checked/tabindex tracking, and the `editReview` request captured as JSON body (no query string).

### Deferred to PR-C (needs mockups)
- Own-review card ("your review") still shows `DefaultAvatar` even when the user has a photo — `checkIfReviewed`/`newReview` aren't avatar-enriched (server-side, PR-A scope) and the clean frontend fix is the shared avatar component PR-C owns.
- The `breakdown` histogram UI (only the type landed here); `displayName` as the visible name; extracting a shared `UserAvatar` (this is the 5th copy of the fallback pattern).

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK
