### PR TITLE
V2: Guard admin GET /api/reports pagination parameters

### DIFF
--- a/server/__tests__/reports.test.js
+++ b/server/__tests__/reports.test.js
@@ -395,6 +395,93 @@ describe('GET /api/reports', () => {
     expect(res.body.totalCount).toBe(1)
     expect(res.body.reports[0].status).toBe('open')
   })
+
+  it('coerces non-numeric perPage to default (20)', async () => {
+    admin.__setClaims({ admin: true })
+    // Create 30 reports
+    const docs = Array.from({ length: 30 }, () => ({
+      _id: new ObjectId(),
+      targetType: 'recipe',
+      recipeId: `r-${Math.random()}`,
+      reporterUid: 'u1',
+      reason: 'spam',
+      status: 'open',
+      createdAt: new Date(),
+    }))
+    await getDB().collection('reports').insertMany(docs)
+
+    // With perPage=abc, should default to 20
+    const res = await request(app).get('/api/reports?perPage=abc').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.reports.length).toBe(20)
+  })
+
+  it('clamps negative page to 0 (first page)', async () => {
+    admin.__setClaims({ admin: true })
+    await getDB().collection('reports').insertOne({
+      _id: new ObjectId(),
+      targetType: 'recipe',
+      recipeId: 'r1',
+      reporterUid: 'u1',
+      reason: 'spam',
+      status: 'open',
+      createdAt: new Date(),
+    })
+
+    // With page=-1, should return first page (page=0)
+    const res = await request(app).get('/api/reports?page=-1').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.reports.length).toBe(1)
+  })
+
+  it('caps perPage at MAX_PER_PAGE (50)', async () => {
+    admin.__setClaims({ admin: true })
+    // Create 60 reports
+    const docs = Array.from({ length: 60 }, () => ({
+      _id: new ObjectId(),
+      targetType: 'recipe',
+      recipeId: `r-${Math.random()}`,
+      reporterUid: 'u1',
+      reason: 'spam',
+      status: 'open',
+      createdAt: new Date(),
+    }))
+    await getDB().collection('reports').insertMany(docs)
+
+    // With perPage=1000, should cap at 50
+    const res = await request(app).get('/api/reports?perPage=1000').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.reports.length).toBe(50)
+  })
+
+  it('handles page-2 request correctly', async () => {
+    admin.__setClaims({ admin: true })
+    // Create 25 reports, sorted by createdAt (newest first)
+    const now = new Date()
+    const docs = Array.from({ length: 25 }, (_, i) => ({
+      _id: new ObjectId(),
+      targetType: 'recipe',
+      recipeId: `r-${i}`,
+      reporterUid: 'u1',
+      reason: 'spam',
+      status: 'open',
+      createdAt: new Date(now.getTime() + i * 1000),
+    }))
+    await getDB().collection('reports').insertMany(docs)
+
+    // First page with perPage=10
+    const res1 = await request(app).get('/api/reports?page=0&perPage=10').set(AUTH_HEADER)
+    expect(res1.status).toBe(200)
+    expect(res1.body.reports.length).toBe(10)
+
+    // Second page with perPage=10
+    const res2 = await request(app).get('/api/reports?page=1&perPage=10').set(AUTH_HEADER)
+    expect(res2.status).toBe(200)
+    expect(res2.body.reports.length).toBe(10)
+
+    // Reports should be different
+    expect(res2.body.reports[0]._id).not.toBe(res1.body.reports[0]._id)
+  })
 })
 
 describe('PATCH /api/reports/:id', () => {

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -33,18 +33,21 @@ const isAutomodRecipeReport = (r) => r && r.source === 'automod' && r.targetType
 
 const router = Router()
 
+// Hard ceiling on client-requested page sizes (audit §4.5); mirrors recipes.js.
+const MAX_PER_PAGE = 50
+
 // Per-user breadth limiter for filing reports, keyed by req.uid (an independent
 // bucket from the content-write limiters — see middleware/writeLimiter). The
 // one-open-report-per-(reporter,target) rule below already stops re-filing the
 // SAME target, but nothing caps the breadth: one account could open a report
 // against a distinct recipe/user/review every few seconds and bloat the
 // moderation queue, with only the coarse global per-IP backstop applying. 10/min
-// is far above any human's manual report cadence (read → pick a reason → submit)
+// is far above any human’s manual report cadence (read → pick a reason → submit)
 // yet bounds a scripted breadth-spam run hard. Mounted after verifyToken so
 // req.uid is set; skipped under Jest like every makeUserLimiter instance.
 const reportLimiter = makeUserLimiter({
   limit: 10,
-  message: 'You’re filing reports too quickly — wait a minute and try again.',
+  message: "You’re filing reports too quickly - wait a minute and try again.",
 })
 
 // A report targets a recipe, a single review, or a whole user. Reviews have no
@@ -192,8 +195,10 @@ router.get('/reports', verifyToken, requireAdmin, asyncHandler(async (req, res) 
   if (status && ['open', ...RESOLUTIONS].includes(status)) filter.status = status
   if (targetType && TARGET_TYPES.includes(targetType)) filter.targetType = targetType
 
-  const skip = parseInt(page) * parseInt(perPage)
-  const limit = parseInt(perPage)
+  const limit = Math.min(parseInt(perPage) || 20, MAX_PER_PAGE)
+  // Floor at 0 so a negative ?page never produces a negative .skip() (which
+  // MongoDB rejects, surfacing as a 500 instead of a clean first page).
+  const skip = Math.max(0, parseInt(page) || 0) * limit
 
   const [reports, totalCount, openCount] = await Promise.all([
     db.collection('reports').find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit).toArray(),

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -42,12 +42,12 @@ const MAX_PER_PAGE = 50
 // SAME target, but nothing caps the breadth: one account could open a report
 // against a distinct recipe/user/review every few seconds and bloat the
 // moderation queue, with only the coarse global per-IP backstop applying. 10/min
-// is far above any human’s manual report cadence (read → pick a reason → submit)
+// is far above any human's manual report cadence (read → pick a reason → submit)
 // yet bounds a scripted breadth-spam run hard. Mounted after verifyToken so
 // req.uid is set; skipped under Jest like every makeUserLimiter instance.
 const reportLimiter = makeUserLimiter({
   limit: 10,
-  message: "You’re filing reports too quickly - wait a minute and try again.",
+  message: 'You’re filing reports too quickly — wait a minute and try again.',
 })
 
 // A report targets a recipe, a single review, or a whole user. Reviews have no


### PR DESCRIPTION
## Summary

Fixed uncoerced/uncapped pagination parameters in the admin `GET /api/reports` endpoint. The route now validates and guards `page` and `perPage` query parameters to prevent server errors and collection exhaustion attacks.

- `?perPage=abc` no longer throws NaN error; coerces to default (20)
- `?page=-1` no longer produces negative skip; clamps to 0  
- `?perPage=huge` capped at MAX_PER_PAGE (50) to prevent dumping the collection

Mirrors the established pagination pattern in `reviews.js` and `recipes.js` (audit §4.5).

## Test plan

- ✅ Non-numeric perPage coerces to default and returns 20 items
- ✅ Negative page clamps to 0 and returns first page
- ✅ Over-cap perPage (1000) capped at 50 items
- ✅ Normal multi-page pagination works (page-2 request returns different page)
- ✅ Full Jest suite passes (852 tests)

Wave 10, batch one (orchestrated).

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8