### PR TITLE
V6: fix ingredient inline-edit Enter double-submit

### DIFF
--- a/src/pages/AddRecipe/Ingredients/IngredientItem.tsx
+++ b/src/pages/AddRecipe/Ingredients/IngredientItem.tsx
@@ -66,6 +66,16 @@ const IngredientItem: FC<IngredientItemProps> = ({
     return ingredient.parsedIngredient.originalIngredientString
   })
   const editInputRef = useRef<HTMLInputElement>(null)
+  // handleEditSubmit ends by programmatically blur()-ing the input (so a
+  // keyboard Enter-submit also exits edit mode visually). That blur()
+  // synchronously re-fires the same FormInput's onBlur, which is also wired
+  // to submit — without a guard, every Enter-submit double-invokes
+  // handleEditSubmit against the same stale closed-over editedVal/ingredient
+  // (double network call, double toast). This ref is flipped immediately
+  // before the self-triggered blur() and consumed by handleBlur below, so
+  // only a genuine user blur (click-away while editing) reaches
+  // handleEditSubmit a second time.
+  const suppressNextBlurSubmitRef = useRef(false)
 
   // When enrichment last 429'd, hold retryAt (epoch ms) here so the retry
   // button can disable itself instead of immediately re-429ing. Sourced from
@@ -172,7 +182,19 @@ const IngredientItem: FC<IngredientItemProps> = ({
     }
 
     setIsEditing(false)
+    suppressNextBlurSubmitRef.current = true
     editInputRef?.current?.blur()
+  }
+
+  // Wired to FormInput's onBlur. Genuine blur-away (clicking elsewhere while
+  // editing) should still submit; the blur() handleEditSubmit triggers on
+  // itself should not resubmit — see suppressNextBlurSubmitRef above.
+  const handleBlur = () => {
+    if (suppressNextBlurSubmitRef.current) {
+      suppressNextBlurSubmitRef.current = false
+      return
+    }
+    handleEditSubmit()
   }
 
   if (!ingredient) return null
@@ -272,7 +294,7 @@ const IngredientItem: FC<IngredientItemProps> = ({
             val={editedVal}
             setVal={setEditedVal}
             inputRef={editInputRef}
-            onBlur={handleEditSubmit}
+            onBlur={handleBlur}
             onEnter={handleEditSubmit}
           />
           {loading && (

--- a/src/test/IngredientItemEdit.test.tsx
+++ b/src/test/IngredientItemEdit.test.tsx
@@ -124,6 +124,29 @@ describe('IngredientItem inline edit', () => {
     // Reconciled the row in place.
     expect(setIngredients).toHaveBeenCalled()
     expect(mockToastError).not.toHaveBeenCalled()
+    // Pin: Enter-submit must invoke the network call exactly once. Before the
+    // blur-guard fix, handleEditSubmit's own trailing editInputRef.blur()
+    // synchronously re-fired FormInput's onBlur (also wired to submit),
+    // double-calling getIngredientData against the same stale closed-over
+    // editedVal/ingredient — a real duplicate paid lookup.
+    expect(mockGetIngredientData).toHaveBeenCalledTimes(1)
+  })
+
+  it('submits exactly once on genuine blur-away (no Enter)', async () => {
+    mockGetIngredientData.mockResolvedValue(enriched('2 cups flour'))
+    const { container, setItemStatus } = renderItem()
+
+    fireEvent.click(container.querySelector('.item-btn') as HTMLElement)
+    const input = container.querySelector('input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '2 cups flour' } })
+    // Click away without pressing Enter first — a genuine blur.
+    fireEvent.blur(input)
+
+    await waitFor(() =>
+      expect(mockGetIngredientData).toHaveBeenCalledWith('2 cups flour')
+    )
+    await waitFor(() => expect(setItemStatus).toHaveBeenCalledWith('ing-1', null))
+    expect(mockGetIngredientData).toHaveBeenCalledTimes(1)
   })
 
   it('flags the row errored and toasts when the edit enrichment times out', async () => {
@@ -151,11 +174,10 @@ describe('IngredientItem inline edit', () => {
     editTo(container, '2 cups flour')
 
     await waitFor(() => expect(setItemStatus).toHaveBeenCalledWith('ing-1', 'error'))
-    // Not toHaveBeenCalledTimes(1): handleEditSubmit's own trailing
-    // editInputRef.blur() re-fires FormInput's onBlur (wired to the same
-    // handler), double-invoking submit on every edit — a pre-existing quirk
-    // unrelated to B3, tracked separately. Assert the toast content, not the count.
-    expect(mockToastError).toHaveBeenCalled()
+    // The blur-guard (V6) makes this a single submit again: handleEditSubmit's
+    // trailing editInputRef.blur() no longer re-fires FormInput's onBlur into
+    // a second submit.
+    expect(mockToastError).toHaveBeenCalledTimes(1)
     expect(mockToastError.mock.calls[0][0]).toMatch(/lookup limit/i)
   })
 


### PR DESCRIPTION
## Summary

Editing an ingredient inline in AddRecipe double-submitted on Enter: `IngredientItem.tsx`'s `handleEditSubmit` (fired by `FormInput`'s `onEnter`) ended with `setIsEditing(false)` + `editInputRef.current.blur()`, but that `blur()` synchronously re-fires the same `FormInput`'s `onBlur`, which was also wired to `handleEditSubmit`. Every Enter-submit therefore invoked the handler a second time against the same stale closed-over `editedVal`/`ingredient` — identical value resubmitted, enrichment result landing twice, `toast.error` firing twice on error paths, and (the actual cost) a duplicate paid Spoonacular lookup through the parse proxy on every edit.

## Chosen approach

Ref-guard (the cleanest of the filed options): a `suppressNextBlurSubmitRef` is flipped to `true` immediately before `handleEditSubmit`'s own trailing `editInputRef.current.blur()`, and a new `handleBlur` wrapper (now the one actually wired to `FormInput`'s `onBlur`) checks the flag first — if set, it resets it and returns without resubmitting; otherwise it calls `handleEditSubmit` as before. `onEnter` is untouched (still calls `handleEditSubmit` directly). This preserves both behaviors: Enter submits once, and clicking away while editing (a genuine blur, flag not set) still submits once.

## Test evidence

`src/test/IngredientItemEdit.test.tsx`:
- Added `expect(mockGetIngredientData).toHaveBeenCalledTimes(1)` to the existing successful-edit-via-Enter test — **fails at 2 calls pre-fix**, passes at 1 post-fix.
- Added a new test, `submits exactly once on genuine blur-away (no Enter)`, asserting `getIngredientData` is called exactly once when the user clicks away without pressing Enter — this also caught 2 calls pre-fix (the self-triggered blur inside `handleEditSubmit` re-fired even on the blur-away path) and passes at 1 post-fix.
- Tightened the RATE_LIMITED test's toast assertion from `toHaveBeenCalled()` (with a comment explicitly documenting the double-call quirk it was working around) to `toHaveBeenCalledTimes(1)`.

Verified by temporarily reverting only the component fix (`git stash` on `IngredientItem.tsx`) and re-running the suite: 3 of 5 tests failed with "called 2 times" — confirming the tests actually pin the bug, not just assert on the fixed behavior.

## Gates
- `npx tsc --noEmit` — clean
- `npm test` (Vitest, full) — 87 files, 708 passed, 2 skipped
- `npm run build` — succeeds

## Context

Wave 10 batch one (orchestrated). This lane (V6) is scoped to `IngredientItem.tsx`'s edit-submit event flow only; no other files touched. Per lane instructions, `docs/BACKLOG.md` / `docs/BACKLOG_ROADMAP.md` are intentionally not edited here.