### PR TITLE
feat(recipes): stamp createdAt/editedAt server-side on create

### DIFF
--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -515,6 +515,34 @@ describe('POST /addRecipe', () => {
     })
   })
 
+  it('stamps createdAt server-side and ignores a client-forged createdAt/editedAt', async () => {
+    const before = Date.now()
+    const res = await request(server)
+      .post('/api/addRecipe')
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Test Recipe',
+        description: 'A test recipe',
+        ingredients: [{ id: 'i1', name: 'salt' }],
+        instructions: [{ content: 'Add salt', index: 1, id: 's1' }],
+        mealTypes: ['dinner'],
+        // A forged far-future createdAt would pin this recipe to the top of the
+        // "Newest" sort forever; a forged editedAt would fake an edit history.
+        createdAt: '9999999999999',
+        editedAt: '5000',
+      })
+
+    expect(res.status).toBe(201)
+    const { ObjectId } = require('mongodb')
+    const stored = await getDB().collection('recipes').findOne({ _id: new ObjectId(res.body._id) })
+    // Server stamped its own ms-epoch, not the forged value.
+    expect(stored.createdAt).not.toBe('9999999999999')
+    expect(Number(stored.createdAt)).toBeGreaterThanOrEqual(before)
+    expect(Number(stored.createdAt)).toBeLessThanOrEqual(Date.now())
+    // A new recipe is never pre-edited, regardless of what the client sends.
+    expect(stored.editedAt).toBeNull()
+  })
+
   describe('input bounds (defense-in-depth)', () => {
     const validBody = () => ({
       title: 'Test Recipe',

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -537,16 +537,21 @@ router.post('/addRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncH
   }
 
   // Whitelist the insert (mirrors the edit path): only creatable fields are
-  // copied from the client, and the server stamps _id, userId, a zeroed rating
-  // and counters. Anything else the client sends — `status`, `featured`, a
-  // forged rating/counter — is ignored, so a recipe can never be born hidden,
-  // featured, or pre-rated. The medium-hold status is NOT set here; holdRecipeForReview
+  // copied from the client, and the server stamps _id, userId, the createdAt/
+  // editedAt timestamps, a zeroed rating and counters. Anything else the client
+  // sends — `status`, `featured`, a forged rating/counter, a forged createdAt —
+  // is ignored, so a recipe can never be born hidden, featured, pre-rated, or
+  // back/post-dated. The medium-hold status is NOT set here; holdRecipeForReview
   // owns it (and only flips it once the admin-queue report is filed).
   const newId = new ObjectId()
   const docToInsert = {
     ...pickFields(body, CREATABLE_RECIPE_FIELDS),
     _id: newId,
     userId: uid,
+    // A 13-digit ms-epoch string (matches the edit path's editedAt stamp), so the
+    // "Newest"/"Oldest" browse sort's lexicographic ordering stays chronological.
+    createdAt: Date.now().toString(),
+    editedAt: null,
     rating: { rateCount: 0, rateValue: 0, breakdown: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 } },
     numTimesSaved: 0,
     numTimesMade: 0,

--- a/server/util/recipeFields.js
+++ b/server/util/recipeFields.js
@@ -30,16 +30,16 @@ const EDITABLE_RECIPE_FIELDS = [
   'totalTime',
 ]
 
-// Creating a recipe additionally accepts the author snapshot and timestamps the
-// client supplies. The server still stamps _id/userId, zeroes the social
-// counters, and seeds the rating itself — so curation/moderation flags
-// (`status`, `featured`) and any other unlisted key the client sends are
+// Creating a recipe additionally accepts the author snapshot. The server stamps
+// _id/userId, the createdAt/editedAt timestamps, zeroes the social counters, and
+// seeds the rating itself — so the client can't dictate a recipe's creation time
+// (createdAt drives the "Newest"/"Oldest" browse sort, so a forged/skewed client
+// clock could otherwise pin a recipe to the top of Newest). Curation/moderation
+// flags (`status`, `featured`) and any other unlisted key the client sends are
 // ignored on create, exactly as the edit whitelist ignores them on update.
 const CREATABLE_RECIPE_FIELDS = [
   ...EDITABLE_RECIPE_FIELDS,
   'authorUsername',
-  'createdAt',
-  'editedAt',
 ]
 
 // The internal moderation/curation stamps an admin action writes onto a recipe.
@@ -68,6 +68,10 @@ const RECIPE_INTERNAL_STAMPS = [
 const PUBLIC_RECIPE_FIELDS = [
   '_id',
   ...CREATABLE_RECIPE_FIELDS,
+  // Server-stamped timestamps the client renders (formerly client-supplied, now
+  // authoritative on the server — see CREATABLE_RECIPE_FIELDS).
+  'createdAt',
+  'editedAt',
   // Server-maintained stats/social counters + the curation flag the client renders.
   'rating',
   'views',

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -282,7 +282,23 @@ class RecipeAPIClass {
       // Diet labels now come from the form (recipeData.nutritionLabels); Edamam
       // only supplies the numeric nutrition facts.
       const nutritionData = await this.getRecipeNutrition(recipeData.ingredients)
-      const returnRecipeData: Omit<RecipeType, '_id'> = {
+      // The create body carries only what the server actually reads on create
+      // (CREATABLE_RECIPE_FIELDS = editable content + authorUsername). Everything
+      // else on a recipe is server-authoritative and stamped server-side, so we
+      // don't send it: _id, the createdAt/editedAt timestamps (a client clock
+      // must not dictate the "Newest"-sort position), the zeroed rating, and the
+      // view/save/made counters. The server ignores any of these it receives —
+      // omitting them keeps the payload honest about what's authoritative.
+      const returnRecipeData: Omit<
+        RecipeType,
+        | '_id'
+        | 'createdAt'
+        | 'editedAt'
+        | 'rating'
+        | 'views'
+        | 'numTimesSaved'
+        | 'numTimesMade'
+      > = {
         ...this.buildEditableRecipeFields(recipeData, {
           recipeImage,
           nutritionData,
@@ -290,15 +306,6 @@ class RecipeAPIClass {
           totalTime,
         }),
         authorUsername,
-        rating: {
-          rateCount: 0,
-          rateValue: 0,
-        },
-        createdAt: new Date().getTime().toString(),
-        editedAt: null,
-        views: 0,
-        numTimesSaved: 0,
-        numTimesMade: 0,
       }
       setProgress(90)
       const result = await http.post<{ _id: string; pendingReview?: boolean }>(


### PR DESCRIPTION
## Wave 8 — createdAt server-stamp

`createdAt`/`editedAt` were client-supplied on recipe create, so a forged or skewed client clock could dictate a recipe's creation time. `createdAt` is the key for the **Newest**/**Oldest** browse sort, so a far-future value would pin a recipe to the top of Newest indefinitely; a forged `editedAt` could fake an edit history.

### Change
- **`recipeFields.js`** — drop `createdAt`/`editedAt` from `CREATABLE_RECIPE_FIELDS` (so `pickFields` can no longer copy them from the body) and re-add them to `PUBLIC_RECIPE_FIELDS` so reads still return them.
- **`addRecipe` handler** — stamp `createdAt` as a 13-digit ms-epoch string (matching the edit path's `editedAt` format, so the lexicographic sort stays chronological — **no migration needed**) and `editedAt = null`.
- **client `addRecipe`** — stop sending `createdAt`/`editedAt`, and drop the server-seeded `rating`/`views`/`numTimesSaved`/`numTimesMade` too; the create body now carries only the fields the server actually reads (`CREATABLE_RECIPE_FIELDS`).

### Tests
- New server test: a client-forged `createdAt: '9999999999999'` / `editedAt: '5000'` is ignored, and the stored `createdAt` falls within `[before, now]` with `editedAt === null`.

### Verification
- ✅ `/verify` — drove `POST /addRecipe` → `GET /getRecipe` → `DELETE` against a live server on dev Firebase + dev Mongo with a real Firebase ID token; forged value ignored, server-stamped 13-digit value returned, `editedAt` null, omitted-value case still stamped. Cleaned up all artifacts.
- ✅ Code review — traced insert/edit/draft-publish/public-projection/client paths + existing test suite; edit path preserves `createdAt` and stamps `editedAt` in the same format; only one recipe insert path.
- ✅ `tsc --noEmit` clean.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK