### PR TITLE
fix(account): filter recipes/ratings badge counts to match their tab lists (B6)

### DIFF
--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -373,8 +373,8 @@ describe('GET /getCreatedRecipes', () => {
 describe('getAccountCountsFor', () => {
   it("counts a user's ratings by their stable userId (D1)", async () => {
     await seedUser(TEST_UID, 'testuser')
-    await seedRating({ userId: TEST_UID, username: 'testuser', recipeId: 'x', rating: 5 })
     await seedRecipes([{ _id: 'c1', userId: TEST_UID }])
+    await seedRating({ userId: TEST_UID, username: 'testuser', recipeId: 'c1', rating: 5 })
 
     const counts = await getAccountCountsFor(getDB(), TEST_UID)
     expect(counts.ratings).toBe(1)
@@ -477,5 +477,57 @@ describe('GET /getAccountCounts', () => {
     const res = await request(app).get('/api/getAccountCounts').set(AUTH_HEADER)
     expect(res.status).toBe(200)
     expect(res.body.saved).toBe(1)
+  })
+
+  it('excludes hidden/unpublished (but keeps pending_review) recipes from the recipes badge (matches getCreatedRecipes)', async () => {
+    // getCreatedRecipes (the Your-Recipes tab list) filters RECIPE_OWNER_VISIBLE:
+    // takedowns/de-publishes drop, but the owner still sees their own
+    // pending_review recipes — the badge must match exactly.
+    await seedUser(TEST_UID, 'testuser')
+    await seedRecipes([
+      { _id: 'published', userId: TEST_UID },
+      { _id: 'pending', userId: TEST_UID, status: 'pending_review' },
+      { _id: 'hidden', userId: TEST_UID, status: 'hidden' },
+      { _id: 'unpublished', userId: TEST_UID, status: 'unpublished' },
+    ])
+
+    const res = await request(app).get('/api/getAccountCounts').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.recipes).toBe(2)
+  })
+
+  it('excludes ratings on hidden/unpublished/pending_review recipes from the ratings badge (matches the Ratings tab)', async () => {
+    // getSingleUserReviews's returnRecipeData join drops any rating whose
+    // recipe isn't RECIPE_VISIBLE — the badge must match.
+    await seedUser(TEST_UID, 'testuser')
+    await seedRecipes([
+      { _id: 'vis', userId: 'other' },
+      { _id: 'pending', userId: 'other', status: 'pending_review' },
+      { _id: 'hid', userId: 'other', status: 'hidden' },
+    ])
+    await seedRating({ userId: TEST_UID, username: 'testuser', recipeId: 'vis', rating: 5 })
+    await seedRating({ userId: TEST_UID, username: 'testuser', recipeId: 'pending', rating: 4 })
+    await seedRating({ userId: TEST_UID, username: 'testuser', recipeId: 'hid', rating: 3 })
+
+    const res = await request(app).get('/api/getAccountCounts').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.ratings).toBe(1)
+  })
+
+  it('excludes moderation-hidden ratings from the ratings badge', async () => {
+    await seedUser(TEST_UID, 'testuser')
+    await seedRecipes([{ _id: 'c1', userId: 'other' }])
+    await seedRating({ userId: TEST_UID, username: 'testuser', recipeId: 'c1', rating: 5 })
+    await seedRating({
+      userId: TEST_UID,
+      username: 'testuser',
+      recipeId: 'c1',
+      rating: 1,
+      moderationHidden: true,
+    })
+
+    const res = await request(app).get('/api/getAccountCounts').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.ratings).toBe(1)
   })
 })

--- a/server/util/accountCounts.js
+++ b/server/util/accountCounts.js
@@ -4,11 +4,19 @@
 // entry points:
 //
 //  • getAccountCountsFor      → the account-page tab badges. Each count should
-//    match the length of the list its tab renders. `saved` counts only saved
-//    recipes that are still publicly visible, matching the Saved tab's own
-//    totalCount (server/routes/users.js): a soft-hidden saved recipe drops from
-//    the list, so counting it in the badge left the badge reading higher than
-//    the grid it sits on.
+//    match the length of the list its tab renders:
+//      - saved:   only saved recipes still publicly visible, matching the
+//        Saved tab's own totalCount (server/routes/users.js).
+//      - recipes: owner-visible recipes only (RECIPE_OWNER_VISIBLE), matching
+//        getCreatedRecipes (server/routes/users.js) — excludes takedowns/
+//        de-publishes but still counts the owner's own pending_review recipes.
+//      - ratings: REVIEW_VISIBLE ratings whose recipe is still publicly
+//        visible (RECIPE_VISIBLE), matching the Ratings-tab list
+//        (getSingleUserReviews's returnRecipeData join, server/routes/reviews.js)
+//        — a rating on a since-hidden recipe drops from that list, so it must
+//        drop from the badge too.
+//    Un-filtered counts here previously left a badge reading higher than the
+//    grid it sits on.
 //
 //  • getGamificationCountsFor → XP / level / achievements. These must reflect
 //    real, still-visible accomplishments so awards don't overstate, CAN be
@@ -23,7 +31,7 @@
 // Everything keys on the stable uid (ratings carry `userId` since D1), so no
 // username round-trip is needed.
 
-const { RECIPE_VISIBLE, REVIEW_VISIBLE } = require('./moderation')
+const { RECIPE_VISIBLE, RECIPE_OWNER_VISIBLE, REVIEW_VISIBLE } = require('./moderation')
 const { recipeIdInQuery } = require('./recipeIdQuery')
 
 // Count the user's saved recipes whose underlying recipe is still publicly
@@ -40,14 +48,32 @@ async function countVisibleSaved(db, uid) {
     .countDocuments({ ...recipeIdInQuery(ids), ...RECIPE_VISIBLE })
 }
 
-// Tab-badge counts: { saved, ratings, recipes, drafts }. `saved` is
-// visibility-filtered to match the Saved tab list; 0 where the user has none.
+// Count the user's non-hidden ratings whose underlying recipe is still
+// publicly visible. Ratings carry a unique { userId, recipeId } index (one
+// rating per user per recipe — docs/DATA_INTEGRITY_AUDIT.md), so counting
+// visible recipes among the user's rated ids gives the same count as
+// filtering the rating rows directly. Same shape as countVisibleSaved.
+async function countVisibleRatings(db, uid) {
+  const ids = await db
+    .collection('ratings')
+    .find({ userId: uid, ...REVIEW_VISIBLE }, { projection: { recipeId: 1 } })
+    .map((r) => r.recipeId)
+    .toArray()
+  if (ids.length === 0) return 0
+  return db
+    .collection('recipes')
+    .countDocuments({ ...recipeIdInQuery(ids), ...RECIPE_VISIBLE })
+}
+
+// Tab-badge counts: { saved, ratings, recipes, drafts }. `saved`/`recipes`/
+// `ratings` are each visibility-filtered to match their tab's list; 0 where
+// the user has none.
 async function getAccountCountsFor(db, uid) {
   const [saved, recipes, drafts, ratings] = await Promise.all([
     countVisibleSaved(db, uid),
-    db.collection('recipes').countDocuments({ userId: uid }),
+    db.collection('recipes').countDocuments({ userId: uid, ...RECIPE_OWNER_VISIBLE }),
     db.collection('recipeDrafts').countDocuments({ userId: uid }),
-    db.collection('ratings').countDocuments({ userId: uid }),
+    countVisibleRatings(db, uid),
   ])
 
   return { saved, ratings, recipes, drafts }


### PR DESCRIPTION
## Summary
- `getAccountCountsFor`'s `recipes` badge now filters `RECIPE_OWNER_VISIBLE`, matching `getCreatedRecipes` (the Your-Recipes tab list) — excludes takedowns/de-publishes but still counts the owner's own `pending_review` recipes.
- The `ratings` badge now goes through a new `countVisibleRatings`, excluding moderation-hidden ratings and ratings whose recipe isn't `RECIPE_VISIBLE`, matching `getSingleUserReviews`'s `returnRecipeData` join (the Ratings tab list). Ratings carry a unique `{userId, recipeId}` index, so counting visible recipes among the user's rated ids gives the same count as filtering the rating rows directly — same cheap shape as the existing `countVisibleSaved`, no correlated `$lookup` needed.

Same drift class as the `saved` badge fix in #279 — before this, a user with a hidden/unpublished recipe, or a rating on a since-hidden recipe, saw an account-tab badge reading higher than the list it labels.

Board: Wave 9 · B6 (`docs/BACKLOG_ROADMAP.md`), dependent on #279 (merged, which rewrote `accountCounts.js` and added the `saved` filter this mirrors).

## Test plan
- [x] `cd server && npm test` — 846/846 passing (new coverage: pending_review kept / hidden+unpublished excluded from the recipes badge; ratings on hidden/unpublished/pending_review recipes excluded; moderation-hidden ratings excluded)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test -- --run` (Vitest) — 699 passing, 2 pre-existing skips
- [x] `npm run build` — succeeds
- [x] Local code review (medium effort): one simplification finding (duplicated join logic vs. the cheaper id-list pattern) found and fixed before opening this PR

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK