### PR TITLE
V5: normalize legacy ratings field types (Top-sort BSON-type-order fix)

### DIFF
--- a/server/__tests__/normalizeRatingTypes.test.js
+++ b/server/__tests__/normalizeRatingTypes.test.js
@@ -1,0 +1,202 @@
+/**
+ * V5 — scripts/normalizeRatingTypes.js (legacy `ratings` field-type normalization).
+ *
+ * Runs the exported migration against the suite's in-memory Mongo. Pins the
+ * invariants the prod run depends on:
+ *   - legacy string `rating` / `reviewCreatedAt` are rewritten to numbers, and
+ *     the rewritten values compare/sort by VALUE (single-typed collection)
+ *   - review-only docs (rating: null) and empty-string reviewCreatedAt are LEFT
+ *     alone — never coerced to 0
+ *   - already-numeric docs are never rewritten
+ *   - non-numeric garbage is reported and NOT written (no NaN ever lands)
+ *   - dry run writes nothing; --apply is idempotent (a second run finds 0)
+ */
+const { getDB } = require('../db')
+const {
+  classifyRatingDoc,
+  normalizeRatingTypes,
+} = require('../scripts/normalizeRatingTypes')
+
+const RECIPE = 'recipe-abc'
+
+afterEach(async () => {
+  await getDB().collection('ratings').deleteMany({})
+})
+
+// Convenience: fetch a doc's rating + reviewCreatedAt with their JS types intact.
+async function read(id) {
+  return getDB().collection('ratings').findOne({ _id: id })
+}
+
+describe('classifyRatingDoc (pure)', () => {
+  test('converts stringified rating and reviewCreatedAt to numbers', () => {
+    const { set, garbage } = classifyRatingDoc({
+      rating: '5',
+      reviewCreatedAt: '1677605819601',
+    })
+    expect(set).toEqual({ rating: 5, reviewCreatedAt: 1677605819601 })
+    expect(garbage).toEqual([])
+  })
+
+  test('leaves review-only (null) rating and empty-string createdAt untouched', () => {
+    const { set, garbage } = classifyRatingDoc({ rating: null, reviewCreatedAt: '' })
+    expect(set).toEqual({})
+    expect(garbage).toEqual([])
+  })
+
+  test('no-ops when both fields are already numeric', () => {
+    const { set, garbage } = classifyRatingDoc({ rating: 4.5, reviewCreatedAt: 1677605819601 })
+    expect(set).toEqual({})
+    expect(garbage).toEqual([])
+  })
+
+  test('reports non-numeric garbage and never emits NaN', () => {
+    const { set, garbage } = classifyRatingDoc({
+      rating: 'not-a-number',
+      reviewCreatedAt: 'bogus',
+    })
+    expect(set).toEqual({})
+    expect(garbage).toEqual([
+      { field: 'rating', value: 'not-a-number' },
+      { field: 'reviewCreatedAt', value: 'bogus' },
+    ])
+  })
+
+  test('an absent reviewCreatedAt is not created; a fractional rating string parses', () => {
+    const { set, garbage } = classifyRatingDoc({ rating: '4.5' })
+    expect(set).toEqual({ rating: 4.5 })
+    expect(garbage).toEqual([])
+  })
+
+  test('a mixed doc can convert one field while flagging the other as garbage', () => {
+    const { set, garbage } = classifyRatingDoc({ rating: '5', reviewCreatedAt: 'oops' })
+    expect(set).toEqual({ rating: 5 })
+    expect(garbage).toEqual([{ field: 'reviewCreatedAt', value: 'oops' }])
+  })
+})
+
+describe('normalizeRatingTypes', () => {
+  // A representative mixed-type fixture: two legacy string docs, one modern
+  // numeric doc, one review-only null doc, one rating-first doc (createdAt ""),
+  // and one garbage doc.
+  const fixture = () => [
+    { _id: 'legacy-1', recipeId: RECIPE, userId: 'u1', rating: '5', reviewCreatedAt: '1677605819601' },
+    { _id: 'legacy-2', recipeId: RECIPE, userId: 'u2', rating: '3', reviewCreatedAt: '1677605820000' },
+    { _id: 'modern-1', recipeId: RECIPE, userId: 'u3', rating: 4.5, reviewCreatedAt: 1699999999999 },
+    { _id: 'review-only', recipeId: RECIPE, userId: 'u4', rating: null, reviewCreatedAt: '1680000000000' },
+    { _id: 'rating-first', recipeId: RECIPE, userId: 'u5', rating: 2, reviewCreatedAt: '' },
+    { _id: 'garbage-1', recipeId: RECIPE, userId: 'u6', rating: 'abc', reviewCreatedAt: 'xyz' },
+  ]
+
+  test('dry run (default) writes nothing', async () => {
+    const db = getDB()
+    await db.collection('ratings').insertMany(fixture())
+
+    const { counts } = await normalizeRatingTypes(db)
+
+    // reports the work but performs none. legacy-1/-2 (rating + createdAt) plus
+    // review-only (its createdAt is a numeric string, though its rating stays null).
+    expect(counts.migrated).toBe(3)
+    expect(counts.ratingFixed).toBe(2)
+    expect(counts.createdAtFixed).toBe(3)
+    // every doc is byte-identical to what was seeded
+    expect((await read('legacy-1')).rating).toBe('5')
+    expect((await read('legacy-1')).reviewCreatedAt).toBe('1677605819601')
+    expect((await read('legacy-2')).rating).toBe('3')
+  })
+
+  test('apply converts the mixed-type fixture and leaves nulls / empties / garbage', async () => {
+    const db = getDB()
+    await db.collection('ratings').insertMany(fixture())
+
+    const { counts } = await normalizeRatingTypes(db, { apply: true })
+
+    expect(counts).toMatchObject({
+      scanned: 6,
+      migrated: 3, // legacy-1, legacy-2, review-only (createdAt only)
+      ratingFixed: 2, // legacy-1, legacy-2 (review-only's rating stays null)
+      createdAtFixed: 3, // legacy-1, legacy-2, review-only
+      nullRating: 1,
+      garbageDocs: 1, // garbage-1 has no writable field
+    })
+
+    // legacy strings became numbers, ordered by value
+    const l1 = await read('legacy-1')
+    expect(l1.rating).toBe(5)
+    expect(typeof l1.rating).toBe('number')
+    expect(l1.reviewCreatedAt).toBe(1677605819601)
+    expect(typeof l1.reviewCreatedAt).toBe('number')
+    expect((await read('legacy-2')).rating).toBe(3)
+
+    // modern doc untouched (still numeric, same value)
+    expect((await read('modern-1')).rating).toBe(4.5)
+
+    // review-only stays null (NOT coerced to 0); its createdAt string still
+    // converts because the field is present and numeric-looking
+    const ro = await read('review-only')
+    expect(ro.rating).toBeNull()
+    expect(ro.reviewCreatedAt).toBe(1680000000000)
+
+    // rating-first: numeric rating kept, empty createdAt left as "" (not 0)
+    const rf = await read('rating-first')
+    expect(rf.rating).toBe(2)
+    expect(rf.reviewCreatedAt).toBe('')
+
+    // garbage left exactly as seeded — never NaN
+    const g = await read('garbage-1')
+    expect(g.rating).toBe('abc')
+    expect(g.reviewCreatedAt).toBe('xyz')
+  })
+
+  test('a string rating sorts by value once normalized (the Top-sort bug)', async () => {
+    const db = getDB()
+    // "10" would sort ABOVE numeric 9 lexicographically, but 10 > 9 numerically.
+    await db.collection('ratings').insertMany([
+      { _id: 'a', recipeId: RECIPE, rating: '2' },
+      { _id: 'b', recipeId: RECIPE, rating: 5 },
+      { _id: 'c', recipeId: RECIPE, rating: '4' },
+    ])
+
+    await normalizeRatingTypes(db, { apply: true })
+
+    const sorted = await db
+      .collection('ratings')
+      .find({ recipeId: RECIPE })
+      .sort({ rating: -1 })
+      .project({ rating: 1 })
+      .toArray()
+    // all numeric, descending by value — no string block interleaving
+    expect(sorted.map((d) => d.rating)).toEqual([5, 4, 2])
+  })
+
+  test('apply is idempotent — a second run finds nothing to migrate', async () => {
+    const db = getDB()
+    await db.collection('ratings').insertMany(fixture())
+
+    const first = await normalizeRatingTypes(db, { apply: true })
+    expect(first.counts.migrated).toBe(3)
+
+    const second = await normalizeRatingTypes(db, { apply: true })
+    expect(second.counts.migrated).toBe(0)
+    expect(second.counts.ratingFixed).toBe(0)
+    expect(second.counts.createdAtFixed).toBe(0)
+    // the garbage doc is still flagged on the rescan (needs manual attention)
+    expect(second.counts.garbageDocs).toBe(1)
+  })
+
+  test('garbage values are reported via log, not written', async () => {
+    const db = getDB()
+    await db
+      .collection('ratings')
+      .insertOne({ _id: 'garbage-1', recipeId: RECIPE, rating: 'abc', reviewCreatedAt: 'xyz' })
+
+    const lines = []
+    const { counts } = await normalizeRatingTypes(db, { apply: true, log: (l) => lines.push(l) })
+
+    expect(counts.garbageDocs).toBe(1)
+    expect(counts.migrated).toBe(0)
+    expect(lines.some((l) => l.includes('GARBAGE') && l.includes('rating'))).toBe(true)
+    // unchanged on disk
+    expect((await read('garbage-1')).rating).toBe('abc')
+  })
+})

--- a/server/scripts/normalizeRatingTypes.js
+++ b/server/scripts/normalizeRatingTypes.js
@@ -1,0 +1,263 @@
+/**
+ * V5 — one-off `ratings` field-type normalization (filed 2026-07-09, out of §D).
+ *
+ * Legacy `ratings` docs (pre-#266) store their star `rating` as a STRINGIFIED
+ * number ("5") and `reviewCreatedAt` as a stringified epoch-ms ("1677605819601"),
+ * while post-#266 writes store a real double `rating`; review-only docs carry
+ * `rating: null`. The client normalizes at the API boundary (`coerceRating` in
+ * src/api/recipes.ts) so RENDERING is correct, but the server's "Top" review sort
+ * is a raw `{ rating: -1 }` (server/routes/reviews.js) over the mixed-type field,
+ * and MongoDB orders by BSON TYPE first — so every string rating sorts as a block
+ * above (or below) the numeric ones instead of interleaving by value. User-visible
+ * since #271 exposed "Top" as a sort pill.
+ *
+ * This script rewrites, in place, each legacy doc's string `rating` → double and
+ * string `reviewCreatedAt` → numeric epoch-ms, so the whole collection is single-
+ * typed and `{ rating: -1 }` sorts by value. It does NOT touch the server sort or
+ * the client `coerceRating` — retiring that coercion is a deliberate FOLLOW-UP,
+ * done only after this has run against prod.
+ *
+ * Per-field rules (a doc is classified field-by-field; the two are independent):
+ *   rating:
+ *     - null                     → left as-is (review-only doc; NOT coerced to 0)
+ *     - already a finite double  → no-op (never rewritten)
+ *     - numeric string "5"/"4.5" → rewritten to the double
+ *     - non-numeric / empty ""   → GARBAGE: reported, NOT written (never a NaN)
+ *   reviewCreatedAt:
+ *     - absent                   → left absent (nothing to normalize)
+ *     - "" (rating-first doc)    → left as-is ("no review yet"; NOT coerced to 0)
+ *     - already a finite number  → no-op
+ *     - numeric string           → rewritten to the number
+ *     - non-numeric string       → GARBAGE: reported, NOT written
+ *
+ * SAFE BY DEFAULT: DRY RUN unless you pass --apply. The dry run reads only — it
+ * lists every doc it WOULD rewrite and every garbage value it can't.
+ *
+ * IDEMPOTENT: converted docs are single-typed, so they no longer match the
+ * string-typed rescan — a second --apply run finds nothing to do. Garbage docs
+ * stay string-typed on purpose (they need manual attention), so they keep the
+ * exit code non-zero until resolved — this doubles as a cutover check.
+ *
+ * Usage:
+ *   node server/scripts/normalizeRatingTypes.js            # dry run (default)
+ *   node server/scripts/normalizeRatingTypes.js --apply    # actually write
+ *
+ * Reads MONGO_URI from server/.env (override the DB with DB_NAME, default
+ * "prepify"). Exit code 0 = success, nothing pending afterwards; 2 = docs remain
+ * that need attention (a dry run with candidates, or garbage that can't be
+ * auto-fixed); 1 = error.
+ */
+const path = require('path')
+const { MongoClient } = require('mongodb')
+
+// Cap the per-doc lines so a pathological run can't flood the terminal; the
+// summary counts are always exact and the cap is announced (no silent trim).
+const MAX_LISTED = 100
+
+// Docs the post-run rescan still considers "needs attention": a string `rating`,
+// or a non-empty string `reviewCreatedAt`. After a clean --apply this matches
+// only GARBAGE (non-convertible strings) — convertible ones have become numbers,
+// and review-only nulls / empty-string createdAt were never string-typed here.
+// It can't drive the scan cursor itself (a numeric string and a garbage string
+// share the BSON string type, so classification below decides per doc); this
+// query is only for the post-run remaining-count / exit gate.
+const PENDING_QUERY = {
+  $or: [
+    { rating: { $type: 'string' } },
+    { reviewCreatedAt: { $type: 'string', $ne: '' } },
+  ],
+}
+
+// Parse a value that should be numeric. Returns a finite Number, or null if the
+// value can't be a real number (non-numeric string, empty string, NaN). Mirrors
+// the intent of the client's coerceRating but is stricter: empty string is not a
+// number here, and we never emit a non-finite value.
+function toFiniteNumber(v) {
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null
+  if (typeof v !== 'string') return null
+  if (v.trim() === '') return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+// Classify ONE ratings doc. Returns:
+//   { set }      — the fields to $set (may be empty → nothing to write)
+//   { garbage }  — [{ field, value }] values that should be numeric but aren't
+//                  parseable, so they're reported and left untouched.
+// Pure and side-effect-free so tests can drive it directly.
+function classifyRatingDoc(doc) {
+  const set = {}
+  const garbage = []
+
+  // --- rating ---
+  const r = doc.rating
+  if (r === null || r === undefined) {
+    // review-only (or absent): leave as null — never coerce to 0.
+  } else if (typeof r === 'number') {
+    if (!Number.isFinite(r)) garbage.push({ field: 'rating', value: r })
+    // finite number → already normalized, no-op.
+  } else {
+    // string (legacy) or some unexpected type.
+    const n = toFiniteNumber(r)
+    if (n === null) garbage.push({ field: 'rating', value: r })
+    else set.rating = n
+  }
+
+  // --- reviewCreatedAt ---
+  // Only consider the field when the doc actually carries it; an absent field is
+  // nothing to normalize (and must not be created here).
+  if (Object.prototype.hasOwnProperty.call(doc, 'reviewCreatedAt')) {
+    const t = doc.reviewCreatedAt
+    if (t === '' || t === null || t === undefined) {
+      // "" = rating-first doc with no review yet; leave it (not a 0 timestamp).
+    } else if (typeof t === 'number') {
+      if (!Number.isFinite(t)) garbage.push({ field: 'reviewCreatedAt', value: t })
+      // finite number → already normalized, no-op.
+    } else {
+      const n = toFiniteNumber(t)
+      if (n === null) garbage.push({ field: 'reviewCreatedAt', value: t })
+      else set.reviewCreatedAt = n
+    }
+  }
+
+  return { set, garbage }
+}
+
+// The whole run, separated from process/env wiring so tests can drive it against
+// the in-memory Mongo. Streams every ratings doc, classifies it, and (under
+// --apply) rewrites the mistyped fields with a single per-doc $set. Returns the
+// counts; `log` receives the per-doc lines.
+async function normalizeRatingTypes(db, { apply = false, log = () => {} } = {}) {
+  const counts = {
+    scanned: 0,
+    inSync: 0, // no change needed (already numeric, null, absent, or "")
+    migrated: 0, // docs that got (or would get) at least one field rewritten
+    ratingFixed: 0, // string→double rating conversions
+    createdAtFixed: 0, // string→number reviewCreatedAt conversions
+    nullRating: 0, // review-only docs left null (informational)
+    garbageDocs: 0, // docs with at least one non-parseable field (skipped)
+  }
+  let listed = 0
+
+  const cursor = db
+    .collection('ratings')
+    .find({}, { projection: { rating: 1, reviewCreatedAt: 1, recipeId: 1, userId: 1 } })
+
+  for await (const doc of cursor) {
+    counts.scanned++
+    if (doc.rating === null || doc.rating === undefined) counts.nullRating++
+
+    const { set, garbage } = classifyRatingDoc(doc)
+    const hasWrite = Object.keys(set).length > 0
+
+    if (garbage.length > 0) {
+      counts.garbageDocs++
+      if (listed < MAX_LISTED) {
+        listed++
+        const parts = garbage
+          .map((g) => `${g.field}=${JSON.stringify(g.value)}`)
+          .join(', ')
+        log(`  GARBAGE ${doc._id}: non-numeric ${parts} — left untouched, needs manual review`)
+      } else if (listed === MAX_LISTED) {
+        listed++
+        log('  … (further per-doc lines suppressed; see summary counts)')
+      }
+    }
+
+    if (!hasWrite) {
+      if (garbage.length === 0) counts.inSync++
+      continue
+    }
+
+    counts.migrated++
+    if (set.rating !== undefined) counts.ratingFixed++
+    if (set.reviewCreatedAt !== undefined) counts.createdAtFixed++
+
+    if (listed < MAX_LISTED) {
+      listed++
+      const parts = Object.entries(set)
+        .map(([k, v]) => `${k}→${v} (double)`)
+        .join(', ')
+      log(`  ${apply ? 'wrote ' : 'would '} ${doc._id}: ${parts}`)
+    } else if (listed === MAX_LISTED) {
+      listed++
+      log('  … (further per-doc lines suppressed; see summary counts)')
+    }
+
+    if (apply) {
+      await db.collection('ratings').updateOne({ _id: doc._id }, { $set: set })
+    }
+  }
+
+  return { counts }
+}
+
+async function main() {
+  const APPLY = process.argv.includes('--apply')
+  const uri = process.env.MONGO_URI
+  if (!uri) {
+    console.error('MONGO_URI is not set (looked in server/.env).')
+    process.exit(1)
+  }
+  const dbName = process.env.DB_NAME || 'prepify'
+
+  const client = new MongoClient(uri, {
+    tls: true,
+    serverSelectionTimeoutMS: 5000,
+    socketTimeoutMS: 45000,
+    maxPoolSize: 10,
+  })
+
+  try {
+    await client.connect()
+    const db = client.db(dbName)
+    console.log(
+      `Connected to MongoDB (${dbName}). Mode: ${APPLY ? 'APPLY (writing)' : 'DRY RUN (read-only)'}\n`
+    )
+
+    const { counts } = await normalizeRatingTypes(db, { apply: APPLY, log: console.log })
+
+    // Post-run rescan: docs the collection still holds as string-typed (a numeric
+    // string not yet converted, or a garbage string). After a clean --apply this
+    // is only the garbage docs. In a dry run it's every convertible candidate too.
+    const remaining = await db.collection('ratings').countDocuments(PENDING_QUERY)
+
+    console.log('\nSummary')
+    console.log('───────')
+    const row = (label, val) => console.log(`  ${(label + ':').padEnd(28)}${val}`)
+    row('ratings scanned', counts.scanned)
+    row('already in sync', counts.inSync)
+    row('review-only (rating null)', counts.nullRating)
+    row(APPLY ? 'docs rewritten' : 'docs would rewrite', counts.migrated)
+    row('  rating string→double', counts.ratingFixed)
+    row('  reviewCreatedAt string→num', counts.createdAtFixed)
+    if (counts.garbageDocs) row('GARBAGE (skipped)', counts.garbageDocs)
+    row('string-typed docs remaining', remaining)
+
+    if (!APPLY) {
+      console.log('\nDRY RUN — nothing was written. Re-run with --apply to commit.')
+    } else if (remaining === 0) {
+      console.log('\nDone. `ratings` is single-typed — the Top sort now orders by value.')
+    } else {
+      console.log(
+        '\nDone, but string-typed docs remain (see GARBAGE lines above) — resolve them manually.'
+      )
+    }
+    // 0 only when nothing is left string-typed, so this can gate a cutover step
+    // the same way the other ops scripts do (dry runs with candidates exit 2).
+    process.exit(remaining === 0 ? 0 : 2)
+  } catch (err) {
+    console.error('\nNormalization failed:', err.message)
+    process.exit(1)
+  } finally {
+    await client.close().catch(() => {})
+  }
+}
+
+// Export for unit tests; only load env + run when invoked directly, so a test
+// require doesn't pull real server/.env creds into its process.
+module.exports = { classifyRatingDoc, normalizeRatingTypes, toFiniteNumber, PENDING_QUERY }
+if (require.main === module) {
+  require('dotenv').config({ path: path.join(__dirname, '..', '.env') })
+  main()
+}


### PR DESCRIPTION
## V5 — legacy `ratings` field-type normalization

Filed 2026-07-09 out of the §D reviews overhaul.

### Problem
Legacy `ratings` docs store `rating` as a **stringified number** (`"5"`) and `reviewCreatedAt` as a stringified epoch-ms; post-#266 writes store real numbers; review-only docs are `rating: null`. The client `coerceRating` (`src/api/recipes.ts`) fixes *rendering*, but the server's **"Top"** review sort is a raw `{ rating: -1 }` (`server/routes/reviews.js:277,322`) over the mixed-type field, and MongoDB orders by **BSON type first** — so every string rating sorts as a block above/below the numeric ones instead of interleaving by value. User-visible since #271 exposed "Top" as a sort pill.

### This PR
A one-off ops script — `server/scripts/normalizeRatingTypes.js` — mirroring the shape of `reconcileRatingAggregates.js` / `migrateLegacyRecipeIds.js`:

- **Dry-run by default**, owner-gated `--apply` to write.
- Converts string `rating` → double and string `reviewCreatedAt` → number, in place, one `$set` per doc.
- **Leaves `rating: null` and empty-string `reviewCreatedAt` untouched** — never coerced to 0.
- **Already-numeric docs are no-ops** (never rewritten).
- **Non-numeric garbage** (`"abc"`) is **reported, not written** — no NaN ever lands; garbage docs stay string-typed so they keep the exit code non-zero until resolved.
- **Idempotent** — a second `--apply` run finds 0 to migrate.
- **Exit codes**: `0` = nothing pending, `2` = string-typed docs remain (dry run with candidates, or garbage needing manual attention — usable as a cutover check), `1` = error.

Does **NOT** touch the server sort or the client `coerceRating` — retiring that coercion is a deliberate follow-up after the prod run.

### Testing
`server/__tests__/normalizeRatingTypes.test.js` covers: pure classifier cases, mixed-type fixture migrates correctly, null/empty untouched, already-numeric no-op, garbage reported-not-written, dry-run writes nothing, idempotency, and the value-sort invariant (a `"10"`-style string sorting above a numeric 9 only after conversion). Full server suite green: **859 tests**.

### ⚠️ Owner-gated: the prod `--apply` has NOT been run
This PR ships the **script + tests only**. No real/prod/dev database was connected to during development (Jest uses in-memory Mongo). The `--apply` run against prod is **owner-gated** and is **NOT** part of this change — the owner runs it later, verifying the dry-run output first.

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8