### PR TITLE
V4: fold unicode homoglyphs/fullwidth before moderation blocklist matching

### DIFF
--- a/server/__tests__/textModeration.test.js
+++ b/server/__tests__/textModeration.test.js
@@ -101,6 +101,33 @@ describe('moderationBlocklist.checkBlocklist', () => {
     expect(normalizeToken('Fuuuck')).toBe('fuck')
     expect(normalizeToken('SH!T')).toBe('sht')
   })
+
+  it('defeats Cyrillic homoglyph evasion (confusables fold)', () => {
+    // "fuсk" — the middle character is Cyrillic "с" (U+0441), not Latin "c".
+    // Before the unicode fold this bypassed the blocklist entirely: tokenize()
+    // treated the homoglyph as a non-alphanumeric separator, splitting the word
+    // into the harmless tokens "fu" + "k".
+    expect(checkBlocklist('fuсk you', 'review')).toMatchObject({ kind: 'slur' })
+    expect(normalizeToken('fuсk')).toBe('fuck')
+  })
+
+  it('defeats fullwidth evasion (NFKC fold)', () => {
+    // Fullwidth Unicode forms (U+FF00 block) — "ｓｈｉｔ" reads
+    // as "shit" but every char is a distinct fullwidth code point. Before the
+    // NFKC fold this normalized to the empty string (all chars fell outside
+    // `[a-z0-9]`), so the blocklist never saw it.
+    expect(checkBlocklist('ｓｈｉｔ happens', 'review')).toMatchObject({ kind: 'slur' })
+    expect(normalizeToken('ｓｈｉｔ')).toBe('shit')
+  })
+
+  it('does not false-positive on clean non-Latin text', () => {
+    // Legitimate Cyrillic prose (a borscht recipe title, and a review greeting)
+    // must not start tripping the blocklist just because the unicode fold now
+    // runs — the confusables map only swaps a curated handful of lookalike
+    // characters, it does not transliterate whole scripts.
+    expect(checkBlocklist('Классический рецепт борща', 'recipe.title')).toBeNull()
+    expect(checkBlocklist('Привет, это отличный рецепт', 'review')).toBeNull()
+  })
 })
 
 describe('moderateText — gating', () => {

--- a/server/util/moderationBlocklist.js
+++ b/server/util/moderationBlocklist.js
@@ -23,13 +23,46 @@
 //
 // Extend the lists in place; the matching logic below should not need to change.
 
-// Normalize a single token for slur matching: lowercase, fold common leetspeak,
-// collapse 3+ repeated chars to one, and drop anything non-alphanumeric. This
-// makes "F.U.C.K", "fuuuck", and "f4ck" all normalize to the same stem.
+// Curated confusables map: unicode lookalikes commonly used to dodge the
+// blocklist, keyed by the lookalike character and mapped to the ASCII Latin
+// letter it visually mimics. Deliberately NOT a full confusables library (that
+// would be large, easy to get subtly wrong, and risks over-transliterating
+// legitimate non-Latin text) — just the common Cyrillic/Greek lookalikes seen
+// in evasion attempts (e.g. Cyrillic "с" in "fuсk"). Keep it tight and obvious;
+// extend only with confirmed evasion characters, not whole alphabets.
+const CONFUSABLES_MAP = {
+  // Cyrillic lowercase
+  а: 'a', е: 'e', о: 'o', р: 'p', с: 'c', у: 'y', х: 'x', і: 'i', ј: 'j', ѕ: 's', м: 'm', н: 'h',
+  // Cyrillic uppercase
+  А: 'a', В: 'b', Е: 'e', К: 'k', М: 'm', Н: 'h', О: 'o', Р: 'p', С: 'c', Т: 't', У: 'y', Х: 'x',
+  // Greek lowercase
+  α: 'a', β: 'b', ο: 'o', ρ: 'p', υ: 'u', κ: 'k', ν: 'v', ε: 'e',
+  // Greek uppercase
+  Α: 'a', Β: 'b', Ε: 'e', Ζ: 'z', Η: 'h', Ι: 'i', Κ: 'k', Μ: 'm', Ν: 'n', Ο: 'o', Ρ: 'p', Τ: 't', Υ: 'y', Χ: 'x',
+}
+
+// NFKC-normalize (folds compatibility/fullwidth forms — e.g. fullwidth
+// "ｓｈｉｔ" — down to their canonical ASCII form) and swap curated confusable
+// characters for the Latin letter they mimic. Applied to the RAW text/token
+// before any other fold, and in particular before tokenize() below: a
+// homoglyph like Cyrillic "с" is otherwise treated as a non-alphanumeric
+// separator, silently splitting "fuсk" into the harmless tokens "fu" + "k"
+// rather than normalizing it to "fuck".
+function foldUnicode(str) {
+  const nfkc = String(str).normalize('NFKC')
+  let out = ''
+  for (const ch of nfkc) out += CONFUSABLES_MAP[ch] || ch
+  return out
+}
+
+// Normalize a single token for slur matching: unicode-fold (see foldUnicode),
+// lowercase, fold common leetspeak, collapse 3+ repeated chars to one, and drop
+// anything non-alphanumeric. This makes "F.U.C.K", "fuuuck", "f4ck", and the
+// Cyrillic-с "fuсk" all normalize to the same stem.
 const LEET_MAP = { '0': 'o', '1': 'i', '3': 'e', '4': 'a', '5': 's', '7': 't', '@': 'a', $: 's' }
 
 function normalizeToken(token) {
-  return String(token)
+  return foldUnicode(token)
     .toLowerCase()
     .replace(/[01345 7@$]/g, (c) => LEET_MAP[c] || c)
     .replace(/(.)\1{2,}/g, '$1')
@@ -156,7 +189,11 @@ function checkBlocklist(text, context = '') {
   if (!text || typeof text !== 'string') return null
 
   const isIdentity = IDENTITY_CONTEXTS.has(context)
-  const tokens = tokenize(text)
+  // Unicode-fold BEFORE tokenizing (not just inside normalizeToken): tokenize()
+  // splits on any non-ASCII-alphanumeric character, so an un-folded homoglyph
+  // would fragment the word (e.g. Cyrillic-с "fuсk" -> "fu" + "k") before
+  // normalizeToken ever saw it as one token.
+  const tokens = tokenize(foldUnicode(text))
 
   // Per-token pass: exact on every surface, substring per the tier rules above.
   for (const token of tokens) {
@@ -181,6 +218,7 @@ function checkBlocklist(text, context = '') {
 module.exports = {
   checkBlocklist,
   normalizeToken,
+  foldUnicode,
   SLUR_TERMS,
   SUBSTRING_SLURS,
   BENIGN_ALLOWLIST,


### PR DESCRIPTION
## Summary

`normalizeToken` (`server/util/moderationBlocklist.js`) had no NFKC/confusables fold, so unicode evasion silently bypassed the curated blocklist and fell through to the OpenAI moderation layer, which is env-gated and can be off:

- Cyrillic homoglyph: `fuсk` (middle char is Cyrillic "с", U+0441, not Latin "c") — actually worse than a `normalizeToken` gap: `tokenize()` splits on any non-ASCII-alphanumeric character, so the un-folded homoglyph fragmented the word into the harmless tokens `fu` + `k` *before* `normalizeToken` ever saw it as one token.
- Fullwidth: `ｓｈｉｔ` (Unicode fullwidth forms, U+FF00 block) — every char fell outside `[a-z0-9]` and got stripped by the trailing `.replace(/[^a-z0-9]/g, '')`, normalizing to `''`.

Leetspeak (`f4ggot`) and letter-spacing were already covered; this closes the unicode gap. Defense-in-depth only — the OpenAI layer remains the semantic backstop.

## Fix

Added `foldUnicode()`:
1. `String.prototype.normalize('NFKC')` — folds compatibility/fullwidth forms down to their canonical ASCII form (handles the fullwidth case directly).
2. A small curated confusables map (Cyrillic + Greek lookalikes only — `а/е/о/р/с/у/х/...` etc. and their uppercase forms, plus a handful of Greek letters) swapping each lookalike for the Latin letter it mimics. Deliberately **not** a full confusables library — just the common lookalikes used in real evasion attempts, per the filed issue's guidance to keep this a curated map, not a dependency.

**Fold order matters and is applied in two places:**
- Inside `normalizeToken`, before the existing leet/repeat/strip folds (as the ticket specified).
- Also on the raw text in `checkBlocklist`, *before* `tokenize()` splits it — otherwise an un-folded homoglyph is still treated as a token separator and the word never reaches `normalizeToken` intact. This is the part that made the Cyrillic case a two-layer bug, not just a `normalizeToken` gap.

## Tests

Added to `server/__tests__/textModeration.test.js`:
- Cyrillic-с `fuсk` → blocklist hit (`kind: 'slur'`), plus `normalizeToken('fuсk') === 'fuck'`.
- Fullwidth `ｓｈｉｔ` → blocklist hit, plus `normalizeToken('ｓｈｉｔ') === 'shit'`.
- Negative test: clean Cyrillic prose (a borscht recipe title, a review greeting) does **not** false-positive — the confusables map swaps a curated handful of characters, it does not transliterate whole scripts, so legitimate non-Latin text is unaffected.

Full server suite: `cd server && npm test` → **37 suites / 851 tests, all green** (existing blocklist tests unchanged and still passing).

## Notes

Wave 10 batch one (orchestrated, lane V4). Not merging — leaving for review/merge per the batch protocol.

Claude-Session: https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8