### PR TITLE
V1: recompute servingPrice server-side on addRecipe/editRecipe

### DIFF
--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -672,6 +672,77 @@ describe('POST /addRecipe', () => {
       expect(res.status).toBe(201)
     })
   })
+
+  // V1: the server no longer trusts the client-sent `servingPrice` — it
+  // recomputes it from the submitted ingredients/servings (server/util/
+  // calculateServingPrice.js, a mirror of src/util/calculateServingPrice.ts).
+  describe('server-recomputed servingPrice (V1)', () => {
+    // A fully-priced, real ingredient row (has both `parsedIngredient` and a
+    // non-null `ingredientData` carrying a price) — the only row shape the
+    // recompute counts.
+    const priced = (id, cents) => ({
+      id,
+      parsedIngredient: { originalIngredientString: `${id} ingredient` },
+      ingredientData: { name: id, totalPriceUSACents: cents },
+    })
+    // An errored/unenriched row — still a real parsed ingredient, but the
+    // lookup never resolved. Per the backlog note, these rows are legitimately
+    // publishable by design; the recompute must skip them (contribute $0)
+    // rather than reject the request.
+    const nullRow = (id) => ({
+      id,
+      parsedIngredient: { originalIngredientString: `${id} ingredient` },
+      ingredientData: null,
+      error: { message: 'lookup failed' },
+    })
+
+    it('ignores a lowball client-sent servingPrice and null ingredientData rows, storing the server recompute instead', async () => {
+      const res = await request(server)
+        .post('/api/addRecipe')
+        .set(AUTH_HEADER)
+        .send({
+          title: 'Test Recipe',
+          description: 'A test recipe',
+          // 1000 cents total from the one priced row; the null row must NOT
+          // error the request and must NOT count toward the total.
+          ingredients: [priced('i1', 1000), nullRow('i2')],
+          instructions: [{ content: 'Cook it', index: 1, id: 's1' }],
+          mealTypes: ['dinner'],
+          servings: 4,
+          // A stale-tab / raced-submit / direct-API-caller lowball price that
+          // understates the true cost — the server must not trust this.
+          servingPrice: 1,
+        })
+
+      expect(res.status).toBe(201)
+      const { ObjectId } = require('mongodb')
+      const stored = await getDB().collection('recipes').findOne({ _id: new ObjectId(res.body._id) })
+      // 1000 cents / 4 servings = 250, matching src/util/calculateServingPrice.ts.
+      expect(stored.servingPrice).toBe(250)
+      expect(stored.servingPrice).not.toBe(1)
+    })
+
+    it('matches the client util\'s calculation for an all-enriched ingredient list', async () => {
+      const res = await request(server)
+        .post('/api/addRecipe')
+        .set(AUTH_HEADER)
+        .send({
+          title: 'Test Recipe',
+          description: 'A test recipe',
+          // 600 + 400 = 1000 cents over 4 servings = 250 cents/serving — the
+          // same fixture as src/test/calculateServingPrice.test.ts's first case.
+          ingredients: [priced('i1', 600), priced('i2', 400)],
+          instructions: [{ content: 'Cook it', index: 1, id: 's1' }],
+          mealTypes: ['dinner'],
+          servings: 4,
+        })
+
+      expect(res.status).toBe(201)
+      const { ObjectId } = require('mongodb')
+      const stored = await getDB().collection('recipes').findOne({ _id: new ObjectId(res.body._id) })
+      expect(stored.servingPrice).toBe(250)
+    })
+  })
 })
 
 // ─── PUT /editRecipe ──────────────────────────────────────────────────────────
@@ -813,6 +884,61 @@ describe('PUT /editRecipe', () => {
     expect(stored.userId).toBe(TEST_UID)
     expect(stored._id).toBe(RECIPE_ID)
     expect(stored.createdAt).toBe(OWNED_RECIPE.createdAt)
+  })
+
+  // V1: the edit path recomputes servingPrice too — same helper, same rules.
+  describe('server-recomputed servingPrice (V1)', () => {
+    const priced = (id, cents) => ({
+      id,
+      parsedIngredient: { originalIngredientString: `${id} ingredient` },
+      ingredientData: { name: id, totalPriceUSACents: cents },
+    })
+    const nullRow = (id) => ({
+      id,
+      parsedIngredient: { originalIngredientString: `${id} ingredient` },
+      ingredientData: null,
+      error: { message: 'lookup failed' },
+    })
+
+    it('ignores a lowball client-sent servingPrice and null ingredientData rows on edit', async () => {
+      const res = await request(server)
+        .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+        .set(AUTH_HEADER)
+        .send({
+          ...validEdit(),
+          ingredients: [priced('i1', 1000), nullRow('i2')],
+          servings: 4,
+          servingPrice: 1, // stale/forged lowball — must be ignored
+        })
+
+      expect(res.status).toBe(200)
+      const db = getDB()
+      const stored = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+      expect(stored.servingPrice).toBe(250)
+      expect(stored.servingPrice).not.toBe(1)
+    })
+
+    it('falls back to the recipe\'s existing stored servings when the edit payload omits it', async () => {
+      // OWNED_RECIPE (seeded in beforeEach) carries no `servings` field of its
+      // own; seed one directly so the fallback path has a real value to read.
+      const db = getDB()
+      await db.collection('recipes').updateOne({ _id: RECIPE_ID }, { $set: { servings: 5 } })
+
+      const res = await request(server)
+        .put(`/api/editRecipe?recipeId=${RECIPE_ID}`)
+        .set(AUTH_HEADER)
+        .send({
+          ...validEdit(), // omits `servings` entirely
+          ingredients: [priced('i1', 1000)],
+        })
+
+      expect(res.status).toBe(200)
+      const stored = await db.collection('recipes').findOne({ _id: RECIPE_ID })
+      // 1000 cents / the pre-existing 5 servings = 200, not divided by
+      // something undefined (which would be 0 under the server's guard).
+      expect(stored.servingPrice).toBe(200)
+      expect(stored.servings).toBe(5)
+    })
   })
 })
 

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -17,6 +17,7 @@ const { moderateText } = require('../util/textModeration')
 const { moderateImage } = require('../util/imageModeration')
 const { gatherRecipeText, holdRecipeForReview, respondBlocked, worstVerdict, openAutomodReportQuery, restoreHeldRecipe } = require('../util/automod')
 const { EDITABLE_RECIPE_FIELDS, CREATABLE_RECIPE_FIELDS, pickFields, publicRecipeProjection, publicRecipeCardProjection } = require('../util/recipeFields')
+const { calculateServingPrice } = require('../util/calculateServingPrice')
 const { deleteRecipeImage } = require('../util/firebaseStorage')
 const { teardownRecipeDocs } = require('../util/teardownRecipe')
 const { facetsCache } = require('../util/facetsCache')
@@ -558,6 +559,15 @@ router.post('/addRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncH
     numTimesSaved: 0,
     numTimesMade: 0,
     views: 0,
+    // Server-recomputed from the submitted ingredients/servings, overriding
+    // whatever pickFields just copied from the client body above — the client's
+    // servingPrice is UI-preview-only now (see util/calculateServingPrice, a
+    // mirror of src/util/calculateServingPrice.ts). A stale tab, raced submit,
+    // or a direct API caller can otherwise persist a price inconsistent with
+    // the stored rows (e.g. understated when a lowball price rides along with
+    // unenriched/null ingredientData rows, which are still legitimately
+    // publishable by design).
+    servingPrice: calculateServingPrice(body.ingredients, body.servings),
   }
   await db.collection('recipes').insertOne(docToInsert)
   // A new recipe can introduce a cuisine/diet/mealType the browse filter UI has
@@ -631,9 +641,19 @@ router.put('/editRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncH
   // else the client sends (rating, numTimesSaved, views, userId, _id, …) is
   // ignored. The hold status is NOT set here — holdRecipeForReview owns it, so
   // the recipe is only hidden once its admin-queue report exists.
+  //
+  // servingPrice is server-recomputed, not trusted from the client (see
+  // addRecipe / util/calculateServingPrice). `servings` is optional at this
+  // layer (not in REQUIRED_RECIPE_FIELDS), so an edit that doesn't touch it
+  // won't include it in `body` — fall back to the recipe's current stored
+  // servings so the recompute divides by what will actually be persisted,
+  // not `undefined`. `ingredients` IS required, so body.ingredients is always
+  // present here.
+  const effectiveServings = 'servings' in body ? body.servings : recipe.servings
   const update = {
     ...pickFields(body, EDITABLE_RECIPE_FIELDS),
     editedAt: Date.now().toString(),
+    servingPrice: calculateServingPrice(body.ingredients, effectiveServings),
   }
   // Medium → re-hold as 'pending_review', BUT never downgrade an admin takedown:
   // if the recipe is already 'hidden'/'unpublished', an owner edit must not lift

--- a/server/scripts/backfillServingPrice.js
+++ b/server/scripts/backfillServingPrice.js
@@ -9,10 +9,14 @@
  * recipes already recompute with the corrected formula; this script fixes the
  * docs that haven't been touched since.
  *
- * The recompute below MIRRORS src/util/calculateServingPrice.ts exactly:
+ * The recompute uses server/util/calculateServingPrice.js — itself a hand-kept
+ * mirror of src/util/calculateServingPrice.ts (the server can't import client
+ * TS). That shared helper is also what V1 (server/routes/recipes.js) uses to
+ * recompute `servingPrice` server-side on every create/edit, so this script and
+ * the live routes can't drift apart:
  *   servingPrice = round( sum(ingredient.ingredientData.totalPriceUSACents) / servings )
  * counting only real ingredient rows (those with a `parsedIngredient`) and
- * skipping NaN prices. Keep the two in sync if the util changes.
+ * skipping NaN prices.
  *
  * SAFE BY DEFAULT: this is a DRY RUN unless you pass --apply. The dry run reads
  * only — it counts what would change and prints a sample of before/after values
@@ -32,22 +36,10 @@
 const path = require('path')
 require('dotenv').config({ path: path.join(__dirname, '..', '.env') })
 const { MongoClient } = require('mongodb')
+const { calculateServingPrice } = require('../util/calculateServingPrice')
 
 const APPLY = process.argv.includes('--apply')
 const SAMPLE_LIMIT = 25 // how many before/after rows to print
-
-// Mirror of src/util/calculateServingPrice.ts. Returns whole cents.
-function calculateServingPrice(ingredientsList, numServings) {
-  if (!Array.isArray(ingredientsList) || numServings <= 0) return 0
-  let totalRecipeCents = 0
-  for (const ingr of ingredientsList) {
-    if (ingr && 'parsedIngredient' in ingr && ingr.ingredientData) {
-      const ingrPrice = Number(ingr.ingredientData.totalPriceUSACents)
-      if (!Number.isNaN(ingrPrice)) totalRecipeCents += ingrPrice
-    }
-  }
-  return Math.round(totalRecipeCents / numServings)
-}
 
 const fmt = (cents) =>
   cents == null || Number.isNaN(Number(cents))

--- a/server/util/calculateServingPrice.js
+++ b/server/util/calculateServingPrice.js
@@ -1,0 +1,32 @@
+// Server-side mirror of src/util/calculateServingPrice.ts. The server can't
+// import client TypeScript, so this is a hand-kept port — keep the two in sync
+// if the algorithm ever changes. Used to RECOMPUTE `servingPrice` server-side
+// on create/edit (server/routes/recipes.js) so a stale/forged client-sent price
+// is never trusted, and by the one-off backfill script
+// (server/scripts/backfillServingPrice.js) that corrects historical documents.
+//
+// Semantics (must match the client util exactly):
+//   - numServings <= 0 (or not a finite number) → 0.
+//   - Sum `ingredientData.totalPriceUSACents` across ingredient rows, but only
+//     rows that are real parsed ingredients (`'parsedIngredient' in ingr`) with
+//     a non-null `ingredientData` — label rows and un-enriched/errored rows
+//     (`ingredientData: null`, e.g. a failed lookup the app still lets the user
+//     publish) contribute $0, not an error.
+//   - A non-numeric/NaN totalPriceUSACents on an otherwise-real row is skipped
+//     (also contributes $0) rather than poisoning the sum.
+//   - Result is `Math.round(totalRecipeCents / numServings)`, whole cents.
+function calculateServingPrice(ingredientsList, numServings) {
+  if (!Array.isArray(ingredientsList) || !(Number(numServings) > 0)) return 0
+
+  let totalRecipeCents = 0
+  for (const ingr of ingredientsList) {
+    if (ingr && 'parsedIngredient' in ingr && ingr.ingredientData) {
+      const ingrPrice = Number(ingr.ingredientData.totalPriceUSACents)
+      if (!Number.isNaN(ingrPrice)) totalRecipeCents += ingrPrice
+    }
+  }
+
+  return Math.round(totalRecipeCents / Number(numServings))
+}
+
+module.exports = { calculateServingPrice }


### PR DESCRIPTION
## Summary

Wave 10 batch two, lane V1 (orchestrated). Filed 2026-07-10 off the B1 #281 review.

- The server whitelisted the client-computed `servingPrice` straight from the request body (`pickFields` + range bounds only), so a stale tab, raced submit, or a direct API caller could persist a price inconsistent with the stored ingredient rows — e.g. understated when a lowball price rides along with unenriched/`null` `ingredientData` rows. Those rows stay **legitimately publishable by design**; the server still doesn't reject them.
- Added `server/util/calculateServingPrice.js`, a hand-kept mirror of `src/util/calculateServingPrice.ts` (the server can't import client TS), with a comment naming the client file and the sync requirement.
- Both `POST /addRecipe` and `PUT /editRecipe` (`server/routes/recipes.js`) now recompute `servingPrice` server-side from the submitted `ingredients`/`servings` and store that instead of the client-sent value. The API contract is unchanged — the client may still send `servingPrice`, it's just ignored.
- `PUT /editRecipe` falls back to the recipe's existing stored `servings` when the edit payload omits it (`servings` isn't a required field), so the recompute always divides by what will actually be persisted, not `undefined`.
- `server/scripts/backfillServingPrice.js` previously carried its own duplicate copy of the same recompute logic — refactored it to `require` the new shared helper instead, so the script and the live routes can't drift apart.

## Test plan

- [x] New Jest coverage in `server/__tests__/recipes.test.js`:
  - `addRecipe`: a lowball client-sent `servingPrice` + a `null`-`ingredientData` row is corrected to the server recompute (null row contributes $0, doesn't error the request).
  - `addRecipe`: an all-enriched ingredient list matches the client util's own test fixture (600¢ + 400¢ over 4 servings → 250¢).
  - `editRecipe`: same lowball/null-row correction on the edit path.
  - `editRecipe`: an edit payload that omits `servings` falls back to the recipe's existing stored `servings` for the recompute.
- [x] `cd server && npm test` — 852/852 passing (37 suites).

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8