### PR TITLE
Fix collections 50-cap TOCTOU with post-insert trim (V3 sibling)

### DIFF
--- a/server/__tests__/collections.test.js
+++ b/server/__tests__/collections.test.js
@@ -84,6 +84,54 @@ describe('POST /collections', () => {
     const data = await getUserData()
     expect(data.collections).toHaveLength(1)
   })
+
+  it('rejects creation past the 50-collection cap with 409', async () => {
+    const mine = Array.from({ length: 50 }, (_, i) => ({
+      id: `c${i}`,
+      name: `Collection ${i}`,
+      createdAt: '1',
+    }))
+    await seedUserRecipeData(TEST_UID, { collections: mine })
+
+    const res = await request(app)
+      .post('/api/collections')
+      .set(AUTH_HEADER)
+      .send({ name: 'One too many' })
+    expect(res.status).toBe(409)
+    expect(res.body.error).toMatch(/at most 50 collections/)
+
+    const data = await getUserData()
+    expect(data.collections).toHaveLength(50)
+  })
+
+  it('holds the 50-collection cap under concurrent POSTs (TOCTOU regression): 5 concurrent creates at 49 existing land exactly 1, reject 4 with 409', async () => {
+    const mine = Array.from({ length: 49 }, (_, i) => ({
+      id: `c${i}`,
+      name: `Collection ${i}`,
+      createdAt: '1',
+    }))
+    await seedUserRecipeData(TEST_UID, { collections: mine })
+
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        request(app)
+          .post('/api/collections')
+          .set(AUTH_HEADER)
+          .send({ name: `Concurrent ${i}` })
+      )
+    )
+
+    const succeeded = responses.filter((res) => res.status === 201)
+    const rejected = responses.filter((res) => res.status === 409)
+    expect(succeeded).toHaveLength(1)
+    expect(rejected).toHaveLength(4)
+    rejected.forEach((res) =>
+      expect(res.body.error).toMatch(/at most 50 collections/)
+    )
+
+    const data = await getUserData()
+    expect(data.collections).toHaveLength(50)
+  })
 })
 
 // ─── GET /collections ─────────────────────────────────────────────────────────

--- a/server/routes/collections.js
+++ b/server/routes/collections.js
@@ -158,6 +158,47 @@ router.post('/collections', verifyToken, requireActive, asyncHandler(async (req,
   if (pushed.matchedCount === 0) {
     return res.status(409).json({ error: 'A collection with that name already exists' })
   }
+
+  // The early `existing.length >= MAX_COLLECTIONS` check above is a read-then-write
+  // TOCTOU (same shape V3 closed for drafts, #291): concurrent creates that all read
+  // under the cap can all pass it and all land, overshooting MAX_COLLECTIONS. Unlike
+  // the name check, this can't be folded into the guarded push's $expr — the push
+  // above is already committed by the time we'd know the resulting size, and adding a
+  // pre-push $expr size guard would just move the same race onto the *set* of racing
+  // requests (they'd all read the pre-push size and could still all pass).
+  //
+  // So, mirroring V3: enforce the cap post-insert. Collections are array elements on
+  // a single per-user document (unlike drafts' separate documents), so a $push's
+  // position in the array IS the commit order — no separate _id/createdAt sort is
+  // needed the way V3 needed one across sibling documents. Re-read the live array,
+  // keep the oldest MAX_COLLECTIONS (array order = insertion order), and $pull
+  // anything beyond that. This converges under arbitrary interleaving: every pass
+  // reads live state and targets the same well-defined "newest beyond the cap" set,
+  // so redundant/out-of-order trims from racing requests agree and are idempotent
+  // (pulling an already-pulled id is a no-op). Whichever request's collection lands
+  // outside the surviving oldest-N finds itself pulled and replies 409 — concurrent
+  // creates at the cap admit only as many as there's room for.
+  const userDataAfter = await db
+    .collection('userRecipeData')
+    .findOne({ _id: req.uid }, { projection: { collections: 1 } })
+  const allCollections = userDataAfter?.collections ?? []
+  const overflow = allCollections.slice(MAX_COLLECTIONS)
+  if (overflow.length > 0) {
+    await db
+      .collection('userRecipeData')
+      .updateOne(
+        { _id: req.uid },
+        { $pull: { collections: { id: { $in: overflow.map((c) => c.id) } } } }
+      )
+  }
+  const survived = allCollections
+    .slice(0, MAX_COLLECTIONS)
+    .some((c) => c.id === collection.id)
+  if (!survived) {
+    return res
+      .status(409)
+      .json({ error: `You can have at most ${MAX_COLLECTIONS} collections` })
+  }
   res.status(201).json(withStats(collection, []))
 }))
 


### PR DESCRIPTION
## What

Closes the read-then-insert TOCTOU on the collections 50-cap in `POST /api/collections` (`server/routes/collections.js`) — the same shape [V3 #291](https://github.com/jclind/prepify/pull/291) closed for the draft cap, filed off that lane.

## Why

`existing.length >= MAX_COLLECTIONS` was a read, then the insert happened afterward. Concurrent creates that all read the count while still under 50 could all pass the check and all land, overshooting the cap — the classic TOCTOU. The name-uniqueness check right below it was already race-safe (a guarded `$expr` update, untouched by this PR); only the count check raced.

## How

Mirrors V3's post-insert trim, adapted to this data's shape:

- **V3 (drafts):** each draft is its own document, so after an unconditional insert, V3 re-reads the caller's drafts sorted by `_id` (oldest first) and deletes anything beyond the cap.
- **This fix (collections):** collections are *array elements* on one per-user `userRecipeData` document, not separate documents. The create already does a guarded `$push` (conditioned on no name collision — left untouched). After that push lands, the array's element order already **is** the commit/insertion order (each `$push` appends under the document write lock), so no separate sort key is needed — just re-read the live `collections` array and `$pull` anything at index ≥ 50.

**Keep-oldest vs keep-newest:** kept oldest, matching V3's choice for drafts — array order (= commit order) is preserved and everything from index 50 onward is trimmed, so whichever request's write lands earliest survives. No functional reason favors either policy here (both are "pick a consistent convergent rule"); keeping V3's precedent means the two cap lanes behave identically.

Client-visible contract preserved exactly: same 409 status, same `{ error: "You can have at most 50 collections" }` body shape/text the route already returned for the (now non-atomic-but-still-present) early check — the early check is left in place as a friendly fast-path, with the post-insert trim as the actual race-safe enforcement, same layering the name-uniqueness check already uses (friendly early read + atomic guard).

## How tested

- Added a Jest concurrency regression test in `server/__tests__/collections.test.js`: 5 concurrent `POST /api/collections` at 49 existing collections must land exactly 1 (201) and reject 4 (409), holding the final count at 50.
- **Proved it fails pre-fix:** stashed the route fix (kept the new test), ran it against the old read-then-insert code — got 2 successes (51 total collections, overshooting the cap) instead of 1, confirming the test catches the race. Restored the fix and reran green.
- Reran the new test 5x in a row post-fix — all green, no flakes.
- Gates: `cd server && npm test` → 873/873 passed (38 suites). `npx tsc --noEmit` → clean. `npm run build` → succeeds.

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8