### PR TITLE
Make FormInput's setVal type-honest (remove the as-T cast)

### DIFF
--- a/src/Components/Form/FormInput.tsx
+++ b/src/Components/Form/FormInput.tsx
@@ -2,7 +2,7 @@ import { EyeIcon, EyeOffIcon } from 'src/Components/icons'
 import React, { ChangeEvent, ReactElement, useState } from 'react'
 import './FormInput.scss'
 
-interface FormInputProps<T extends string | number | undefined> {
+interface FormInputProps {
   /** Visual density. `md` (default) = the auth/profile field (48px, focus ring);
    *  `compact` = the denser AddRecipe field (40px, no focus ring). */
   size?: 'md' | 'compact'
@@ -11,8 +11,14 @@ interface FormInputProps<T extends string | number | undefined> {
   type?: string
   placeholder?: string
   name?: string
-  val: T
-  setVal: (value: T) => void
+  val: string
+  /**
+   * Receives the field's raw DOM string on every change — `<input>` values are
+   * always strings, so this is the honest type. A numeric field (e.g.
+   * ServingsInput) must accept the string and parse/coerce it itself rather than
+   * relying on a cast that would let a numeric *string* masquerade as a `number`.
+   */
+  setVal: (value: string) => void
   /** Visible label above the field. Defaults to a capitalized `name`; omitted when neither is set. */
   label?: string
   /** Small helper / validation line below the field. */
@@ -35,7 +41,7 @@ interface FormInputProps<T extends string | number | undefined> {
   describedBy?: string
 }
 
-const FormInput = <T extends string | number | undefined>({
+const FormInput = ({
   size = 'md',
   icon,
   type = 'text',
@@ -56,7 +62,7 @@ const FormInput = <T extends string | number | undefined>({
   onBlur,
   invalid,
   describedBy,
-}: FormInputProps<T>) => {
+}: FormInputProps) => {
   // Password fields render a show/hide toggle and swap their input type.
   const [show, setShow] = useState(false)
   const isPassword = type === 'password'
@@ -69,7 +75,7 @@ const FormInput = <T extends string | number | undefined>({
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const next = e.target.value
     if (characterLimit && next.length > characterLimit) return
-    setVal(next as T)
+    setVal(next)
   }
 
   return (

--- a/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
+++ b/src/pages/AddRecipe/AddRecipeSummaryBar.tsx
@@ -8,7 +8,9 @@ import './AddRecipeSummaryBar.scss'
 type TimeVal = { hours: number; minutes: number } | null
 
 interface AddRecipeSummaryBarProps {
-  servings: number | ''
+  // Raw servings field string (see RecipeFormState.servings); coerced with
+  // Number() for the price calc below.
+  servings: string
   prepTime: TimeVal
   cookTime: TimeVal
   ingredients: IngredientsType[]

--- a/src/pages/AddRecipe/ServingsInput/ServingsInput.tsx
+++ b/src/pages/AddRecipe/ServingsInput/ServingsInput.tsx
@@ -2,8 +2,12 @@ import React from 'react'
 import FormInput from 'src/Components/Form/FormInput'
 
 interface ServingSizeInputProps {
-  servings: number | ''
-  setServings: (value: number | '') => void
+  // The raw field string (empty until the user types). Numeric coercion is the
+  // caller's job at submit time (useRecipeForm's `Number(servings)`) — storing
+  // the raw string keeps the field byte-identical to what was typed and avoids a
+  // `number` type that's a lie for a DOM-string value.
+  servings: string
+  setServings: (value: string) => void
   invalid?: boolean
   describedBy?: string
 }
@@ -14,15 +18,14 @@ const ServingSizeInput: React.FC<ServingSizeInputProps> = ({
   invalid,
   describedBy,
 }) => {
-  const handleChange = (inputVal: number | '') => {
+  const handleChange = (raw: string) => {
+    const num = Number(raw)
     if (
-      inputVal === '' ||
-      (!isNaN(inputVal) &&
-        inputVal % 1 === 0 &&
-        inputVal >= 1 &&
-        inputVal <= 99)
+      raw === '' ||
+      (!isNaN(num) && num % 1 === 0 && num >= 1 && num <= 99)
     ) {
-      setServings(inputVal)
+      // Store the raw string as typed; submit-time Number() does the coercion.
+      setServings(raw)
     }
   }
 
@@ -32,7 +35,7 @@ const ServingSizeInput: React.FC<ServingSizeInputProps> = ({
       type='number'
       placeholder='How many servings does your recipe make?'
       val={servings}
-      setVal={(val: number | '') => handleChange(val)}
+      setVal={handleChange}
       invalid={invalid}
       describedBy={describedBy}
     />

--- a/src/pages/AddRecipe/TimeInput/TimeInput.tsx
+++ b/src/pages/AddRecipe/TimeInput/TimeInput.tsx
@@ -27,8 +27,11 @@ const TimeInput: React.FC<TimeInputProps> = ({
   invalid,
   describedBy,
 }) => {
-  const [minutes, setMinutes] = useState<number | ''>('')
-  const [hours, setHours] = useState<number | ''>('')
+  // Held as the raw field strings (FormInput hands back a DOM string). The
+  // aggregate effect below coerces to numbers when it builds the { hours,
+  // minutes } object the parent stores.
+  const [minutes, setMinutes] = useState<string>('')
+  const [hours, setHours] = useState<string>('')
   // True once the user has typed in either field. Distinguishes a genuine
   // clear-both-fields (which must propagate null to the parent) from the initial
   // pre-hydration render — where both fields are also empty, but the parent still
@@ -40,8 +43,8 @@ const TimeInput: React.FC<TimeInputProps> = ({
     // `val` is an object, so the old `Number(val)` produced NaN and blanked the
     // fields — read the members directly instead.
     if (val && !minutes && !hours) {
-      setMinutes(val.minutes || '')
-      setHours(val.hours || '')
+      setMinutes(val.minutes ? String(val.minutes) : '')
+      setHours(val.hours ? String(val.hours) : '')
     }
     if (!val) {
       setMinutes('')
@@ -50,34 +53,32 @@ const TimeInput: React.FC<TimeInputProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [val])
 
-  const onHoursChange = (inputVal: number | '') => {
+  const onHoursChange = (raw: string) => {
+    const num = Number(raw)
     if (
-      inputVal === '' ||
-      (!isNaN(inputVal) &&
-        inputVal % 1 === 0 &&
-        inputVal >= 0 &&
-        inputVal <= 99)
+      raw === '' ||
+      (!isNaN(num) && num % 1 === 0 && num >= 0 && num <= 99)
     ) {
       hasUserEdited.current = true
-      setHours(inputVal)
+      setHours(raw)
     }
   }
-  const onMinutesChange = (inputVal: number | '') => {
+  const onMinutesChange = (raw: string) => {
+    const num = Number(raw)
     if (
-      inputVal === '' ||
-      (!isNaN(inputVal) &&
-        inputVal % 1 === 0 &&
-        inputVal >= 0 &&
-        inputVal <= 59)
+      raw === '' ||
+      (!isNaN(num) && num % 1 === 0 && num >= 0 && num <= 59)
     ) {
       hasUserEdited.current = true
-      setMinutes(inputVal)
+      setMinutes(raw)
     }
   }
 
   useEffect(() => {
     if (minutes || hours) {
-      setVal({ hours: hours || 0, minutes: minutes || 0 })
+      // Coerce the raw field strings to the numeric { hours, minutes } the parent
+      // persists — an empty field becomes 0.
+      setVal({ hours: Number(hours) || 0, minutes: Number(minutes) || 0 })
     } else if (hasUserEdited.current) {
       // Both fields cleared by the user: propagate the cleared state so the
       // parent drops the stale pre-clear time instead of silently keeping it
@@ -98,7 +99,7 @@ const TimeInput: React.FC<TimeInputProps> = ({
           type='number'
           placeholder='0'
           val={hours}
-          setVal={(val: number | '') => onHoursChange(val)}
+          setVal={onHoursChange}
           characterLimit={3}
           inputBeginningText='Hours'
           invalid={invalid}
@@ -109,7 +110,7 @@ const TimeInput: React.FC<TimeInputProps> = ({
           type='number'
           placeholder='0'
           val={minutes}
-          setVal={(val: number | '') => onMinutesChange(val)}
+          setVal={onMinutesChange}
           characterLimit={3}
           inputBeginningText='Minutes'
           invalid={invalid}

--- a/src/pages/AddRecipe/recipeFormValidation.ts
+++ b/src/pages/AddRecipe/recipeFormValidation.ts
@@ -26,7 +26,9 @@ export type ValidatableRecipeForm = {
   // existing stored image.
   existingImageUrl: string | undefined
   description: string
-  servings: number | ''
+  // The raw servings field string (see RecipeFormState.servings). Coerced with
+  // Number() below rather than trusted as a real number.
+  servings: string
   prepTime: TimeVal
   ingredients: IngredientsType[]
   instructions: InstructionsType[]
@@ -73,10 +75,11 @@ export function validateRecipeForm(
   }
 
   // Servings must be a positive whole number — a truthiness check alone let
-  // negative and fractional values (e.g. -2, 1.5) through. Coerce with Number()
-  // rather than assuming a real `number`: FormInput's generic setVal passes the
-  // raw input string straight through (untyped cast), so `form.servings` is
-  // sometimes a numeric string at runtime despite the `number | ''` type.
+  // negative and fractional values (e.g. -2, 1.5) through. `form.servings` is the
+  // raw field string (FormInput now hands back a DOM string honestly), so coerce
+  // with Number() before the range check. Defence-in-depth: this coercion stays
+  // even though the type is now `string`, since the value's numeric-ness is still
+  // only guaranteed at this boundary.
   if (!form.servings) {
     errors.servings = 'Servings amount is required'
   } else {

--- a/src/pages/AddRecipe/useRecipeForm.ts
+++ b/src/pages/AddRecipe/useRecipeForm.ts
@@ -68,7 +68,11 @@ export type RecipeFormState = {
   // pick a new file. Cleared if they remove the image (forcing a new pick).
   existingImageUrl: string | undefined
   description: string
-  servings: number | ''
+  // The raw servings field string ('' until typed). ServingsInput stores what was
+  // typed; the numeric coercion lives at submit time (`Number(servings)` below)
+  // and in the validator — so the type is honestly `string`, not a `number` that
+  // a DOM string only pretends to be.
+  servings: string
   prepTime: TimeVal
   cookTime: TimeVal
   fridgeLife: number
@@ -126,7 +130,7 @@ function initFormState(initialRecipe?: RecipeType): RecipeFormState {
     recipeImage: undefined,
     existingImageUrl: initialRecipe?.recipeImage,
     description: initialRecipe?.description ?? '',
-    servings: initialRecipe?.servings ?? '',
+    servings: String(initialRecipe?.servings ?? ''),
     prepTime: initialRecipe ? minToHrMin(initialRecipe.prepTime) : null,
     cookTime: initialRecipe ? minToHrMin(initialRecipe.cookTime) : null,
     fridgeLife: initialRecipe?.fridgeLife ?? 0,
@@ -280,7 +284,7 @@ export function useRecipeForm(initialRecipe?: RecipeType) {
             values: {
               title: draft.title ?? '',
               description: draft.description ?? '',
-              servings: draft.servings ?? '',
+              servings: String(draft.servings ?? ''),
               prepTime: draft.prepTime != null ? minToHrMin(draft.prepTime) : null,
               cookTime: draft.cookTime != null ? minToHrMin(draft.cookTime) : null,
               fridgeLife: draft.fridgeLife ?? 0,

--- a/src/test-d/FormInput.setVal.test-d.ts
+++ b/src/test-d/FormInput.setVal.test-d.ts
@@ -1,0 +1,42 @@
+/**
+ * Type-level assertions — checked by `tsc --noEmit` (the Static gate), NOT run by
+ * Vitest — that FormInput's value surface is honestly a `string`. The T3 pass
+ * removed `setVal(next as T)`: `<input>` values are always DOM strings, so
+ * `setVal` is typed `(value: string) => void` and `val` is `string`. A numeric
+ * consumer (ServingsInput, TimeInput) must accept that string and coerce it
+ * itself rather than leaning on a cast that let a numeric *string* pose as a
+ * `number`.
+ *
+ * The `@ts-expect-error` directives below are self-verifying: if the honest
+ * typing regresses (e.g. FormInput goes generic again and accepts a number
+ * setter), the expected error disappears and tsc fails on the now-unused
+ * directive. `src/test` is excluded from tsconfig, so this lives in `src/test-d`
+ * (Vitest's include is `*.test.{ts,tsx}`, so `.test-d.ts` is not collected as a
+ * runtime test) to stay inside the typecheck gate.
+ */
+import FormInput from 'src/Components/Form/FormInput'
+import type { ComponentProps } from 'react'
+
+type Props = ComponentProps<typeof FormInput>
+
+// Honest surface: a string setter and a string value compile cleanly.
+const okSetter: Props['setVal'] = (value: string): void => void value
+const okVal: Props['val'] = ''
+void okSetter
+void okVal
+
+// A numeric setter is rejected — the raw DOM string cannot flow into `(n: number)`.
+const badSetter: Props = {
+  val: '',
+  // @ts-expect-error setVal must accept the raw input string, not a number
+  setVal: (value: number): void => void value,
+}
+void badSetter
+
+// A numeric value is rejected — `val` is the raw field string.
+const badVal: Props = {
+  // @ts-expect-error val is the raw DOM string; a number is not assignable
+  val: 5,
+  setVal: () => {},
+}
+void badVal

--- a/src/test/AddRecipe.test.tsx
+++ b/src/test/AddRecipe.test.tsx
@@ -370,6 +370,11 @@ describe('AddRecipe form', () => {
     expect(payload.recipeImage).toBeInstanceOf(File)
     expect(payload.ingredients).toHaveLength(1)
     expect(payload.instructions).toHaveLength(1)
+    // Servings is a raw string in form state (FormInput's honest setVal); the
+    // submit boundary coerces it to a real number — the payload carries 4, not
+    // '4'. (The toEqual above already distinguishes them; assert the type too so
+    // the coercion boundary is explicit.)
+    expect(typeof payload.servings).toBe('number')
   })
 
   it('navigates to the new recipe page after a successful submission', async () => {

--- a/src/test/ServingsInput.test.tsx
+++ b/src/test/ServingsInput.test.tsx
@@ -5,7 +5,7 @@ import ServingsInput from 'src/pages/AddRecipe/ServingsInput/ServingsInput'
 
 // ServingsInput guards its setter: only an integer in [1, 99] (or empty) is
 // accepted; anything else is dropped so the field can't hold an invalid value.
-const setup = (initial: number | '' = '') => {
+const setup = (initial: string = '') => {
   const setServings = vi.fn()
   render(<ServingsInput servings={initial} setServings={setServings} />)
   const input = screen.getByPlaceholderText(
@@ -25,9 +25,24 @@ describe('ServingsInput validation', () => {
   })
 
   it('accepts clearing a populated field (empty)', () => {
-    const { setServings, input } = setup(4)
+    const { setServings, input } = setup('4')
     change(input, '')
     expect(setServings).toHaveBeenCalledWith('')
+  })
+
+  // Regression for the T3 type-honesty pass: FormInput now hands ServingsInput
+  // the raw DOM string, and ServingsInput stores exactly that string (no cast to
+  // `number`, no parse). The value is a `string` at rest — coercion happens only
+  // at submit — so setServings must receive the literal typed string, byte for
+  // byte, exactly as before the pass.
+  it('stores the raw string as typed (no numeric coercion at rest)', () => {
+    const { setServings, input } = setup()
+    change(input, '8')
+    expect(setServings).toHaveBeenCalledWith('8')
+    // The argument is a string, not the number 8 — the honest surface.
+    const arg = setServings.mock.calls[0][0]
+    expect(typeof arg).toBe('string')
+    expect(arg).not.toBe(8)
   })
 
   it.each(['0', '-3', '100', '150'])('rejects out-of-range value %s', val => {


### PR DESCRIPTION
## What

`FormInput`'s generic `setVal(next as T)` handed the raw DOM input string to callers cast to `T`, so numeric consumers (`ServingsInput`, `TimeInput`) carried a `number | ''` type that was a lie at runtime — the value was a numeric *string* until submit-time coercion. This removes the lying cast and makes the value surface honest.

## Design chosen — type the surface as `string` (not a `parse` prop)

I surveyed all `FormInput` call sites: ~11 pass plain string state, and only two (`ServingsInput`, `TimeInput`) are numeric. Of the two directions the backlog item offered:

- **Rejected — a `parse`/`coerce` prop** (`T` honest via `parse(raw): T`): with a generic `T` it can't drop the cast on the no-`parse` (string) path, so it *relocates* the cast rather than deleting it, and it forces `parse` boilerplate on ~11 string sites. Coercing servings to a real `number` at the boundary would also change form state (numeric string → number) and risk display normalization (typing `"05"` would render `5`) — not byte-identical.
- **Chosen — type the value/setter surface as `string`**: drop the generic, `val: string`, `setVal: (value: string) => void`, `setVal(next)` with no cast. `<input>` values are always DOM strings, so this is the honest type. The ~11 string sites are untouched. The two numeric consumers accept the raw string, coerce for their range gate (`Number(raw)`), and store the string **verbatim** — so form state is byte-identical to what was typed. `form.servings` is now honestly `string`; existing coercion stays where it always was (submit-time `Number(servings)` in `useRecipeForm`, and the validator's defensive `Number()`).

Smallest, clearest diff; deletes the cast outright with no `any` and no replacement cast.

## Zero runtime behavior change

- **Typing path** is byte-identical: the raw typed string is stored exactly as before (the previous code already stored a numeric *string* at runtime; only the type was wrong).
- **Numeric guards** are equivalent: today's `!isNaN(inputVal) && inputVal % 1 === 0 && inputVal >= 1` ran on a string via JS coercion; it now runs on `Number(raw)` explicitly — same result.
- **Edit/draft hydration** now stores `String(servings)` / `String(val.hours)` instead of a raw `number`, but both render identically in the field and both `Number()`-coerce identically downstream (`String(4)` has no leading-zero risk).
- `TimeInput`'s aggregate effect coerces to a real number at the `{ hours, minutes }` object boundary (`Number(hours) || 0`), which actually makes `prepTime.hours` *honestly* a number (it was a string before); `hrMinToMin` coerces either way.

## Now impossible by construction vs still guarded at runtime

- **Compile-impossible now:** a numeric consumer wired with a `number` val/setter — it's a type error at the `FormInput` boundary. A future numeric field is forced to accept the honest string. Demonstrated by `src/test-d/FormInput.setVal.test-d.ts` (`@ts-expect-error` assertions checked by the `tsc` gate; `src/test` is excluded from tsconfig, so the type-test lives in `src/test-d`, outside Vitest's `*.test.{ts,tsx}` include).
- **Still guarded at runtime (defence in depth, intentionally kept):** the submit-time `Number(servings)` in `useRecipeForm` and the validator's `Number(form.servings)` in `recipeFormValidation.ts` — the value's numeric-ness is still only guaranteed at those boundaries, and V7's defensive validator coercion stays.

## Tests / gates

- `npx tsc --noEmit` — clean (incl. the self-verifying type-test).
- `npm test` — 90 files, **735 passed / 2 skipped**. Added: ServingsInput "stores the raw string as typed" (state-at-rest is a string); extended AddRecipe's submit-payload test to assert `typeof payload.servings === 'number'` (typing → state → submit round-trip: string at rest, coerced to a real number in the payload).
- `npm run build` — ok.

## Adjacent issues noticed (not fixed here)

- `TimeInput` flowed the same lie one level deeper: it stored raw strings into a `{ hours: number; minutes: number }` object typed as numbers. This PR fixes it at the object boundary (`Number(...)`), but the broader pattern (child components feeding numeric objects from string fields) is worth a future sweep.
- `src/test` is excluded from `tsconfig` (`exclude: ["src/test", ...]`), so `@ts-expect-error`/type errors in the Vitest suite are **not** caught by the typecheck gate — only esbuild-transpiled at runtime. Type-level assertions must live outside `src/test` to be gate-enforced (hence `src/test-d`). Flagging as a possible gap.
- `recipeFormValidation.test.ts` passes numeric literals (`servings: 4`, `0`, `-2`) to `validateRecipeForm`, now typed `servings: string`. Left as-is: the file isn't type-checked (excluded from tsc) and the numeric inputs still exercise the validator's defensive coercion at runtime.

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8