### PR TITLE
feat(scripts): W1 — Phase 5-D legacy string-_id → ObjectId migration script

### DIFF
--- a/server/__tests__/migrateLegacyRecipeIds.test.js
+++ b/server/__tests__/migrateLegacyRecipeIds.test.js
@@ -1,0 +1,229 @@
+/**
+ * W1 — scripts/migrateLegacyRecipeIds.js (Phase 5-D string→ObjectId migration).
+ *
+ * Runs the exported migration against the suite's in-memory replica set (the
+ * same topology as prod Atlas, so the multi-document transaction is exercised
+ * for real). Pins the invariants the prod run depends on:
+ *   - hex-preserving convert: the doc re-appears under ObjectId(sameHex) with
+ *     every other field byte-identical, and `String(_id)` is unchanged
+ *   - foreign refs (ratings/reports/userRecipeData string ids) are NOT written,
+ *     and still resolve through util/recipeIdQuery.js after the convert
+ *   - dry run writes nothing; --apply is idempotent (second run finds 0)
+ *   - non-hex string _ids and ObjectId-collision docs are reported + skipped,
+ *     never half-migrated
+ */
+const { ObjectId } = require('mongodb')
+const { getDB, getClient } = require('../db')
+const { recipeIdQuery } = require('../util/recipeIdQuery')
+const {
+  isLegacyHexObjectId,
+  planLegacyIdMigration,
+  migrateLegacyRecipeIds,
+} = require('../scripts/migrateLegacyRecipeIds')
+
+// A real legacy id shape from prod (24-char hex stored as a string).
+const LEGACY_HEX = '63fe34ad3d057633b6e2970e'
+const LEGACY_HEX_2 = '65302e782ea38768dea80749'
+const NON_HEX = 'recipe_12345'
+
+const legacyRecipe = (id, title) => ({
+  _id: id,
+  title,
+  userId: 'owner-uid',
+  authorUsername: 'chef',
+  servings: 4,
+  ingredients: [{ ingredientString: '1 cup flour' }],
+  rating: { rateCount: 2, rateValue: 4.5 },
+})
+
+afterEach(async () => {
+  const db = getDB()
+  for (const coll of ['recipes', 'ratings', 'reports', 'userRecipeData']) {
+    await db.collection(coll).deleteMany({})
+  }
+})
+
+describe('isLegacyHexObjectId', () => {
+  test('true only for a genuine 24-char hex string', () => {
+    expect(isLegacyHexObjectId(LEGACY_HEX)).toBe(true)
+    expect(isLegacyHexObjectId(NON_HEX)).toBe(false)
+    // ObjectId.isValid is true for any 12-byte string — the round-trip must reject it
+    expect(isLegacyHexObjectId('twelve-bytes')).toBe(false)
+    expect(isLegacyHexObjectId(new ObjectId(LEGACY_HEX))).toBe(false)
+    expect(isLegacyHexObjectId(null)).toBe(false)
+  })
+})
+
+describe('planLegacyIdMigration', () => {
+  test('classifies convert / skip-non-hex / skip-collision and ignores ObjectId docs', async () => {
+    const db = getDB()
+    await db.collection('recipes').insertMany([
+      legacyRecipe(LEGACY_HEX, 'Clean convert'),
+      legacyRecipe(NON_HEX, 'Non-hex'),
+      legacyRecipe(LEGACY_HEX_2, 'Collision'),
+      // the collision: LEGACY_HEX_2's ObjectId form already exists as its own doc
+      { _id: new ObjectId(LEGACY_HEX_2), title: 'Occupies the ObjectId slot' },
+      { _id: new ObjectId(), title: 'Modern recipe — not part of the plan' },
+    ])
+
+    const plan = await planLegacyIdMigration(db)
+    const byId = Object.fromEntries(plan.map((p) => [p.id, p.action]))
+    expect(plan).toHaveLength(3)
+    expect(byId[LEGACY_HEX]).toBe('convert')
+    expect(byId[NON_HEX]).toBe('skip-non-hex')
+    expect(byId[LEGACY_HEX_2]).toBe('skip-collision')
+  })
+
+  test('counts the string refs per recipe (informational)', async () => {
+    const db = getDB()
+    await db.collection('recipes').insertOne(legacyRecipe(LEGACY_HEX, 'Referenced'))
+    await db.collection('ratings').insertMany([
+      { recipeId: LEGACY_HEX, userId: 'u1', rating: 5 },
+      { recipeId: LEGACY_HEX, userId: 'u2', rating: 4 },
+    ])
+    await db.collection('reports').insertOne({ recipeId: LEGACY_HEX, targetType: 'recipe' })
+    await db.collection('userRecipeData').insertMany([
+      { _id: 'uid-a', savedRecipes: [{ recipeId: LEGACY_HEX }] },
+      { _id: 'uid-b', madeRecipes: [{ recipeId: LEGACY_HEX }], userRecipes: [] },
+      { _id: 'uid-c', savedRecipes: [{ recipeId: 'some-other-recipe' }] },
+    ])
+
+    const [entry] = await planLegacyIdMigration(db)
+    expect(entry.refs).toEqual({
+      ratings: 2,
+      reports: 1,
+      'userRecipeData lists': 2,
+    })
+  })
+})
+
+describe('migrateLegacyRecipeIds', () => {
+  test('dry run (default) writes nothing', async () => {
+    const db = getDB()
+    await db.collection('recipes').insertOne(legacyRecipe(LEGACY_HEX, 'Untouched'))
+
+    const { counts } = await migrateLegacyRecipeIds(getClient(), db)
+
+    expect(counts).toEqual({ legacy: 1, converted: 1, skippedNonHex: 0, skippedCollision: 0 })
+    // still the string doc, no ObjectId twin
+    expect(await db.collection('recipes').findOne({ _id: LEGACY_HEX })).not.toBeNull()
+    expect(await db.collection('recipes').findOne({ _id: new ObjectId(LEGACY_HEX) })).toBeNull()
+  })
+
+  test('apply converts under the SAME hex with every other field intact', async () => {
+    const db = getDB()
+    const original = legacyRecipe(LEGACY_HEX, 'Yogurt and Fruit Parfaits')
+    await db.collection('recipes').insertOne(original)
+
+    const { counts } = await migrateLegacyRecipeIds(getClient(), db, { apply: true })
+    expect(counts.converted).toBe(1)
+
+    expect(await db.collection('recipes').findOne({ _id: LEGACY_HEX })).toBeNull()
+    const migrated = await db.collection('recipes').findOne({ _id: new ObjectId(LEGACY_HEX) })
+    expect(migrated).not.toBeNull()
+    // the string form is byte-identical — this is what keeps every ref resolving
+    expect(String(migrated._id)).toBe(LEGACY_HEX)
+    const { _id, ...rest } = migrated
+    const { _id: _oldId, ...expected } = original
+    expect(rest).toEqual(expected)
+  })
+
+  test('foreign string refs are not written and still resolve via recipeIdQuery', async () => {
+    const db = getDB()
+    await db.collection('recipes').insertOne(legacyRecipe(LEGACY_HEX, 'Referenced'))
+    const rating = { recipeId: LEGACY_HEX, userId: 'u1', rating: 5 }
+    await db.collection('ratings').insertOne(rating)
+    await db.collection('userRecipeData').insertOne({
+      _id: 'uid-a',
+      savedRecipes: [{ recipeId: LEGACY_HEX, dateSaved: '1677605819601' }],
+    })
+
+    await migrateLegacyRecipeIds(getClient(), db, { apply: true })
+
+    // refs byte-identical (never written) …
+    expect(await db.collection('ratings').findOne({ recipeId: LEGACY_HEX })).toMatchObject(rating)
+    expect(
+      await db.collection('userRecipeData').findOne({ 'savedRecipes.recipeId': LEGACY_HEX })
+    ).not.toBeNull()
+    // … and the app's lookup path — string id through the shim — finds the migrated doc
+    const viaShim = await db.collection('recipes').findOne(recipeIdQuery(LEGACY_HEX))
+    expect(viaShim).not.toBeNull()
+    expect(String(viaShim._id)).toBe(LEGACY_HEX)
+  })
+
+  test('apply is idempotent — a second run finds nothing to do', async () => {
+    const db = getDB()
+    await db.collection('recipes').insertMany([
+      legacyRecipe(LEGACY_HEX, 'One'),
+      legacyRecipe(LEGACY_HEX_2, 'Two'),
+    ])
+
+    const first = await migrateLegacyRecipeIds(getClient(), db, { apply: true })
+    expect(first.counts).toMatchObject({ legacy: 2, converted: 2 })
+
+    const second = await migrateLegacyRecipeIds(getClient(), db, { apply: true })
+    expect(second.counts).toEqual({ legacy: 0, converted: 0, skippedNonHex: 0, skippedCollision: 0 })
+    expect(await db.collection('recipes').countDocuments({ _id: { $type: 'string' } })).toBe(0)
+    expect(await db.collection('recipes').countDocuments({})).toBe(2)
+  })
+
+  test('onlyId targets a single doc and leaves the other legacy docs pending', async () => {
+    const db = getDB()
+    await db.collection('recipes').insertMany([
+      legacyRecipe(LEGACY_HEX, 'Targeted'),
+      legacyRecipe(LEGACY_HEX_2, 'Left alone'),
+    ])
+
+    const { counts } = await migrateLegacyRecipeIds(getClient(), db, {
+      apply: true,
+      onlyId: LEGACY_HEX,
+    })
+
+    expect(counts).toMatchObject({ legacy: 1, converted: 1 })
+    expect(await db.collection('recipes').findOne({ _id: new ObjectId(LEGACY_HEX) })).not.toBeNull()
+    // the untargeted legacy doc is still the string doc
+    expect(await db.collection('recipes').findOne({ _id: LEGACY_HEX_2 })).not.toBeNull()
+    expect(await db.collection('recipes').findOne({ _id: new ObjectId(LEGACY_HEX_2) })).toBeNull()
+
+    // an --id pointing at an already-migrated (ObjectId) recipe plans nothing
+    const rerun = await migrateLegacyRecipeIds(getClient(), db, {
+      apply: true,
+      onlyId: LEGACY_HEX,
+    })
+    expect(rerun.counts.legacy).toBe(0)
+  })
+
+  test('non-hex and collision docs are skipped untouched, others still convert', async () => {
+    const db = getDB()
+    await db.collection('recipes').insertMany([
+      legacyRecipe(LEGACY_HEX, 'Converts'),
+      legacyRecipe(NON_HEX, 'Non-hex survivor'),
+      legacyRecipe(LEGACY_HEX_2, 'Collision survivor'),
+      { _id: new ObjectId(LEGACY_HEX_2), title: 'Occupies the ObjectId slot' },
+    ])
+
+    const lines = []
+    const { counts } = await migrateLegacyRecipeIds(getClient(), db, {
+      apply: true,
+      log: (l) => lines.push(l),
+    })
+
+    expect(counts).toEqual({ legacy: 3, converted: 1, skippedNonHex: 1, skippedCollision: 1 })
+    // skipped docs byte-identical in place
+    expect(await db.collection('recipes').findOne({ _id: NON_HEX })).toMatchObject({
+      title: 'Non-hex survivor',
+    })
+    expect(await db.collection('recipes').findOne({ _id: LEGACY_HEX_2 })).toMatchObject({
+      title: 'Collision survivor',
+    })
+    // the collision's ObjectId doc was not overwritten
+    expect(
+      await db.collection('recipes').findOne({ _id: new ObjectId(LEGACY_HEX_2) })
+    ).toMatchObject({ title: 'Occupies the ObjectId slot' })
+    // the clean one converted
+    expect(await db.collection('recipes').findOne({ _id: new ObjectId(LEGACY_HEX) })).not.toBeNull()
+    // and both skips were reported, not silent
+    expect(lines.some((l) => l.includes('SKIP') && l.includes('not a 24-char hex'))).toBe(true)
+    expect(lines.some((l) => l.includes('SKIP') && l.includes('already exists'))).toBe(true)
+  })
+})

--- a/server/scripts/migrateLegacyRecipeIds.js
+++ b/server/scripts/migrateLegacyRecipeIds.js
@@ -1,0 +1,262 @@
+/**
+ * W1 — Phase 5-D one-off recipe `_id` migration: legacy string → native ObjectId.
+ *
+ * Recipes created before the Phase-5 refactor store `_id` as a plain STRING;
+ * everything since stores a native BSON ObjectId. Reads/writes already work for
+ * both shapes through the util/recipeIdQuery.js compatibility shim ($or over both
+ * forms), so this migration is about retiring that duality, not fixing a bug.
+ * `checkMigrationState.js` counts the docs still pending it (8 on prod + dev as
+ * of 2026-07-09).
+ *
+ * HOW: every legacy `_id` in prod/dev is a genuine 24-char hex string (verified
+ * 2026-07-09 — all 8 round-trip `String(new ObjectId(id)) === id`), so each doc
+ * is re-inserted under `new ObjectId(sameHex)` and the string doc deleted, both
+ * inside one multi-document transaction (prod Atlas is a replica set). Because
+ * the hex is PRESERVED, the recipe's string form — `String(_id)` — is byte-for-
+ * byte unchanged, and every foreign reference keeps resolving with NO repointing:
+ * `ratings.recipeId`, `reports.recipeId`, and the `userRecipeData` lists
+ * (`userRecipes`/`savedRecipes`/`madeRecipes`) all store the STRING id for every
+ * recipe — including post-migration ObjectId recipes — and every lookup path goes
+ * through the string id (route params) + `recipeIdQuery()`. The per-recipe ref
+ * counts printed below are therefore INFORMATIONAL (visibility for the operator),
+ * not a write surface. This supersedes the BACKLOG sketch of "insert under a
+ * fresh ObjectId + repoint every ref" — a fresh id would force exactly that
+ * repointing; preserving the hex makes it unnecessary.
+ *
+ * A legacy `_id` that is NOT 24-char hex, or whose ObjectId form already exists
+ * as another doc (neither occurs in prod/dev today), is REPORTED AND SKIPPED —
+ * migrating those safely would require the fresh-id + repoint machinery, which
+ * is deliberately not built for data that doesn't exist. The exit code flags
+ * them so a cutover gate can't miss it.
+ *
+ * SAFE BY DEFAULT: DRY RUN unless you pass --apply. The dry run reads only — it
+ * lists each legacy doc, whether it converts cleanly, and its ref counts.
+ *
+ * IDEMPOTENT: converted docs no longer match `{ _id: { $type: 'string' } }`, so
+ * a second --apply run finds nothing to do.
+ *
+ * AFTERWARDS: re-run `checkMigrationState.js` (the legacy-string-_id check goes
+ * to 0). The recipeIdQuery shim's string branch is then a no-op; actually
+ * removing the shim is a separate code change once PROD has been migrated.
+ *
+ * Usage:
+ *   node server/scripts/migrateLegacyRecipeIds.js                 # dry run (default)
+ *   node server/scripts/migrateLegacyRecipeIds.js --apply         # actually migrate
+ *   node server/scripts/migrateLegacyRecipeIds.js --apply --id=<recipeId>
+ *                                                  # target one doc — for a cautious first run
+ *
+ * Reads MONGO_URI from server/.env (override the DB with DB_NAME, default
+ * "prepify"). Exit code 0 = success (nothing pending afterwards), 2 = docs
+ * remain that need attention (dry run with candidates, or skipped docs),
+ * 1 = error.
+ */
+const path = require('path')
+const { MongoClient, ObjectId } = require('mongodb')
+
+// Same round-trip check as util/recipeIdQuery.js `isObjectIdHex`: ObjectId.isValid
+// alone is permissive (any 12-byte string passes), so pin to genuine 24-char hex.
+function isLegacyHexObjectId(id) {
+  return (
+    typeof id === 'string' && ObjectId.isValid(id) && String(new ObjectId(id)) === id
+  )
+}
+
+// The string-id reference sites, counted per recipe for the operator's benefit.
+// NONE of these are modified — the hex-preserving convert keeps `String(_id)`
+// identical, so string refs resolve before and after. Any collection not listed
+// here that stores the string id (audit trails, drafts, …) keeps working for the
+// same reason.
+const REF_SITES = [
+  { label: 'ratings', collection: 'ratings', filter: (id) => ({ recipeId: id }) },
+  { label: 'reports', collection: 'reports', filter: (id) => ({ recipeId: id }) },
+  {
+    label: 'userRecipeData lists',
+    collection: 'userRecipeData',
+    filter: (id) => ({
+      $or: [
+        { 'userRecipes.recipeId': id },
+        { 'savedRecipes.recipeId': id },
+        { 'madeRecipes.recipeId': id },
+      ],
+    }),
+  },
+]
+
+// Classify every legacy string-_id recipe:
+//   { action: 'convert' }         → clean hex, no collision — migratable
+//   { action: 'skip-non-hex' }    → string _id that isn't 24-char hex
+//   { action: 'skip-collision' }  → ObjectId(hex) already exists as its own doc
+// plus informational per-recipe ref counts.
+async function planLegacyIdMigration(db, { onlyId = null } = {}) {
+  const filter = { _id: { $type: 'string' } }
+  // --id targets one doc; the $type guard stays, so passing an already-migrated
+  // (ObjectId) recipe's id simply plans nothing rather than re-migrating.
+  if (onlyId) filter._id = { $type: 'string', $eq: onlyId }
+  const legacy = await db
+    .collection('recipes')
+    .find(filter)
+    .project({ _id: 1, title: 1 })
+    .toArray()
+
+  const plan = []
+  for (const doc of legacy) {
+    const id = doc._id
+    let action = 'convert'
+    if (!isLegacyHexObjectId(id)) {
+      action = 'skip-non-hex'
+    } else if (
+      await db
+        .collection('recipes')
+        .findOne({ _id: new ObjectId(id) }, { projection: { _id: 1 } })
+    ) {
+      action = 'skip-collision'
+    }
+
+    const refs = {}
+    for (const site of REF_SITES) {
+      refs[site.label] = await db
+        .collection(site.collection)
+        .countDocuments(site.filter(id))
+    }
+    plan.push({ id, title: doc.title, action, refs })
+  }
+  return plan
+}
+
+// Re-insert one legacy doc under ObjectId(sameHex) and delete the string doc,
+// atomically. withTransaction retries on transient conflicts, and the findOne
+// runs INSIDE the transaction so a write landing just before it is still copied.
+async function convertRecipeId(client, db, id) {
+  const session = client.startSession()
+  try {
+    await session.withTransaction(async () => {
+      const doc = await db.collection('recipes').findOne({ _id: id }, { session })
+      if (!doc) throw new Error(`recipe ${id} disappeared mid-run`)
+      await db
+        .collection('recipes')
+        .insertOne({ ...doc, _id: new ObjectId(id) }, { session })
+      await db.collection('recipes').deleteOne({ _id: id }, { session })
+    })
+  } finally {
+    await session.endSession()
+  }
+}
+
+// The whole run, separated from process/env wiring so tests can drive it
+// against the in-memory replica set. Returns the plan + counts; `log` receives
+// the per-recipe lines.
+async function migrateLegacyRecipeIds(
+  client,
+  db,
+  { apply = false, onlyId = null, log = () => {} } = {}
+) {
+  const plan = await planLegacyIdMigration(db, { onlyId })
+  const counts = {
+    legacy: plan.length,
+    converted: 0,
+    skippedNonHex: 0,
+    skippedCollision: 0,
+  }
+
+  for (const entry of plan) {
+    const refs = Object.entries(entry.refs)
+      .map(([label, n]) => `${label} ${n}`)
+      .join(', ')
+    if (entry.action === 'skip-non-hex') {
+      counts.skippedNonHex++
+      log(`  SKIP   ${JSON.stringify(entry.id)}: not a 24-char hex string — needs the fresh-id + repoint path (refs: ${refs})`)
+      continue
+    }
+    if (entry.action === 'skip-collision') {
+      counts.skippedCollision++
+      log(`  SKIP   ${entry.id}: ObjectId form already exists as another doc — resolve manually (refs: ${refs})`)
+      continue
+    }
+    if (apply) {
+      await convertRecipeId(client, db, entry.id)
+      counts.converted++
+      log(`  moved  ${entry.id} → ObjectId (refs untouched: ${refs}) — "${entry.title}"`)
+    } else {
+      counts.converted++
+      log(`  would  ${entry.id} → ObjectId (refs untouched: ${refs}) — "${entry.title}"`)
+    }
+  }
+  return { plan, counts }
+}
+
+async function main() {
+  const APPLY = process.argv.includes('--apply')
+  const idArg = process.argv.find((a) => a.startsWith('--id='))
+  const ONLY_ID = idArg ? idArg.slice('--id='.length) : null
+  const uri = process.env.MONGO_URI
+  if (!uri) {
+    console.error('MONGO_URI is not set (looked in server/.env).')
+    process.exit(1)
+  }
+  const dbName = process.env.DB_NAME || 'prepify'
+
+  const client = new MongoClient(uri, {
+    tls: true,
+    serverSelectionTimeoutMS: 5000,
+    socketTimeoutMS: 45000,
+    maxPoolSize: 10,
+  })
+
+  try {
+    await client.connect()
+    const db = client.db(dbName)
+    console.log(
+      `Connected to MongoDB (${dbName}). Mode: ${APPLY ? 'APPLY (writing)' : 'DRY RUN (read-only)'}` +
+        `${ONLY_ID ? ` — only recipe ${ONLY_ID}` : ''}\n`
+    )
+
+    const { counts } = await migrateLegacyRecipeIds(client, db, {
+      apply: APPLY,
+      onlyId: ONLY_ID,
+      log: console.log,
+    })
+
+    // Post-run verification: the pending-count the cutover gate
+    // (checkMigrationState.js) will see. Always catalog-wide, even under --id,
+    // so a targeted run still reports how much is left overall.
+    const remaining = await db
+      .collection('recipes')
+      .countDocuments({ _id: { $type: 'string' } })
+
+    console.log('\nSummary')
+    console.log('───────')
+    const row = (label, val) => console.log(`  ${(label + ':').padEnd(26)}${val}`)
+    row('legacy string-_id docs', counts.legacy)
+    row(APPLY ? 'converted' : 'would convert', counts.converted)
+    if (counts.skippedNonHex) row('skipped (non-hex _id)', counts.skippedNonHex)
+    if (counts.skippedCollision) row('skipped (id collision)', counts.skippedCollision)
+    row('string _ids remaining', remaining)
+
+    if (!APPLY) {
+      console.log('\nDRY RUN — nothing was written. Re-run with --apply to commit.')
+    } else if (remaining === 0) {
+      console.log('\nDone. Re-run checkMigrationState.js — the legacy-_id check should now be 0.')
+    } else if (counts.skippedNonHex || counts.skippedCollision) {
+      console.log('\nDone, but docs were SKIPPED (see lines above) — resolve them before retiring the shim.')
+    } else {
+      console.log('\nDone. Other legacy docs remain (targeted run) — re-run without --id for the rest.')
+    }
+    // 0 only when nothing is left pending, so this can gate a cutover step the
+    // same way checkMigrationState.js does (dry runs with candidates exit 2).
+    process.exit(remaining === 0 ? 0 : 2)
+  } catch (err) {
+    console.error('\nMigration failed:', err.message)
+    process.exit(1)
+  } finally {
+    await client.close().catch(() => {})
+  }
+}
+
+// Export for unit tests; only load env + run when invoked directly
+// (`node scripts/migrateLegacyRecipeIds.js`), so a test require doesn't pull
+// real server/.env creds into its process.
+module.exports = { isLegacyHexObjectId, planLegacyIdMigration, migrateLegacyRecipeIds }
+if (require.main === module) {
+  require('dotenv').config({ path: path.join(__dirname, '..', '.env') })
+  main()
+}


### PR DESCRIPTION
## What

The one-time backfill that retires the `util/recipeIdQuery.js` string/ObjectId duality (Phase 5-D): `server/scripts/migrateLegacyRecipeIds.js` + a 9-case Jest suite. **New files only** — verified disjoint from the §D reviews-overhaul stack (#266/#267).

## Design: hex-preserving convert, no repointing

The BACKLOG sketch assumed a fresh ObjectId per doc + repointing every foreign ref. Inspecting the real data showed a simpler, safer shape: **all 8 legacy `_id`s (prod + dev) are genuine 24-char hex, collision-free**, so each doc is re-inserted under `ObjectId(sameHex)` and the string doc deleted — in one multi-document transaction. `String(_id)` is byte-identical, and since every ref site stores the **string** id for every recipe (verified: ratings 20/20 string, reports 15/15 with recipeId, userRecipeData lists), all refs keep resolving with **zero writes outside the recipes collection**. Ref counts are printed per doc as operator visibility, not a write surface.

Non-hex or colliding `_id`s (none exist today) are reported + SKIPPED, never half-migrated; exit code 2 flags anything pending so the run gates a cutover like `checkMigrationState.js`.

## Posture (matches the S6/I2 siblings)

- **Dry-run by default**, `--apply` to write, `--id=<recipeId>` for a cautious targeted first run, `DB_NAME` honored
- Idempotent — a second `--apply` finds 0 pending
- **The prod `--apply` run stays owner-gated**; the script is the deliverable

## Verification

- New Jest suite (9) drives the exported migration against the in-memory **replica set** — real transaction, hex-preservation byte-for-byte, refs untouched + still resolving through `recipeIdQuery`, dry-run no-op, idempotency, skip paths, `--id` targeting
- Full server suite **789/789**
- **Live dev run**: dry run listed exactly the 8 real docs (all convert-clean); a synthetic legacy probe (string `_id` + rating + saved ref) was served by `GET /getRecipe` and counted by `GET /getReviews` **before and after** `--apply --id=<probe>` on the same URLs, then dev was restored to baseline (8 legacy docs untouched, probe cleaned up)

## Note for the reviewer

While verifying I found the **local :4000 server is connected to prod Mongo** (its Tuscan aggregate matches prod's post-S6-heal 8/3.75, not dev's 10/3.9; dev `views` don't move on hits). It was started 2026-07-08 17:21 — around the S6 prod ops run's temporary `MONGO_URI` swap — and still holds that connection. Worth restarting it so local traffic stops hitting prod.

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8