### PR TITLE
test: strengthen weak suites + pin missing failure modes (test-quality audit)

### DIFF
--- a/cypress/e2e/browse.cy.ts
+++ b/cypress/e2e/browse.cy.ts
@@ -22,7 +22,7 @@ describe('Browse', () => {
     cy.wait('@getRecipes')
     // The navbar also renders a SearchRecipesInput, so scope to the page's input/button.
     cy.get('.recipes-page input.search-recipes-input', { timeout: 10000 }).should('be.visible').type('Tuscan')
-    cy.get('.recipes-page .search-recipes-btn', { timeout: 5000 }).should('be.visible').click().and('be.visible')
+    cy.get('.recipes-page .search-recipes-btn', { timeout: 5000 }).should('be.visible').click()
     // App navigates to /recipes?q=Tuscan and fires a new getRecipes call
     cy.wait('@getRecipes')
     cy.url().should('include', 'q=Tuscan')

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -57,6 +57,35 @@ The triage date stamped on items is the date they were filed here, not when they
   again.") instead of the empty state, and correct the loading-states.md example in the same PR. For
   contrast, Home, `/recipes`, and SingleRecipe all show real error copy with the API down (SingleRecipe only
   after its ~7s retry budget — acceptable, documented). Med.
+- `[ ]` **Admin `GET /api/reports` pagination is uncoerced and uncapped** *(filed 2026-07-10, test-quality
+  audit)* — `server/routes/reports.js:186-187` does `skip = parseInt(page) * parseInt(perPage)` and
+  `limit = parseInt(perPage)` with no `|| default`, no negative clamp, and no `MAX_PER_PAGE`-style cap, so
+  `?perPage=abc` → `limit(NaN)` throws (500), `?page=-1` → negative skip (500), and a huge `perPage` dumps the
+  collection. Admin-only surface (gated behind `requireAdmin`), so low blast radius — but it should get the
+  same coercion + cap the public list routes now all have (reviews/recipes/publicProfile) plus a pagination
+  test (the suite currently only tests admin-gate/enrichment/status-filter). Low-med.
+- `[ ]` **Draft cap is a read-then-insert race (TOCTOU)** *(filed 2026-07-10, test-quality audit)* —
+  `server/routes/drafts.js:36-44` enforces the 25-draft cap with `countDocuments({ userId })` followed by
+  `insertOne`; concurrent POSTs at 24 drafts can all pass the count and exceed the cap. Every neighboring
+  surface pins its races concurrently (collections create/rename, recipes save), so this is the documented
+  odd one out — the existing cap test is sequential only. Fix lane: post-insert recount + delete-overflow, or
+  an atomic guard; add the 5-concurrent-POSTs-at-24 test with it. Low.
+- `[ ]` **Moderation blocklist misses unicode homoglyph / fullwidth evasion** *(filed 2026-07-10, test-quality
+  audit)* — `normalizeToken` (`server/util/moderationBlocklist.js:31-37`) does no NFKC/confusables fold and
+  ends with `.replace(/[^a-z0-9]/g, '')`, so a Cyrillic-с `fuсk` normalizes to `fuk` and fullwidth `ｓｈｉｔ`
+  to `''` — no blocklist hit; the text silently defers to the OpenAI layer, which is env-gated and can be off.
+  Leet (`f4ggot`) and letter-spacing are covered; unicode is the gap. Fix lane: NFKC-normalize (+ a small
+  confusables map for the common Cyrillic/Greek lookalikes) before the existing folds, with bypass tests
+  pinning both examples. Low-med (defense-in-depth; the OpenAI layer catches these when enabled).
+- `[ ]` **Small client contract nits from the test-quality audit** *(filed 2026-07-10)* — three tiny,
+  related "the code accepts what it shouldn't / renders what it shouldn't" gaps, none release-gating:
+  **(1)** `src/api/recipes.ts:546,568` interpolate `filter`/`username` into query strings unencoded
+  (inconsistent with the `URLSearchParams` convention used at `:96-107`; breaks on reserved chars — current
+  inputs are safe, it's drift waiting to bite); **(2)** `recipeFormValidation.ts:61` accepts negative or
+  fractional `servings` (`!form.servings` truthiness only — the whitespace-description sibling was fixed in
+  the audit PR; decide the servings contract and pin it); **(3)** `src/util/formatRating.ts:5-6` renders the
+  literal string `"NaN"` if `rateValue` arrives NaN (no guard → should fall back to the "No Ratings" branch).
+  All three are one-liners plus a test each. Low.
 - `[ ]` **Legacy rating docs are mistyped — "Top" review sort interleaves wrong** *(filed 2026-07-09, out of
   the §D overhaul)* — old `ratings` docs store `rating` as **stringified numbers** (`"5"`) and
   `reviewCreatedAt` as stringified epoch-ms, while post-#266 writes store floats; review-only docs are
@@ -1335,6 +1364,24 @@ findings table.)*
   already covered indirectly by `addRecipe.cy.ts`), `recipeLimits`, `invalidateSavedCaches`, `defaultAvatar`.
   Most are trivial; `updateIngredients` is the one worth a real test pass. *(surfaced 2026-06-27 in the
   code-quality & tests sweep coverage audit.)*
+- `[ ]` **Test-quality audit follow-ups (2026-07-10)** — the six-slice suite-quality audit (see the
+  test-quality PR of the same date for what already shipped) left these filed rather than fixed:
+  - **Real ingredient-parser contract test (the headline gap).** `server/__tests__/ingredients.test.js:26`
+    mocks `@jclind/ingredient-parser` wholesale, so **no server test anywhere exercises real parsing** — a
+    v2 package regression on fractions (`1 1/2`), unicode (`½`), ranges (`2-3`), unknown units, or
+    parenthetical comments is invisible. Add a fixture-table contract test that runs the real parser (network
+    enrichment stubbed, parse layer real) and pins `quantity/min/max/unit/ingredient/comment` per shape. Med.
+  - **Flake-hardening nits:** `cypress/e2e/addRecipe.cy.ts:162-168` keyboard-DnD helper uses fixed
+    `cy.wait(300/500)` sleeps (replace by polling the dnd aria-live announcement); the
+    `writeLimiter.test.js` window-reset test sleeps a real 1.2 s (wall-clock race under load);
+    `reviews.test.js:820`'s `__getUsers.mockRejectedValueOnce` can leak a queued rejection into a later test
+    if the request short-circuits (clear queued one-shots in `afterEach`).
+  - **Coverage gaps (component/e2e):** SavedRecipes fetch-error path (its 3 sibling tabs have error tests,
+    it doesn't); AdminUsers failure toast on rejected `setUserStatus`; browse filter-drawer e2e (filters →
+    URL → `recipes` request is never driven end-to-end); named-collection add via the recipe-page popover
+    e2e; `getReviews` `filter=new`/`filter=top` ordering tests (blocked on the legacy stringified-rating
+    migration filed under Bugs — write them with it); auth.test.js storage-cleanup asserting the two exact
+    deleted object paths instead of `toHaveBeenCalledTimes(2)` (needs a small `__deleteFile` mock extension).
 
 ## Ideas / needs a decision
 

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -23,6 +23,34 @@ afterEach(async () => {
   admin.__deleteUser.mockClear()
 })
 
+// ─── verifyToken — rejected / malformed tokens ───────────────────────────────
+// The shared mock's verifyIdToken resolves by default; override it per-test via
+// admin.__verifyIdToken to drive the middleware's catch branch (auth.js:30-32).
+
+describe('verifyToken rejects bad tokens', () => {
+  it('returns 401 with no DB side effect when verifyIdToken rejects (expired/garbage token)', async () => {
+    admin.__verifyIdToken.mockRejectedValueOnce(new Error('Firebase ID token has expired'))
+
+    const res = await request(app)
+      .post('/api/setUsername?username=newuser')
+      .set({ Authorization: 'Bearer garbage' })
+
+    expect(res.status).toBe(401)
+    expect(res.body).toEqual({ error: 'Invalid or expired token' })
+    expect(await getDB().collection('usernames').countDocuments({})).toBe(0)
+  })
+
+  it('returns 401 for a bare "Bearer" header with no token', async () => {
+    const res = await request(app)
+      .post('/api/setUsername?username=newuser')
+      .set({ Authorization: 'Bearer' })
+
+    expect(res.status).toBe(401)
+    expect(res.body).toEqual({ error: 'Missing or invalid Authorization header' })
+    expect(await getDB().collection('usernames').countDocuments({})).toBe(0)
+  })
+})
+
 // ─── GET /getUsername ─────────────────────────────────────────────────────────
 
 describe('GET /getUsername', () => {

--- a/server/__tests__/ingredient-telemetry.test.js
+++ b/server/__tests__/ingredient-telemetry.test.js
@@ -116,6 +116,35 @@ describe('POST /api/ingredients/parse — telemetry writes', () => {
     expect(count).toBe(0)
   })
 
+  it('never breaks the parse response when the telemetry write fails', async () => {
+    ingredientParser.mockResolvedValue(miss())
+    const db = getDB()
+    // db.collection() mints a new Collection instance per call, so intercept the
+    // factory and reject updateOne only on the telemetry collection — the route's
+    // own handle then hits the recordIngredientTelemetry catch (ingredients.js).
+    const realCollection = db.collection.bind(db)
+    const collectionSpy = jest.spyOn(db, 'collection').mockImplementation((name) => {
+      const coll = realCollection(name)
+      if (name === 'ingredientMisses') {
+        jest.spyOn(coll, 'updateOne').mockRejectedValue(new Error('telemetry db down'))
+      }
+      return coll
+    })
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      const res = await request(app)
+        .post('/api/ingredients/parse')
+        .set(AUTH_HEADER)
+        .send({ ingredientString: '1 cup zzqxnonexistent' })
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ ingredientData: null })
+    } finally {
+      collectionSpy.mockRestore()
+      errorSpy.mockRestore()
+    }
+  })
+
   it('increments the counter (not a new doc) on a repeat of the same string', async () => {
     ingredientParser.mockResolvedValue(miss())
     for (let i = 0; i < 3; i++) {

--- a/server/__tests__/moderation-routes.test.js
+++ b/server/__tests__/moderation-routes.test.js
@@ -231,6 +231,24 @@ describe('reviews — high|medium both block', () => {
     expect(res.status).toBe(200)
     expect(await getDB().collection('ratings').countDocuments({ userId: TEST_UID, recipeId: 'r-1' })).toBe(1)
   })
+
+  it('medium edit → 422 and the stored review text is unchanged', async () => {
+    await getDB().collection('ratings').insertOne({
+      userId: TEST_UID,
+      username: 'chef_test',
+      recipeId: 'r-1',
+      rating: 4,
+      reviewText: 'original text',
+      reviewCreatedAt: '1000',
+      reviewLastUpdated: '1000',
+    })
+    moderateText.mockResolvedValue(MEDIUM)
+    const res = await request(app).post('/api/editReview').set(AUTH).send({ recipeId: 'r-1', text: 'borderline edit' })
+    expect(res.status).toBe(422)
+    expect(res.body.code).toBe('CONTENT_BLOCKED')
+    const stored = await getDB().collection('ratings').findOne({ userId: TEST_UID, recipeId: 'r-1' })
+    expect(stored.reviewText).toBe('original text')
+  })
 })
 
 describe('username + profile blocking', () => {

--- a/server/__tests__/nutrition.test.js
+++ b/server/__tests__/nutrition.test.js
@@ -82,15 +82,29 @@ describe('POST /api/nutrition/details', () => {
   // ── Misconfiguration ─────────────────────────────────────────────────────────
 
   it('returns 503 (not 500/200) when the Edamam keys are not configured', async () => {
-    // Keys are undefined at test time (dotenv not loaded). Assert the graceful
-    // degrade path runs before any network call.
+    // Don't rely on the ambient env being empty (dotenv isn't loaded, but a
+    // shell/CI env could still carry the keys) — explicitly unset and restore,
+    // mirroring the save/restore in the configured block below.
+    const ORIGINAL = {
+      id: process.env.EDAMAM_APP_ID,
+      key: process.env.EDAMAM_APP_KEY,
+    }
+    delete process.env.EDAMAM_APP_ID
+    delete process.env.EDAMAM_APP_KEY
     global.fetch = jest.fn()
-    const res = await request(app)
-      .post('/api/nutrition/details')
-      .set(AUTH_HEADER)
-      .send({ ingr: ['2 cups flour'] })
-    expect(res.status).toBe(503)
-    expect(global.fetch).not.toHaveBeenCalled()
+    try {
+      const res = await request(app)
+        .post('/api/nutrition/details')
+        .set(AUTH_HEADER)
+        .send({ ingr: ['2 cups flour'] })
+      expect(res.status).toBe(503)
+      expect(global.fetch).not.toHaveBeenCalled()
+    } finally {
+      if (ORIGINAL.id === undefined) delete process.env.EDAMAM_APP_ID
+      else process.env.EDAMAM_APP_ID = ORIGINAL.id
+      if (ORIGINAL.key === undefined) delete process.env.EDAMAM_APP_KEY
+      else process.env.EDAMAM_APP_KEY = ORIGINAL.key
+    }
   })
 
   // ── With keys configured ───────────────────────────────────────────────────────
@@ -171,23 +185,28 @@ describe('POST /api/nutrition/details', () => {
       expect(res.body).toHaveProperty('error', 'Internal server error')
     })
 
-    it('soft-fails to 200/null when Edamam responds non-2xx (e.g. 404 "no nutrition")', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: false,
-        status: 404,
-        json: async () => ({}),
-      })
+    // Any upstream non-2xx — "no nutrition" (404/555), rate limit (429), or a
+    // genuine Edamam 500 — soft-fails the same way (pins nutrition.js:69-72).
+    it.each([404, 429, 500, 555])(
+      'soft-fails to 200/null when Edamam responds %i',
+      async (status) => {
+        global.fetch = jest.fn().mockResolvedValue({
+          ok: false,
+          status,
+          json: async () => ({}),
+        })
 
-      const res = await request(app)
-        .post('/api/nutrition/details')
-        .set(AUTH_HEADER)
-        .send({ ingr: ['asdf'] })
+        const res = await request(app)
+          .post('/api/nutrition/details')
+          .set(AUTH_HEADER)
+          .send({ ingr: ['asdf'] })
 
-      // 200 + null keeps the client's null-guard happy and avoids a false 5xx
-      // Sentry alert for a routine "couldn't compute" answer.
-      expect(res.status).toBe(200)
-      expect(res.body).toBeNull()
-    })
+        // 200 + null keeps the client's null-guard happy and avoids a false 5xx
+        // Sentry alert for a routine "couldn't compute" answer.
+        expect(res.status).toBe(200)
+        expect(res.body).toBeNull()
+      }
+    )
 
     it('returns a generic 500 (not the raw error) when the fetch throws', async () => {
       global.fetch = jest.fn().mockRejectedValue(new Error('network exploded'))

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -132,6 +132,30 @@ describe('GET /recipes', () => {
     expect(res.body.recipeList).toHaveLength(1)
     expect(res.body.total_results).toBe(3)
   })
+
+  it('treats a negative page as page 0 (no negative skip / 500)', async () => {
+    const res = await request(server).get('/api/recipes?page=-1')
+    expect(res.status).toBe(200)
+    expect(res.body.recipeList).toHaveLength(3)
+    expect(res.body.total_results).toBe(3)
+  })
+
+  it('caps recipesPerPage at 50 even when a larger page is requested', async () => {
+    const db = getDB()
+    // 3 seeded in beforeEach + 52 more = 55 total, so a capped page shows exactly 50.
+    await db.collection('recipes').insertMany(
+      Array.from({ length: 52 }, (_, i) => ({
+        ...BASE_RECIPE,
+        _id: `cap-recipe-${i}`,
+        title: `Cap Recipe ${i}`,
+      }))
+    )
+
+    const res = await request(server).get('/api/recipes?page=0&recipesPerPage=500')
+    expect(res.status).toBe(200)
+    expect(res.body.recipeList).toHaveLength(50)
+    expect(res.body.total_results).toBe(55)
+  })
 })
 
 // ─── GET /recipes — sorting & meal filter ─────────────────────────────────────
@@ -1062,6 +1086,34 @@ describe('GET /getRecipe', () => {
     expect(res.status).toBe(200)
     expect(res.body._id).toBe(RECIPE_ID)
     expect(res.body.views).toBe(6)
+  })
+
+  // optionalAuth's catch-and-continue (middleware/auth.js): a Bearer header whose
+  // token fails verification must be treated as anonymous — req.uid/req.isAdmin
+  // never set from the bad token — so a hidden recipe stays 404, not leaked.
+  it('treats a rejected token as anonymous (hidden recipe stays 404)', async () => {
+    await seedRecipe({ ...BASE_RECIPE, _id: 'hidden-opt', userId: TEST_UID, status: 'hidden' })
+    admin.__verifyIdToken.mockRejectedValueOnce(new Error('Firebase ID token has expired'))
+
+    const res = await request(server)
+      .get('/api/getRecipe?id=hidden-opt')
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(404)
+    expect(res.body).toEqual({ error: 'Not found' })
+  })
+
+  // Discriminating variant: the OWNER of a pending_review recipe would get 200,
+  // so a 404 here proves the bad token never populated req.uid.
+  it('does not set req.uid from a rejected token (owner pending_review preview denied)', async () => {
+    await seedRecipe({ ...BASE_RECIPE, _id: 'pending-opt', userId: TEST_UID, status: 'pending_review' })
+    admin.__verifyIdToken.mockRejectedValueOnce(new Error('invalid signature'))
+
+    const res = await request(server)
+      .get('/api/getRecipe?id=pending-opt')
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(404)
   })
 })
 

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -150,6 +150,52 @@ describe('POST /addRating', () => {
     expect(Number.isNaN(recipe.rating.rateValue)).toBe(false)
   })
 
+  // Same-user re-rate is an upsert on the unique (userId, recipeId) key: the
+  // second rating replaces the first — one doc, and the aggregate counts the
+  // user once at the new value. Pins routes/reviews.js:74-91 + util/recipeRating.
+  it('re-rating replaces the previous rating (one doc, aggregate counts the user once)', async () => {
+    const first = await request(app)
+      .post(`/api/addRating?recipeId=${RECIPE_ID}&rating=4`)
+      .set(AUTH_HEADER)
+    expect(first.status).toBe(200)
+    const second = await request(app)
+      .post(`/api/addRating?recipeId=${RECIPE_ID}&rating=5`)
+      .set(AUTH_HEADER)
+    expect(second.status).toBe(200)
+
+    const db = getDB()
+    const docs = await db
+      .collection('ratings')
+      .find({ userId: TEST_UID, recipeId: RECIPE_ID })
+      .toArray()
+    expect(docs).toHaveLength(1)
+    expect(docs[0].rating).toBe(5)
+
+    const recipe = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+    expect(recipe.rating.rateCount).toBe(1)
+    expect(recipe.rating.rateValue).toBe(5)
+    expect(recipe.rating.breakdown[4]).toBe(0)
+    expect(recipe.rating.breakdown[5]).toBe(1)
+  })
+
+  // Mirror of newReview's review-first $setOnInsert test (rating defaulted to
+  // null): a rating-first insert must default the review fields so every ratings
+  // doc has the consistent shape getReviews expects.
+  it('defaults the review fields on a rating-first upsert ($setOnInsert)', async () => {
+    const res = await request(app)
+      .post(`/api/addRating?recipeId=${RECIPE_ID}&rating=4`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+
+    const stored = await getDB()
+      .collection('ratings')
+      .findOne({ userId: TEST_UID, recipeId: RECIPE_ID })
+    expect(stored).toHaveProperty('reviewText', '')
+    expect(stored).toHaveProperty('reviewCreatedAt', '')
+    expect(stored).toHaveProperty('reviewLastUpdated', '')
+    expect(stored.username).toBe(TEST_USERNAME)
+  })
+
   // Bug 2 regression: adding a 5-star can never LOWER a correctly-stored
   // average. Seed an existing 4-star from another user, then add a 5 → the
   // aggregate must rise to 4.5 (count 2), proving the recompute math is sound.
@@ -773,6 +819,49 @@ describe('GET /getReviews', () => {
     expect(res.body.totalCount).toBe(3)
   })
 
+  it('treats a negative page as page 0 (no negative skip / 500)', async () => {
+    await seedRating({
+      username: TEST_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 5,
+      reviewText: 'First review',
+      reviewCreatedAt: '1000',
+    })
+    await seedRating({
+      username: OTHER_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 4,
+      reviewText: 'Second review',
+      reviewCreatedAt: '2000',
+    })
+
+    const res = await request(app).get(`/api/getReviews?recipeId=${RECIPE_ID}&page=-1`)
+    expect(res.status).toBe(200)
+    expect(res.body.totalCount).toBe(2)
+    expect(res.body.reviews).toHaveLength(2)
+  })
+
+  it('caps reviewsPerPage at 50 even when a larger page is requested', async () => {
+    const db = getDB()
+    await db.collection('ratings').insertMany(
+      Array.from({ length: 55 }, (_, i) => ({
+        userId: `cap-uid-${i}`,
+        username: `capuser${i}`,
+        recipeId: RECIPE_ID,
+        rating: 3,
+        reviewText: `Review ${i}`,
+        reviewCreatedAt: `${i}`,
+      }))
+    )
+
+    const res = await request(app).get(
+      `/api/getReviews?recipeId=${RECIPE_ID}&page=0&reviewsPerPage=500`
+    )
+    expect(res.status).toBe(200)
+    expect(res.body.reviews).toHaveLength(50)
+    expect(res.body.totalCount).toBe(55)
+  })
+
   // ── avatar + display-name enrichment (§D) ──────────────────────────────────
   describe('reviewer identity enrichment', () => {
     // __setUsers mutates shared mock state; restore the default registry after
@@ -1079,6 +1168,32 @@ describe('GET /getSingleUserReviews', () => {
     expect(res.status).toBe(200)
     expect(res.body.reviews).toHaveLength(2)
     expect(res.body.totalCount).toBe(4)
+  })
+
+  it('treats a negative page as page 0 (no negative skip / 500)', async () => {
+    await seedRating({
+      userId: TEST_UID,
+      username: TEST_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 5,
+      reviewText: 'A',
+      reviewCreatedAt: '1000',
+    })
+    await seedRating({
+      userId: TEST_UID,
+      username: TEST_USERNAME,
+      recipeId: 'recipe-x',
+      rating: 4,
+      reviewText: 'B',
+      reviewCreatedAt: '2000',
+    })
+
+    const res = await request(app).get(
+      `/api/getSingleUserReviews?username=${TEST_USERNAME}&page=-1`
+    )
+    expect(res.status).toBe(200)
+    expect(res.body.totalCount).toBe(2)
+    expect(res.body.reviews).toHaveLength(2)
   })
 })
 

--- a/server/__tests__/textModeration.test.js
+++ b/server/__tests__/textModeration.test.js
@@ -32,6 +32,11 @@ beforeEach(() => {
 afterEach(() => {
   global.fetch = realFetch
   jest.restoreAllMocks()
+  // Restore per-test env tweaks here too (not just in beforeEach) so the LAST
+  // test in the file can't leak them into later suites under --runInBand.
+  delete process.env.MODERATION_ENABLED
+  delete process.env.MODERATION_HIGH_THRESHOLD
+  delete process.env.MODERATION_MEDIUM_THRESHOLD
 })
 
 // process.env is shared across files under --runInBand; don't leak an enabled
@@ -119,6 +124,22 @@ describe('moderateText — gating', () => {
     expect(await moderateText('   ', 'bio')).toMatchObject({ allowed: true, severity: 'clean' })
     expect(global.fetch).not.toHaveBeenCalled()
   })
+
+  it('kill switch: MODERATION_ENABLED=false disables the API even with a key set', async () => {
+    process.env.MODERATION_ENABLED = 'false' // OPENAI_API_KEY is set in beforeEach
+    global.fetch = jest.fn()
+    const v = await moderateText('a perfectly normal sentence', 'review')
+    expect(v).toMatchObject({ allowed: true, severity: 'clean', source: 'disabled' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('kill switch leaves the blocklist active — a listed term still blocks', async () => {
+    process.env.MODERATION_ENABLED = 'false'
+    global.fetch = jest.fn()
+    const v = await moderateText('total bitch move', 'review')
+    expect(v).toMatchObject({ allowed: false, severity: 'high', source: 'blocklist' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
 })
 
 describe('moderateText — OpenAI grading', () => {
@@ -151,6 +172,33 @@ describe('moderateText — OpenAI grading', () => {
     mockModeration({ flagged: true, category_scores: { hate: 0.55 } })
     const v = await moderateText('borderline content', 'review')
     expect(v.severity).toBe('high')
+  })
+
+  it('respects an env-tuned MODERATION_MEDIUM_THRESHOLD', async () => {
+    process.env.MODERATION_MEDIUM_THRESHOLD = '0.3'
+    // 0.35 would be clean at the default 0.5 floor; the override makes it medium.
+    mockModeration({ flagged: false, category_scores: { harassment: 0.35 } })
+    const v = await moderateText('borderline content', 'review')
+    expect(v.severity).toBe('medium')
+  })
+
+  // Threshold boundaries — grade() uses >= on both cutoffs (textModeration.js).
+  it('grades a score exactly at the 0.85 high cutoff as high', async () => {
+    mockModeration({ flagged: true, category_scores: { hate: 0.85 } })
+    const v = await moderateText('borderline content', 'review')
+    expect(v.severity).toBe('high')
+  })
+
+  it('grades a score exactly at the 0.5 medium cutoff as medium (even unflagged)', async () => {
+    mockModeration({ flagged: false, category_scores: { harassment: 0.5 } })
+    const v = await moderateText('borderline content', 'review')
+    expect(v.severity).toBe('medium')
+  })
+
+  it('grades an unflagged score just under the medium cutoff as clean', async () => {
+    mockModeration({ flagged: false, category_scores: { harassment: 0.4999 } })
+    const v = await moderateText('borderline content', 'review')
+    expect(v).toMatchObject({ allowed: true, severity: 'clean' })
   })
 
   it('flagged with no usable category scores → medium with a non-null reason', async () => {

--- a/server/__tests__/writeLimiter.test.js
+++ b/server/__tests__/writeLimiter.test.js
@@ -106,13 +106,17 @@ describe('makeUserLimiter — per-user content-write cap', () => {
 
   it('is bypassed entirely under NODE_ENV=test', async () => {
     process.env.NODE_ENV = 'test'
-    const server = start({ '/write': makeUserLimiter({ limit: 5 }) })
-    // Far more than the limit, all allowed because skip() short-circuits.
-    for (let i = 0; i < 40; i++) {
-      const res = await request(server).post('/write').set('x-test-uid', 'user-d')
-      expect(res.status).toBe(200)
+    try {
+      const server = start({ '/write': makeUserLimiter({ limit: 5 }) })
+      // Far more than the limit, all allowed because skip() short-circuits.
+      for (let i = 0; i < 40; i++) {
+        const res = await request(server).post('/write').set('x-test-uid', 'user-d')
+        expect(res.status).toBe(200)
+      }
+    } finally {
+      // finally, so a failed assertion can't leak NODE_ENV=test into later tests.
+      process.env.NODE_ENV = 'development'
     }
-    process.env.NODE_ENV = 'development' // restore for any later tests in this file
   })
 })
 

--- a/server/__tests__/writeLimiter.wiring.test.js
+++ b/server/__tests__/writeLimiter.wiring.test.js
@@ -25,6 +25,8 @@ const authRouter = require('../routes/auth')
 const ingredientsRouter = require('../routes/ingredients')
 const gamificationRouter = require('../routes/gamification')
 const reportsRouter = require('../routes/reports')
+const collectionsRouter = require('../routes/collections')
+const draftsRouter = require('../routes/drafts')
 
 // Ordered handler chain for a single route on a router, or throws if missing.
 const routeHandlers = (router, method, path) => {
@@ -93,4 +95,32 @@ describe('per-surface write limiters are wired onto every moderated write route'
     expect(handlers[1]).toBe(requireActive)
     expect(handlers).toHaveLength(4) // verifyToken, requireActive, reportLimiter, handler
   })
+})
+
+// Same reference-identity pattern for the suspended/banned gate: the 403 behavior
+// is exercised end-to-end on a few surfaces (user-status-enforcement.test.js);
+// this pins that the remaining blocked-user write surfaces actually mount
+// requireActive, after verifyToken (it reads req.uid).
+describe('requireActive is wired onto every blocked-user write surface', () => {
+  const cases = [
+    ['collections', collectionsRouter, 'post', '/collections'],
+    ['collections', collectionsRouter, 'patch', '/collections/:id'],
+    ['collections', collectionsRouter, 'delete', '/collections/:id'],
+    ['collections', collectionsRouter, 'patch', '/recipes/:recipeId/collections'],
+    ['drafts', draftsRouter, 'post', '/'],
+    ['drafts', draftsRouter, 'put', '/:id'],
+    ['recipes', recipesRouter, 'post', '/recipes/:id/save'],
+    ['recipes', recipesRouter, 'delete', '/recipes/:id/save'],
+    ['recipes', recipesRouter, 'post', '/madeRecipe'],
+  ]
+
+  it.each(cases)(
+    '%s %s %s mounts requireActive after verifyToken',
+    (_group, router, method, path) => {
+      const handlers = routeHandlers(router, method, path)
+      expect(handlers).toContain(verifyToken)
+      expect(handlers).toContain(requireActive)
+      expect(handlers.indexOf(verifyToken)).toBeLessThan(handlers.indexOf(requireActive))
+    }
+  )
 })

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -58,7 +58,9 @@ router.get('/recipes', asyncHandler(async (req, res) => {
   // a string or string[] — never a `{$ne:…}` operator object — so the helpers
   // below only have to coerce those two shapes.
   const limit = Math.min(parseInt(recipesPerPage) || 5, MAX_PER_PAGE)
-  const skip = (parseInt(page) || 0) * limit
+  // Floor at 0 so a negative ?page never produces a negative .skip() (which
+  // MongoDB rejects, surfacing as a 500 instead of a clean first page).
+  const skip = Math.max(0, parseInt(page) || 0) * limit
 
   // Soft-hidden recipes never surface in public browse.
   const filter = { ...RECIPE_VISIBLE }

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -268,7 +268,9 @@ router.get('/getReviews', optionalAuth, asyncHandler(async (req, res) => {
   if (!recipeId || typeof recipeId !== 'string') return res.status(400).json({ error: 'recipeId is required' })
 
   const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
-  const skip = (parseInt(page) || 0) * limit
+  // Floor at 0 so a negative ?page never produces a negative .skip() (which
+  // MongoDB rejects, surfacing as a 500 instead of a clean first page).
+  const skip = Math.max(0, parseInt(page) || 0) * limit
   // Exclude admin-taken-down reviews from the public list.
   const query = { recipeId, reviewText: { $exists: true, $ne: '' }, ...REVIEW_VISIBLE }
 
@@ -313,7 +315,8 @@ router.get('/getSingleUserReviews', asyncHandler(async (req, res) => {
   if (!ownerDoc) return res.json({ reviews: [], totalCount: 0 })
 
   const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
-  const skip = (parseInt(page) || 0) * limit
+  // Floor at 0 — see getReviews: negative skip is a MongoDB error (500).
+  const skip = Math.max(0, parseInt(page) || 0) * limit
   // Suppress admin-taken-down reviews from a user's public review list too.
   const query = { userId: ownerDoc._id, ...REVIEW_VISIBLE }
 

--- a/src/pages/AddRecipe/recipeFormValidation.ts
+++ b/src/pages/AddRecipe/recipeFormValidation.ts
@@ -52,7 +52,10 @@ export function validateRecipeForm(
     errors.image = 'Image is required'
   }
 
-  if (!form.description) {
+  // Trim before the presence check, same as title: an all-whitespace
+  // description must count as missing, not pass a truthiness test.
+  const trimmedDescription = form.description.trim()
+  if (!trimmedDescription) {
     errors.description = 'Description is required'
   } else if (form.description.length > DESCRIPTION_MAX_LENGTH) {
     errors.description = `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`

--- a/src/test/AddRecipe.test.tsx
+++ b/src/test/AddRecipe.test.tsx
@@ -280,16 +280,37 @@ describe('AddRecipe form', () => {
     await waitFor(() => expect(submitBtn).toHaveClass('valid'))
   })
 
-  it('clicking "Create Recipe" when valid calls RecipeAPI.addRecipe', async () => {
+  it('clicking "Create Recipe" when valid calls RecipeAPI.addRecipe with the mapped payload', async () => {
     const user = userEvent.setup()
     mockAddRecipe.mockResolvedValue({ status: 'success', id: 'new-1', pendingReview: false })
     renderAddRecipe()
     await fillAllFields(user)
+    // Trailing whitespace on the title must be trimmed out of the payload.
+    await user.type(
+      screen.getByPlaceholderText('Add a title to your recipe.'),
+      '   '
+    )
     await waitFor(() =>
       expect(screen.getByText('Create Recipe').closest('button')).toHaveClass('valid')
     )
     await user.click(screen.getByText('Create Recipe'))
     await waitFor(() => expect(mockAddRecipe).toHaveBeenCalledTimes(1))
+
+    // The submit maps form state → API payload (see useRecipeForm.handleSubmit):
+    // trimmed title, numeric servings, prep time flattened to minutes.
+    const payload = mockAddRecipe.mock.calls[0][0]
+    expect(payload).toEqual(
+      expect.objectContaining({
+        title: 'My Great Recipe',
+        description: 'A delicious recipe',
+        servings: 4,
+        prepTime: 30,
+        mealTypes: ['dinner'],
+      })
+    )
+    expect(payload.recipeImage).toBeInstanceOf(File)
+    expect(payload.ingredients).toHaveLength(1)
+    expect(payload.instructions).toHaveLength(1)
   })
 
   it('navigates to the new recipe page after a successful submission', async () => {

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -5,20 +5,27 @@
  * any module-level Firebase code executes (e.g. `const auth = getAuth()` in
  * AuthContext.tsx and `initializeApp(...)` in src/client/db.ts).
  *
- * The onAuthStateChanged stub never calls its callback, so AuthProvider stays in
- * `loading: true` and renders only the loading spinner — no page components
- * mount, no API calls fire.
+ * The onAuthStateChanged stub captures its callback (h.authCallback) instead of
+ * firing it, so AuthProvider starts in `loading: true` and renders only the
+ * loading spinner. Tests can then fire the callback themselves to settle auth
+ * and let the real route table render.
  *
  * App.tsx has no Router; it relies on context from react-router-dom (useLocation
  * in ScrollToTop, useNavigate in AuthProvider). The MemoryRouter wrapper below
- * supplies that context.
+ * supplies that context; QueryClientProvider mirrors index.tsx for the
+ * react-query hooks on the home route.
  */
 
 import React from 'react'
 import { vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from 'src/App'
+
+const h = vi.hoisted(() => ({
+  authCallback: null as ((user: unknown) => void) | null,
+}))
 
 vi.mock('firebase/app', () => ({
   initializeApp: vi.fn().mockReturnValue({}),
@@ -26,7 +33,10 @@ vi.mock('firebase/app', () => ({
 
 vi.mock('firebase/auth', () => ({
   getAuth: vi.fn().mockReturnValue({
-    onAuthStateChanged: vi.fn().mockReturnValue(() => {}),
+    onAuthStateChanged: (cb: (user: unknown) => void) => {
+      h.authCallback = cb
+      return () => {}
+    },
     currentUser: null,
   }),
   signOut: vi.fn(),
@@ -53,12 +63,59 @@ vi.mock('firebase/firestore', () => ({
   getFirestore: vi.fn().mockReturnValue({}),
 }))
 
-describe('App', () => {
-  it('renders without crashing', () => {
-    render(
+// The home route fetches recipe rows on mount; keep it network-free.
+vi.mock('src/api/recipes', () => ({
+  default: {
+    getTrendingRecipes: vi.fn().mockResolvedValue([]),
+    getAllRecipes: vi.fn().mockResolvedValue({ recipes: [], totalCount: 0 }),
+    getForYouRecipes: vi.fn().mockResolvedValue([]),
+    getRandomRecipe: vi.fn().mockResolvedValue(null),
+    searchAutoCompleteRecipes: vi.fn().mockResolvedValue([]),
+  },
+}))
+
+const renderApp = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
       <MemoryRouter>
         <App />
       </MemoryRouter>
-    )
+    </QueryClientProvider>
+  )
+
+describe('App', () => {
+  beforeEach(() => {
+    h.authCallback = null
+    // jsdom has no Element.scrollTo; ScrollToTop calls it on the body.
+    document.body.scrollTo = vi.fn()
+  })
+
+  it('shows the auth-loading state until onAuthStateChanged settles', () => {
+    renderApp()
+    expect(
+      screen.getByRole('heading', { name: /auth loading/i })
+    ).toBeInTheDocument()
+    // No route content while auth is unresolved.
+    expect(screen.queryByRole('main')).not.toBeInTheDocument()
+  })
+
+  it('renders the home route once auth settles signed-out', async () => {
+    renderApp()
+    expect(h.authCallback).not.toBeNull()
+
+    await act(async () => {
+      h.authCallback!(null)
+    })
+
+    // The route table + Layout rendered: page landmarks plus real home content.
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    // Navbar + mobile menu both expose nav landmarks — at least one rendered.
+    expect(screen.getAllByRole('navigation').length).toBeGreaterThan(0)
+    expect(
+      screen.getByRole('heading', { name: /trending this week/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: /auth loading/i })
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/test/AuthContext.test.tsx
+++ b/src/test/AuthContext.test.tsx
@@ -15,6 +15,11 @@ import {
   updateProfile,
   signOut,
   EmailAuthProvider,
+  setPersistence,
+  browserLocalPersistence,
+  browserSessionPersistence,
+  signInWithEmailAndPassword,
+  sendPasswordResetEmail,
 } from 'firebase/auth'
 import { uploadBytes, getDownloadURL } from 'firebase/storage'
 import AuthAPI from 'src/api/auth'
@@ -37,7 +42,11 @@ vi.mock('firebase/auth', () => ({
   signInWithPopup: vi.fn(),
   signInWithEmailAndPassword: vi.fn(),
   createUserWithEmailAndPassword: vi.fn(),
-  sendPasswordResetEmail: vi.fn(),
+  sendPasswordResetEmail: vi.fn().mockResolvedValue(undefined),
+  setPersistence: vi.fn().mockResolvedValue(undefined),
+  // Sentinel values — the provider only passes these through to setPersistence.
+  browserLocalPersistence: { type: 'LOCAL' },
+  browserSessionPersistence: { type: 'SESSION' },
   updateProfile: vi.fn().mockResolvedValue(undefined),
   verifyBeforeUpdateEmail: vi.fn().mockResolvedValue(undefined),
   reauthenticateWithCredential: vi.fn().mockResolvedValue(undefined),
@@ -287,6 +296,91 @@ describe('AuthContext — updateProfileData', () => {
     })
 
     expect(verifyBeforeUpdateEmail).not.toHaveBeenCalled()
+  })
+})
+
+// ─── signInDefault ────────────────────────────────────────────────────────────
+
+describe('AuthContext — signInDefault persistence', () => {
+  beforeEach(() => {
+    ;(signInWithEmailAndPassword as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: makeUser(),
+    })
+  })
+
+  it('uses session persistence when "remember me" is unchecked', async () => {
+    const result = await mountAuth(makeUser())
+
+    await act(async () => {
+      result.current!.signInDefault(
+        'john@example.com',
+        'hunter2',
+        false,
+        vi.fn(),
+        vi.fn()
+      )
+    })
+
+    // Session persistence: the login is dropped when the tab/window closes.
+    expect(setPersistence).toHaveBeenCalledWith(
+      expect.anything(),
+      browserSessionPersistence
+    )
+    expect(signInWithEmailAndPassword).toHaveBeenCalledWith(
+      expect.anything(),
+      'john@example.com',
+      'hunter2'
+    )
+  })
+
+  it('uses local persistence when "remember me" is checked', async () => {
+    const result = await mountAuth(makeUser())
+
+    await act(async () => {
+      result.current!.signInDefault(
+        'john@example.com',
+        'hunter2',
+        true,
+        vi.fn(),
+        vi.fn()
+      )
+    })
+
+    expect(setPersistence).toHaveBeenCalledWith(
+      expect.anything(),
+      browserLocalPersistence
+    )
+  })
+})
+
+// ─── forgotPassword ───────────────────────────────────────────────────────────
+
+describe('AuthContext — forgotPassword', () => {
+  it('reports success even for an unregistered email (no account enumeration)', async () => {
+    ;(sendPasswordResetEmail as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      Object.assign(new Error('no user'), { code: 'auth/user-not-found' })
+    )
+    const result = await mountAuth(makeUser())
+    const setLoading = vi.fn()
+    const setSuccess = vi.fn()
+    const setError = vi.fn()
+
+    await act(async () => {
+      result.current!.forgotPassword(
+        'ghost@example.com',
+        setLoading,
+        setSuccess,
+        setError
+      )
+    })
+
+    // A missing account shows the same confirmation as a real one — the error
+    // callback must never fire for auth/user-not-found.
+    expect(setSuccess).toHaveBeenCalledWith(
+      'Email sent! Check your inbox for instructions.'
+    )
+    expect(setError).not.toHaveBeenCalled()
+    expect(setLoading).toHaveBeenLastCalledWith(false)
   })
 })
 

--- a/src/test/CreateUsername.test.tsx
+++ b/src/test/CreateUsername.test.tsx
@@ -123,6 +123,40 @@ describe('CreateUsername (onboarding)', () => {
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith('/'))
   })
 
+  it('keeps Continue disabled when the username is taken', async () => {
+    checkAvailMock.mockResolvedValue(false)
+    renderOnboarding()
+    await screen.findByText('Finish your profile')
+    fireEvent.change(screen.getByLabelText('Username'), {
+      target: { value: 'takenname' },
+    })
+    await waitFor(() => expect(checkAvailMock).toHaveBeenCalled(), {
+      timeout: 2500,
+    })
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled()
+    expect(setUsernameMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the server reason inline and re-enables Continue when the save is rejected', async () => {
+    // Axios-shaped 422 — e.g. the server's moderation block on the username.
+    setUsernameMock.mockRejectedValue(
+      Object.assign(new Error('Request failed with status code 422'), {
+        isAxiosError: true,
+        response: { status: 422, data: { error: 'Username was blocked' } },
+      })
+    )
+    renderOnboarding()
+    await screen.findByText('Finish your profile')
+    const cont = await pickAvailableUsername()
+    fireEvent.click(cont)
+
+    // getApiErrorMessage prefers the server's reason over the generic axios text.
+    await screen.findByText('Username was blocked')
+    expect(screen.getByRole('button', { name: /continue/i })).toBeEnabled()
+    expect(navigateMock).not.toHaveBeenCalledWith('/')
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+  })
+
   // Escape hatch: a signed-in user without a username must be able to get out
   // rather than getting stuck on this page (the auth signout is the way out).
   it('logs the user out via the cancel/escape hatch', async () => {

--- a/src/test/ForgotPassword.test.tsx
+++ b/src/test/ForgotPassword.test.tsx
@@ -54,4 +54,36 @@ describe('ForgotPassword', () => {
       screen.getByText('Email sent! Check your inbox for instructions.')
     ).toBeInTheDocument()
   })
+
+  it('renders the error message the auth layer reports', () => {
+    renderForgot()
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'a@b.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    // 4th arg is the page's setError — drive it the way a failed send would.
+    const setError = forgotPasswordMock.mock.calls[0][3]
+    act(() => setError('Too many attempts. Please try again later.'))
+    const error = screen.getByText('Too many attempts. Please try again later.')
+    expect(error).toBeInTheDocument()
+    expect(error).toHaveClass('error')
+  })
+
+  it('disables the submit button while the request is loading', () => {
+    renderForgot()
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'a@b.com' },
+    })
+    const button = screen.getByRole('button', { name: /send reset link/i })
+    fireEvent.click(button)
+    expect(button).toBeEnabled()
+
+    // 2nd arg is the page's setLoading — while true, re-submits are blocked.
+    const setLoading = forgotPasswordMock.mock.calls[0][1]
+    act(() => setLoading(true))
+    expect(button).toBeDisabled()
+    act(() => setLoading(false))
+    expect(button).toBeEnabled()
+  })
 })

--- a/src/test/Help.test.tsx
+++ b/src/test/Help.test.tsx
@@ -99,6 +99,15 @@ describe('Help', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: /send message/i }))
     expect(formspree.submit).toHaveBeenCalled()
+
+    // Formspree reads the named fields off the submitted <form>: the typed
+    // email/message plus the hidden category carrying the chosen topic.
+    const submittedForm = formspree.submit.mock.calls[0][0]
+      .target as HTMLFormElement
+    const data = new FormData(submittedForm)
+    expect(data.get('email')).toBe('visitor@example.com')
+    expect(data.get('description')).toBe('It would be great if…')
+    expect(data.get('category')).toBe('Suggest an idea')
   })
 
   it('pre-fills the email for a signed-in user, but stays empty when logged out', () => {

--- a/src/test/Home.test.tsx
+++ b/src/test/Home.test.tsx
@@ -94,10 +94,6 @@ describe('Home page', () => {
     mockUseAuth.mockReturnValue({ user: null })
   })
 
-  it('renders without crashing', () => {
-    renderHome()
-  })
-
   it('renders the hero heading text', () => {
     renderHome()
     expect(

--- a/src/test/MadeRecipeBtn.test.tsx
+++ b/src/test/MadeRecipeBtn.test.tsx
@@ -16,6 +16,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import MadeRecipeBtn from 'src/pages/SingleRecipe/Buttons/MadeRecipeBtn'
 import RecipeAPI from 'src/api/recipes'
+import toast from 'react-hot-toast'
+import { GENERIC_ERROR } from 'src/util/toastMessages'
 
 vi.mock('src/api/recipes', () => ({
   __esModule: true,
@@ -102,14 +104,37 @@ it('marks the recipe made on click, then disables the button', async () => {
   expect(btn.className).toContain('is-made')
 })
 
-it('does not re-POST when already made (idempotent, no throttle needed)', async () => {
-  mockedCheck.mockResolvedValue({ made: true })
+it('POSTs only once when clicked again while the first call is in-flight', async () => {
+  mockedCheck.mockResolvedValue({ made: false })
+  // Deferred promise: hold the POST open so the second click lands mid-flight.
+  let resolveMade!: () => void
+  mockedMade.mockImplementation(
+    () => new Promise<void>(resolve => (resolveMade = resolve))
+  )
   renderBtn()
   const btn = await screen.findByRole('button', { name: /made it/i })
+  await waitFor(() => expect(btn).not.toBeDisabled())
+
+  fireEvent.click(btn)
+  fireEvent.click(btn)
+  expect(mockedMade).toHaveBeenCalledTimes(1)
+
+  resolveMade()
   await waitFor(() => expect(btn).toBeDisabled())
+  expect(mockedMade).toHaveBeenCalledTimes(1)
+})
+
+it('surfaces a toast and re-enables the button (still unmade) when the POST fails', async () => {
+  mockedCheck.mockResolvedValue({ made: false })
+  mockedMade.mockRejectedValue(new Error('server down'))
+  renderBtn()
+  const btn = await screen.findByRole('button', { name: /made it/i })
+  await waitFor(() => expect(btn).not.toBeDisabled())
 
   fireEvent.click(btn)
-  fireEvent.click(btn)
 
-  expect(mockedMade).not.toHaveBeenCalled()
+  await waitFor(() => expect(toast.error).toHaveBeenCalledWith(GENERIC_ERROR))
+  // The failed mark doesn't stick: the button is actionable again, not made.
+  await waitFor(() => expect(btn).not.toBeDisabled())
+  expect(btn.className).not.toContain('is-made')
 })

--- a/src/test/RatingsAndReviews.integration.test.tsx
+++ b/src/test/RatingsAndReviews.integration.test.tsx
@@ -300,6 +300,13 @@ describe('RatingsAndReviews integration', () => {
       await screen.findByText('No reviews yet.')
       expect(screen.queryByText(/be the first/)).toBeNull()
     })
+
+    it('a failed fetch renders the error copy, never the empty state', async () => {
+      mockGetReviews.mockRejectedValue(new Error('network down'))
+      renderSection()
+      await screen.findByText(/Couldn’t load reviews\. Please try again later\./)
+      expect(screen.queryByText('No reviews yet.')).toBeNull()
+    })
   })
 
   describe('submit → own card flow', () => {

--- a/src/test/RecipesApi.test.ts
+++ b/src/test/RecipesApi.test.ts
@@ -18,6 +18,7 @@ vi.mock('src/api/auth', () => ({
 
 const httpPost = vi.fn()
 const httpPut = vi.fn()
+const httpGet = vi.fn()
 // Nutrition now goes through the server proxy (POST api/nutrition/details) on the
 // shared `http` instance rather than a separate Edamam axios client. Keep the two
 // concerns split in tests by routing that one URL to its own mock, so existing
@@ -30,14 +31,21 @@ vi.mock('src/api/http-common', () => ({
         ? nutritionPost(url, ...rest)
         : httpPost(url, ...rest),
     put: (...args: unknown[]) => httpPut(...args),
+    get: (...args: unknown[]) => httpGet(...args),
   },
 }))
 
 // Import after mocks are in place.
 import RecipeAPI from 'src/api/recipes'
 import AuthAPI from 'src/api/auth'
+import type { ParsedIngredient } from '@jclind/ingredient-parser'
 import { deleteObject, ref, uploadBytes } from 'firebase/storage'
-import type { RecipeEditFormType, RecipeFormType, RecipeType } from 'types'
+import type {
+  IngredientsType,
+  RecipeEditFormType,
+  RecipeFormType,
+  RecipeType,
+} from 'types'
 
 const makeFormData = (): RecipeFormType => ({
   title: 'Soft-fail Test Recipe',
@@ -106,7 +114,9 @@ describe('RecipeAPI.addRecipe — nutrition soft-fail (High #4)', () => {
     const result = await RecipeAPI.addRecipe(makeFormData(), () => {})
 
     expect(result).toEqual({ status: 'success', id: 'srv-2', pendingReview: false })
-    expect(httpPost).toHaveBeenCalledWith('api/addRecipe', expect.any(Object))
+    expect(httpPost.mock.calls[0][0]).toBe('api/addRecipe')
+    // Empty nutrition data degrades to an explicit null in the posted body.
+    expect(httpPost.mock.calls[0][1].nutritionData).toBeNull()
   })
 })
 
@@ -295,6 +305,11 @@ describe('RecipeAPI.editRecipe', () => {
     await RecipeAPI.editRecipe('recipe-1', changed, makeOriginal(), () => {})
 
     expect(nutritionPost).toHaveBeenCalledTimes(1)
+    // The lookup is fed the exact 'quantity unit name' strings for the NEW set.
+    expect(nutritionPost).toHaveBeenCalledWith('api/nutrition/details', {
+      title: 'recipe 1',
+      ingr: ['1 cup Sugar'],
+    })
     const payload = httpPut.mock.calls[0][1]
     expect(payload.nutritionData).toEqual({
       uri: 'new',
@@ -342,6 +357,10 @@ describe('RecipeAPI.editRecipe', () => {
     await RecipeAPI.editRecipe('recipe-1', changed, makeOriginal(), () => {})
 
     expect(nutritionPost).toHaveBeenCalledTimes(1)
+    expect(nutritionPost).toHaveBeenCalledWith('api/nutrition/details', {
+      title: 'recipe 1',
+      ingr: ['1 cup Sugar'],
+    })
     const payload = httpPut.mock.calls[0][1]
     // The soft-fail must NOT erase the recipe's stored numeric nutrition; diet
     // labels are form-driven and pass through regardless.
@@ -416,6 +435,111 @@ describe('RecipeAPI.editRecipe', () => {
     await RecipeAPI.editRecipe('recipe-1', makeEditData(), makeOriginal(), () => {})
 
     expect(deleteObject).not.toHaveBeenCalled()
+  })
+})
+
+describe('RecipeAPI.getAllRecipes — query-string encoding', () => {
+  beforeEach(() => {
+    httpGet.mockReset()
+    httpGet.mockResolvedValue({ data: { recipes: [], totalCount: 0 } })
+  })
+
+  it('URL-encodes a multi-word cuisine', async () => {
+    await RecipeAPI.getAllRecipes({ cuisine: 'Middle Eastern' })
+    expect(httpGet.mock.calls[0][0]).toBe(
+      'api/recipes?q=&page=0&recipesPerPage=5&order=new&cuisine=Middle+Eastern'
+    )
+  })
+
+  it('URL-encodes an &-containing search term so it survives the round-trip', async () => {
+    await RecipeAPI.getAllRecipes({ query: 'mac & cheese' })
+    const url: string = httpGet.mock.calls[0][0]
+    expect(url).toBe(
+      'api/recipes?q=mac+%26+cheese&page=0&recipesPerPage=5&order=new&cuisine='
+    )
+    // The server-side parse recovers the raw term intact.
+    const parsed = new URLSearchParams(url.split('?')[1])
+    expect(parsed.get('q')).toBe('mac & cheese')
+  })
+})
+
+describe('RecipeAPI.getReviews — legacy rating normalization (coerceRating)', () => {
+  beforeEach(() => {
+    httpGet.mockReset()
+  })
+
+  it("coerces '4.5'→4.5 and ''/'abc'→null at the API boundary", async () => {
+    httpGet.mockResolvedValue({
+      data: {
+        totalCount: 3,
+        reviews: [
+          { reviewText: 'stringified float', rating: '4.5' },
+          { reviewText: 'rating-less legacy doc', rating: '' },
+          { reviewText: 'corrupt value', rating: 'abc' },
+        ],
+      },
+    })
+
+    const result = await RecipeAPI.getReviews('recipe-1', 'new', 0)
+
+    expect(result.reviews.map(r => r.rating)).toEqual([4.5, null, null])
+  })
+})
+
+describe('RecipeAPI.getRecipeNutrition — ingr payload rules', () => {
+  const parsed = (overrides: Partial<ParsedIngredient> = {}): ParsedIngredient => ({
+    ingredient: 'Flour',
+    quantity: 2,
+    unit: 'cups',
+    unitPlural: 'cups',
+    symbol: null,
+    minQty: 2,
+    maxQty: 2,
+    originalIngredientString: '2 cups flour',
+    comment: '',
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    nutritionPost.mockReset()
+    nutritionPost.mockResolvedValue({ data: null })
+  })
+
+  it('sends "quantity unit name" rows, dropping labels and quantity-less rows', async () => {
+    const ingredients: IngredientsType[] = [
+      { id: 'i1', parsedIngredient: parsed(), ingredientData: null },
+      // Section label — no parsedIngredient, must not reach Edamam.
+      { id: 'lbl', label: 'For the sauce' },
+      // No quantity — unparseable by the lookup, dropped.
+      {
+        id: 'i2',
+        parsedIngredient: parsed({
+          ingredient: 'Salt',
+          quantity: null,
+          unit: null,
+          originalIngredientString: 'Salt to taste',
+        }),
+        ingredientData: null,
+      },
+      // No unit — padded with '' (double space preserved by the template).
+      {
+        id: 'i3',
+        parsedIngredient: parsed({
+          ingredient: 'Eggs',
+          quantity: 3,
+          unit: null,
+          originalIngredientString: '3 eggs',
+        }),
+        ingredientData: null,
+      },
+    ]
+
+    await RecipeAPI.getRecipeNutrition(ingredients)
+
+    expect(nutritionPost).toHaveBeenCalledWith('api/nutrition/details', {
+      title: 'recipe 1',
+      ingr: ['2 cups Flour', '3  Eggs'],
+    })
   })
 })
 

--- a/src/test/Signup.test.tsx
+++ b/src/test/Signup.test.tsx
@@ -83,4 +83,26 @@ describe('Signup confirm-password validation', () => {
       expect.any(Function)
     )
   })
+
+  it('renders the friendly error the auth layer reports in the live banner', () => {
+    signUpMock.mockImplementation((_e, _p, _setLoading, setError) =>
+      setError('An account with this email already exists.')
+    )
+    renderSignup()
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'a@b.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'abc123' },
+    })
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'abc123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    const error = screen.getByText('An account with this email already exists.')
+    expect(error).toBeInTheDocument()
+    // Announced to assistive tech: the banner sits in the aria-live region.
+    expect(error.closest('[aria-live="polite"]')).not.toBeNull()
+  })
 })

--- a/src/test/StarRating.test.tsx
+++ b/src/test/StarRating.test.tsx
@@ -39,6 +39,21 @@ describe('StarRating (interactive radiogroup)', () => {
     })
   })
 
+  it('clicking a star reports its value through onChange', () => {
+    const onChange = vi.fn()
+    render(<StarRating interactive rating={0} onChange={onChange} />)
+    fireEvent.click(screen.getAllByRole('radio')[1])
+    expect(onChange).toHaveBeenCalledWith(2)
+  })
+
+  it('ArrowRight moves DOM focus onto the newly-selected star', () => {
+    render(<StarRating interactive rating={3} onChange={vi.fn()} />)
+    const radios = screen.getAllByRole('radio')
+    fireEvent.keyDown(radios[2], { key: 'ArrowRight' })
+    // Roving tabindex: the selection move must carry keyboard focus with it.
+    expect(radios[3]).toHaveFocus()
+  })
+
   it('ArrowRight moves selection forward by one', () => {
     const onChange = vi.fn()
     render(<StarRating interactive rating={3} onChange={onChange} />)

--- a/src/test/recipeFormValidation.test.ts
+++ b/src/test/recipeFormValidation.test.ts
@@ -92,6 +92,13 @@ describe('validateRecipeForm', () => {
     expect(validateRecipeForm({ ...validForm(), title: '  Soup  ' }).title).toBeUndefined()
   })
 
+  it('treats a whitespace-only description as missing', () => {
+    // Mirrors the whitespace-title rule: `!form.description` let '   ' through.
+    const errors = validateRecipeForm({ ...validForm(), description: '   ' })
+    expect(errors.description).toBe('Description is required')
+    expect(isRecipeFormValid(errors)).toBe(false)
+  })
+
   it('caps the title length', () => {
     const ok = validateRecipeForm({ ...validForm(), title: 'A'.repeat(TITLE_MAX_LENGTH) })
     expect(ok.title).toBeUndefined()


### PR DESCRIPTION
## What this is

HIGH_VALUE_PROMPTS #3 — the **test-suite quality audit** (meaningfulness, not coverage). Six parallel audit agents swept all 122 unit/integration suites + 7 Cypress specs against concrete criteria (trivially-passing tests, mocked-away subjects, missing failure modes on high-risk paths, weak assertions, flake patterns). Overall verdict: the suite is genuinely strong — mocking is confined to real external boundaries and most suites assert DB/DOM side effects. This PR ships the targeted gaps the audit confirmed, and files the rest.

## Two real bugs the missing tests were hiding (both fixed test-first, red observed)

1. **`?page=-1` → 500 on public list routes.** `getReviews` / `getSingleUserReviews` (`server/routes/reviews.js`) and browse (`server/routes/recipes.js`) computed an unclamped negative `skip()`, which MongoDB rejects. The clamp (`Math.max(0, …)`) mirrors the fix `publicProfile.js` already got — these routes were missed. Now pinned on all three routes.
2. **Whitespace-only description passes recipe validation.** `recipeFormValidation.ts` trimmed the title but not the description; `'   '` could publish a blank description. Now trims like the title rule.

## Server tests (Jest 799 → 830)

- **Rejected/expired Firebase token → 401** — the shared firebase-admin mock always resolved, so the `verifyIdToken`-rejects branch of `verifyToken` was never exercised by any of the 36 suites. Also: bare-`Bearer` 401, and `optionalAuth` treating a bad token as anonymous (hidden-recipe 404 + an owner-preview-denied variant that proves `req.uid` was never set).
- **`requireActive` wiring guard** — banned/suspended enforcement was behaviorally tested on only 3 of ~13 write surfaces; a reference-identity wiring test now pins all 9 previously-uncovered routes (collections ×4, drafts ×2, save/unsave/made) incl. middleware ordering.
- **Review CRUD:** moderation gate on `editReview` (only `newReview` was tested — clean-then-edit-in-blocked-content would have passed CI), same-user re-rate upsert (one doc; aggregate + per-star breakdown use the new value), rating-first `$setOnInsert` defaults, `MAX_PER_PAGE=50` cap pinned on reviews + recipes (was fully unasserted — a collection-dump regression would have passed).
- **Moderation:** kill switch (`MODERATION_ENABLED=false` → source `disabled`, no fetch, blocklist still fires) and exact threshold boundaries (0.85 / 0.5 / 0.4999 against the `>=` comparisons) + the untested `MODERATION_MEDIUM_THRESHOLD` override.
- **Hardening:** nutrition 503 test no longer depends on ambient env (explicit Edamam key delete/restore); upstream soft-fail parameterized over 404/429/500/555; telemetry write failure can't break `/ingredients/parse`; `writeLimiter`'s `NODE_ENV` mutation is leak-proofed with try/finally.

## Client tests (Vitest 655 → 672)

- **`App.test.tsx` had zero assertions** and its mocks guaranteed only the auth spinner ever mounted. Now asserts the loading state, then fires the captured auth callback and asserts the home route actually renders.
- **`RecipesApi` read side had zero tests** (mock only implemented `post`/`put`): now covers `getAllRecipes` query encoding (`Middle Eastern`, `mac & cheese`), `coerceRating` legacy-string normalization, the Edamam `ingr` payload rules (label rows dropped, quantity-less dropped), and replaces a vacuous `expect.any(Object)` with a real `nutritionData: null` assertion.
- **AuthContext real-provider gaps** (sign-in flows were mocked on both sides of the seam everywhere): `remember=false` → session persistence, and `forgotPassword` masking `auth/user-not-found` as success (the email-enumeration guard).
- **Error paths pinned:** MadeRecipeBtn failure (+ replaced a jsdom-vacuous disabled-double-click test with a real in-flight dedupe test), reviews fetch failure renders "Couldn't load reviews" not the empty state, CreateUsername 422/unavailable, ForgotPassword error+loading, Signup error banner, StarRating click + focus-follows-selection, AddRecipe submit payload (trimmed title, numeric servings, minutes conversion — was call-count only), Help submit FormData. Deleted Home's assertion-free duplicate test; dropped a dead Cypress chain assertion.

## Filed, not fixed (docs/BACKLOG.md)

Admin `/reports` uncoerced/uncapped pagination (500 on `perPage=abc`), drafts-cap TOCTOU race, blocklist unicode-homoglyph evasion, three small client contract nits, and the headline remaining gap: **no server test runs the real ingredient parser** (mocked wholesale) — filed as a fixture-table contract test, plus smaller coverage/flake follow-ups. The known legacy stringified-rating Top-sort bug was deliberately left to its already-filed migration.

## Gates

- `tsc --noEmit` clean · Vitest **672 pass / 2 skip** · server Jest **830 pass** (`--runInBand`, CI-style) · production build clean.
- Note: a separate bug-hunt session is running on `fix/bug-hunt-2026-07-09`; if it lands overlapping fixes (e.g. the negative-page clamp), the conflict surface here is 3 small hunks.

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8