### PR TITLE
refactor(types): narrow recipe-list/read methods to card projections (X2)

### DIFF
--- a/docs/BACKLOG_ROADMAP.md
+++ b/docs/BACKLOG_ROADMAP.md
@@ -114,7 +114,7 @@ Status: `[ ]` not started · `[~]` in a worktree · `[P]` PR open · `[x]` merge
 | **7** | **W2 · AddRecipe a11y wiring** | `aria-describedby` on TimeInput / Cuisine-Course-Diet selects / ImagePicker / list containers; `SectionHeader` label `id` + section `aria-labelledby` (BACKLOG A11y follow-ups) | `[x]` [#269](https://github.com/jclind/prepify/pull/269) (2026-07-09) | `src/pages/AddRecipe/**` | **merged** |
 | **7** | **W3 · housekeeping smalls** | CI `actions/checkout`+`setup-node` v4→v5 (Node-20-runtime deprecation); `VITE_APP_VERSION` build define replacing `ReleaseNotes.tsx`'s `package.json` import (BACKLOG Tech debt ×2) | `[x]` [#270](https://github.com/jclind/prepify/pull/270) (2026-07-09) | `.github/workflows/test.yml`, `vite.config.ts`, `ReleaseNotes.tsx` + `footerData.ts` | **merged** |
 | **8** | **X1 · `createdAt` server-stamp** | drop `createdAt`/`editedAt` from `CREATABLE_RECIPE_FIELDS`, stamp both in the `addRecipe` handler (13-digit ms-epoch matching the edit path), re-add to `PUBLIC_RECIPE_FIELDS` for reads (BACKLOG Tech debt) | `[x]` [#272](https://github.com/jclind/prepify/pull/272) (2026-07-09) | `server/routes/recipes.js`, `server/util/recipeFields.js`, `src/api/recipes.ts` + `recipes.test.js` | **merged** — folded in the client-payload cleanup (stop sending server-seeded rating/counters). Runtime-verified + local review |
-| **8** | **X2 · `RecipeCardType` typing cleanup** | tighten the card-shape typing across `src/types.ts` + `src/api/recipes.ts` (BACKLOG Tech debt) | `[ ]` | `src/types.ts`, `src/api/recipes.ts` | ready — §D file ownership released |
+| **8** | **X2 · `RecipeCardType` typing cleanup** | tighten the card-shape typing across `src/types.ts` + `src/api/recipes.ts` (BACKLOG Tech debt) | `[P]` [#273](https://github.com/jclind/prepify/pull/273) | `src/types.ts`, `src/api/recipes.ts` | PR open — three card types mirror the three server projections |
 | **8** | **X3 · orphaned-image-on-failed-create** | delete the uploaded Storage object when `POST /addRecipe` fails after the image upload (`src/api/recipes.ts`) | `[ ]` | `src/api/recipes.ts` | ready — overlaps X2 file surface (serialize or one lane) |
 | **8** | **X4 · server-Jest flakiness structural fix** | the intermittent server-suite failures (test files/mocks/setup) (BACKLOG Tech debt) | `[ ]` | `server/__tests__/**` + Jest setup | ready — disjoint from X1–X3 |
 | **—** | **Deferred / post-1.0 / owner** | see [that section](#deferred--post-10--owner-off-the-active-board) | `[blocked]`/`[dropped]` | — | prerendering, Edamam, theming, brand-orange, DB relocation, ideas |
@@ -1867,3 +1867,23 @@ Append-only; newest at the bottom. Mirror each merge into the item's box in [`BA
   value is dropped, a 13-digit server value returned, and the omitted-value case still stamped. All six checks
   green; remote branch deleted. **Still open in Wave 8:** X2 (`RecipeCardType` typing), X3
   (orphaned-image-on-failed-create — overlaps X2's `src/api/recipes.ts`), X4 (server-Jest flakiness).
+- **2026-07-09** — **X2** implemented in `feat/x2-recipecard-typing` → PR
+  [#273](https://github.com/jclind/prepify/pull/273) opened (`[P]`). The recipe list/read endpoints ship a lean
+  card **projection**, not the full doc, but the client typed them `RecipeType[]`/`RecipeType` — so a component
+  reaching for an unprojected detail field (`ingredients`/`instructions`/`nutritionData`/`description`/`userId`/
+  `createdAt`/…) compiled while the field was `undefined` at runtime. Root cause: the three server projections
+  (`PUBLIC_RECIPE_CARD_FIELDS` in `recipeFields.js`; `SAVED_CARD_PROJECTION`/`CREATED_CARD_PROJECTION` in
+  `users.js`) genuinely **differ**, so there's no single "card shape" — introduced **three** card types mirroring
+  them exactly (shared `RecipeCardBase` of the 6 common fields): `RecipeCardType` (public — browse/trending/
+  For-You/random/profile tiles, 10 fields), `SavedRecipeCardType` (saved grid, base+cuisine), and
+  `CreatedRecipeCardType` (My-Recipes grid, base + createdAt/views/saves/made). Typed the six list methods +
+  `getPublicProfileRecipes` + `PublicProfile.recipes` against them; `getRecipe` stays `RecipeType` (detail
+  endpoint = full projection). Also dropped the phantom `page`/`filters`/`entries_per_page` from
+  `RecipeDBResponseType` (server returns only `{ recipeList, total_results }`). Consumer prop/annotation updates
+  (RecipeCard's prop = `RecipeCardType | SavedRecipeCardType`, HomeRecipeCard, MealRow, UserRecipeThumbnail,
+  HomeCookSuggestion, the `usePaginatedLoadMore`/`useQuery` generics, PublicProfile `extraPages`) fell out of the
+  narrowing — **tsc drove every one and confirmed no consumer currently over-reads** (matches the backlog
+  FE-read check → typing-only, no runtime behaviour change). Gates: `tsc --noEmit` clean, Vitest **645 passed**,
+  `npm run build` succeeds; live dev `GET /api/recipes` returned exactly `{ recipeList, total_results }` with the
+  10-field card shape. **X3** (orphaned-image cleanup) still overlaps X2's `src/api/recipes.ts` — serialize onto
+  this once it lands.

--- a/src/Components/RecipeCard/RecipeCard.tsx
+++ b/src/Components/RecipeCard/RecipeCard.tsx
@@ -10,7 +10,7 @@ import { formatRating } from 'src/util/formatRating'
 import { formatPrice } from 'src/util/formatPrice'
 import { minToHrMin } from 'src/util/minToHrMin'
 import { recipeImageSrcSet } from 'src/util/recipeImageVariants'
-import { RecipeType } from 'types'
+import { RecipeCardType, SavedRecipeCardType } from 'types'
 import './RecipeCard.scss'
 
 
@@ -37,7 +37,9 @@ const Rating: FC<{ value: number; count: number }> = ({ value, count }) => {
 }
 
 type RecipeCardProps = {
-  recipe: RecipeType | null
+  // Fed by both the browse grid (`RecipeCardType`) and the Saved tab
+  // (`SavedRecipeCardType`); the card renders only the fields common to both.
+  recipe: RecipeCardType | SavedRecipeCardType | null
   loading?: boolean
   // Extra refresh after a save/membership change (the Saved tab passes this so
   // unsaving/refiling resets its paged grid). Caches always refetch regardless.

--- a/src/api/publicProfile.ts
+++ b/src/api/publicProfile.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import { http } from 'src/api/http-common'
-import { PublicProfile, RecipeType } from 'types'
+import { PublicProfile, RecipeCardType } from 'types'
 
 class PublicProfileAPIClass {
   // Public endpoint — no auth required. A missing username is an expected
@@ -26,7 +26,7 @@ class PublicProfileAPIClass {
     username: string,
     page: number,
     recipesPerPage: number
-  ): Promise<{ recipes: RecipeType[]; totalCount: number }> {
+  ): Promise<{ recipes: RecipeCardType[]; totalCount: number }> {
     const result = await http.get(
       `api/getPublicProfileRecipes?username=${encodeURIComponent(
         username

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -7,14 +7,17 @@ import {
   IngredientsType,
   NewReviewType,
   NutritionDataType,
+  CreatedRecipeCardType,
   OptionalReviewType,
   OwnReviewStatus,
+  RecipeCardType,
   RecipeDBResponseType,
   RecipeEditFormType,
   RecipeFormType,
   RecipeSearchResponseType,
   RecipeType,
   ReviewType,
+  SavedRecipeCardType,
 } from 'types'
 import AuthAPI from 'src/api/auth'
 import { fetchIngredientEnrichment } from 'src/api/ingredientParserApi'
@@ -108,13 +111,13 @@ class RecipeAPIClass {
     )
     return result.data
   }
-  async getTrendingRecipes(limit = 4): Promise<RecipeType[]> {
+  async getTrendingRecipes(limit = 4): Promise<RecipeCardType[]> {
     const result = await http.get(`api/getTrendingRecipes?limit=${limit}`)
     return result.data
   }
   // Personalized home row. Requires auth (token attached by the http
   // interceptor); returns [] when the user has too little signal to personalize.
-  async getForYouRecipes(limit = 8): Promise<RecipeType[]> {
+  async getForYouRecipes(limit = 8): Promise<RecipeCardType[]> {
     const result = await http.get(`api/getForYouRecipes?limit=${limit}`)
     return result.data
   }
@@ -122,7 +125,7 @@ class RecipeAPIClass {
   // signed in (token attached by the interceptor); a uniform random pick
   // otherwise. `excludeId` re-rolls without repeating the current pick. Resolves
   // null when the catalog is empty (404) so the caller can show a soft message.
-  async getRandomRecipe(excludeId?: string): Promise<RecipeType | null> {
+  async getRandomRecipe(excludeId?: string): Promise<RecipeCardType | null> {
     const params = excludeId ? `?exclude=${encodeURIComponent(excludeId)}` : ''
     try {
       const result = await http.get(`api/recipes/random${params}`)
@@ -579,7 +582,7 @@ class RecipeAPIClass {
     order: string,
     collectionId?: string,
     q?: string
-  ): Promise<{ recipes: RecipeType[]; totalCount: number } | null> {
+  ): Promise<{ recipes: SavedRecipeCardType[]; totalCount: number } | null> {
     if (!AuthAPI.getUID()) return null
     const params = new URLSearchParams({
       page: String(page),
@@ -595,7 +598,7 @@ class RecipeAPIClass {
     page: number,
     recipesPerPage: number,
     order: string
-  ): Promise<{ recipes: RecipeType[]; totalCount: number } | null> {
+  ): Promise<{ recipes: CreatedRecipeCardType[]; totalCount: number } | null> {
     if (!AuthAPI.getUID()) return null
     const result = await http.get(
       `api/getCreatedRecipes?page=${page}&recipesPerPage=${recipesPerPage}&order=${order}`

--- a/src/pages/Account/SavedRecipes/SavedRecipes.tsx
+++ b/src/pages/Account/SavedRecipes/SavedRecipes.tsx
@@ -10,7 +10,7 @@ import './SavedRecipes.scss'
 import RecipeAPI from 'src/api/recipes'
 import CollectionsAPI from 'src/api/collections'
 import AuthAPI from 'src/api/auth'
-import { RecipeType } from 'types'
+import { SavedRecipeCardType } from 'types'
 import { useDelayedLoading } from 'src/hooks/useDelayedLoading'
 import { COLLECTION_CREATE_ERROR } from 'src/util/toastMessages'
 import { useDebounce } from 'src/hooks/useDebounce'
@@ -63,7 +63,7 @@ const SavedRecipes: FC = () => {
     isMore: isMoreRecipes,
     loadMore: handleLoadMoreRecipes,
     reset: resetToFirstPage,
-  } = usePaginatedLoadMore<RecipeType>({
+  } = usePaginatedLoadMore<SavedRecipeCardType>({
     queryKey: page => [
       'saved-recipes',
       sort.value,

--- a/src/pages/Account/UserRecipes/UserRecipeThumbnail.tsx
+++ b/src/pages/Account/UserRecipes/UserRecipeThumbnail.tsx
@@ -6,7 +6,7 @@ import { skeletonBase as skeletonColor } from 'src/util/loadingStyles'
 import 'react-loading-skeleton/dist/skeleton.css'
 
 import './UserRecipeThumbnail.scss'
-import { RecipeType } from 'types'
+import { CreatedRecipeCardType } from 'types'
 import { formatRating } from 'src/util/formatRating'
 import { formatCompactCount } from 'src/util/formatCompactCount'
 import { formatPrice } from 'src/util/formatPrice'
@@ -23,7 +23,7 @@ const formatDate = (createdAt: string) => {
 }
 
 type UserRecipeThumbnailType = {
-  recipe: RecipeType | null
+  recipe: CreatedRecipeCardType | null
   loading?: boolean
 }
 

--- a/src/pages/Account/UserRecipes/UserRecipes.tsx
+++ b/src/pages/Account/UserRecipes/UserRecipes.tsx
@@ -4,7 +4,7 @@ import React, { FC } from 'react'
 import './UserRecipes.scss'
 import EmptyState from 'src/Components/EmptyState/EmptyState'
 import RecipeAPI from 'src/api/recipes'
-import { RecipeType } from 'types'
+import { CreatedRecipeCardType } from 'types'
 import { usePaginatedLoadMore } from 'src/pages/Account/usePaginatedLoadMore'
 import UserRecipeThumbnail from './UserRecipeThumbnail'
 
@@ -23,7 +23,7 @@ const UserRecipes: FC = () => {
     isMore,
     showList: showGrid,
     loadMore,
-  } = usePaginatedLoadMore<RecipeType>({
+  } = usePaginatedLoadMore<CreatedRecipeCardType>({
     queryKey: page => ['created-recipes', SORT, page],
     queryFn: page =>
       RecipeAPI.getCreatedRecipes(page, 6, SORT).then(

--- a/src/pages/Home/HomeBrowseByMeal.tsx
+++ b/src/pages/Home/HomeBrowseByMeal.tsx
@@ -5,14 +5,14 @@ import { useQueries } from '@tanstack/react-query'
 import Skeleton from 'react-loading-skeleton'
 import 'react-loading-skeleton/dist/skeleton.css'
 import RecipeAPI from 'src/api/recipes'
-import { RecipeType } from 'types'
+import { RecipeCardType } from 'types'
 import { useDelayedLoading } from 'src/hooks/useDelayedLoading'
 import { skeletonColor, fmtPrice, ratingLabel } from './homeFormat'
 
 const MEALS = ['Breakfast', 'Lunch', 'Dinner'] as const
 const PER_COL = 4
 
-const MealRow: FC<{ recipe: RecipeType }> = ({ recipe }) => (
+const MealRow: FC<{ recipe: RecipeCardType }> = ({ recipe }) => (
   <li>
     <Link to={`/recipes/${recipe._id}`}>
       <img
@@ -71,7 +71,7 @@ const HomeBrowseByMeal: FC = () => {
   // a distinct set rather than repeating the same trending recipes.
   const claimed = new Set<string>()
   const columns = MEALS.map((meal, i) => {
-    const picks: RecipeType[] = []
+    const picks: RecipeCardType[] = []
     for (const r of results[i].data?.recipeList ?? []) {
       if (picks.length >= PER_COL) break
       if (claimed.has(r._id)) continue

--- a/src/pages/Home/HomeCookSuggestion.tsx
+++ b/src/pages/Home/HomeCookSuggestion.tsx
@@ -5,7 +5,7 @@ import Modal from 'react-modal'
 import { Link } from 'react-router-dom'
 import Skeleton from 'react-loading-skeleton'
 import RecipeAPI from 'src/api/recipes'
-import { RecipeType } from 'types'
+import { RecipeCardType } from 'types'
 import { fmtPrice, ratingLabel, skeletonColor } from './homeFormat'
 import { bareModalStyles } from 'src/util/modalStyles'
 import './HomeCookSuggestion.scss'
@@ -38,9 +38,9 @@ const HomeCookSuggestion: FC = () => {
   // The currently displayed pick is held in state (not read off the mutation)
   // so a re-roll keeps the previous card on screen — stable size, no squish —
   // until the next pick arrives. undefined = nothing fetched yet, null = 404.
-  const [pick, setPick] = useState<RecipeType | null | undefined>(undefined)
+  const [pick, setPick] = useState<RecipeCardType | null | undefined>(undefined)
 
-  const { mutate, isPending, isError, reset } = useMutation<RecipeType | null, unknown, string | undefined>({
+  const { mutate, isPending, isError, reset } = useMutation<RecipeCardType | null, unknown, string | undefined>({
     mutationFn: (excludeId) => RecipeAPI.getRandomRecipe(excludeId),
     onSuccess: (r) => setPick(r),
   })

--- a/src/pages/Home/HomeForYou.tsx
+++ b/src/pages/Home/HomeForYou.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import RecipeAPI from 'src/api/recipes'
 import { useAuth } from 'src/context/AuthContext'
-import { RecipeType } from 'types'
+import { RecipeCardType } from 'types'
 import { HomeRecipeCard } from './HomeRecipeCard'
 
 // Personalized "For You" row. "Hide until personalized": only renders for a
@@ -18,7 +18,7 @@ import { HomeRecipeCard } from './HomeRecipeCard'
 const HomeForYou: FC = () => {
   const user = useAuth()?.user ?? null
 
-  const { data, isLoading, isError } = useQuery<RecipeType[]>({
+  const { data, isLoading, isError } = useQuery<RecipeCardType[]>({
     queryKey: ['for-you-recipes', user?.uid],
     // Match the Trending row's count (4) so the desktop grid stays even.
     queryFn: () => RecipeAPI.getForYouRecipes(4),

--- a/src/pages/Home/HomeRecipeCard.tsx
+++ b/src/pages/Home/HomeRecipeCard.tsx
@@ -3,13 +3,13 @@ import React, { FC, useState } from 'react'
 import { Link } from 'react-router-dom'
 import Skeleton from 'react-loading-skeleton'
 import 'react-loading-skeleton/dist/skeleton.css'
-import { RecipeType } from 'types'
+import { RecipeCardType } from 'types'
 import { skeletonColor, fmtPrice, ratingLabel } from './homeFormat'
 
 // Shared recipe card for the Home rows (Trending, For You). A lightweight
 // thumbnail+meta link — intentionally simpler than the full RecipeCard (no save
 // control) to keep the rows fast and uncluttered.
-export const HomeRecipeCard: FC<{ recipe: RecipeType }> = ({ recipe }) => {
+export const HomeRecipeCard: FC<{ recipe: RecipeCardType }> = ({ recipe }) => {
   // Hold a skeleton over the thumb until the image decodes (onLoad), then fade it
   // in — otherwise the image paints in top-down over an empty box on a slow load.
   const [imgLoaded, setImgLoaded] = useState(false)

--- a/src/pages/Home/HomeTrending.tsx
+++ b/src/pages/Home/HomeTrending.tsx
@@ -1,12 +1,12 @@
 import React, { FC } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import RecipeAPI from 'src/api/recipes'
-import { RecipeType } from 'types'
+import { RecipeCardType } from 'types'
 import { useDelayedLoading } from 'src/hooks/useDelayedLoading'
 import { HomeRecipeCard, HomeRecipeCardSkeleton } from './HomeRecipeCard'
 
 const HomeTrending: FC = () => {
-  const { data, isLoading, isError } = useQuery<RecipeType[]>({
+  const { data, isLoading, isError } = useQuery<RecipeCardType[]>({
     queryKey: ['trending-recipes'],
     queryFn: () => RecipeAPI.getTrendingRecipes(4),
     // Trending shifts slowly; match the For-You / by-meal rows (5 min) so a

--- a/src/pages/Home/homeFormat.ts
+++ b/src/pages/Home/homeFormat.ts
@@ -1,5 +1,5 @@
 import { formatRating } from 'src/util/formatRating'
-import { RecipeType } from 'types'
+import { RecipeCardType } from 'types'
 
 // Re-exported so the home skeleton components share the one app-wide skeleton grey.
 export { skeletonBase as skeletonColor } from 'src/util/loadingStyles'
@@ -8,7 +8,7 @@ export { skeletonBase as skeletonColor } from 'src/util/loadingStyles'
 export const fmtPrice = (cents: number) => `$${(cents / 100).toFixed(2)}`
 
 /** "New" when a recipe has no ratings yet, otherwise the formatted average. */
-export const ratingLabel = (rating: RecipeType['rating']) => {
+export const ratingLabel = (rating: RecipeCardType['rating']) => {
   const count = Number(rating?.rateCount) || 0
   return count === 0 ? 'New' : formatRating(rating.rateValue, count)
 }

--- a/src/pages/PublicProfile/PublicProfile.tsx
+++ b/src/pages/PublicProfile/PublicProfile.tsx
@@ -21,7 +21,7 @@ import {
   PROFILE_LINK_COPY_ERROR,
 } from 'src/util/toastMessages'
 import { SITE_URL, DEFAULT_OG_IMAGE } from 'src/util/seo'
-import { RecipeType } from 'types'
+import { RecipeCardType } from 'types'
 
 // Page size for "load more". Matches the server's initial-batch limit so the
 // first extra page (page 1) picks up exactly where the profile payload ended.
@@ -131,7 +131,7 @@ const PublicProfile: FC = () => {
   // accumulation idempotent: a re-fetch of a page overwrites its slot instead of
   // duplicating recipes. `extraPage` is the next page to request (0 = none yet;
   // the profile payload is effectively page 0).
-  const [extraPages, setExtraPages] = useState<Record<number, RecipeType[]>>({})
+  const [extraPages, setExtraPages] = useState<Record<number, RecipeCardType[]>>({})
   const [extraPage, setExtraPage] = useState(0)
 
   // The viewer's own handle, so we can hide the "report" control on their own

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,52 @@ export type RecipeType = {
   // the hold inline. null when held by a non-automod path; absent otherwise.
   automodClassifier?: ReportClassifier | null
 }
+
+// ---- Recipe CARD shapes ----
+// The recipe LIST/read endpoints don't return the full `RecipeType` doc — the
+// server projects a lean card shape (see `server/util/recipeFields.js`'s
+// PUBLIC_RECIPE_CARD_FIELDS and the SAVED/CREATED projections in
+// `server/routes/users.js`). Typing those methods as `RecipeType` over-promised:
+// detail fields (`ingredients`/`instructions`/`nutritionData`/`description`/
+// `userId`/`createdAt`/…) are absent at runtime, yet a component reaching for one
+// would still compile. These three card types mirror the three server
+// projections exactly, so a card consumer that reads a non-projected field now
+// fails to compile instead.
+
+// Fields present on every card projection (browse, saved, created, profile).
+type RecipeCardBase = {
+  _id: string
+  title: string
+  recipeImage: string
+  totalTime: number
+  servingPrice: number | null
+  rating: RatingAggregate
+}
+
+// The public card — PUBLIC_RECIPE_CARD_FIELDS. Shared by browse (`GET /recipes`),
+// the home trending / For-You / random rows, and the public-profile tiles.
+export type RecipeCardType = RecipeCardBase & {
+  cuisine: string
+  mealTypes: string[]
+  nutritionLabels: string[] | null
+  numTimesSaved: number
+}
+
+// The Saved-grid card — SAVED_CARD_PROJECTION. base + cuisine (no meal/diet tags
+// or save count: the saved grid's `RecipeCard` renders neither).
+export type SavedRecipeCardType = RecipeCardBase & {
+  cuisine: string
+}
+
+// The "My Recipes" thumbnail card — CREATED_CARD_PROJECTION. base + the created
+// date and the views/saves/made performance strip.
+export type CreatedRecipeCardType = RecipeCardBase & {
+  createdAt: string
+  views: number
+  numTimesSaved: number
+  numTimesMade: number
+}
+
 export type RecipeFormType = {
   title: string
   prepTime: number
@@ -195,11 +241,10 @@ export interface NutritionDataType {
   totalNutrientsKCal: Record<string, NutrientInfo>
 }
 
+// GET /api/recipes (browse) returns only these two keys — the earlier
+// `page`/`filters`/`entries_per_page` were never sent by the server.
 export interface RecipeDBResponseType {
-  recipeList: RecipeType[]
-  page: number
-  filters: {}
-  entries_per_page: number
+  recipeList: RecipeCardType[]
   total_results: number
 }
 export interface RecipeSearchResponseType {
@@ -611,7 +656,7 @@ export type PublicProfile = {
   xpNext: number
   pct: number
   achievements: Achievement[]
-  recipes: RecipeType[]
+  recipes: RecipeCardType[]
   recipesTotalCount: number
   // Cross-recipe sums over the user's publicly-visible recipes (not just the
   // initial `recipes` batch), used for the header Saves/Made counts.


### PR DESCRIPTION
**Wave 8 · X2 — `RecipeCardType` typing cleanup** ([BACKLOG_ROADMAP.md](docs/BACKLOG_ROADMAP.md) Wave 8)

## Problem
The recipe list/read endpoints ship a lean **card projection**, not the full recipe doc, but the client typed them `RecipeType[]`/`RecipeType`. So a component reaching for an unprojected detail field (`ingredients`, `instructions`, `nutritionData`, `description`, `userId`, `createdAt`, …) compiled fine even though the field is `undefined` at runtime. `RecipeDBResponseType` also declared `page`/`filters`/`entries_per_page` that `GET /api/recipes` never returns.

## Change (typing-only — no runtime behaviour change)
Three card types mirror the three server projections **exactly** (`server/util/recipeFields.js` + `server/routes/users.js`):

| Type | Server projection | Consumers |
|---|---|---|
| `RecipeCardType` | `PUBLIC_RECIPE_CARD_FIELDS` (10) | browse, trending, For-You, random, public-profile tiles |
| `SavedRecipeCardType` | `SAVED_CARD_PROJECTION` (7) | Saved grid |
| `CreatedRecipeCardType` | `CREATED_CARD_PROJECTION` (10) | "My Recipes" grid |

- Typed `getAllRecipes` / `getTrendingRecipes` / `getForYouRecipes` / `getRandomRecipe` / `getSavedRecipes` / `getCreatedRecipes` (`src/api/recipes.ts`) + `getPublicProfileRecipes` (`src/api/publicProfile.ts`) + `PublicProfile.recipes` against the card types.
- Dropped the phantom `page`/`filters`/`entries_per_page` from `RecipeDBResponseType` (server returns only `{ recipeList, total_results }`).
- Consumer prop/annotation updates follow from the narrowing (RecipeCard, HomeRecipeCard, MealRow, UserRecipeThumbnail, HomeCookSuggestion, the `usePaginatedLoadMore`/`useQuery` generics, PublicProfile `extraPages`).
- `getRecipe` stays `RecipeType` — the detail endpoint returns the full projection.

Now a card consumer that reads a non-projected field **fails to compile**. tsc confirmed no consumer currently over-reads (matches the backlog FE-read check).

## Verification
- `tsc --noEmit` clean
- Vitest **645 passed** / 2 skipped (86 files)
- `npm run build` succeeds
- Live dev `GET /api/recipes` returns exactly `{ recipeList, total_results }` with the 10-field card shape (`_id, cuisine, mealTypes, numTimesSaved, nutritionLabels, rating, recipeImage, servingPrice, title, totalTime`)

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK