### PR TITLE
Fix InstructionItem Enter double-submit (ref-guard, V6 sibling)

### DIFF
--- a/src/pages/AddRecipe/Ingredients/IngredientItem.tsx
+++ b/src/pages/AddRecipe/Ingredients/IngredientItem.tsx
@@ -126,6 +126,12 @@ const IngredientItem: FC<IngredientItemProps> = ({
   }
   const handleIngrClick = () => {
     if (editInputRef?.current) {
+      // A genuine blur-away submit leaves the suppress flag set: focus has
+      // already left the input by the time handleEditSubmit runs, so its
+      // trailing self-blur() no-ops on the already-blurred element (no event)
+      // and never consumes the flag. Reset on edit-entry so stale suppression
+      // can't swallow the next session's genuine blur-away.
+      suppressNextBlurSubmitRef.current = false
       setIsEditing(true)
       editInputRef.current.focus()
     }

--- a/src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem.tsx
+++ b/src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem.tsx
@@ -41,6 +41,12 @@ const InstructionItem: FC<InstructionItemProps> = ({
   const suppressNextBlurSubmitRef = useRef(false)
 
   const handleInstrClick = () => {
+    // A genuine blur-away submit leaves the suppress flag set: focus has
+    // already left the textarea by the time handleEditSubmit runs, so its
+    // trailing self-blur() no-ops on the already-blurred element (no event)
+    // and never consumes the flag. Reset on edit-entry so stale suppression
+    // can't swallow the next session's genuine blur-away.
+    suppressNextBlurSubmitRef.current = false
     setIsEditing(true)
     textAreaRef?.current && textAreaRef.current.focus()
   }

--- a/src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem.tsx
+++ b/src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem.tsx
@@ -28,6 +28,17 @@ const InstructionItem: FC<InstructionItemProps> = ({
     if ('label' in instruction) return instruction.label
     return instruction.content
   })
+  // handleEditSubmit ends by programmatically blur()-ing the textarea (so a
+  // keyboard Enter-submit also exits edit mode visually). That blur()
+  // synchronously re-fires the same RecipeFormTextArea's onBlur, which is
+  // also wired to submit — without a guard, every Enter-submit double-invokes
+  // handleEditSubmit against the same stale closed-over editedVal/instruction
+  // (duplicate, idempotent setInstructions call). This ref is flipped
+  // immediately before the self-triggered blur() and consumed by handleBlur
+  // below, so only a genuine user blur (click-away while editing) reaches
+  // handleEditSubmit a second time. Mirrors the identical fix in
+  // IngredientItem.tsx (V6, #287).
+  const suppressNextBlurSubmitRef = useRef(false)
 
   const handleInstrClick = () => {
     setIsEditing(true)
@@ -51,8 +62,21 @@ const InstructionItem: FC<InstructionItemProps> = ({
 
       editInstruction(instruction.id, updatedInstruction)
     }
+    suppressNextBlurSubmitRef.current = true
     blur()
     setIsEditing(false)
+  }
+
+  // Wired to RecipeFormTextArea's onBlur. Genuine blur-away (clicking
+  // elsewhere while editing) should still submit; the blur() handleEditSubmit
+  // triggers on itself should not resubmit — see suppressNextBlurSubmitRef
+  // above.
+  const handleBlur = () => {
+    if (suppressNextBlurSubmitRef.current) {
+      suppressNextBlurSubmitRef.current = false
+      return
+    }
+    handleEditSubmit()
   }
 
   const isContent = 'content' in instruction
@@ -105,7 +129,7 @@ const InstructionItem: FC<InstructionItemProps> = ({
             val={editedVal}
             setVal={setEditedVal}
             textAreaRef={textAreaRef}
-            onBlur={handleEditSubmit}
+            onBlur={handleBlur}
             onEnter={handleEditSubmit}
             smallTextArea={true}
             characterLimit={INSTRUCTION_MAX_LENGTH}

--- a/src/test/IngredientItemEdit.test.tsx
+++ b/src/test/IngredientItemEdit.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import IngredientItem from 'src/pages/AddRecipe/Ingredients/IngredientItem'
 import RecipeAPI from 'src/api/recipes'
 import { toast } from 'react-hot-toast'
@@ -147,6 +147,40 @@ describe('IngredientItem inline edit', () => {
     )
     await waitFor(() => expect(setItemStatus).toHaveBeenCalledWith('ing-1', null))
     expect(mockGetIngredientData).toHaveBeenCalledTimes(1)
+  })
+
+  // Stale-suppression regression: on a GENUINE blur-away, real focus has
+  // already left the input by the time handleEditSubmit runs, so its trailing
+  // self-blur() no-ops (per spec, blur() on a non-focused element fires no
+  // event — jsdom conforms) and never consumes the suppress flag. Without the
+  // edit-entry reset in handleIngrClick, the flag stays stuck true and the
+  // NEXT edit session's genuine blur-away is swallowed (no submit, edit mode
+  // stays open). This test moves REAL focus (element.focus() on another
+  // control) instead of fireEvent.blur, so the browser-faithful ordering —
+  // blur event first, self-blur() a no-op — is what actually runs.
+  it('a second edit session still submits on blur-away after a prior blur-away submit', async () => {
+    mockGetIngredientData.mockImplementation(async (s: string) => enriched(s))
+    const { container } = renderItem()
+    const removeBtn = container.querySelector('.ingr-remove') as HTMLButtonElement
+
+    const blurAwaySession = (value: string) => {
+      fireEvent.click(container.querySelector('.item-btn') as HTMLElement)
+      const input = container.querySelector('input') as HTMLInputElement
+      expect(document.activeElement).toBe(input) // real focus from click-to-edit
+      fireEvent.change(input, { target: { value } })
+      // Genuine blur-away: move real DOM focus to another control. jsdom
+      // fires the real blur on the input; the handler's trailing blur() then
+      // targets an already-unfocused element and fires nothing.
+      act(() => removeBtn.focus())
+    }
+
+    blurAwaySession('2 cups flour')
+    await waitFor(() => expect(mockGetIngredientData).toHaveBeenCalledTimes(1))
+
+    blurAwaySession('3 cups sugar')
+    // Pre-fix: the stale flag from session 1 swallows this submit (stays 1).
+    await waitFor(() => expect(mockGetIngredientData).toHaveBeenCalledTimes(2))
+    expect(mockGetIngredientData).toHaveBeenLastCalledWith('3 cups sugar')
   })
 
   it('flags the row errored and toasts when the edit enrichment times out', async () => {

--- a/src/test/InstructionItemEdit.test.tsx
+++ b/src/test/InstructionItemEdit.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { vi } from 'vitest'
-import { render, fireEvent, waitFor } from '@testing-library/react'
+import { render, fireEvent, waitFor, act } from '@testing-library/react'
 import InstructionItem from 'src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem'
 
 const contentInstruction = (id: string, content: string, index = 1) => ({
@@ -64,5 +64,37 @@ describe('InstructionItem inline edit', () => {
     const { container, setInstructions } = renderItem()
     editTo(container, '')
     expect(setInstructions).not.toHaveBeenCalled()
+  })
+
+  // Stale-suppression regression: on a GENUINE blur-away, real focus has
+  // already left the textarea by the time handleEditSubmit runs, so its
+  // trailing self-blur() no-ops (per spec, blur() on a non-focused element
+  // fires no event — jsdom conforms) and never consumes the suppress flag.
+  // Without the edit-entry reset, the flag stays stuck true and the NEXT edit
+  // session's genuine blur-away is swallowed (no submit, edit mode stays
+  // open). This test moves REAL focus (element.focus() on another control)
+  // instead of fireEvent.blur, so the browser-faithful ordering — blur event
+  // first, self-blur() a no-op — is what actually runs.
+  it('a second edit session still submits on blur-away after a prior blur-away submit', async () => {
+    const { container, setInstructions } = renderItem()
+    const removeBtn = container.querySelector('.instr-remove') as HTMLButtonElement
+
+    const blurAwaySession = (value: string) => {
+      fireEvent.click(container.querySelector('.item-btn') as HTMLElement)
+      const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+      expect(document.activeElement).toBe(textarea) // real focus from click-to-edit
+      fireEvent.change(textarea, { target: { value } })
+      // Genuine blur-away: move real DOM focus to another control. jsdom
+      // fires the real blur on the textarea; the handler's trailing blur()
+      // then targets an already-unfocused element and fires nothing.
+      act(() => removeBtn.focus())
+    }
+
+    blurAwaySession('Preheat the oven to 350F')
+    await waitFor(() => expect(setInstructions).toHaveBeenCalledTimes(1))
+
+    blurAwaySession('Preheat the oven to 375F')
+    // Pre-fix: the stale flag from session 1 swallows this submit (stays 1).
+    await waitFor(() => expect(setInstructions).toHaveBeenCalledTimes(2))
   })
 })

--- a/src/test/InstructionItemEdit.test.tsx
+++ b/src/test/InstructionItemEdit.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { vi } from 'vitest'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import InstructionItem from 'src/pages/AddRecipe/Instructions/InstructionItem/InstructionItem'
+
+const contentInstruction = (id: string, content: string, index = 1) => ({
+  id,
+  content,
+  index,
+})
+
+const renderItem = () => {
+  const instruction = contentInstruction('instr-1', 'Preheat the oven')
+  const removeInstruction = vi.fn()
+  const setInstructions = vi.fn()
+  const { container } = render(
+    <InstructionItem
+      instruction={instruction as any}
+      removeInstruction={removeInstruction}
+      setInstructions={setInstructions}
+    />
+  )
+  return { container, removeInstruction, setInstructions }
+}
+
+// Enter edit mode, type a new value, and submit it (Enter).
+const editTo = (container: HTMLElement, value: string) => {
+  fireEvent.click(container.querySelector('.item-btn') as HTMLElement)
+  const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+  fireEvent.change(textarea, { target: { value } })
+  fireEvent.keyDown(textarea, { key: 'Enter' })
+}
+
+describe('InstructionItem inline edit', () => {
+  it('submits exactly once on Enter (no double-submit from the trailing blur())', async () => {
+    const { container, setInstructions } = renderItem()
+
+    editTo(container, 'Preheat the oven to 350F')
+
+    await waitFor(() => expect(setInstructions).toHaveBeenCalled())
+    // Pin: Enter-submit must invoke setInstructions exactly once. Before the
+    // blur-guard fix, handleEditSubmit's own trailing textAreaRef.blur()
+    // synchronously re-fired RecipeFormTextArea's onBlur (also wired to
+    // submit), double-calling setInstructions against the same stale
+    // closed-over editedVal/instruction — the identical V6 shape fixed in
+    // IngredientItem.tsx (#287).
+    expect(setInstructions).toHaveBeenCalledTimes(1)
+  })
+
+  it('submits exactly once on genuine blur-away (no Enter)', async () => {
+    const { container, setInstructions } = renderItem()
+
+    fireEvent.click(container.querySelector('.item-btn') as HTMLElement)
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: 'Preheat the oven to 350F' } })
+    // Click away without pressing Enter first — a genuine blur.
+    fireEvent.blur(textarea)
+
+    await waitFor(() => expect(setInstructions).toHaveBeenCalled())
+    expect(setInstructions).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not submit when the edited value is unchanged but is empty', async () => {
+    const { container, setInstructions } = renderItem()
+    editTo(container, '')
+    expect(setInstructions).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What

Two commits, one pattern:

**Commit 1 — the T1 fix.** `InstructionItem`'s `handleEditSubmit` wires both `onBlur` and `onEnter` on `RecipeFormTextArea` to itself, then ends by programmatically calling `textAreaRef.current.blur()` (so a keyboard Enter-submit also visually exits edit mode). That trailing `blur()` synchronously re-fires the textarea's `onBlur`, which was wired to the same handler — so every Enter-submit invoked `handleEditSubmit` twice against the same stale closed-over `editedVal`/`instruction`. Mirrored #287's ref-guard exactly: `suppressNextBlurSubmitRef` flipped before the self-triggered `blur()`, consumed by a new `handleBlur` wrapper.

**Commit 2 — stale-flag hardening in BOTH components (orchestrator-expanded scope).** Review found a latent edge in the ref-guard pattern itself, present in both the new InstructionItem code and the merged #287 original in `IngredientItem.tsx`: the flag is set unconditionally at the end of `handleEditSubmit`, including on the GENUINE blur-away path. In a real browser, focus has already left the field by the time the blur handler runs, so the trailing self-`blur()` is a spec-mandated no-op (`blur()` on a non-focused element fires no event) and never consumes the flag. It stays stuck `true`, and the NEXT edit session's genuine click-away is swallowed — submit skipped, edit mode visually stays open. Fixed by resetting the flag to `false` at the top of the click-to-edit handler (`handleInstrClick` / `handleIngrClick`) so stale suppression can't leak into the next session — strictly safer than making the flag-set conditional.

## Why

The Enter double-submit is the identical shape V6 (#287) fixed in `IngredientItem.tsx`; on this path it's just a duplicate, idempotent `setInstructions` (cosmetic), but it's the same latent double-side-effect. The stale-flag edge is a real UX wart on both components' click-away flow, and no other live lane touches `IngredientItem.tsx`, so both files are hardened here.

## How tested

**T1 double-submit tests** (`src/test/InstructionItemEdit.test.tsx`, mirrors `IngredientItemEdit.test.tsx`): Enter-submit calls `setInstructions` exactly once; genuine blur-away calls it exactly once; empty-value submit is a no-op.
- Fails-before proof: with the fix stashed, both assertions failed at `expected "vi.fn()" to be called 1 times, but got 2 times`.

**Stale-flag tests** (one per component, in both edit-test files): a two-session regression that moves REAL DOM focus (`element.focus()` on the row's remove button) instead of `fireEvent.blur`, so the browser-faithful ordering — real blur event first, self-`blur()` a no-op on the already-unfocused element — actually runs. Verified jsdom is spec-conformant here first (moving real focus fires React's `onBlur` exactly once; `blur()` on a non-focused element fires nothing), so the test is honest, not a simulation trick.
- Fails-before proof (per file, with only that component's hardening stashed): second session's submit swallowed — `expected "vi.fn()" to be called 2 times, but got 1 times`; the InstructionItem failure dump even shows the textarea container stuck in the `edit-input` (open) state.

**Gates** (after both commits):
- `npx tsc --noEmit` — clean.
- `npm test` — 90 test files, 734 passed, 2 skipped (736 total).
- `npm run build` — succeeds.

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8