### PR TITLE
fix(drafts): add updatedAt concurrency guard to draft PUT (B5/D2)

### DIFF
--- a/.claude/skills/run-prepify/SKILL.md
+++ b/.claude/skills/run-prepify/SKILL.md
@@ -100,6 +100,43 @@ curl -s "http://localhost:4000/api/recipes?limit=1" | head -c 300
 # e.g. 65302e782ea38768dea80749  ("Homemade Granola")
 ```
 
+## Driving a signed-in flow (auth-gated pages)
+
+Anything behind login (`/add-recipe`, `/account/**`) needs a real Firebase
+session, not just a page load. The app exposes the same bridge Cypress uses:
+
+- Build with `VITE_CYPRESS=true` in `.env` (a Vite dev server needs a restart —
+  not just HMR — to pick up a *new* env var; kill the port and re-run
+  `npm start -- --port <n>`). This attaches `window.__cy_signIn__(customToken)`
+  in `src/client/db.ts`.
+- Mint the custom token with `firebase-admin` (already a root/`server`
+  dependency) against the dev project's service account
+  (`server/.env`'s `FIREBASE_SERVICE_ACCOUNT`) — `getAuth().createCustomToken(uid)`.
+  Do this **in the same script that drives the browser**, and never `console.log`
+  the token/ID token — printing a live credential to the transcript gets
+  blocked by the permission classifier. Keep mint → sign-in → drive in one
+  process.
+- Sign in: `page.goto('/')` first (mounts the bridge) →
+  `page.waitForFunction(() => !!window.__cy_signIn__)` →
+  `page.evaluate(t => window.__cy_signIn__(t), token)` →
+  wait for `.dnav__create` (desktop nav's "Create Recipe" button) to confirm
+  the auth state landed → then `page.goto()` wherever you actually need.
+- **Use the fixture uid `test-cypress-user`**, not an arbitrary uid. A brand
+  new uid has no username yet and the app redirects to `/create-username`
+  instead of rendering the page you wanted (cost 15 minutes to discover this
+  the first time). `test-cypress-user` already has a username + is what
+  `cypress/support/commands.ts`'s `cy.login()` uses, so it's a stable,
+  pre-provisioned dev-Firebase identity.
+- **Two "tabs" of the same user** = two `page`s from one `browser.newContext()`
+  (not two contexts) — Firebase persists the session in that context's
+  storage, so signing in once on `pageA` authenticates `pageB`/`pageC` too.
+  This is the pattern for concurrency/multi-tab bugs (e.g. the B5 draft-PUT
+  guard): drive the real UI in each page rather than curling the API — the
+  bug (and the fix) lives in the browser-side hook, not just the route.
+- Clean up scratch data you create through the real UI when you can (e.g. the
+  Drafts page's per-card `aria-label='Delete draft'` button) rather than
+  leaving debris in the shared dev fixture account.
+
 ## Run (human path)
 
 `npm start` opens the client at http://localhost:3000 in your browser; the API

--- a/server/__tests__/drafts.test.js
+++ b/server/__tests__/drafts.test.js
@@ -119,7 +119,7 @@ describe('POST /api/drafts', () => {
     const res = await request(app)
       .put(`/api/drafts/${mine[0]._id}`)
       .set(AUTH_HEADER)
-      .send({ title: 'edited at cap' })
+      .send({ title: 'edited at cap', updatedAt: now })
     expect(res.status).toBe(200)
     expect(res.body.title).toBe('edited at cap')
   })
@@ -179,7 +179,7 @@ describe('PUT /api/drafts/:id', () => {
     const res = await request(app)
       .put(`/api/drafts/${draft._id}`)
       .set(AUTH_HEADER)
-      .send({ title: 'after', servings: 4 })
+      .send({ title: 'after', servings: 4, updatedAt: '1000' })
     expect(res.status).toBe(200)
     expect(res.body.title).toBe('after')
     expect(res.body.servings).toBe(4)
@@ -200,10 +200,50 @@ describe('PUT /api/drafts/:id', () => {
     const res = await request(app)
       .put(`/api/drafts/${draft._id}`)
       .set(AUTH_HEADER)
-      .send({ title: 'x', userId: 'other-uid', createdAt: '999' })
+      .send({
+        title: 'x',
+        userId: 'other-uid',
+        createdAt: '999',
+        updatedAt: draft.updatedAt,
+      })
     expect(res.status).toBe(200)
     expect(res.body.userId).toBe(TEST_UID)
     expect(res.body.createdAt).toBe('500')
+  })
+
+  it('rejects a PUT with no updatedAt precondition', async () => {
+    const draft = await seedDraft()
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'no version sent' })
+    expect(res.status).toBe(400)
+  })
+
+  it("409s with DRAFT_CONFLICT + the current draft when updatedAt doesn't match — the two-tab clobber this closes (B5/D2)", async () => {
+    const draft = await seedDraft({ title: 'original', updatedAt: '1000' })
+    // Tab A saves first, moving the stored updatedAt forward.
+    const tabA = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'from tab A', updatedAt: '1000' })
+    expect(tabA.status).toBe(200)
+
+    // Tab B still thinks the base version is '1000' (its last known state
+    // before Tab A saved) and tries to overwrite on top of it.
+    const tabB = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'from tab B', updatedAt: '1000' })
+    expect(tabB.status).toBe(409)
+    expect(tabB.body.code).toBe('DRAFT_CONFLICT')
+    expect(tabB.body.draft.title).toBe('from tab A')
+
+    // Tab A's save must survive untouched — the whole point of the guard.
+    const stored = await getDB()
+      .collection('recipeDrafts')
+      .findOne({ _id: draft._id })
+    expect(stored.title).toBe('from tab A')
   })
 
   it('rejects content that exceeds bounds', async () => {

--- a/server/routes/drafts.js
+++ b/server/routes/drafts.js
@@ -85,6 +85,11 @@ router.get('/:id', verifyToken, asyncHandler(async (req, res) => {
 
 // PUT /drafts/:id — overwrite a draft's content (autosave). Owner-only. Only
 // whitelisted content fields are written; userId/createdAt/_id are immutable.
+//
+// The client must echo back the `updatedAt` of the version it's editing from;
+// the update is conditioned on the stored draft still carrying that value, so
+// a tab that's saved on top of a since-changed draft gets a 409 instead of
+// blindly clobbering it with a full `$set` of its (now-stale) content.
 router.put('/:id', verifyToken, requireActive, asyncHandler(async (req, res) => {
   const db = getDB()
   if (!ObjectId.isValid(req.params.id)) {
@@ -105,13 +110,35 @@ router.put('/:id', verifyToken, requireActive, asyncHandler(async (req, res) => 
   if (boundsError) {
     return res.status(400).json({ error: boundsError })
   }
+  const { updatedAt: baseUpdatedAt } = req.body
+  if (typeof baseUpdatedAt !== 'string') {
+    return res.status(400).json({ error: 'Missing updatedAt precondition' })
+  }
   const update = {
     ...pickFields(req.body, RECIPE_CONTENT_FIELDS),
     updatedAt: Date.now().toString(),
   }
   const updated = await db
     .collection('recipeDrafts')
-    .findOneAndUpdate({ _id }, { $set: update }, { returnDocument: 'after' })
+    .findOneAndUpdate(
+      { _id, updatedAt: baseUpdatedAt },
+      { $set: update },
+      { returnDocument: 'after' }
+    )
+  if (!updated) {
+    // Either someone else's save moved `updatedAt` out from under this
+    // request, or the draft was deleted in the interim — distinguish so the
+    // caller doesn't render a conflict banner for a draft that's simply gone.
+    const latest = await db.collection('recipeDrafts').findOne({ _id })
+    if (!latest) {
+      return res.status(404).json({ error: 'Draft not found' })
+    }
+    return res.status(409).json({
+      code: 'DRAFT_CONFLICT',
+      error: 'This draft was updated elsewhere. Reload it to see the latest version.',
+      draft: latest,
+    })
+  }
   res.json(updated)
 }))
 

--- a/src/api/drafts.ts
+++ b/src/api/drafts.ts
@@ -7,6 +7,12 @@ import { http } from 'src/api/http-common'
 // can distinguish "at limit" from a generic save failure.
 export const DRAFT_LIMIT_CODE = 'DRAFT_LIMIT'
 
+// Server-set `code` on the 409 returned when updateDraft's `baseUpdatedAt`
+// no longer matches the stored draft — another tab/session saved on top of it
+// since the caller last fetched (server/routes/drafts.js). The response body
+// also carries the server's current `draft` so the caller can reconcile.
+export const DRAFT_CONFLICT_CODE = 'DRAFT_CONFLICT'
+
 // Client for the recipe-draft endpoints (server/routes/drafts.js). Drafts are
 // the autosaved, in-progress state of the create-recipe flow. The image is not
 // part of a draft — see RecipeDraftContent / AddRecipe autosave.
@@ -17,12 +23,19 @@ class DraftAPIClass {
     return result.data
   }
 
+  // `baseUpdatedAt` is the `updatedAt` of the version being edited from — the
+  // server conditions the write on the stored draft still carrying that value
+  // and 409s (DRAFT_CONFLICT_CODE) if another save has moved it since.
   async updateDraft(
     id: string,
-    content: RecipeDraftContent
+    content: RecipeDraftContent,
+    baseUpdatedAt: string
   ): Promise<RecipeDraftType | null> {
     if (!AuthAPI.getUID()) return null
-    const result = await http.put<RecipeDraftType>(`api/drafts/${id}`, content)
+    const result = await http.put<RecipeDraftType>(`api/drafts/${id}`, {
+      ...content,
+      updatedAt: baseUpdatedAt,
+    })
     return result.data
   }
 

--- a/src/pages/AddRecipe/useDraftAutosave.ts
+++ b/src/pages/AddRecipe/useDraftAutosave.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import axios from 'axios'
 import { RecipeDraftContent, RecipeDraftType } from 'types'
-import DraftAPI, { DRAFT_LIMIT_CODE } from 'src/api/drafts'
+import DraftAPI, { DRAFT_CONFLICT_CODE, DRAFT_LIMIT_CODE } from 'src/api/drafts'
 
 export type DraftStatus = 'idle' | 'saving' | 'saved' | 'error'
 
@@ -63,6 +63,17 @@ function isDraftLimitError(err: unknown): boolean {
   )
 }
 
+// The server rejects an update whose base `updatedAt` no longer matches the
+// stored draft (another tab/session saved on top of it) with a 409 + this code.
+function isDraftConflictError(err: unknown): boolean {
+  return (
+    axios.isAxiosError(err) &&
+    err.response?.status === 409 &&
+    (err.response.data as { code?: string } | undefined)?.code ===
+      DRAFT_CONFLICT_CODE
+  )
+}
+
 type Params = {
   // Serializable draft content derived from the form state (no image).
   content: RecipeDraftContent
@@ -79,12 +90,23 @@ type Params = {
   canCreate: boolean
   // The current draft's id, or null until the first save creates one.
   draftId: string | null
+  // The `updatedAt` of the draft version currently on screen — set alongside
+  // `draftId` by the caller (on resume-load, or from the create response).
+  // Sent as the update precondition; only re-synced when `draftId` itself
+  // changes; a save response bumps the hook's own internal copy in between; see
+  // the effect below.
+  draftUpdatedAt: string | null
   // Called once with the created draft after the first successful save so the
   // caller can adopt the new id (and reflect it in the URL).
   onDraftCreated: (draft: RecipeDraftType) => void
   // Called when creation is rejected because the user is at their draft cap,
   // with the server's message. The caller surfaces it (e.g. a toast).
   onLimitReached?: (message: string) => void
+  // Called when an update is rejected because another tab/session saved newer
+  // content first (the stored `updatedAt` moved since this draft was loaded).
+  // Autosave stops retrying for the rest of the session; the caller should
+  // tell the user to reload the page to see the latest version.
+  onConflict?: (message: string) => void
 }
 
 type DraftAutosave = {
@@ -100,8 +122,10 @@ export function useDraftAutosave({
   enabled,
   canCreate,
   draftId,
+  draftUpdatedAt,
   onDraftCreated,
   onLimitReached,
+  onConflict,
 }: Params): DraftAutosave {
   const [status, setStatus] = useState<DraftStatus>('idle')
 
@@ -115,6 +139,20 @@ export function useDraftAutosave({
   canCreateRef.current = canCreate
   draftIdRef.current = draftId
   enabledRef.current = enabled
+
+  // The `updatedAt` this hook will send as the next update's precondition.
+  // Unlike the refs above, this is deliberately NOT mirrored from the
+  // `draftUpdatedAt` prop on every render — a successful update bumps it
+  // in-place (see saveNow) from the server's response, and re-mirroring the
+  // prop on every keystroke-driven render would clobber that with the stale
+  // value the caller last knew about. It's only re-synced (below) when
+  // `draftId` itself changes, i.e. exactly when the caller hands the hook a
+  // "new" draft (a resume-load, or the create response).
+  const updatedAtRef = useRef(draftUpdatedAt)
+  useEffect(() => {
+    updatedAtRef.current = draftUpdatedAt
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftId])
 
   // Serialized snapshot of the content we last persisted, so a save is skipped
   // when nothing actually changed.
@@ -133,10 +171,17 @@ export function useDraftAutosave({
   // Set once the server rejects creation at the draft cap. Stops further create
   // attempts this session so we don't fire a failing POST on every keystroke.
   const capReachedRef = useRef(false)
+  // Set once an update 409s as a conflict (another tab/session saved newer
+  // content). Stops further autosave attempts against this draft — retrying
+  // would just 409 again on the same stale `updatedAtRef` — until the page is
+  // reloaded to pick up the latest version.
+  const conflictRef = useRef(false)
   const onDraftCreatedRef = useRef(onDraftCreated)
   const onLimitReachedRef = useRef(onLimitReached)
+  const onConflictRef = useRef(onConflict)
   onDraftCreatedRef.current = onDraftCreated
   onLimitReachedRef.current = onLimitReached
+  onConflictRef.current = onConflict
 
   const saveNow = async () => {
     // `enabled` is false in edit mode (and before a resume finishes hydrating);
@@ -148,15 +193,23 @@ export function useDraftAutosave({
     const id = draftIdRef.current
     // Creating a new draft requires draftable content (canCreate) and that
     // we're not already at the cap. Updates to an existing draft are always
-    // allowed.
+    // allowed, unless a prior update already hit a version conflict.
     if (!id && (!canCreateRef.current || capReachedRef.current)) return
+    if (id && conflictRef.current) return
     inFlightRef.current = true
     try {
       setStatus('saving')
       let persisted = false
       if (id) {
-        const updated = await DraftAPI.updateDraft(id, contentRef.current)
+        const updated = await DraftAPI.updateDraft(
+          id,
+          contentRef.current,
+          updatedAtRef.current ?? ''
+        )
         persisted = !!updated
+        if (updated) {
+          updatedAtRef.current = updated.updatedAt
+        }
       } else {
         const created = await DraftAPI.createDraft(contentRef.current)
         if (created) {
@@ -170,9 +223,11 @@ export function useDraftAutosave({
             )
             return
           }
-          // Adopt the id immediately so a save that fires before the parent
-          // re-renders updates this draft instead of creating a second one.
+          // Adopt the id (and its version) immediately so a save that fires
+          // before the parent re-renders updates this draft instead of
+          // creating a second one.
           draftIdRef.current = created._id
+          updatedAtRef.current = created.updatedAt
           onDraftCreatedRef.current(created)
           persisted = true
         }
@@ -196,6 +251,16 @@ export function useDraftAutosave({
             (err.response?.data as { error?: string } | undefined)?.error) ||
           'You have too many saved drafts. Delete some to start a new one.'
         onLimitReachedRef.current?.(message)
+      } else if (isDraftConflictError(err)) {
+        // Another tab/session saved on top of this draft since it was loaded.
+        // Stop autosaving so we don't keep clobbering (or 409ing against) it;
+        // the caller tells the user to reload for the latest version.
+        conflictRef.current = true
+        const message =
+          (axios.isAxiosError(err) &&
+            (err.response?.data as { error?: string } | undefined)?.error) ||
+          'This draft was updated elsewhere. Reload the page to see the latest version.'
+        onConflictRef.current?.(message)
       } else {
         console.error('Draft autosave failed:', err)
       }

--- a/src/pages/AddRecipe/useRecipeForm.ts
+++ b/src/pages/AddRecipe/useRecipeForm.ts
@@ -237,6 +237,11 @@ export function useRecipeForm(initialRecipe?: RecipeType) {
   const [searchParams, setSearchParams] = useSearchParams()
   const urlDraftId = isEditMode ? null : searchParams.get('draftId')
   const [draftId, setDraftId] = useState<string | null>(urlDraftId)
+  // The `updatedAt` of the draft version currently on screen — set alongside
+  // `draftId` (on resume-load below, and from the create response) so
+  // useDraftAutosave has a base version to condition its first update on. See
+  // useDraftAutosave's own tracking of subsequent saves.
+  const [draftUpdatedAt, setDraftUpdatedAt] = useState<string | null>(null)
   // "Hydrated" gates autosave: true for a fresh create, briefly false while a
   // resumed draft loads into the fields.
   const [hydrated, setHydrated] = useState(!urlDraftId)
@@ -264,6 +269,7 @@ export function useRecipeForm(initialRecipe?: RecipeType) {
         ownedDraftsRef.current.add(urlDraftId)
         if (draft) {
           setDraftId(urlDraftId)
+          setDraftUpdatedAt(draft.updatedAt)
           dispatch({
             type: 'HYDRATE',
             values: {
@@ -367,14 +373,17 @@ export function useRecipeForm(initialRecipe?: RecipeType) {
     enabled: !isEditMode && hydrated,
     canCreate: canCreateDraft,
     draftId,
+    draftUpdatedAt,
     onDraftCreated: (draft: RecipeDraftType) => {
       // Mark as owned before the URL sync below points the URL at it, so the
       // hydration effect doesn't reload the draft we just created.
       ownedDraftsRef.current.add(draft._id)
       setDraftId(draft._id)
+      setDraftUpdatedAt(draft.updatedAt)
       queryClient.invalidateQueries({ queryKey: ['drafts'] })
     },
     onLimitReached: (message: string) => toast.error(message),
+    onConflict: (message: string) => toast.error(message),
   })
 
   // Reflect the active draft id in the URL (replace) so a refresh resumes the

--- a/src/test/RecipeDrafts.test.tsx
+++ b/src/test/RecipeDrafts.test.tsx
@@ -43,6 +43,7 @@ vi.mock('src/api/drafts', () => ({
     deleteDraft: vi.fn(),
   },
   DRAFT_LIMIT_CODE: 'DRAFT_LIMIT',
+  DRAFT_CONFLICT_CODE: 'DRAFT_CONFLICT',
 }))
 
 vi.mock('react-top-loading-bar', () => ({ default: () => null }))

--- a/src/test/useDraftAutosave.test.tsx
+++ b/src/test/useDraftAutosave.test.tsx
@@ -14,6 +14,7 @@ vi.mock('src/api/drafts', () => ({
     deleteDraft: vi.fn(),
   },
   DRAFT_LIMIT_CODE: 'DRAFT_LIMIT',
+  DRAFT_CONFLICT_CODE: 'DRAFT_CONFLICT',
 }))
 
 const mockedDraftAPI = DraftAPI as unknown as {
@@ -123,6 +124,7 @@ describe('useDraftAutosave — publish during in-flight create (finding #2)', ()
           enabled: true,
           canCreate: true,
           draftId: null,
+          draftUpdatedAt: null,
           onDraftCreated,
         }),
       { initialProps: { content: { title: '' } as Record<string, unknown> } }
@@ -173,6 +175,7 @@ describe('useDraftAutosave — draft cap (finding #4)', () => {
           enabled: true,
           canCreate: true,
           draftId: null,
+          draftUpdatedAt: null,
           onDraftCreated: vi.fn(),
           onLimitReached,
         }),
@@ -197,5 +200,99 @@ describe('useDraftAutosave — draft cap (finding #4)', () => {
     })
     expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1)
     expect(onLimitReached).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useDraftAutosave — updatedAt concurrency guard (B5)', () => {
+  it("sends the known base updatedAt and bumps it from each response, so the next save's precondition is current", async () => {
+    mockedDraftAPI.updateDraft
+      .mockResolvedValueOnce({ ...createdDraft, updatedAt: '2000' })
+      .mockResolvedValueOnce({ ...createdDraft, updatedAt: '3000' })
+
+    const { rerender } = renderHook(
+      ({ content }) =>
+        useDraftAutosave({
+          content,
+          enabled: true,
+          canCreate: true,
+          draftId: 'existing-draft',
+          draftUpdatedAt: '1000',
+          onDraftCreated: vi.fn(),
+        }),
+      { initialProps: { content: { title: '' } as Record<string, unknown> } }
+    )
+
+    rerender({ content: { title: 'Soup' } })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+    expect(mockedDraftAPI.updateDraft).toHaveBeenNthCalledWith(
+      1,
+      'existing-draft',
+      { title: 'Soup' },
+      '1000'
+    )
+
+    rerender({ content: { title: 'Soup, again' } })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+    // The precondition is the '2000' the first save's response returned, not
+    // the '1000' the hook was originally handed — proves the bump, not a
+    // resend of the stale prop.
+    expect(mockedDraftAPI.updateDraft).toHaveBeenNthCalledWith(
+      2,
+      'existing-draft',
+      { title: 'Soup, again' },
+      '2000'
+    )
+  })
+
+  it('surfaces a conflict and stops autosaving once the server 409s a stale base version', async () => {
+    mockedDraftAPI.updateDraft.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        status: 409,
+        data: {
+          code: 'DRAFT_CONFLICT',
+          error: 'This draft was updated elsewhere.',
+        },
+      },
+    })
+    const onConflict = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ content }) =>
+        useDraftAutosave({
+          content,
+          enabled: true,
+          canCreate: true,
+          draftId: 'existing-draft',
+          draftUpdatedAt: '1000',
+          onDraftCreated: vi.fn(),
+          onConflict,
+        }),
+      { initialProps: { content: { title: '' } as Record<string, unknown> } }
+    )
+
+    rerender({ content: { title: 'Soup' } })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+    expect(mockedDraftAPI.updateDraft).toHaveBeenCalledTimes(1)
+    expect(onConflict).toHaveBeenCalledWith('This draft was updated elsewhere.')
+
+    // Further edits must NOT retry against the same (now-known-stale) draft —
+    // no repeated 409s, and no silent clobber attempt.
+    rerender({ content: { title: 'Soup, one more edit' } })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+    expect(mockedDraftAPI.updateDraft).toHaveBeenCalledTimes(1)
+    expect(onConflict).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- `PUT /drafts/:id` did a full-document `$set` with no version precondition, so two tabs autosaving the same draft would silently clobber each other (last save wins, erasing the other tab's changes) — bug hunt D2, boarded as backlog B5.
- The client now sends the `updatedAt` of the draft version it's editing from; the server conditions the update on the stored draft still carrying that value and 409s with `{code: 'DRAFT_CONFLICT', draft: <latest>}` instead of overwriting (distinguished from a genuine 404 if the draft was deleted in the interim).
- `useDraftAutosave` tracks the known version across saves (bumped from each successful response, re-seeded only when `draftId` itself changes so a stale parent re-render can't clobber it internally), surfaces the conflict via a toast, and stops retrying against that draft until the page reloads.
- Folds a "driving a signed-in flow" recipe into `.claude/skills/run-prepify/SKILL.md` — learned while verifying the fix through a real two-tab browser session (Cypress sign-in bridge, the `test-cypress-user` fixture, shared-context multi-tab pattern).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Vitest full suite green (701/701, 2 pre-existing skips)
- [x] Jest full suite green (845/845)
- [x] `npm run build` succeeds
- [x] New targeted tests: server-side precondition/conflict/missing-version paths; client-side version-bump and conflict-surfacing/stop-retrying behavior
- [x] Live runtime verification against the dev server: direct HTTP two-tab simulation (tab A saves, tab B's stale save 409s, tab A's content survives, normal single-tab path still works)
- [x] Live runtime verification through the real browser UI: three real tabs (one Firebase session) — tab B's conflicting save surfaces the "Couldn't save draft" status + toast, a fresh third tab confirms tab A's edit persisted, not tab B's