### PR TITLE
Fix quantity display: round fractions past 7/8 + render ingredient ranges (Wave 9 · B4)

### DIFF
--- a/src/Components/IngredientItemText/IngredientItemText.tsx
+++ b/src/Components/IngredientItemText/IngredientItemText.tsx
@@ -1,9 +1,11 @@
 import React, { FC } from 'react'
-import { closestFraction } from 'src/util/formatQuantity'
+import { formatIngredientQuantity } from 'src/util/formatQuantity'
 import './IngredientItemText.scss'
 
 type IngredientItemTextProps = {
   quantity: number | null
+  minQty: number | null
+  maxQty: number | null
   unit: string | null
   ingredientName: string | null
   comment: string | null
@@ -11,16 +13,19 @@ type IngredientItemTextProps = {
 
 const IngredientItemText: FC<IngredientItemTextProps> = ({
   quantity,
+  minQty,
+  maxQty,
   unit,
   ingredientName,
   comment,
 }) => {
+  const quantityText = formatIngredientQuantity(quantity, minQty, maxQty)
   return (
     <div className='ingredient-item-text'>
       <p>
-        {quantity ? (
+        {quantityText ? (
           <>
-            <strong>{closestFraction(quantity)}</strong>{' '}
+            <strong>{quantityText}</strong>{' '}
           </>
         ) : null}
         {unit ? (

--- a/src/pages/AddRecipe/Ingredients/IngredientItem.tsx
+++ b/src/pages/AddRecipe/Ingredients/IngredientItem.tsx
@@ -70,6 +70,8 @@ const IngredientItem: FC<IngredientItemProps> = ({
     if (typeof ingredient !== 'undefined' && 'parsedIngredient' in ingredient) {
       const {
         quantity,
+        minQty,
+        maxQty,
         unit,
         ingredient: ingredientName,
         comment,
@@ -77,6 +79,8 @@ const IngredientItem: FC<IngredientItemProps> = ({
       return (
         <IngredientItemText
           quantity={quantity}
+          minQty={minQty}
+          maxQty={maxQty}
           unit={unit}
           ingredientName={ingredientName}
           comment={comment}

--- a/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.tsx
+++ b/src/pages/SingleRecipe/PrintableRecipe/PrintableRecipe.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react'
 import './PrintableRecipe.scss'
 
 import { capitalize } from 'src/util/capitalize'
-import { closestFraction } from 'src/util/formatQuantity'
+import { formatIngredientQuantity } from 'src/util/formatQuantity'
 import { formatRating } from 'src/util/formatRating'
 import { formatMonthYear } from 'src/util/formatDate'
 import { formatPrice } from 'src/util/formatPrice'
@@ -100,9 +100,11 @@ const PrintableRecipe: FC<PrintableRecipeProps> = ({
               'parsedIngredient' in ingr ? (
                 <li key={ingr.id} className='pr-ing'>
                   <span className='pr-qty'>
-                    {ingr.parsedIngredient.quantity
-                      ? closestFraction(ingr.parsedIngredient.quantity)
-                      : ''}
+                    {formatIngredientQuantity(
+                      ingr.parsedIngredient.quantity,
+                      ingr.parsedIngredient.minQty,
+                      ingr.parsedIngredient.maxQty
+                    )}
                     {ingr.parsedIngredient.unit
                       ? ` ${ingr.parsedIngredient.unit}`
                       : ''}

--- a/src/pages/SingleRecipe/SingleRecipe.tsx
+++ b/src/pages/SingleRecipe/SingleRecipe.tsx
@@ -31,7 +31,7 @@ import { capitalize } from 'src/util/capitalize'
 import { formatRating } from 'src/util/formatRating'
 import { formatMonthYear } from 'src/util/formatDate'
 import { formatPrice } from 'src/util/formatPrice'
-import { closestFraction } from 'src/util/formatQuantity'
+import { formatIngredientQuantity } from 'src/util/formatQuantity'
 import { recipeImageSrcSet } from 'src/util/recipeImageVariants'
 
 import { IngredientsType, InstructionsType, RecipeType } from 'types'
@@ -193,7 +193,8 @@ const SingleRecipe: FC = () => {
 
   const renderIngredient = (ingr: IngredientsType) => {
     if ('parsedIngredient' in ingr) {
-      const { quantity, unit, ingredient, comment } = ingr.parsedIngredient
+      const { quantity, minQty, maxQty, unit, ingredient, comment } =
+        ingr.parsedIngredient
       const isChecked = checked.has(ingr.id)
       const image = ingr.ingredientData?.imagePath
       return (
@@ -225,7 +226,7 @@ const SingleRecipe: FC = () => {
             </span>
             <span className='ing-text'>
               <span className='qty'>
-                {quantity ? closestFraction(quantity) : ''}
+                {formatIngredientQuantity(quantity, minQty, maxQty)}
                 {unit ? ` ${unit}` : ''}
               </span>{' '}
               <span className='name'>

--- a/src/test/closestFraction.test.ts
+++ b/src/test/closestFraction.test.ts
@@ -77,5 +77,8 @@ describe('formatIngredientQuantity', () => {
   it('returns an empty string when there is no numeric amount', () => {
     expect(formatIngredientQuantity(null, null, null)).toBe('')
     expect(formatIngredientQuantity(null)).toBe('')
+    // The parser returns 0 for "salt, to taste" — render just the name, not "0".
+    expect(formatIngredientQuantity(0, 0, 0)).toBe('')
+    expect(formatIngredientQuantity(0)).toBe('')
   })
 })

--- a/src/test/closestFraction.test.ts
+++ b/src/test/closestFraction.test.ts
@@ -66,6 +66,13 @@ describe('formatIngredientQuantity', () => {
     expect(formatIngredientQuantity(1.5, 1.5, 2.5)).toBe('1 1/2–2 1/2')
   })
 
+  it('collapses a range whose bounds round to the same fraction', () => {
+    // 0.96 and 0.99 both round to "1" — render "1", not "1–1".
+    expect(formatIngredientQuantity(0.96, 0.96, 0.99)).toBe('1')
+    // Bounds inside the same fraction bucket (both snap to 1/2) collapse too.
+    expect(formatIngredientQuantity(1.51, 1.51, 1.52)).toBe('1 1/2')
+  })
+
   it('renders a single quantity when there is no distinct upper bound', () => {
     // Non-range parses come back with quantity == minQty == maxQty.
     expect(formatIngredientQuantity(1.5, 1.5, 1.5)).toBe('1 1/2')

--- a/src/test/closestFraction.test.ts
+++ b/src/test/closestFraction.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { closestFraction } from 'src/util/formatQuantity'
+import {
+  closestFraction,
+  formatIngredientQuantity,
+} from 'src/util/formatQuantity'
 
 // closestFraction renders a decimal ingredient quantity as the nearest "nice"
 // cooking fraction for display (the recipe page + printable view + ingredient
@@ -39,5 +42,40 @@ describe('closestFraction', () => {
     expect(closestFraction(0.4)).toBe('3/8')
     // Just under 1/8 still snaps to 1/8 (it's the smallest entry).
     expect(closestFraction(0.1)).toBe('1/8')
+  })
+
+  it('rounds up to the next whole number past 7/8 instead of snapping down', () => {
+    // Regression (BUG_HUNT I2): decimals in [0.9375, 1) used to render "7/8".
+    expect(closestFraction(0.95)).toBe('1')
+    expect(closestFraction(0.99)).toBe('1')
+    expect(closestFraction(1.96)).toBe('2')
+    // The 0.9375 midpoint between 7/8 and 1 ties toward rounding up.
+    expect(closestFraction(0.9375)).toBe('1')
+    // Just below the midpoint still snaps to 7/8 (closer to 0.875 than to 1).
+    expect(closestFraction(0.9)).toBe('7/8')
+    expect(closestFraction(0.875)).toBe('7/8')
+  })
+})
+
+// formatIngredientQuantity is the single display entry point: it renders a
+// "min–max" range when the parser captured a distinct upper bound, and falls
+// back to the single quantity (via closestFraction) otherwise.
+describe('formatIngredientQuantity', () => {
+  it('renders a range with an en dash when maxQty exceeds minQty', () => {
+    expect(formatIngredientQuantity(2, 2, 3)).toBe('2–3')
+    expect(formatIngredientQuantity(1.5, 1.5, 2.5)).toBe('1 1/2–2 1/2')
+  })
+
+  it('renders a single quantity when there is no distinct upper bound', () => {
+    // Non-range parses come back with quantity == minQty == maxQty.
+    expect(formatIngredientQuantity(1.5, 1.5, 1.5)).toBe('1 1/2')
+    // Legacy documents predating range capture carry null bounds.
+    expect(formatIngredientQuantity(0.5, null, null)).toBe('1/2')
+    expect(formatIngredientQuantity(2)).toBe('2')
+  })
+
+  it('returns an empty string when there is no numeric amount', () => {
+    expect(formatIngredientQuantity(null, null, null)).toBe('')
+    expect(formatIngredientQuantity(null)).toBe('')
   })
 })

--- a/src/test/updateIngredients.test.ts
+++ b/src/test/updateIngredients.test.ts
@@ -90,4 +90,17 @@ describe('updateIngredients', () => {
     const scaled = asItem(out)
     expect(scaled.ingredientData?.totalPriceUSACents).toBeCloseTo(33.33, 2)
   })
+
+  it('scales both range bounds so a "2-3" range does not lose its upper end', () => {
+    const ranged: IngredientsType = {
+      id: 'r1',
+      parsedIngredient: { ...parsed(2), minQty: 2, maxQty: 3 },
+      ingredientData: null,
+    }
+    const [out] = updateIngredients([ranged], 2, 4)
+    const scaled = asItem(out)
+    expect(scaled.parsedIngredient.quantity).toBe(4)
+    expect(scaled.parsedIngredient.minQty).toBe(4)
+    expect(scaled.parsedIngredient.maxQty).toBe(6)
+  })
 })

--- a/src/util/formatQuantity.ts
+++ b/src/util/formatQuantity.ts
@@ -64,7 +64,10 @@ export const formatIngredientQuantity = (
   if (minQty != null && maxQty != null && maxQty > minQty) {
     return `${closestFraction(minQty)}–${closestFraction(maxQty)}`
   }
-  if (quantity != null) {
+  // Falsy quantity (null or 0) means "no numeric amount" — e.g. the parser
+  // returns 0 for "salt, to taste". Matches the truthiness guard every renderer
+  // used before this helper, so those rows show just the name, not "0".
+  if (quantity) {
     return closestFraction(quantity)
   }
   return ''

--- a/src/util/formatQuantity.ts
+++ b/src/util/formatQuantity.ts
@@ -62,7 +62,12 @@ export const formatIngredientQuantity = (
   maxQty?: number | null
 ): string => {
   if (minQty != null && maxQty != null && maxQty > minQty) {
-    return `${closestFraction(minQty)}–${closestFraction(maxQty)}`
+    const low = closestFraction(minQty)
+    const high = closestFraction(maxQty)
+    // A narrow range whose bounds round to the same display fraction (e.g.
+    // 0.96–0.99 → "1", or float noise from servings scaling nudging maxQty
+    // barely past minQty) would read as "1–1". Collapse it to the single value.
+    return low === high ? low : `${low}–${high}`
   }
   // Falsy quantity (null or 0) means "no numeric amount" — e.g. the parser
   // returns 0 for "salt, to taste". Matches the truthiness guard every renderer

--- a/src/util/formatQuantity.ts
+++ b/src/util/formatQuantity.ts
@@ -31,6 +31,15 @@ export const closestFraction = (num: number): string => {
       : prev
   })
 
+  // Roll over to the next whole number when the remainder is at least as close
+  // to 1 as it is to the nearest table fraction (which tops out at 7/8). Without
+  // this, decimals in [0.9375, 1) snapped down to "7/8" instead of rounding up
+  // — e.g. 0.95 → "1", 1.96 → "2". The 0.9375 midpoint ties toward rounding up.
+  const closestDistance = Math.abs(closest.num / closest.den - decimal)
+  if (1 - decimal <= closestDistance) {
+    return (wholeNum + 1).toString()
+  }
+
   const numerator = closest.num
   const denominator = closest.den
   const gcd = (a: number, b: number): number => (b === 0 ? a : gcd(b, a % b))
@@ -39,4 +48,24 @@ export const closestFraction = (num: number): string => {
   return `${wholeNum ? wholeNum + ' ' : ''}${numerator / divisor}/${
     denominator / divisor
   }`
+}
+
+// Renders an ingredient amount for display, honouring a captured quantity range
+// (e.g. "2-3 cups") when the parser recorded a distinct upper bound. A range is
+// present when `maxQty` exceeds `minQty`; otherwise the single `quantity` is
+// shown. Returns '' when there is no numeric amount (e.g. "salt, to taste").
+// This is the one place ranges get rendered — SingleRecipe, the printable view,
+// and the add-recipe row all route through it so a "2-3" never collapses to "2".
+export const formatIngredientQuantity = (
+  quantity: number | null,
+  minQty?: number | null,
+  maxQty?: number | null
+): string => {
+  if (minQty != null && maxQty != null && maxQty > minQty) {
+    return `${closestFraction(minQty)}–${closestFraction(maxQty)}`
+  }
+  if (quantity != null) {
+    return closestFraction(quantity)
+  }
+  return ''
 }

--- a/src/util/updateIngredients.ts
+++ b/src/util/updateIngredients.ts
@@ -12,33 +12,33 @@ export const updateIngredients = (
 
   const updatedIngredients: IngredientsType[] = ingredients.map(ingr => {
     if ('parsedIngredient' in ingr) {
-      let quantity = null
-      let price = null
-
-      if (ingr.parsedIngredient.quantity) {
-        quantity = ingr.parsedIngredient.quantity * fractionMulti
-      }
-
-      if (ingr?.ingredientData?.totalPriceUSACents) {
-        price = (fractionMulti * ingr.ingredientData.totalPriceUSACents)
-          .toFixed(2)
-          .toString()
-      }
-
-      let updatedIngredientData: IngredientData | null = structuredClone(
+      const updatedIngredientData: IngredientData | null = structuredClone(
         ingr.ingredientData,
       )
-      let updatedParsedIngredient: ParsedIngredient = structuredClone(
+      const updatedParsedIngredient: ParsedIngredient = structuredClone(
         ingr.parsedIngredient,
       )
-      if (price && quantity) {
-        // If quantity exists, updatedIngredientData will exist
-        updatedIngredientData!.totalPriceUSACents = Number(price)
-        updatedParsedIngredient.quantity = quantity
-      } else if (price) {
-        updatedIngredientData!.totalPriceUSACents = Number(price)
-      } else if (quantity) {
-        updatedParsedIngredient.quantity = quantity
+
+      // Scale the quantity and both range bounds so a "2-3 cups" range rescales
+      // to e.g. "4-6 cups" instead of dropping its upper bound. Null/zero
+      // amounts (e.g. "salt, to taste") have nothing to scale.
+      if (updatedParsedIngredient.quantity) {
+        updatedParsedIngredient.quantity =
+          updatedParsedIngredient.quantity * fractionMulti
+      }
+      if (updatedParsedIngredient.minQty) {
+        updatedParsedIngredient.minQty =
+          updatedParsedIngredient.minQty * fractionMulti
+      }
+      if (updatedParsedIngredient.maxQty) {
+        updatedParsedIngredient.maxQty =
+          updatedParsedIngredient.maxQty * fractionMulti
+      }
+
+      if (updatedIngredientData?.totalPriceUSACents) {
+        updatedIngredientData.totalPriceUSACents = Number(
+          (fractionMulti * updatedIngredientData.totalPriceUSACents).toFixed(2),
+        )
       }
 
       return {


### PR DESCRIPTION
Wave 9 · **B4** — the quantity-rendering lane from the [2026-07-09 bug hunt](../blob/development/docs/sweeps/BUG_HUNT_2026-07-09.md) (findings I2 + I3).

## I2 — `closestFraction` never rounded up past 7/8
`closestFraction` snapped every fractional remainder to one of 9 table entries topping out at 7/8, so decimals in `[0.9375, 1)` rendered **"7/8"** instead of rounding up — `0.95 lb` → "7/8 lb", `1.96` → "1 7/8". `parseIngredientString` returns literal decimals, so directly-typed amounts were distorted too.

**Fix:** roll over to the next whole number when the remainder is at least as close to 1 as to the nearest table fraction (the 0.9375 midpoint ties toward rounding up). `0.95` → "1", `1.96` → "2". Sub-threshold values are unchanged — `1.9` → "1 7/8" (genuinely nearest to 1⅞).

## I3 — ingredient ranges flattened to the low end everywhere
`ParsedIngredient` carries `minQty`/`maxQty` but no renderer read them, so **"2-3 cups flour"** displayed as **"2 cups flour"** on the recipe page, the printable view, and the add-recipe row — silently dropping the "-3" the author typed.

**Fix:** new `formatIngredientQuantity()` in `formatQuantity.ts` is the single display entry point — renders `min–max` (en dash) when the parser captured a distinct upper bound, else the single `quantity`, else `''`. Routed `SingleRecipe`, `PrintableRecipe`, and `IngredientItemText` (+ its `IngredientItem` caller) through it. `updateIngredients` now scales `minQty`/`maxQty` alongside `quantity`, so a range rescales with servings (**2–3 → 4–6**) instead of losing its upper bound.

## Tests
- `closestFraction`: rollover cases (0.95/0.99/1.96 → whole; 0.9375 midpoint up; 0.9/0.875 still 7/8).
- `formatIngredientQuantity`: range / single (incl. null-bound legacy docs) / empty.
- `updateIngredients`: range scaling keeps both bounds.
- Gates: `tsc` clean, Vitest 682 passed, `npm run build` ✓.

## Runtime verification (headless, real client+API on dev)
Created a recipe with `2-3 cups flour` + `0.95 lb beef`:
- AddRecipe row → **"2–3 cup flour"**, **"1 pound beef"**
- SingleRecipe @ 4 servings → same
- After doubling servings → **"4–6 cup flour"** (range scaled)

(The nutrition 503s seen during verification are the Edamam proxy being retired — unrelated; the recipe saved fine.)

https://claude.ai/code/session_01XmdmH3rveCU2BbU2x8m8ee