### PR TITLE
V3: fix draft-cap TOCTOU with post-insert recount + overflow trim

### DIFF
--- a/server/__tests__/drafts.test.js
+++ b/server/__tests__/drafts.test.js
@@ -105,6 +105,38 @@ describe('POST /api/drafts', () => {
     expect(res.body.code).toBe('DRAFT_LIMIT')
   })
 
+  it('holds the cap under concurrent POSTs (TOCTOU regression): 5 concurrent creates at 24 existing drafts land exactly 1, reject 4 with 409 DRAFT_LIMIT', async () => {
+    const now = Date.now().toString()
+    const mine = Array.from({ length: 24 }, (_, i) => ({
+      _id: new ObjectId(),
+      userId: TEST_UID,
+      title: `draft ${i}`,
+      createdAt: now,
+      updatedAt: now,
+    }))
+    await getDB().collection('recipeDrafts').insertMany(mine)
+
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        request(app)
+          .post('/api/drafts')
+          .set(AUTH_HEADER)
+          .send({ title: `concurrent ${i}` })
+      )
+    )
+
+    const succeeded = responses.filter((res) => res.status === 201)
+    const rejected = responses.filter((res) => res.status === 409)
+    expect(succeeded).toHaveLength(1)
+    expect(rejected).toHaveLength(4)
+    rejected.forEach((res) => expect(res.body.code).toBe('DRAFT_LIMIT'))
+
+    const finalCount = await getDB()
+      .collection('recipeDrafts')
+      .countDocuments({ userId: TEST_UID })
+    expect(finalCount).toBe(25)
+  })
+
   it('still allows editing an existing draft when at the cap', async () => {
     const now = Date.now().toString()
     const mine = Array.from({ length: 25 }, (_, i) => ({

--- a/server/routes/drafts.js
+++ b/server/routes/drafts.js
@@ -31,17 +31,6 @@ router.post('/', verifyToken, requireActive, asyncHandler(async (req, res) => {
   if (boundsError) {
     return res.status(400).json({ error: boundsError })
   }
-  // Cap the number of drafts per user. 409 + a machine-readable code so the
-  // client can show a specific "delete some drafts" message and stop retrying.
-  const draftCount = await db
-    .collection('recipeDrafts')
-    .countDocuments({ userId: req.uid })
-  if (draftCount >= MAX_DRAFTS_PER_USER) {
-    return res.status(409).json({
-      code: 'DRAFT_LIMIT',
-      error: `You've reached the maximum of ${MAX_DRAFTS_PER_USER} saved drafts. Delete some from your Drafts to start a new one.`,
-    })
-  }
   const now = Date.now().toString()
   const doc = {
     _id: new ObjectId(),
@@ -51,6 +40,44 @@ router.post('/', verifyToken, requireActive, asyncHandler(async (req, res) => {
     updatedAt: now,
   }
   await db.collection('recipeDrafts').insertOne(doc)
+
+  // Cap the number of drafts per user. A plain read-then-insert (count, then
+  // insert if under the cap) is a TOCTOU: concurrent POSTs can all pass the
+  // count before any of them lands, overshooting the cap. Unlike the
+  // save/unsave conditional-filter pattern in recipes.js, there's no single
+  // document to condition an atomic write on here — each draft is its own
+  // document, so a per-request conditional filter can't see sibling requests'
+  // not-yet-committed inserts either.
+  //
+  // Instead, enforce the cap post-insert: insert unconditionally, then
+  // recompute the caller's *current* drafts sorted oldest-first (by _id) and
+  // delete anything beyond the cap. This converges under arbitrary
+  // concurrent interleaving because every pass reads live state and targets
+  // the same well-defined "newest beyond the cap" set — redundant or
+  // out-of-order trims from racing requests agree and are idempotent
+  // (deleting an already-deleted id is a no-op). Whichever requests' docs
+  // land outside the surviving oldest-N find themselves deleted and reply
+  // 409; concurrent POSTs at the cap admit only as many as there's room for.
+  const ids = await db
+    .collection('recipeDrafts')
+    .find({ userId: req.uid }, { projection: { _id: 1 } })
+    .sort({ _id: 1 })
+    .toArray()
+  const overflow = ids.slice(MAX_DRAFTS_PER_USER)
+  if (overflow.length > 0) {
+    await db
+      .collection('recipeDrafts')
+      .deleteMany({ _id: { $in: overflow.map((d) => d._id) } })
+  }
+  const survived = ids
+    .slice(0, MAX_DRAFTS_PER_USER)
+    .some((d) => d._id.equals(doc._id))
+  if (!survived) {
+    return res.status(409).json({
+      code: 'DRAFT_LIMIT',
+      error: `You've reached the maximum of ${MAX_DRAFTS_PER_USER} saved drafts. Delete some from your Drafts to start a new one.`,
+    })
+  }
   res.status(201).json(doc)
 }))
 


### PR DESCRIPTION
## Summary

Closes the 25-draft-per-user cap TOCTOU filed in the Wave 10 test-quality audit (`docs/BACKLOG.md`, lane V3).

`server/routes/drafts.js`'s `POST /` handler enforced the cap with a plain read-then-insert: `countDocuments({ userId })` followed by `insertOne`. Concurrent POSTs arriving at 24 existing drafts could all pass the count check before any of them landed, overshooting the cap.

## Approach

Studied how sibling routes pin races (`docs/CONVENTIONS.md` §3.6, `recipes.js` save/unsave conditional-filter pattern, `collections.js` guarded-push-on-`$expr` pattern). Neither transfers directly: those guard a single array field inside one document, so a conditional filter can see the live state of that one document under the write lock. Drafts are separate top-level documents (`recipeDrafts`), so there's no single document to condition an atomic write on — a per-request conditional filter still can't see a sibling request's not-yet-committed insert into a *different* document.

Chose the "post-insert recount + delete-overflow" fix lane suggested in the filing:

1. Insert the new draft unconditionally.
2. Re-query the caller's current drafts, sorted oldest-first by `_id`, and delete anything beyond the cap (`MAX_DRAFTS_PER_USER = 25`).
3. If the just-inserted doc didn't survive the trim, reply `409 DRAFT_LIMIT` (matches the prior error shape/code); otherwise `201`.

This converges correctly under arbitrary concurrent interleaving: every trim pass reads live DB state and targets the same well-defined "newest-beyond-cap" set (by `_id` order), so redundant or out-of-order trims from racing requests agree and are idempotent (deleting an already-deleted id is a no-op). Existing drafts are never at risk since they always sort before any newly-inserted one. Considered a multi-document transaction instead, but Mongo's default snapshot isolation doesn't serialize independent count-then-insert transactions either (same TOCTOU, just wrapped) without extra locking — the trim approach is simpler and matches the codebase's existing "recompute + reconcile" style used elsewhere (e.g. `collections.js`'s guarded push).

## Test plan

- New Jest test in `server/__tests__/drafts.test.js`: 5 concurrent `POST /api/drafts` at 24 existing drafts → exactly 1 succeeds (201), 4 reject with `409` + `DRAFT_LIMIT`, final count is exactly 25.
- Verified the test fails against the pre-fix code (reverted temporarily): 3/5 succeeded instead of 1, confirming the regression test actually catches the race.
- Ran the new test 5x back-to-back post-fix with no flakes.
- Full gate: `cd server && npm test` → 849/849 passing (37 suites).

Wave 10 batch one (orchestrated, part of a set of parallel worktree lanes). Not merging — leaving for review per the orchestration protocol.

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8