### PR TITLE
chore: W3 housekeeping — CI actions to v5 + VITE_APP_VERSION build define

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,6 @@
 
 name: Tests
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   pull_request:
   push:
@@ -30,8 +27,8 @@ jobs:
     name: Backend (Supertest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -47,8 +44,8 @@ jobs:
     name: Frontend (Vitest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
       - name: Install dependencies
@@ -61,8 +58,8 @@ jobs:
     name: Static (typecheck + build)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
       - name: Install dependencies
@@ -98,8 +95,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
       - name: Install root dependencies
@@ -174,11 +171,11 @@ jobs:
     # and drop `continue-on-error`. See the `regression` config in fallow docs.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full history so `fallow audit` can diff changed files against the base.
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
       # node_modules must be present so Fallow can resolve imports/deps;

--- a/src/Components/Footer/footerData.ts
+++ b/src/Components/Footer/footerData.ts
@@ -1,4 +1,3 @@
-import pjson from '../../../package.json'
 import {
   ACCOUNT_SAVED_RECIPES_PATH,
   ACCOUNT_YOUR_RECIPES_PATH,
@@ -10,7 +9,7 @@ import {
 // socials, and version. Keeping it data-driven keeps the Footer components thin.
 // ---------------------------------------------------------------------------
 
-export const version = pjson.version
+export const version = import.meta.env.VITE_APP_VERSION
 export const contactEmail = 'JesseLindCS@gmail.com'
 export const longTagline =
   'Real recipes with the prices and nutrition baked in. Plan, shop and cook with zero guesswork.'

--- a/src/Components/ReleaseNotes/ReleaseNotes.tsx
+++ b/src/Components/ReleaseNotes/ReleaseNotes.tsx
@@ -3,10 +3,11 @@ import React, { FC, useEffect } from 'react'
 import './ReleaseNotes.scss'
 import { useLocation } from 'react-router-dom'
 import Modal from 'react-modal'
-import packageJSON from '../../../package.json'
 import { panelModalStyles } from 'src/util/modalStyles'
 
-const version = packageJSON.version
+// Injected at build time from package.json (see `define` in vite.config.ts) so
+// this component doesn't reach out of src/ for the repo manifest.
+const version = import.meta.env.VITE_APP_VERSION
 
 // NOTE: confirm/update RELEASE_DATE to the actual ship date at cutover, alongside
 // the package.json 1.0.0 bump and flipping `isBeta` to false (see RELEASE_PLAN.md).

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  // Injected at build time from package.json via `define` in vite.config.ts.
+  readonly VITE_APP_VERSION: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,20 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import fs from 'fs'
+
+// The app version, injected at build time (VITE_APP_VERSION) so components can
+// render it without importing package.json from inside src/ (which reaches out
+// of the source root and bundles the whole manifest shape). Read via fs rather
+// than a JSON import so the config doesn't depend on resolveJsonModule.
+const { version: appVersion } = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8')
+)
 
 export default defineConfig(async () => ({
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(appVersion),
+  },
   plugins: [
     react(),
     // Opt-in bundle analysis: `ANALYZE=1 npm run build` writes reports/stats.html


### PR DESCRIPTION
## What

The two remaining low-risk tech-debt one-liners (BACKLOG Tech debt), bundled F5-style.

### CI actions v4 → v5
`actions/checkout` + `actions/setup-node` bumped on all 10 uses. v4 targets the deprecated **Node 20 actions runtime** — the `node-version: 24` input never affected this, and GitHub currently force-runs v4 on Node 24 with a deprecation annotation on every CI run. The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workflow env is removed with the bump: it existed solely to opt the v4 actions onto Node 24 early, and v5 is Node-24-native, so it's now a no-op. **This PR's own CI run validates the change.**

### `VITE_APP_VERSION` build define
`ReleaseNotes.tsx` and `footerData.ts` (found in-pass — the second, previously untracked importer) read a new `VITE_APP_VERSION` define instead of `import … from '../../../package.json'`, so components no longer reach out of the source root for the repo manifest. Wired in `vite.config.ts` off `package.json` (fs read, no `resolveJsonModule` dependency), typed in `vite-env.d.ts`. Verified in the built output: the `package` manifest content is gone from `footerData-*.js` while the version string is still injected into both chunks.

## Verification
- `tsc` clean · Vitest **625 passed / 2 skipped** (85 files) · `npm run build` clean
- Bundle inspection as above; the workflow bump is validated by this PR's checks

Disjoint from the §D reviews-overhaul stack (#266/#267) and from W1/W2 (#268/#269).

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8