### PR TITLE
a11y(add-recipe): W2 — wire section labels + error/hint text to their controls

### DIFF
--- a/src/pages/AddRecipe/AddRecipe.tsx
+++ b/src/pages/AddRecipe/AddRecipe.tsx
@@ -128,7 +128,7 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
               errorId='error-image'
             >
               {resumedFromDraft && !recipeImage && (
-                <p className='draft-image-hint'>
+                <p className='draft-image-hint' id='draft-image-hint'>
                   <InfoIcon className='icon' />
                   Drafts don't save your image — add it again before publishing.
                 </p>
@@ -138,6 +138,14 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
                 setImage={setRecipeImage}
                 initialPreviewUrl={existingImageUrl}
                 onRemove={() => setExistingImageUrl(undefined)}
+                describedBy={
+                  [
+                    errors.image ? 'error-image' : null,
+                    resumedFromDraft && !recipeImage ? 'draft-image-hint' : null,
+                  ]
+                    .filter(Boolean)
+                    .join(' ') || undefined
+                }
               />
             </FormField>
             <FormField
@@ -181,6 +189,8 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
                 label={'How long will your recipe take to prepare?'}
                 val={prepTime}
                 setVal={setPrepTime}
+                invalid={!!errors.prepTime}
+                describedBy={errors.prepTime ? 'error-prepTime' : undefined}
               />
             </FormField>
             <FormField className='cook-time' label='Cook Time'>
@@ -227,6 +237,8 @@ const AddRecipe: FC<AddRecipeProps> = ({ initialRecipe }) => {
               <MealTypeSelector
                 mealTypes={mealTypes}
                 setMealTypes={setMealTypes}
+                invalid={!!errors.mealType}
+                errorMessageId='error-mealType'
               />
             </FormField>
             <FormField className='diet' label='Diet'>

--- a/src/pages/AddRecipe/FormField.tsx
+++ b/src/pages/AddRecipe/FormField.tsx
@@ -19,6 +19,15 @@ type FormFieldProps = {
 // error + the field's control. Collapses the header/error/wrapper boilerplate
 // that every field in AddRecipe repeated verbatim; markup is identical to the
 // former inline blocks so CSS and the field tests are unaffected.
+//
+// The row is exposed as a labelled group: the SectionHeader gets a stable id
+// (derived from the row's className, which is already unique per field) and the
+// wrapper points at it via role='group' + aria-labelledby, so assistive tech
+// knows which fields the orange label governs — the visual grouping alone
+// carried no programmatic link. When the field is in error, the group also
+// carries aria-describedby to the alert, which covers multi-control children
+// (the ingredient/instruction list containers) that no single input can
+// meaningfully own the message for.
 const FormField: FC<FormFieldProps> = ({
   className,
   label,
@@ -26,12 +35,20 @@ const FormField: FC<FormFieldProps> = ({
   error,
   errorId,
   children,
-}) => (
-  <div className={`${className} input-field`}>
-    <SectionHeader label={label} required={required} />
-    {error && <AddRecipeFormError error={error} id={errorId} />}
-    {children}
-  </div>
-)
+}) => {
+  const headerId = `section-${className}`
+  return (
+    <div
+      className={`${className} input-field`}
+      role='group'
+      aria-labelledby={headerId}
+      aria-describedby={error && errorId ? errorId : undefined}
+    >
+      <SectionHeader label={label} required={required} id={headerId} />
+      {error && <AddRecipeFormError error={error} id={errorId} />}
+      {children}
+    </div>
+  )
+}
 
 export default FormField

--- a/src/pages/AddRecipe/ImagePicker/ImagePicker.tsx
+++ b/src/pages/AddRecipe/ImagePicker/ImagePicker.tsx
@@ -16,6 +16,9 @@ interface ImagePickerProps {
   // Edit mode: fires when the user clears the image, so the parent can drop the
   // existing-image URL it tracks for validation.
   onRemove?: () => void
+  // Accessibility: id(s) of the text describing the picker (the section's error
+  // message and/or the draft-image hint), announced with the dropzone control.
+  describedBy?: string
 }
 
 const ImagePicker: React.FC<ImagePickerProps> = ({
@@ -23,6 +26,7 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
   setImage,
   initialPreviewUrl,
   onRemove,
+  describedBy,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [imagePreview, setImagePreview] = useState<string | undefined>(
@@ -115,6 +119,7 @@ const ImagePicker: React.FC<ImagePickerProps> = ({
         role={imagePreview ? undefined : 'button'}
         tabIndex={imagePreview ? undefined : 0}
         aria-label={imagePreview ? undefined : 'Select an image'}
+        aria-describedby={imagePreview ? undefined : describedBy}
         onKeyDown={
           imagePreview
             ? undefined

--- a/src/pages/AddRecipe/MealTypeSelector/MealTypeSelector.tsx
+++ b/src/pages/AddRecipe/MealTypeSelector/MealTypeSelector.tsx
@@ -16,6 +16,12 @@ const mealTypeOptions: OptionType[] = mealTypesList.map(m => ({
 type MealTypeSelectorProps = {
   mealTypes: string[]
   setMealTypes: React.Dispatch<React.SetStateAction<string[]>>
+  // Accessibility: mark the select invalid and point it at the section's error
+  // message. react-select exposes aria-invalid/aria-errormessage (it has no
+  // aria-describedby prop), and aria-errormessage is only exposed to assistive
+  // tech while aria-invalid is set, so the two are passed as a gated pair.
+  invalid?: boolean
+  errorMessageId?: string
 }
 const getMealTypesByString = (mealTypesString: string[]): OptionType[] => {
   const matchingMealTypes = mealTypeOptions.filter(option =>
@@ -28,6 +34,8 @@ const getMealTypesByString = (mealTypesString: string[]): OptionType[] => {
 const MealTypeSelector: FC<MealTypeSelectorProps> = ({
   mealTypes,
   setMealTypes,
+  invalid,
+  errorMessageId,
 }) => {
   const handleChange = (
     newValue: MultiValue<OptionType> | null,
@@ -52,6 +60,8 @@ const MealTypeSelector: FC<MealTypeSelectorProps> = ({
         placeholder='Select meal type(s)...'
         closeMenuOnSelect={false}
         aria-label='Course'
+        aria-invalid={invalid || undefined}
+        aria-errormessage={invalid ? errorMessageId : undefined}
       />
     </div>
   )

--- a/src/pages/AddRecipe/SectionHeader.tsx
+++ b/src/pages/AddRecipe/SectionHeader.tsx
@@ -5,13 +5,16 @@ interface SectionHeaderProps {
   // Marks the section as required, surfacing a small "Required" tag beside the
   // divider. Optional sections (cook time, cuisine) omit it.
   required?: boolean
+  // Stable id so the section's control group can point back at this label via
+  // aria-labelledby (FormField wires it).
+  id?: string
 }
 
 // Section label styled as the recipe-page pattern: an orange uppercase label
 // followed by a divider rule. Kept as an <h2> so screen-reader users can still
 // navigate the form by heading.
-const SectionHeader: FC<SectionHeaderProps> = ({ label, required = false }) => (
-  <h2 className='section-header'>
+const SectionHeader: FC<SectionHeaderProps> = ({ label, required = false, id }) => (
+  <h2 className='section-header' id={id}>
     <span className='text'>{label}</span>
     <span className='divider' aria-hidden='true' />
     {required && <span className='req'>Required</span>}

--- a/src/pages/AddRecipe/TimeInput/TimeInput.tsx
+++ b/src/pages/AddRecipe/TimeInput/TimeInput.tsx
@@ -14,9 +14,19 @@ interface TimeInputProps {
       minutes: number
     } | null
   ) => void
+  // Accessibility: flag both time fields as invalid and point them at the
+  // section's error message (AddRecipe passes the FormField errorId).
+  invalid?: boolean
+  describedBy?: string
 }
 
-const TimeInput: React.FC<TimeInputProps> = ({ label, val, setVal }) => {
+const TimeInput: React.FC<TimeInputProps> = ({
+  label,
+  val,
+  setVal,
+  invalid,
+  describedBy,
+}) => {
   const [minutes, setMinutes] = useState<number | ''>('')
   const [hours, setHours] = useState<number | ''>('')
   // True once the user has typed in either field. Distinguishes a genuine
@@ -91,6 +101,8 @@ const TimeInput: React.FC<TimeInputProps> = ({ label, val, setVal }) => {
           setVal={(val: number | '') => onHoursChange(val)}
           characterLimit={3}
           inputBeginningText='Hours'
+          invalid={invalid}
+          describedBy={describedBy}
         />
         <FormInput
           size='compact'
@@ -100,6 +112,8 @@ const TimeInput: React.FC<TimeInputProps> = ({ label, val, setVal }) => {
           setVal={(val: number | '') => onMinutesChange(val)}
           characterLimit={3}
           inputBeginningText='Minutes'
+          invalid={invalid}
+          describedBy={describedBy}
         />{' '}
       </div>
     </div>

--- a/src/test/FormField.test.tsx
+++ b/src/test/FormField.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import FormField from 'src/pages/AddRecipe/FormField'
+
+// W2 a11y wiring: each create-recipe row is a labelled group — the orange
+// SectionHeader gets a stable id and the wrapper points at it, so the label's
+// governance over the row's control(s) is programmatic, not just visual. In
+// error, the group also references the alert, which covers multi-control
+// children (the ingredient/instruction list containers) that no single input
+// can own the message for.
+describe('FormField group semantics', () => {
+  it('exposes a group labelled by its section header', () => {
+    render(
+      <FormField className='ingredients' label='Ingredients' required>
+        <input aria-label='child control' />
+      </FormField>
+    )
+    const group = screen.getByRole('group')
+    expect(group).toHaveAttribute('aria-labelledby', 'section-ingredients')
+    const header = screen.getByRole('heading', { name: /ingredients/i })
+    expect(header).toHaveAttribute('id', 'section-ingredients')
+    expect(group).not.toHaveAttribute('aria-describedby')
+  })
+
+  it('references the error alert from the group while in error', () => {
+    render(
+      <FormField
+        className='instructions'
+        label='Instructions'
+        required
+        error='At least one instruction is required.'
+        errorId='error-instructions'
+      >
+        <input aria-label='child control' />
+      </FormField>
+    )
+    const group = screen.getByRole('group')
+    expect(group).toHaveAttribute('aria-describedby', 'error-instructions')
+    expect(screen.getByRole('alert')).toHaveAttribute('id', 'error-instructions')
+  })
+})

--- a/src/test/ImagePicker.test.tsx
+++ b/src/test/ImagePicker.test.tsx
@@ -82,3 +82,31 @@ describe('ImagePicker — accessibility', () => {
     expect(click).toHaveBeenCalledTimes(2)
   })
 })
+
+// W2 a11y wiring: the empty-state dropzone is the picker control, so the
+// section's error/hint text ids are announced with it via aria-describedby.
+describe('ImagePicker — a11y wiring', () => {
+  it('carries describedBy on the empty dropzone control', () => {
+    const { container } = render(
+      <ImagePicker
+        image={undefined}
+        setImage={vi.fn()}
+        describedBy='error-image draft-image-hint'
+      />
+    )
+    const dropzone = container.querySelector('.image-picker-box') as HTMLElement
+    expect(dropzone).toHaveAttribute('role', 'button')
+    expect(dropzone).toHaveAttribute(
+      'aria-describedby',
+      'error-image draft-image-hint'
+    )
+  })
+
+  it('omits aria-describedby when none is provided', () => {
+    const { container } = render(
+      <ImagePicker image={undefined} setImage={vi.fn()} />
+    )
+    const dropzone = container.querySelector('.image-picker-box') as HTMLElement
+    expect(dropzone).not.toHaveAttribute('aria-describedby')
+  })
+})

--- a/src/test/MealTypeSelector.test.tsx
+++ b/src/test/MealTypeSelector.test.tsx
@@ -8,10 +8,20 @@ import MealTypeSelector from 'src/pages/AddRecipe/MealTypeSelector/MealTypeSelec
 // test exercises MealTypeSelector's own value<->option mapping rather than the
 // real widget.
 vi.mock('react-select', () => ({
-  default: ({ value, onChange, options, placeholder, 'aria-label': ariaLabel }: any) => (
+  default: ({
+    value,
+    onChange,
+    options,
+    placeholder,
+    'aria-label': ariaLabel,
+    'aria-invalid': ariaInvalid,
+    'aria-errormessage': ariaErrorMessage,
+  }: any) => (
     <div>
       <span data-testid='placeholder'>{placeholder}</span>
       <span data-testid='aria-label'>{ariaLabel}</span>
+      <span data-testid='aria-invalid'>{String(ariaInvalid)}</span>
+      <span data-testid='aria-errormessage'>{String(ariaErrorMessage)}</span>
       <span data-testid='selected'>
         {(value ?? []).map((o: any) => o.label).join(',')}
       </span>
@@ -85,5 +95,34 @@ describe('MealTypeSelector', () => {
     // The null-newValue branch of handleChange must yield [], not crash.
     await user.click(screen.getByTestId('clear'))
     expect(screen.getByTestId('meal-types')).toHaveTextContent('')
+  })
+
+  // W2 a11y wiring: react-select has no aria-describedby prop, so the invalid
+  // state rides its aria-invalid/aria-errormessage pair — and aria-errormessage
+  // is only exposed while aria-invalid is set, so the pair must be gated
+  // together.
+  it('passes the gated aria-invalid/aria-errormessage pair when in error', () => {
+    render(
+      <MealTypeSelector
+        mealTypes={[]}
+        setMealTypes={() => {}}
+        invalid
+        errorMessageId='error-mealType'
+      />
+    )
+    expect(screen.getByTestId('aria-invalid')).toHaveTextContent('true')
+    expect(screen.getByTestId('aria-errormessage')).toHaveTextContent('error-mealType')
+  })
+
+  it('emits neither aria attribute while valid — even with an id supplied', () => {
+    render(
+      <MealTypeSelector
+        mealTypes={[]}
+        setMealTypes={() => {}}
+        errorMessageId='error-mealType'
+      />
+    )
+    expect(screen.getByTestId('aria-invalid')).toHaveTextContent('undefined')
+    expect(screen.getByTestId('aria-errormessage')).toHaveTextContent('undefined')
   })
 })

--- a/src/test/TimeInput.test.tsx
+++ b/src/test/TimeInput.test.tsx
@@ -119,3 +119,34 @@ describe('TimeInput clear-both-fields', () => {
     expect(setVal).not.toHaveBeenCalledWith(null)
   })
 })
+
+// W2 a11y wiring: when the section is in error, both time fields carry the
+// invalid flag and point at the section's error message.
+describe('TimeInput a11y wiring', () => {
+  it('threads invalid + describedBy to both fields', () => {
+    render(
+      <TimeInput
+        label='Prep time'
+        val={null}
+        setVal={vi.fn()}
+        invalid
+        describedBy='error-prepTime'
+      />
+    )
+    const inputs = screen.getAllByPlaceholderText('0') as HTMLInputElement[]
+    expect(inputs).toHaveLength(2)
+    for (const input of inputs) {
+      expect(input).toHaveAttribute('aria-invalid', 'true')
+      expect(input).toHaveAttribute('aria-describedby', 'error-prepTime')
+    }
+  })
+
+  it('emits neither attribute when the field is valid', () => {
+    render(<TimeInput label='Prep time' val={null} setVal={vi.fn()} />)
+    const inputs = screen.getAllByPlaceholderText('0') as HTMLInputElement[]
+    for (const input of inputs) {
+      expect(input).not.toHaveAttribute('aria-invalid')
+      expect(input).not.toHaveAttribute('aria-describedby')
+    }
+  })
+})


### PR DESCRIPTION
## What

The two open AddRecipe a11y follow-ups from `ADD_RECIPE_UX_AUDIT.md` (BACKLOG § Accessibility), on the now-free post-R1 surface. Attribute-only — no layout/behaviour change.

### Section label → controls (`aria-labelledby`)
`SectionHeader` takes a stable `id` (`section-<row-className>`, unique per field) and stays an `<h2>` (heading nav preserved). `FormField`'s wrapper becomes `role='group' aria-labelledby={headerId}`, so the orange label programmatically governs the row's control(s) for every field at once.

### Error/hint text → controls (`aria-describedby`)
- **Group level:** in error, the `FormField` group carries `aria-describedby` to the alert — this is what covers the **ingredient/instruction list containers**, where no single input can own the message.
- **TimeInput:** new `invalid`/`describedBy` props threaded to both time fields; AddRecipe wires prep-time (`error-prepTime`). Cook time has no error state.
- **ImagePicker:** empty-state dropzone (the actual control) announces the section error and/or the *drafts don't save your image* hint (hint now has an id); composed in AddRecipe.
- **Course selector:** react-select has **no `aria-describedby` prop**, so it gets the supported pairing — `aria-invalid` + `aria-errormessage` — passed as a **gated pair** (`aria-errormessage` is only exposed to AT while `aria-invalid` is set). Cuisine/Diet have no validation or hint copy to associate; the group labelling covers them.

## Verification
- +8 regression tests: new `FormField` group-semantics suite; a11y blocks in the TimeInput / ImagePicker / MealTypeSelector suites (the react-select double extended to surface the aria pair)
- `tsc` clean · Vitest **633 passed / 2 skipped** (86 files) · `npm run build` clean
- jsdom asserts the exact runtime DOM attributes; the only visual delta is FormInput's existing invalid styling now applying to an errored prep-time (same pattern as title/description)

Disjoint from the §D reviews-overhaul stack (#266/#267) — `src/pages/AddRecipe/**` + its test files only.

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8