### PR TITLE
V7: client-contract nits — query encoding, servings validation, NaN rating, ratings sort

### DIFF
--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -551,9 +551,15 @@ class RecipeAPIClass {
     page: number,
     reviewsPerPage = 5
   ): Promise<{ reviews: ReviewType[]; totalCount: number }> {
-    const result = await http.get(
-      `api/getReviews?recipeId=${recipeId}&page=${page}&reviewsPerPage=${reviewsPerPage}&filter=${filter}`
-    )
+    // Build via URLSearchParams (matches getAllRecipes) so a reserved char in
+    // `filter` can't corrupt the query string.
+    const params = new URLSearchParams({
+      recipeId,
+      page: String(page),
+      reviewsPerPage: String(reviewsPerPage),
+      filter,
+    })
+    const result = await http.get(`api/getReviews?${params.toString()}`)
     const data = result.data
     return data
       ? {
@@ -573,9 +579,16 @@ class RecipeAPIClass {
   ): Promise<{ reviews: OptionalReviewType[]; totalCount: number } | null> {
     const username = await AuthAPI.getUsername()
     if (!username) return null
-    const reviewResult = await http.get(
-      `api/getSingleUserReviews?username=${username}&page=${page}&reviewsPerPage=${reviewsPerPage}&filter=${filter}&returnRecipeData=${returnRecipeData}`
-    )
+    // Build via URLSearchParams (matches getAllRecipes) so a reserved char in
+    // `username`/`filter` can't corrupt the query string.
+    const params = new URLSearchParams({
+      username,
+      page: String(page),
+      reviewsPerPage: String(reviewsPerPage),
+      filter,
+      returnRecipeData: String(returnRecipeData),
+    })
+    const reviewResult = await http.get(`api/getSingleUserReviews?${params.toString()}`)
     const data = reviewResult.data
     return data
       ? {

--- a/src/pages/Account/UserRatings/UserRatings.tsx
+++ b/src/pages/Account/UserRatings/UserRatings.tsx
@@ -103,7 +103,10 @@ const SingleReview: FC<SingleReviewProps> = ({ review, loading }) => {
 
 // Default order: most recently rated first. (The sort control was removed for
 // now; the query keeps this fixed order.)
-const SORT = 'newAdd'
+// NOTE: the server (`getSingleUserReviews`) only recognizes 'new'/'top' — an
+// unrecognized value silently falls through to no sort at all (natural/
+// insertion order), so this must stay one of those two literals.
+const SORT = 'new'
 const Ratings: FC = () => {
   // `showList` stays true across the one-frame gap where the query has settled
   // but the accumulator hasn't populated `reviews` yet, so the "no ratings"

--- a/src/pages/AddRecipe/recipeFormValidation.ts
+++ b/src/pages/AddRecipe/recipeFormValidation.ts
@@ -72,7 +72,19 @@ export function validateRecipeForm(
     errors.description = `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`
   }
 
-  if (!form.servings) errors.servings = 'Servings amount is required'
+  // Servings must be a positive whole number — a truthiness check alone let
+  // negative and fractional values (e.g. -2, 1.5) through. Coerce with Number()
+  // rather than assuming a real `number`: FormInput's generic setVal passes the
+  // raw input string straight through (untyped cast), so `form.servings` is
+  // sometimes a numeric string at runtime despite the `number | ''` type.
+  if (!form.servings) {
+    errors.servings = 'Servings amount is required'
+  } else {
+    const numServings = Number(form.servings)
+    if (!Number.isInteger(numServings) || numServings < 1) {
+      errors.servings = 'Servings must be a whole number of at least 1'
+    }
+  }
   if (!form.prepTime) errors.prepTime = 'Prep time is required'
 
   if (form.ingredients.length <= 0) {

--- a/src/test/AccountSections.loading.test.tsx
+++ b/src/test/AccountSections.loading.test.tsx
@@ -291,6 +291,26 @@ describe('UserRatings — image rendering (Bug A) + empty-state flash', () => {
     expect(screen.getByText('Granola')).toBeInTheDocument()
   })
 
+  it('sends a sort literal the server recognizes ("new", not "newAdd")', async () => {
+    // Regression: the server's getSingleUserReviews only matches on 'new'/'top'
+    // (server/routes/reviews.js) — any other value silently falls through to no
+    // sort at all (natural/insertion order), which Mongo doesn't guarantee.
+    mockedAPI.getSingleUserReviews.mockResolvedValue({
+      reviews: [makeReview({ recipeTitle: 'Granola' })],
+      totalCount: 1,
+    })
+
+    renderWithProviders(<UserRatings />)
+
+    await screen.findByText('Granola')
+    expect(mockedAPI.getSingleUserReviews).toHaveBeenCalledWith(
+      0,
+      5,
+      'new',
+      true
+    )
+  })
+
   it('never flashes the empty state while a load that returns ratings settles', async () => {
     mockedAPI.getSingleUserReviews.mockResolvedValue({
       reviews: [makeReview({ recipeTitle: 'Granola' })],

--- a/src/test/RecipesApi.test.ts
+++ b/src/test/RecipesApi.test.ts
@@ -463,6 +463,31 @@ describe('RecipeAPI.getAllRecipes — query-string encoding', () => {
   })
 })
 
+describe('RecipeAPI.getReviews / getSingleUserReviews — query-string encoding', () => {
+  beforeEach(() => {
+    httpGet.mockReset()
+    httpGet.mockResolvedValue({ data: { reviews: [], totalCount: 0 } })
+  })
+
+  it('getReviews URL-encodes a filter value with reserved characters', async () => {
+    // Aligns with the URLSearchParams convention used by getAllRecipes — a raw
+    // template-string interpolation would let a reserved char in `filter`
+    // corrupt the query string.
+    await RecipeAPI.getReviews('recipe-1', 'new & top', 0, 5)
+    expect(httpGet.mock.calls[0][0]).toBe(
+      'api/getReviews?recipeId=recipe-1&page=0&reviewsPerPage=5&filter=new+%26+top'
+    )
+  })
+
+  it('getSingleUserReviews URL-encodes a username with reserved characters', async () => {
+    vi.mocked(AuthAPI.getUsername).mockResolvedValueOnce('chef & co')
+    await RecipeAPI.getSingleUserReviews(0, 5, 'new', true)
+    expect(httpGet.mock.calls[0][0]).toBe(
+      'api/getSingleUserReviews?username=chef+%26+co&page=0&reviewsPerPage=5&filter=new&returnRecipeData=true'
+    )
+  })
+})
+
 describe('RecipeAPI.getIngredientData — RATE_LIMITED soft-fail (B3)', () => {
   beforeEach(() => {
     httpPost.mockReset()

--- a/src/test/formatRating.test.ts
+++ b/src/test/formatRating.test.ts
@@ -11,6 +11,12 @@ describe('formatRating', () => {
     expect(formatRating(0, 0)).toBe('No Ratings')
   })
 
+  it('falls back to "No Ratings" instead of rendering "NaN" when avg is NaN', () => {
+    // Regression: a NaN average (e.g. a corrupt/legacy rating doc) previously
+    // reached Math.round/.toFixed and rendered the literal string "NaN".
+    expect(formatRating(NaN, 5)).toBe('No Ratings')
+  })
+
   it('rounds to one decimal place', () => {
     expect(formatRating(4.27, 3)).toBe('4.3')
     expect(formatRating(4.24, 3)).toBe('4.2')

--- a/src/test/recipeFormValidation.test.ts
+++ b/src/test/recipeFormValidation.test.ts
@@ -146,6 +146,21 @@ describe('validateRecipeForm', () => {
     )
   })
 
+  it('rejects negative or fractional servings', () => {
+    // Regression: `!form.servings` only caught falsy values, letting negative
+    // and fractional servings (e.g. -2, 1.5) through as "valid". Contract:
+    // servings must be a positive integer (>= 1).
+    expect(
+      validateRecipeForm({ ...validForm(), servings: -2 }).servings
+    ).toBe('Servings must be a whole number of at least 1')
+    expect(
+      validateRecipeForm({ ...validForm(), servings: 1.5 }).servings
+    ).toBe('Servings must be a whole number of at least 1')
+    expect(
+      validateRecipeForm({ ...validForm(), servings: 1 }).servings
+    ).toBeUndefined()
+  })
+
   it('requires prep time, but a truthy {0,0} object (zero total) passes', () => {
     expect(validateRecipeForm({ ...validForm(), prepTime: null }).prepTime).toBe(
       'Prep time is required'

--- a/src/util/formatRating.ts
+++ b/src/util/formatRating.ts
@@ -1,5 +1,5 @@
 export const formatRating = (avg: number, count: number) => {
-  if (avg === 0 || count === 0) {
+  if (avg === 0 || count === 0 || Number.isNaN(avg)) {
     return 'No Ratings'
   }
   const roundedNumber = Math.round(Number(avg) * 10) / 10


### PR DESCRIPTION
Wave 10 batch one (orchestrated). Four small, related client-contract fixes, each with a regression test.

## Items

1. **Unencoded query interpolation** — `RecipeAPI.getReviews`/`getSingleUserReviews` (`src/api/recipes.ts`) now build their query strings via `URLSearchParams`, matching the convention already used in `getAllRecipes`, so a reserved character in `filter`/`username` can't corrupt the query string.
2. **Servings validation** — `recipeFormValidation.ts` now requires `servings` to be a positive integer (>= 1) instead of only a truthiness check, which let negative/fractional values through. Coerces with `Number()` since `FormInput`'s generic `setVal` can hand back a numeric string at runtime despite the `number | ''` type.
3. **`formatRating` NaN render** — falls back to `"No Ratings"` instead of rendering the literal string `"NaN"` when `avg` arrives NaN.
4. **UserRatings sort fold-in** (tech debt, filed 2026-07-09) — `UserRatings.tsx` now sends `sort='new'` instead of the server-unrecognized `'newAdd'`, which previously fell through to no sort at all (natural/insertion order) in `getSingleUserReviews` (`server/routes/reviews.js`).

## Gates
- `npx tsc --noEmit` — clean
- `npm test` — 712 passed, 2 pre-existing skips (unrelated)
- `npm run build` — clean

## Test plan
- [x] `recipeFormValidation.test.ts`: rejects negative/fractional servings, accepts 1
- [x] `formatRating.test.ts`: NaN average falls back to "No Ratings"
- [x] `RecipesApi.test.ts`: `getReviews`/`getSingleUserReviews` URL-encode reserved characters in `filter`/`username`
- [x] `AccountSections.loading.test.tsx`: `UserRatings` calls `getSingleUserReviews` with `sort='new'`