### PR TITLE
X4: structural fix for load-dependent server-Jest flakiness

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -320,7 +320,7 @@ which Lucide can't provide; see [`design/icon-system.md`](./design/icon-system.m
 | Layer | Tool | Location | Config |
 |---|---|---|---|
 | Frontend unit/component | **Vitest** (jsdom) | `src/test/*.test.{ts,tsx}` (flat) | `vite.config.ts` `test:` block; setup `src/test/setup.ts` |
-| Backend | **Jest** (node, `--runInBand`) | `server/__tests__/*.test.js` | `server/jest.config.js`; setup spins a `MongoMemoryReplSet` |
+| Backend | **Jest** (node, `--runInBand`) | `server/__tests__/*.test.js` | `server/jest.config.js`; one run-wide `MongoMemoryReplSet` (`globalSetup.js`), each file connects + drops its DB in `setup.js` |
 | E2E | **Cypress** | `cypress/` | `cypress.config.ts` (mints tokens via Admin v14) |
 
 `src/test/setup.ts` creates the `#root` element react-modal needs, stubs `matchMedia`, and shims Web Storage

--- a/server/__mocks__/supertest.js
+++ b/server/__mocks__/supertest.js
@@ -1,0 +1,38 @@
+// Auto-mock for 'supertest' (mocks adjacent to node_modules apply to
+// node_modules packages automatically, like the sibling firebase-admin mock).
+//
+// Real supertest, handed an express app, binds a BRAND-NEW ephemeral server for
+// every single request and closes it when the response lands — ~800
+// listen/connect/close cycles per full suite run. Under CPU/socket pressure
+// that churn intermittently breaks at the TCP layer: a connect times out
+// (`connect ETIMEDOUT 127.0.0.1:<port>`) or lands on the wrong/stale listener
+// and comes back as a bewildering 404/401 from a route that provably exists.
+// (Characterized in the X4 flakiness investigation: failing ports sat inside
+// the run's own ephemeral-allocation window — they were supertest's own
+// one-shot listeners.)
+//
+// This wrapper keeps ONE listening server per app instance for the whole test
+// file and hands supertest that server (supertest reuses a server that is
+// already listening instead of binding its own). setup.js closes the servers
+// in its afterAll via the __SUPERTEST_SERVERS__ registry. Anything that isn't
+// an express app — an http.Server a test manages itself, a URL string — passes
+// through to real supertest untouched.
+const actual = jest.requireActual('supertest')
+
+const servers = new Map() // app fn -> listening http.Server
+globalThis.__SUPERTEST_SERVERS__ = servers
+
+function sharedServerRequest(target, options) {
+  if (typeof target === 'function' && typeof target.listen === 'function') {
+    let server = servers.get(target)
+    if (!server) {
+      server = target.listen(0)
+      servers.set(target, server)
+    }
+    return actual(server, options)
+  }
+  return actual(target, options)
+}
+
+// Preserve request.agent / Test / etc.
+module.exports = Object.assign(sharedServerRequest, actual)

--- a/server/__tests__/globalSetup.js
+++ b/server/__tests__/globalSetup.js
@@ -1,0 +1,22 @@
+const { MongoMemoryReplSet } = require('mongodb-memory-server')
+
+// One in-memory Mongo for the WHOLE run, not one per test file. The suite runs
+// --runInBand, so files execute sequentially against it; setup.js gives each
+// file a fresh view by dropping the database in its afterAll. Before this,
+// every one of the ~30 suites booted (and tore down) its own MongoMemoryReplSet;
+// under CPU contention that churn tripped the driver's serverSelection timeout
+// mid-test and randomly failed one DB-heavy test per run (see BACKLOG "Server
+// Jest suite is flaky under CPU contention").
+//
+// A single-node replica set (not a standalone) so multi-document transactions —
+// used by DELETE /deleteRecipe and the migration scripts — work in tests,
+// matching the replica-set topology of the production Atlas deployment.
+//
+// globalSetup runs in Jest's main process before any worker/test file, so the
+// URI handed to setup.js travels via process.env; the replset instance itself
+// stays on globalThis for globalTeardown (same process) to stop.
+module.exports = async () => {
+  const mongod = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
+  globalThis.__MONGOD__ = mongod
+  process.env.MONGO_TEST_URI = mongod.getUri()
+}

--- a/server/__tests__/globalTeardown.js
+++ b/server/__tests__/globalTeardown.js
@@ -1,0 +1,7 @@
+// Stops the run-wide in-memory Mongo started by globalSetup.js (same process,
+// so the instance is reachable on globalThis).
+module.exports = async () => {
+  if (globalThis.__MONGOD__) {
+    await globalThis.__MONGOD__.stop()
+  }
+}

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -5,14 +5,13 @@
  * a jest.fn() whose default implementation returns { verifyIdToken } resolving
  * to { uid: 'test-uid' }.
  *
- * For tests that need a DIFFERENT uid (non-author 403 cases), we call:
- *
- *   getAuth.mockReturnValueOnce({
- *     verifyIdToken: jest.fn().mockResolvedValueOnce({ uid: OTHER_UID }),
- *   })
- *
- * mockReturnValueOnce is consumed by the very next getAuth() call inside
- * verifyToken middleware, then the default implementation resumes.
+ * Tests that need a DIFFERENT uid (non-author 403 cases) call asUser(uid),
+ * which swaps the implementation for the REST OF THE TEST; the shared
+ * beforeEach restores the TEST_UID default before the next test. Deliberately
+ * NOT mockReturnValueOnce: a one-shot override is consumed by whichever
+ * getAuth() call happens to come next, so a stray async call (e.g. leaked
+ * fire-and-forget audit/email work from an earlier test) could eat it and
+ * shift the identity onto the wrong request — a real, load-dependent flake.
  *
  * Why beforeEach instead of beforeAll for seeding:
  * setupFilesAfterEnv registers setup.js's connectDB as a top-level beforeAll.
@@ -37,6 +36,14 @@ const OTHER_UID = 'other-uid'
 const OTHER_USERNAME = 'otheruser'
 const RECIPE_ID = 'recipe-rev-001'
 const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
+
+// Authenticate as `uid` for the rest of the current test (see header comment).
+const asUser = uid => {
+  getAuth.mockImplementation(() => ({
+    verifyIdToken: jest.fn().mockResolvedValue({ uid }),
+    getUsers: admin.__getUsers,
+  }))
+}
 
 // ─── Shared setup/teardown ────────────────────────────────────────────────────
 // Seed shared fixtures and reset auth mock before every test.
@@ -191,11 +198,9 @@ describe('POST /editReview', () => {
   })
 
   it('rejects request from non-author (403)', async () => {
-    // Next getAuth() call in verifyToken returns other-uid →
-    // route looks up 'otheruser' → no ratings doc matches → matchedCount 0 → 403
-    getAuth.mockReturnValueOnce({
-      verifyIdToken: jest.fn().mockResolvedValueOnce({ uid: OTHER_UID }),
-    })
+    // verifyToken resolves other-uid → route looks up 'otheruser' → no ratings
+    // doc matches → matchedCount 0 → 403
+    asUser(OTHER_UID)
 
     const res = await request(app)
       .post(`/api/editReview?recipeId=${RECIPE_ID}&text=Modified`)
@@ -282,9 +287,7 @@ describe('DELETE /deleteReview', () => {
   })
 
   it('rejects request from non-author (403)', async () => {
-    getAuth.mockReturnValueOnce({
-      verifyIdToken: jest.fn().mockResolvedValueOnce({ uid: OTHER_UID }),
-    })
+    asUser(OTHER_UID)
 
     const res = await request(app)
       .delete(`/api/deleteReview?recipeId=${RECIPE_ID}`)
@@ -491,9 +494,7 @@ describe('POST /newReview', () => {
   })
 
   it('returns 400 if the user has no username set', async () => {
-    getAuth.mockReturnValueOnce({
-      verifyIdToken: jest.fn().mockResolvedValueOnce({ uid: 'no-username-uid' }),
-    })
+    asUser('no-username-uid')
 
     const res = await request(app)
       .post('/api/newReview')

--- a/server/__tests__/security.test.js
+++ b/server/__tests__/security.test.js
@@ -153,13 +153,17 @@ describe('recipeIdQuery non-string ids', () => {
 
 // ─── Admin surface (audit §5 step 3) ─────────────────────────────────────────
 // The default beforeEach mock resolves a NON-admin token (uid only). Admin
-// tests opt in with a one-shot mock returning { admin: true }, mirroring how
-// verifyToken sets req.isAdmin = decoded.admin === true.
+// tests opt in with asAdmin(), which resolves { admin: true } for the rest of
+// the test (beforeEach restores the non-admin default), mirroring how
+// verifyToken sets req.isAdmin = decoded.admin === true. Deliberately sticky
+// rather than mockReturnValueOnce: a one-shot override is consumed by whichever
+// getAuth() call comes next, so a stray async call (leaked fire-and-forget
+// audit/email work) could eat it and demote the intended request to 403.
 
-function asAdminOnce() {
-  getAuth.mockReturnValueOnce({
-    verifyIdToken: jest.fn().mockResolvedValueOnce({ uid: TEST_UID, admin: true }),
-  })
+function asAdmin() {
+  getAuth.mockImplementation(() => ({
+    verifyIdToken: jest.fn().mockResolvedValue({ uid: TEST_UID, admin: true }),
+  }))
 }
 
 describe('admin route auth chaining', () => {
@@ -185,7 +189,7 @@ describe('admin route auth chaining', () => {
 
 describe('admin endpoints reject injected / malformed ids', () => {
   it('PATCH /reports/bulk drops operator-shaped ids → 400 (no valid ids)', async () => {
-    asAdminOnce()
+    asAdmin()
     const res = await request(app)
       .patch('/api/reports/bulk')
       .set(AUTH_HEADER)
@@ -195,7 +199,7 @@ describe('admin endpoints reject injected / malformed ids', () => {
   })
 
   it('PATCH /reports/:id rejects a non-ObjectId id (404, no crash)', async () => {
-    asAdminOnce()
+    asAdmin()
     const res = await request(app)
       .patch('/api/reports/not-a-valid-objectid')
       .set(AUTH_HEADER)
@@ -204,7 +208,7 @@ describe('admin endpoints reject injected / malformed ids', () => {
   })
 
   it('PATCH /admin/recipes/:id/moderation rejects a non-string status (400)', async () => {
-    asAdminOnce()
+    asAdmin()
     const res = await request(app)
       .patch(`/api/admin/recipes/${RECIPE_ID}/moderation`)
       .set(AUTH_HEADER)
@@ -213,7 +217,7 @@ describe('admin endpoints reject injected / malformed ids', () => {
   })
 
   it('PATCH /admin/reviews/moderation rejects object recipeId/username (400)', async () => {
-    asAdminOnce()
+    asAdmin()
     const res = await request(app)
       .patch('/api/admin/reviews/moderation')
       .set(AUTH_HEADER)

--- a/server/__tests__/setup.js
+++ b/server/__tests__/setup.js
@@ -1,6 +1,5 @@
 const timers = require('node:timers')
-const { MongoMemoryReplSet } = require('mongodb-memory-server')
-const { connectDB, closeDB } = require('../db')
+const { connectDB, closeDB, getClient } = require('../db')
 const { facetsCache } = require('../util/facetsCache')
 
 // Under Node 26's jest environment the global timer functions aren't stable
@@ -32,17 +31,17 @@ beforeEach(installRealTimers)
 // into another test that seeded different recipes.
 beforeEach(() => facetsCache.invalidate())
 
-let mongod
-
-// A single-node replica set (rather than a standalone) so multi-document
-// transactions — used by DELETE /deleteRecipe — work in tests, matching the
-// replica-set topology of the production Atlas deployment.
+// Connect to the run-wide in-memory Mongo created by globalSetup.js (one
+// MongoMemoryReplSet for the whole --runInBand run, not one per file — the
+// per-file replSet churn was the main flakiness vector under CPU contention).
+// Each file still gets its own client connection and a FRESH database: afterAll
+// drops it, so nothing a suite (or its leaked fire-and-forget work) wrote can
+// leak into the next file — the same isolation the per-file replSet provided.
 beforeAll(async () => {
-  mongod = await MongoMemoryReplSet.create({ replSet: { count: 1 } })
-  await connectDB(mongod.getUri())
+  await connectDB(process.env.MONGO_TEST_URI)
 }, 60000)
 
 afterAll(async () => {
+  await getClient().db('prepify').dropDatabase()
   await closeDB()
-  await mongod.stop()
 })

--- a/server/__tests__/setup.js
+++ b/server/__tests__/setup.js
@@ -32,16 +32,38 @@ beforeEach(installRealTimers)
 beforeEach(() => facetsCache.invalidate())
 
 // Connect to the run-wide in-memory Mongo created by globalSetup.js (one
-// MongoMemoryReplSet for the whole --runInBand run, not one per file — the
-// per-file replSet churn was the main flakiness vector under CPU contention).
-// Each file still gets its own client connection and a FRESH database: afterAll
-// drops it, so nothing a suite (or its leaked fire-and-forget work) wrote can
-// leak into the next file — the same isolation the per-file replSet provided.
+// MongoMemoryReplSet for the whole run, not one per file — the per-file replSet
+// churn was the main flakiness vector under CPU contention). Each file still
+// gets its own client connection and a FRESH database: afterAll drops it, so
+// nothing a suite (or its leaked fire-and-forget work) wrote can leak into the
+// next file — the same isolation the per-file replSet provided.
+//
+// The database name is per-WORKER: `npm test` is --runInBand (always worker 1),
+// but an ad-hoc `npx jest <pattern>` that matches several files runs them in
+// parallel workers, and with a single shared database their seeds/cleanup would
+// stomp each other (e.g. `npx jest reports` matches reports + bugReports).
+const TEST_DB = `prepify-test-${process.env.JEST_WORKER_ID || '1'}`
+
 beforeAll(async () => {
-  await connectDB(process.env.MONGO_TEST_URI)
+  await connectDB(process.env.MONGO_TEST_URI, TEST_DB)
 }, 60000)
 
 afterAll(async () => {
-  await getClient().db('prepify').dropDatabase()
+  // Close the file's shared supertest server(s) (see __mocks__/supertest.js) so
+  // the process doesn't hold listeners open at the end of the run.
+  const servers = globalThis.__SUPERTEST_SERVERS__
+  if (servers) {
+    await Promise.all(
+      [...servers.values()].map(
+        server =>
+          new Promise(resolve => {
+            if (server.closeAllConnections) server.closeAllConnections()
+            server.close(resolve)
+          })
+      )
+    )
+    servers.clear()
+  }
+  await getClient().db(TEST_DB).dropDatabase()
   await closeDB()
 })

--- a/server/db.js
+++ b/server/db.js
@@ -5,8 +5,12 @@ let db
 
 async function connectDB(uri) {
   const mongoUri = uri || process.env.MONGO_URI
+  // The explicit-`uri` path is test-only (Jest's in-memory Mongo; index.js calls
+  // connectDB() bare), and a CPU-starved test run can stall the topology monitor
+  // past a tight selection window — so it keeps the driver's default 30s instead
+  // of prod's deliberate 5s fail-fast.
   const options = uri
-    ? { serverSelectionTimeoutMS: 5000 }
+    ? { serverSelectionTimeoutMS: 30000 }
     : { serverSelectionTimeoutMS: 5000, socketTimeoutMS: 45000, maxPoolSize: 10 }
 
   // Force TLS for the remote (Atlas/prod) MONGO_URI connection, but never for a

--- a/server/db.js
+++ b/server/db.js
@@ -3,7 +3,10 @@ const { MongoClient } = require('mongodb')
 let client
 let db
 
-async function connectDB(uri) {
+// `dbName` is test-only, like the explicit `uri`: Jest workers each pass their
+// own database name so parallel workers sharing the run-wide in-memory Mongo
+// can't stomp each other's seeds. Production always uses 'prepify'.
+async function connectDB(uri, dbName = 'prepify') {
   const mongoUri = uri || process.env.MONGO_URI
   // The explicit-`uri` path is test-only (Jest's in-memory Mongo; index.js calls
   // connectDB() bare), and a CPU-starved test run can stall the topology monitor
@@ -25,7 +28,7 @@ async function connectDB(uri) {
 
   client = new MongoClient(mongoUri, options)
   await client.connect()
-  db = client.db('prepify')
+  db = client.db(dbName)
   console.log('Connected to MongoDB')
   await ensureIndexes()
 }

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -2,4 +2,13 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/__tests__/**/*.test.js'],
   setupFilesAfterEnv: ['./__tests__/setup.js'],
+  // One in-memory Mongo for the whole run (see globalSetup.js); each file
+  // connects to it in setup.js and drops the database when it finishes.
+  globalSetup: './__tests__/globalSetup.js',
+  globalTeardown: './__tests__/globalTeardown.js',
+  // A timeout's job is to catch a HUNG test, not to race a busy CPU: with the
+  // default 5s, a DB-heavy test on a loaded machine (dev servers + a concurrent
+  // jest run) intermittently blew the deadline and failed the suite. 30s still
+  // catches real hangs without flaking under contention.
+  testTimeout: 30000,
 }


### PR DESCRIPTION
## Summary

Wave-8 **X4** — the server suite intermittently failed one random DB-/auth-heavy test per run under CPU contention (~10–30% repro under load; every suite green in isolation). This PR fixes **five** structural vectors — the two boarded in the backlog entry plus three more surfaced by stress-testing during verification:

1. **Per-file `MongoMemoryReplSet` churn** (boarded): each of the 36 suites booted + tore down its own in-memory replica set; the churn tripped the driver's server-selection window mid-test. Now `globalSetup`/`globalTeardown` run **one** replSet for the whole run; each file connects to it and drops its database in `afterAll` (same fresh-DB-per-file isolation). Suite wall time drops **~53s → ~33s**.
2. **One-shot auth mocks** (boarded): `getAuth.mockReturnValueOnce(...mockResolvedValueOnce...)` in `reviews.test.js` / `security.test.js` is consumed by whichever `getAuth()` call comes next, so a stray async call (leaked fire-and-forget audit/email work) could shift the identity onto the wrong request. Replaced with sticky per-test `asUser(uid)` / `asAdmin()` helpers reset by the existing `beforeEach`.
3. **Jest's default 5s per-test timeout** (found in stress round 1): a DB-heavy test on a loaded machine blew the deadline with a healthy harness. `testTimeout: 30000` — still catches real hangs, stops racing a busy CPU. Same philosophy for the test-only DB path: driver-default 30s `serverSelectionTimeoutMS` instead of prod's deliberate 5s fail-fast (`index.js` still calls `connectDB()` bare; prod unchanged).
4. **supertest's one-shot listener per request** (found in stress rounds 2–3; **the dominant residual**): ~800 listen/connect/close cycles per run; under socket churn a connect occasionally timed out (`connect ETIMEDOUT 127.0.0.1:<port>`) or surfaced as bewildering 404/401s from routes that provably exist — the exact signatures in the original flake report. Smoking gun: three ETIMEDOUT failures across independent runs targeted the *same port number*, which sat inside each run's own ephemeral-port allocation window — supertest's own listener at a recurring allocation offset. Fixed with `server/__mocks__/supertest.js` (adjacent auto-mock, same mechanism as the existing firebase-admin mock): **one long-lived server per app per file**, closed in `setup.js` `afterAll`. Zero changes to the 23 test files.
5. **Parallel-worker DB stomping** (regression introduced by #1, caught in verification): with one shared mongod, an ad-hoc `npx jest <pattern>` matching several files (e.g. `npx jest reports` → reports + bugReports) runs them in parallel workers against one database. Fixed with per-worker database names (`JEST_WORKER_ID`); `connectDB` gains a test-only `dbName` param, prod stays `'prepify'`.

## Verification

On the final code, with the dev servers running throughout:

- **12/12** sequential full-suite runs green — identical conditions scored **8/12** before vector 4 was fixed
- **12/12** green with **two full suites running concurrently** (extreme profile) — previously 14/16
- Parallel-worker invocation (`npx jest reports.test.js`, 2 files / 2 workers) green — failed 10/60 tests before vector 5 was fixed
- Single-file runs (`npx jest reviews.test.js`) green
- Pre-fix baseline from the backlog characterization: 10–30% failure per run under lighter load
- Suite wall time: ~53s → ~33s

## Docs

- `docs/CONVENTIONS.md` §5.1 backend row updated (run-wide replSet + per-file DB drop)
- BACKLOG flakiness entry + ROADMAP X4 row deliberately left for land time (the X3 lane is editing the same docs in parallel)

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8