### PR TITLE
V8: draft autosave unload flush + signed-out badge

### DIFF
--- a/src/api/drafts.ts
+++ b/src/api/drafts.ts
@@ -1,6 +1,11 @@
 import { RecipeDraftContent, RecipeDraftType } from 'types'
 import AuthAPI from 'src/api/auth'
-import { http } from 'src/api/http-common'
+import {
+  API_BASE_URL,
+  getCachedIdToken,
+  http,
+  warmIdToken,
+} from 'src/api/http-common'
 
 // Server-set `code` on the 409 returned when a user is at their draft cap
 // (server/routes/drafts.js). createDraft lets this error propagate so callers
@@ -54,6 +59,50 @@ class DraftAPIClass {
   async deleteDraft(id: string): Promise<void> {
     if (!AuthAPI.getUID()) return
     await http.delete(`api/drafts/${id}`)
+  }
+
+  // Warm the cached ID token so a later unload flush can authenticate even if no
+  // autosave request has gone out yet. Best-effort; safe to call repeatedly.
+  warmAuth(): void {
+    if (!AuthAPI.getUID()) return
+    void warmIdToken()
+  }
+
+  // Synchronous, fire-and-forget draft save for page unload (beforeunload /
+  // pagehide). An async axios request won't reliably complete while the page is
+  // being torn down, so this uses `fetch(..., { keepalive: true })`, which the
+  // browser guarantees to run to completion in the background. It mirrors the
+  // normal autosave contract: PUT /drafts/:id (echoing the `baseUpdatedAt`
+  // concurrency precondition the server requires) for an existing draft, or
+  // POST /drafts to create one. The Bearer token is read synchronously from the
+  // cache the axios interceptor maintains (see http-common). Returns false
+  // without firing when no token is available (signed out, or no request has
+  // ever warmed the cache).
+  flushDraftKeepalive(
+    id: string | null,
+    content: RecipeDraftContent,
+    baseUpdatedAt: string
+  ): boolean {
+    if (!AuthAPI.getUID()) return false
+    const token = getCachedIdToken()
+    if (!token) return false
+    const url = id
+      ? `${API_BASE_URL}/api/drafts/${id}`
+      : `${API_BASE_URL}/api/drafts`
+    const body = id ? { ...content, updatedAt: baseUpdatedAt } : content
+    fetch(url, {
+      method: id ? 'PUT' : 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+      keepalive: true,
+    }).catch(() => {
+      // The page is unloading; there's nothing to recover to and no UI left to
+      // surface an error on.
+    })
+    return true
   }
 }
 

--- a/src/api/http-common.ts
+++ b/src/api/http-common.ts
@@ -3,18 +3,49 @@ import { getAuth } from 'firebase/auth'
 import toast from 'react-hot-toast'
 import { Sentry, sentryEnabled } from 'src/util/sentry'
 
+export const API_BASE_URL =
+  import.meta.env.VITE_API_URL || 'http://localhost:4000'
+
 export const http = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:4000',
+  baseURL: API_BASE_URL,
   headers: {
     'Content-type': 'application/json',
   },
 })
+
+// The most recent Firebase ID token, cached synchronously as a side effect of
+// the request interceptor below. `getIdToken()` is async and won't reliably
+// resolve during page unload, so the draft-autosave keepalive flush
+// (src/api/drafts.ts) reads this cached value synchronously to authenticate its
+// fetch. Firebase tokens live ~1h, so a token cached from any recent request is
+// still valid for the flush.
+let cachedIdToken: string | null = null
+
+// The last token the interceptor attached, or null if no authenticated request
+// has gone out yet this session. Used only by the unload keepalive flush.
+export function getCachedIdToken(): string | null {
+  return cachedIdToken
+}
+
+// Proactively populate the token cache so the unload flush has a token even if
+// no authenticated request has happened yet (e.g. the user types and closes the
+// tab within the autosave debounce window). Best-effort and non-throwing.
+export async function warmIdToken(): Promise<void> {
+  try {
+    const user = getAuth().currentUser
+    if (user) cachedIdToken = await user.getIdToken()
+  } catch {
+    // getAuth() throws when no Firebase app is initialized (e.g. in tests);
+    // warming is best-effort, so swallow it.
+  }
+}
 
 http.interceptors.request.use(async config => {
   const auth = getAuth()
   const user = auth.currentUser
   if (user) {
     const token = await user.getIdToken()
+    cachedIdToken = token
     config.headers.set('Authorization', `Bearer ${token}`)
   }
   return config

--- a/src/pages/AddRecipe/DraftSaveStatus.tsx
+++ b/src/pages/AddRecipe/DraftSaveStatus.tsx
@@ -1,4 +1,9 @@
-import { AlertCircleIcon, CheckCircleIcon, CloudIcon } from 'src/Components/icons'
+import {
+  AlertCircleIcon,
+  CheckCircleIcon,
+  CloudIcon,
+  InfoIcon,
+} from 'src/Components/icons'
 import React, { FC } from 'react'
 import { DraftStatus } from 'src/pages/AddRecipe/useDraftAutosave'
 import './DraftSaveStatus.scss'
@@ -12,6 +17,9 @@ const content: Record<
   saving: { icon: <CloudIcon />, label: 'Saving draft…' },
   saved: { icon: <CheckCircleIcon />, label: 'Draft saved' },
   error: { icon: <AlertCircleIcon />, label: "Couldn't save draft" },
+  // Calm guidance, not an error: a signed-out visitor's work can't be autosaved
+  // (drafts are per-user), so point them at signing in rather than alarming them.
+  'signed-out': { icon: <InfoIcon />, label: 'Sign in to save drafts' },
 }
 
 // Small inline indicator beneath the page heading reflecting draft autosave

--- a/src/pages/AddRecipe/useDraftAutosave.ts
+++ b/src/pages/AddRecipe/useDraftAutosave.ts
@@ -160,14 +160,21 @@ export function useDraftAutosave({
   // `draftUpdatedAt` prop on every render — a successful update bumps it
   // in-place (see saveNow) from the server's response, and re-mirroring the
   // prop on every keystroke-driven render would clobber that with the stale
-  // value the caller last knew about. It's only re-synced (below) when
-  // `draftId` itself changes, i.e. exactly when the caller hands the hook a
-  // "new" draft (a resume-load, or the create response).
+  // value the caller last knew about. It re-syncs only when the prop itself
+  // changes (or the draft does): the caller sets `draftUpdatedAt` exactly when
+  // it adopts a fresh server-returned version (resume-hydration, or the create
+  // response), so a prop *change* is always authoritative — while keystroke
+  // renders leave the prop identity untouched and so never re-fire this
+  // effect. `draftUpdatedAt` must be in the deps: when the page mounts with
+  // `?draftId` already in the URL (resuming from the drafts list, or
+  // refreshing a resumed draft), `draftId` never changes after mount — the
+  // hydrated `updatedAt` arrives via this prop alone, and syncing only on
+  // `draftId` left the ref stuck at null, so every autosave sent an empty
+  // precondition and 409'd (found in V8's live verification).
   const updatedAtRef = useRef(draftUpdatedAt)
   useEffect(() => {
     updatedAtRef.current = draftUpdatedAt
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [draftId])
+  }, [draftId, draftUpdatedAt])
 
   // Serialized snapshot of the content we last persisted, so a save is skipped
   // when nothing actually changed.

--- a/src/pages/AddRecipe/useDraftAutosave.ts
+++ b/src/pages/AddRecipe/useDraftAutosave.ts
@@ -3,7 +3,15 @@ import axios from 'axios'
 import { RecipeDraftContent, RecipeDraftType } from 'types'
 import DraftAPI, { DRAFT_CONFLICT_CODE, DRAFT_LIMIT_CODE } from 'src/api/drafts'
 
-export type DraftStatus = 'idle' | 'saving' | 'saved' | 'error'
+export type DraftStatus =
+  | 'idle'
+  | 'saving'
+  | 'saved'
+  | 'error'
+  // No signed-in user: autosave can't run (drafts are per-user), so instead of
+  // firing a doomed save that surfaces as an alarming "Couldn't save draft"
+  // error, we show calm "sign in to save" guidance. See DraftSaveStatus.
+  | 'signed-out'
 
 // How long after the last edit we wait before autosaving. Long enough that
 // typing doesn't fire a request per keystroke, short enough that work isn't
@@ -82,6 +90,10 @@ type Params = {
   // the saved baseline (so resuming a draft, or landing on an empty form,
   // doesn't immediately fire a redundant save).
   enabled: boolean
+  // Whether a user is currently signed in. Drafts are per-user and the API
+  // no-ops without a UID, so when this is false we never attempt a save and
+  // surface calm "sign in to save drafts" copy instead of a scary error badge.
+  isSignedIn: boolean
   // Whether a brand-new draft may be created for the current content. Gated on
   // the form holding any real content (see hasDraftableContent), so an
   // all-default form doesn't spawn a throwaway draft. Only governs creation —
@@ -120,6 +132,7 @@ type DraftAutosave = {
 export function useDraftAutosave({
   content,
   enabled,
+  isSignedIn,
   canCreate,
   draftId,
   draftUpdatedAt,
@@ -129,16 +142,18 @@ export function useDraftAutosave({
 }: Params): DraftAutosave {
   const [status, setStatus] = useState<DraftStatus>('idle')
 
-  // Latest values mirrored into refs so the debounce timer and unmount flush
-  // read current data without being part of their dependency lists.
+  // Latest values mirrored into refs so the debounce timer, unmount flush and
+  // unload flush read current data without being part of their dependency lists.
   const contentRef = useRef(content)
   const canCreateRef = useRef(canCreate)
   const draftIdRef = useRef(draftId)
   const enabledRef = useRef(enabled)
+  const isSignedInRef = useRef(isSignedIn)
   contentRef.current = content
   canCreateRef.current = canCreate
   draftIdRef.current = draftId
   enabledRef.current = enabled
+  isSignedInRef.current = isSignedIn
 
   // The `updatedAt` this hook will send as the next update's precondition.
   // Unlike the refs above, this is deliberately NOT mirrored from the
@@ -186,8 +201,16 @@ export function useDraftAutosave({
   const saveNow = async () => {
     // `enabled` is false in edit mode (and before a resume finishes hydrating);
     // never persist a draft then — most importantly, the unmount flush must not
-    // create a draft out of a recipe the user was only editing.
-    if (!enabledRef.current || disabledRef.current || inFlightRef.current) return
+    // create a draft out of a recipe the user was only editing. `isSignedIn`
+    // guards the same flushes from firing a doomed (UID-less) save that the API
+    // would no-op into a false 'error'.
+    if (
+      !enabledRef.current ||
+      disabledRef.current ||
+      inFlightRef.current ||
+      !isSignedInRef.current
+    )
+      return
     const snapshot = JSON.stringify(contentRef.current)
     if (snapshot === lastSavedRef.current) return
     const id = draftIdRef.current
@@ -295,17 +318,77 @@ export function useDraftAutosave({
       return
     }
     if (JSON.stringify(content) === lastSavedRef.current) return
+    // No signed-in user: a save can't happen. Once the user has typed anything
+    // worth saving (draftable content, or an existing draft), show calm
+    // "sign in to save" guidance rather than scheduling a save that would fail.
+    if (!isSignedIn) {
+      if (draftId || canCreate) setStatus('signed-out')
+      return
+    }
     if (!draftId && (!canCreate || capReachedRef.current)) return
+    // Warm the cached ID token so the unload flush can authenticate its
+    // keepalive fetch even if this debounced save never fires (tab closed first).
+    DraftAPI.warmAuth()
     const timer = setTimeout(saveNow, AUTOSAVE_DELAY)
     return () => clearTimeout(timer)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [content, enabled, draftId, canCreate])
+  }, [content, enabled, draftId, canCreate, isSignedIn])
 
   // Flush pending (debounced) changes when leaving the page mid-edit. saveNow
   // no-ops when autosave isn't enabled, so this is safe in edit mode.
   useEffect(() => {
     return () => {
       void saveNow()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Flush unsaved work on a *hard* leave — refresh, tab/window close, or
+  // navigating away entirely. The unmount flush above only covers in-app (SPA)
+  // navigation; a hard unload tears the component down without running React
+  // cleanup, and even if it did, an async axios save wouldn't complete before
+  // the page dies. So this fires a synchronous keepalive save instead (see
+  // DraftAPI.flushDraftKeepalive). Registered as both `beforeunload` (desktop
+  // refresh/close) and `pagehide` (the reliable mobile/bfcache signal); a guard
+  // prevents the two firing a duplicate flush for the same unload.
+  useEffect(() => {
+    let flushed = false
+    const flush = () => {
+      if (flushed) return
+      // Nothing to do without a live create-mode form and a signed-in user.
+      if (!enabledRef.current || disabledRef.current || !isSignedInRef.current)
+        return
+      if (conflictRef.current) return
+      const id = draftIdRef.current
+      const dirty = JSON.stringify(contentRef.current) !== lastSavedRef.current
+      // No-op when there's nothing pending: no unsaved edits and no save
+      // currently in flight (an in-flight axios save may not survive the unload,
+      // so we still flush to guarantee it lands).
+      if (!dirty && !inFlightRef.current) return
+      if (!id) {
+        // Creating a new draft: needs draftable content and headroom under the
+        // cap. Skip if a create is already in flight — letting the keepalive
+        // create fire too would risk a duplicate draft.
+        if (!canCreateRef.current || capReachedRef.current || inFlightRef.current)
+          return
+      }
+      flushed = DraftAPI.flushDraftKeepalive(
+        id,
+        contentRef.current,
+        updatedAtRef.current ?? ''
+      )
+    }
+    // A bfcache restore reuses the same page; allow a later unload to flush again.
+    const reset = () => {
+      flushed = false
+    }
+    window.addEventListener('beforeunload', flush)
+    window.addEventListener('pagehide', flush)
+    window.addEventListener('pageshow', reset)
+    return () => {
+      window.removeEventListener('beforeunload', flush)
+      window.removeEventListener('pagehide', flush)
+      window.removeEventListener('pageshow', reset)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/src/pages/AddRecipe/useRecipeForm.ts
+++ b/src/pages/AddRecipe/useRecipeForm.ts
@@ -24,6 +24,7 @@ import { hrMinToMin } from 'src/util/hrMinToMin'
 import { minToHrMin } from 'src/util/minToHrMin'
 import RecipeAPI from 'src/api/recipes'
 import DraftAPI from 'src/api/drafts'
+import { useAuth } from 'src/context/AuthContext'
 import {
   useDraftAutosave,
   hasDraftableContent,
@@ -228,6 +229,10 @@ export function useRecipeForm(initialRecipe?: RecipeType) {
 
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  // Drafts are per-user; a signed-out visitor can still open /add-recipe (it's
+  // not auth-guarded), so autosave must know when there's nobody to save for —
+  // it then shows calm "sign in to save" copy instead of erroring.
+  const isSignedIn = !!useAuth()?.user
 
   // ─── Draft autosave (create flow only) ────────────────────────────────────
   // Edit mode never touches drafts. In create mode the form is autosaved to a
@@ -371,6 +376,7 @@ export function useRecipeForm(initialRecipe?: RecipeType) {
   const { status: draftStatus, clearDraft } = useDraftAutosave({
     content: draftContent,
     enabled: !isEditMode && hydrated,
+    isSignedIn,
     canCreate: canCreateDraft,
     draftId,
     draftUpdatedAt,

--- a/src/test/AddRecipe.test.tsx
+++ b/src/test/AddRecipe.test.tsx
@@ -41,6 +41,13 @@ vi.mock('src/api/auth', () => ({
   default: { getUID: vi.fn().mockReturnValue(null) },
 }))
 
+// Signed-in via AuthContext: the D3 tests exercise the *content* gate (does
+// entered content produce a draft?), which the V8 signed-in gate sits in front
+// of — so a signed-in user is what keeps those assertions about autosave valid.
+vi.mock('src/context/AuthContext', () => ({
+  useAuth: () => ({ user: { uid: 'test-uid' } }),
+}))
+
 // Draft autosave hits this API through useDraftAutosave; mocked so the D3
 // tests can assert when a draft is (not) created. Everything resolves null,
 // matching the real client's unauthenticated no-op.
@@ -51,6 +58,8 @@ vi.mock('src/api/drafts', () => ({
     deleteDraft: vi.fn().mockResolvedValue(undefined),
     getDraft: draftGet,
     listDrafts: vi.fn().mockResolvedValue([]),
+    warmAuth: vi.fn(),
+    flushDraftKeepalive: vi.fn(() => true),
   },
   DRAFT_LIMIT_CODE: 'DRAFT_LIMIT',
 }))

--- a/src/test/DraftSaveStatus.test.tsx
+++ b/src/test/DraftSaveStatus.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import DraftSaveStatus from 'src/pages/AddRecipe/DraftSaveStatus'
+
+describe('DraftSaveStatus', () => {
+  it('renders nothing but the reserved slot when idle', () => {
+    const { container } = render(<DraftSaveStatus status='idle' />)
+    const el = container.querySelector('.draft-save-status')
+    expect(el).toBeTruthy()
+    expect(el?.textContent).toBe('')
+    expect(el?.className).toContain('idle')
+  })
+
+  it('shows the calm sign-in copy when signed out (not the error badge)', () => {
+    const { container } = render(<DraftSaveStatus status='signed-out' />)
+    expect(screen.getByText('Sign in to save drafts')).toBeTruthy()
+    const el = container.querySelector('.draft-save-status')
+    expect(el?.className).toContain('signed-out')
+    // The signed-out state must never carry the error class/styling.
+    expect(el?.className).not.toContain('error')
+    expect(screen.queryByText("Couldn't save draft")).toBeNull()
+  })
+
+  it('still shows the error badge for a genuine save failure', () => {
+    render(<DraftSaveStatus status='error' />)
+    expect(screen.getByText("Couldn't save draft")).toBeTruthy()
+  })
+
+  it('reflects the saving and saved states', () => {
+    const { rerender } = render(<DraftSaveStatus status='saving' />)
+    expect(screen.getByText('Saving draft…')).toBeTruthy()
+    rerender(<DraftSaveStatus status='saved' />)
+    expect(screen.getByText('Draft saved')).toBeTruthy()
+  })
+})

--- a/src/test/RecipeDrafts.test.tsx
+++ b/src/test/RecipeDrafts.test.tsx
@@ -34,6 +34,12 @@ vi.mock('src/api/auth', () => ({
   default: { getUID: vi.fn().mockReturnValue('test-uid') },
 }))
 
+// Signed-in via AuthContext too — useRecipeForm gates autosave on useAuth().user
+// (V8): a null user shows "sign in to save drafts" and never autosaves.
+vi.mock('src/context/AuthContext', () => ({
+  useAuth: () => ({ user: { uid: 'test-uid' } }),
+}))
+
 vi.mock('src/api/drafts', () => ({
   default: {
     createDraft: vi.fn(),
@@ -41,6 +47,8 @@ vi.mock('src/api/drafts', () => ({
     listDrafts: vi.fn(),
     getDraft: vi.fn(),
     deleteDraft: vi.fn(),
+    warmAuth: vi.fn(),
+    flushDraftKeepalive: vi.fn(() => true),
   },
   DRAFT_LIMIT_CODE: 'DRAFT_LIMIT',
   DRAFT_CONFLICT_CODE: 'DRAFT_CONFLICT',

--- a/src/test/draftsKeepalive.test.tsx
+++ b/src/test/draftsKeepalive.test.tsx
@@ -1,0 +1,74 @@
+import { vi } from 'vitest'
+import DraftAPI from 'src/api/drafts'
+import AuthAPI from 'src/api/auth'
+import { getCachedIdToken } from 'src/api/http-common'
+import { RecipeDraftContent } from 'types'
+
+// The keepalive flush must not depend on Firebase init or a real axios instance,
+// so stub the auth/token surface it reads. API_BASE_URL is fixed for a stable
+// URL assertion.
+vi.mock('src/api/http-common', () => ({
+  API_BASE_URL: 'http://api.test',
+  http: {},
+  getCachedIdToken: vi.fn(),
+  warmIdToken: vi.fn(),
+}))
+vi.mock('src/api/auth', () => ({
+  default: { getUID: vi.fn() },
+}))
+
+const mockedAuth = AuthAPI as unknown as { getUID: ReturnType<typeof vi.fn> }
+const mockedGetToken = getCachedIdToken as unknown as ReturnType<typeof vi.fn>
+
+const content: RecipeDraftContent = { title: 'Soup', description: 'Cozy' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedAuth.getUID.mockReturnValue('uid-1')
+  mockedGetToken.mockReturnValue('tok-abc')
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(null))))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('DraftAPI.flushDraftKeepalive', () => {
+  it('PUTs an existing draft with the updatedAt precondition and a keepalive Bearer request', () => {
+    const fired = DraftAPI.flushDraftKeepalive('draft-1', content, '1000')
+    expect(fired).toBe(true)
+
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(url).toBe('http://api.test/api/drafts/draft-1')
+    expect(init.method).toBe('PUT')
+    expect(init.keepalive).toBe(true)
+    expect(init.headers.Authorization).toBe('Bearer tok-abc')
+    // The B5 concurrency field must ride along with the content.
+    expect(JSON.parse(init.body)).toEqual({ ...content, updatedAt: '1000' })
+  })
+
+  it('POSTs a brand-new draft (no id) without an updatedAt field', () => {
+    DraftAPI.flushDraftKeepalive(null, content, '')
+
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0]
+    expect(url).toBe('http://api.test/api/drafts')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual(content)
+  })
+
+  it('does not fire without a signed-in user', () => {
+    mockedAuth.getUID.mockReturnValue(null)
+    const fired = DraftAPI.flushDraftKeepalive('draft-1', content, '1000')
+    expect(fired).toBe(false)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('does not fire without a cached token', () => {
+    mockedGetToken.mockReturnValue(null)
+    const fired = DraftAPI.flushDraftKeepalive('draft-1', content, '1000')
+    expect(fired).toBe(false)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/test/useDraftAutosave.test.tsx
+++ b/src/test/useDraftAutosave.test.tsx
@@ -12,6 +12,10 @@ vi.mock('src/api/drafts', () => ({
     createDraft: vi.fn(),
     updateDraft: vi.fn(),
     deleteDraft: vi.fn(),
+    warmAuth: vi.fn(),
+    // Return true by default so the unload flush marks itself as having fired
+    // (mirrors a real flush that found a cached token).
+    flushDraftKeepalive: vi.fn(() => true),
   },
   DRAFT_LIMIT_CODE: 'DRAFT_LIMIT',
   DRAFT_CONFLICT_CODE: 'DRAFT_CONFLICT',
@@ -21,6 +25,8 @@ const mockedDraftAPI = DraftAPI as unknown as {
   createDraft: ReturnType<typeof vi.fn>
   updateDraft: ReturnType<typeof vi.fn>
   deleteDraft: ReturnType<typeof vi.fn>
+  warmAuth: ReturnType<typeof vi.fn>
+  flushDraftKeepalive: ReturnType<typeof vi.fn>
 }
 
 // A promise whose resolution we control, to model an in-flight network request.
@@ -122,6 +128,7 @@ describe('useDraftAutosave — publish during in-flight create (finding #2)', ()
         useDraftAutosave({
           content,
           enabled: true,
+          isSignedIn: true,
           canCreate: true,
           draftId: null,
           draftUpdatedAt: null,
@@ -173,6 +180,7 @@ describe('useDraftAutosave — draft cap (finding #4)', () => {
         useDraftAutosave({
           content,
           enabled: true,
+          isSignedIn: true,
           canCreate: true,
           draftId: null,
           draftUpdatedAt: null,
@@ -214,6 +222,7 @@ describe('useDraftAutosave — updatedAt concurrency guard (B5)', () => {
         useDraftAutosave({
           content,
           enabled: true,
+          isSignedIn: true,
           canCreate: true,
           draftId: 'existing-draft',
           draftUpdatedAt: '1000',
@@ -268,6 +277,7 @@ describe('useDraftAutosave — updatedAt concurrency guard (B5)', () => {
         useDraftAutosave({
           content,
           enabled: true,
+          isSignedIn: true,
           canCreate: true,
           draftId: 'existing-draft',
           draftUpdatedAt: '1000',
@@ -294,5 +304,155 @@ describe('useDraftAutosave — updatedAt concurrency guard (B5)', () => {
     })
     expect(mockedDraftAPI.updateDraft).toHaveBeenCalledTimes(1)
     expect(onConflict).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useDraftAutosave — unload flush (V8 item 1)', () => {
+  // jsdom dispatches beforeunload/pagehide as ordinary events, so we can assert
+  // the handler fires the keepalive save with the right payload. What jsdom
+  // CANNOT model — and must be verified live — is that fetch({keepalive:true})
+  // actually completes after the document is torn down, and that a real Firebase
+  // token was cached; here DraftAPI.flushDraftKeepalive is mocked.
+  const renderCreate = (props?: {
+    canCreate?: boolean
+    isSignedIn?: boolean
+  }) =>
+    renderHook(
+      ({ content }) =>
+        useDraftAutosave({
+          content,
+          enabled: true,
+          isSignedIn: props?.isSignedIn ?? true,
+          canCreate: props?.canCreate ?? true,
+          draftId: null,
+          draftUpdatedAt: null,
+          onDraftCreated: vi.fn(),
+        }),
+      { initialProps: { content: { title: '' } as Record<string, unknown> } }
+    )
+
+  it('flushes an unsaved new draft on beforeunload, before the debounce fires', () => {
+    const { rerender } = renderCreate()
+    // Edit, but do NOT advance to the 1500ms autosave — the change is still
+    // sitting in the debounce window, exactly the work a hard refresh would lose.
+    rerender({ content: { title: 'Soup' } })
+    expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload'))
+    })
+    expect(mockedDraftAPI.flushDraftKeepalive).toHaveBeenCalledTimes(1)
+    expect(mockedDraftAPI.flushDraftKeepalive).toHaveBeenCalledWith(
+      null,
+      { title: 'Soup' },
+      ''
+    )
+  })
+
+  it('carries the current B5 updatedAt precondition when flushing an existing draft', () => {
+    const { rerender } = renderHook(
+      ({ content }) =>
+        useDraftAutosave({
+          content,
+          enabled: true,
+          isSignedIn: true,
+          canCreate: true,
+          draftId: 'existing-draft',
+          draftUpdatedAt: '1000',
+          onDraftCreated: vi.fn(),
+        }),
+      { initialProps: { content: { title: '' } as Record<string, unknown> } }
+    )
+    rerender({ content: { title: 'Soup' } })
+
+    act(() => {
+      window.dispatchEvent(new Event('pagehide'))
+    })
+    // The flush must send the same `updatedAt` the normal PUT path sends, or the
+    // server's concurrency precondition would 409 every flushed save.
+    expect(mockedDraftAPI.flushDraftKeepalive).toHaveBeenCalledWith(
+      'existing-draft',
+      { title: 'Soup' },
+      '1000'
+    )
+  })
+
+  it('no-ops when nothing changed since the last save', () => {
+    renderCreate()
+    // No edits at all — baseline equals current content.
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload'))
+    })
+    expect(mockedDraftAPI.flushDraftKeepalive).not.toHaveBeenCalled()
+  })
+
+  it('does not flush twice when both beforeunload and pagehide fire', () => {
+    const { rerender } = renderCreate()
+    rerender({ content: { title: 'Soup' } })
+
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload'))
+      window.dispatchEvent(new Event('pagehide'))
+    })
+    expect(mockedDraftAPI.flushDraftKeepalive).toHaveBeenCalledTimes(1)
+  })
+
+  it('never flushes for a signed-out visitor', () => {
+    const { rerender } = renderCreate({ isSignedIn: false })
+    rerender({ content: { title: 'Soup' } })
+
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload'))
+    })
+    expect(mockedDraftAPI.flushDraftKeepalive).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDraftAutosave — signed-out (V8 item 2)', () => {
+  it('shows calm sign-in guidance and attempts no save when signed out', async () => {
+    const { result, rerender } = renderHook(
+      ({ content }) =>
+        useDraftAutosave({
+          content,
+          enabled: true,
+          isSignedIn: false,
+          canCreate: true,
+          draftId: null,
+          draftUpdatedAt: null,
+          onDraftCreated: vi.fn(),
+        }),
+      { initialProps: { content: { title: '' } as Record<string, unknown> } }
+    )
+
+    rerender({ content: { title: 'Soup' } })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+
+    // Calm 'signed-out' status (never 'error'), and no doomed save attempt.
+    expect(result.current.status).toBe('signed-out')
+    expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+    expect(mockedDraftAPI.updateDraft).not.toHaveBeenCalled()
+    expect(mockedDraftAPI.warmAuth).not.toHaveBeenCalled()
+  })
+
+  it('stays idle for a signed-out visitor who has typed nothing', async () => {
+    const { result } = renderHook(() =>
+      useDraftAutosave({
+        content: { title: '' },
+        enabled: true,
+        isSignedIn: false,
+        canCreate: false,
+        draftId: null,
+        draftUpdatedAt: null,
+        onDraftCreated: vi.fn(),
+      })
+    )
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+    expect(result.current.status).toBe('idle')
   })
 })

--- a/src/test/useDraftAutosave.test.tsx
+++ b/src/test/useDraftAutosave.test.tsx
@@ -259,6 +259,65 @@ describe('useDraftAutosave — updatedAt concurrency guard (B5)', () => {
     )
   })
 
+  it('adopts the updatedAt that arrives AFTER mount (page opened with ?draftId), so the first autosave does not 409', async () => {
+    // Regression (found in V8 live verification): when AddRecipe mounts with
+    // ?draftId already in the URL — the normal resume flow from the drafts
+    // list, or refreshing a resumed draft — `draftId` never changes after
+    // mount. The hydrated `updatedAt` arrives via the prop alone, later. The
+    // pre-fix hook synced updatedAtRef only on draftId changes, so it stayed
+    // null and every autosave sent an empty precondition → guaranteed
+    // DRAFT_CONFLICT 409 → autosave dead for the session.
+    mockedDraftAPI.updateDraft.mockResolvedValue({
+      ...createdDraft,
+      updatedAt: '2000',
+    })
+
+    const { rerender } = renderHook(
+      ({ content, enabled, draftUpdatedAt }) =>
+        useDraftAutosave({
+          content,
+          enabled,
+          isSignedIn: true,
+          canCreate: true,
+          draftId: 'existing-draft', // fixed from the first render, like a URL param
+          draftUpdatedAt,
+          onDraftCreated: vi.fn(),
+        }),
+      {
+        initialProps: {
+          // While hydration is loading: autosave disabled, no version yet.
+          content: { title: '' } as Record<string, unknown>,
+          enabled: false,
+          draftUpdatedAt: null as string | null,
+        },
+      }
+    )
+
+    // Hydration completes: content + version land, autosave enables. draftId
+    // itself never changes.
+    rerender({
+      content: { title: 'Resumed Soup' },
+      enabled: true,
+      draftUpdatedAt: '1000',
+    })
+    // User edits.
+    rerender({
+      content: { title: 'Resumed Soup, tweaked' },
+      enabled: true,
+      draftUpdatedAt: '1000',
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+
+    expect(mockedDraftAPI.updateDraft).toHaveBeenCalledWith(
+      'existing-draft',
+      { title: 'Resumed Soup, tweaked' },
+      '1000' // pre-fix this was '' (the null the hook saw at mount)
+    )
+  })
+
   it('surfaces a conflict and stops autosaving once the server 409s a stale base version', async () => {
     mockedDraftAPI.updateDraft.mockRejectedValue({
       isAxiosError: true,


### PR DESCRIPTION
Wave 10 batch two (orchestrated). Two items from the B1 #281 review, same files, filed 2026-07-10.

## Item 1 — unload flush
Draft autosave had no `beforeunload`/`pagehide` flush: a hard refresh or tab close inside the 1.5s `AUTOSAVE_DELAY` debounce window (or while a save was in flight) lost up to ~1.5s of work. The existing unmount flush only covers in-app SPA navigation.

- `useDraftAutosave` now registers `beforeunload` + `pagehide` handlers that fire a synchronous, fire-and-forget save via `DraftAPI.flushDraftKeepalive`, using `fetch(..., { keepalive: true })` (an async axios request won't reliably complete during unload).
- Existing draft → `PUT /api/drafts/:id` echoing the **B5 (#286) `updatedAt` concurrency precondition** — read from the same `updatedAtRef` the normal autosave path tracks/bumps, so a flushed save doesn't 409. New draft → `POST /api/drafts`.
- **Auth:** the axios request interceptor (`http-common`) now caches the Firebase ID token synchronously into a module var; the keepalive flush reads it via `getCachedIdToken()`. `DraftAPI.warmAuth()` (called on the first edit) proactively populates that cache so a fast type-then-close still authenticates. Tokens live ~1h, so a cached token stays valid for the flush.
- **No double-save:** no-ops when nothing changed and no save is in flight; a `flushed` guard prevents `beforeunload` + `pagehide` firing a duplicate (with a `pageshow` reset for bfcache restores); create is skipped while a create is already in flight (avoids a duplicate draft).

## Item 2 — signed-out badge
`/add-recipe` isn't auth-guarded and `createDraft` no-ops to `null` without a UID, which surfaced as a persistent, alarming "Couldn't save draft" for a signed-out visitor who typed anything.

- `useRecipeForm` passes `isSignedIn` (`useAuth().user`) to the hook. Signed-out + draftable content now yields a calm `'signed-out'` status ("Sign in to save drafts", `InfoIcon`, neutral tint) and **attempts no save**; a pristine form stays idle.

## Tests
- `useDraftAutosave.test.tsx`: unload flush fires the keepalive save with the right body incl. the `updatedAt` version (create + existing-draft), no-ops when unchanged, dedupes beforeunload+pagehide, never flushes signed-out; signed-out shows calm copy and attempts no save.
- `draftsKeepalive.test.tsx`: `flushDraftKeepalive` PUTs/POSTs the right URL + method + `keepalive:true` + Bearer header + body (updatedAt included), and no-ops without a UID or cached token.
- `DraftSaveStatus.test.tsx`: signed-out copy renders and never carries the error class; error/saving/saved unchanged.
- Updated `AddRecipe.test.tsx` / `RecipeDrafts.test.tsx` to mock `useAuth` signed-in (autosave now sits behind the signed-in gate) and the two new DraftAPI methods.

## Gates
`npx tsc --noEmit` clean · `npm test` 722 passed / 2 skipped · `npm run build` OK. Frontend-only (no server change).

Do not merge.

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8