### PR TITLE
fix(collections): mount per-uid rate limiter on create + rename

### DIFF
--- a/server/__tests__/collectionsLimiter.test.js
+++ b/server/__tests__/collectionsLimiter.test.js
@@ -1,0 +1,76 @@
+/**
+ * routes/collections.js — collectionWriteLimiter's real 429 behaviour on
+ * POST /collections and PATCH /collections/:id.
+ *
+ * Mirrors bugReportsLimiter.test.js / writeLimiter.test.js: the limiter
+ * `skip`s under NODE_ENV=test (so the rest of the suite, which fires many
+ * requests per user via supertest, isn't throttled), so this file flips
+ * NODE_ENV to exercise the real behaviour, then restores it in `finally` so a
+ * failed assertion can't leak the flip into later test files run in the same
+ * --runInBand process. The global per-IP backstop in app.js (limit 1000) is
+ * also live under this flip but nowhere near the ~31 requests driven below.
+ */
+
+const request = require('supertest')
+const app = require('../app')
+const { getDB } = require('../db')
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV
+const TEST_UID = 'test-uid'
+const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
+const COLLECTION_LIMIT = 30 // collectionWriteLimiter's default (makeUserLimiter())
+
+afterEach(async () => {
+  await getDB().collection('userRecipeData').deleteMany({})
+})
+
+// One shared uid draws down collectionWriteLimiter's single bucket across both
+// surfaces in ONE test (rather than a POST-only test and a separate PATCH-only
+// test) because collectionWriteLimiter is a module-level singleton — a second
+// test hitting the same uid within the same 60s window would inherit whatever
+// budget the first test already spent instead of starting fresh.
+describe('collectionWriteLimiter — shared bucket across POST /collections and PATCH /collections/:id', () => {
+  it('429s with the house { error, code: RATE_LIMITED } JSON shape once the per-user cap is hit, and create+rename share one budget', async () => {
+    process.env.NODE_ENV = 'development' // un-skip collectionWriteLimiter
+    try {
+      // Spend 1 on a create so there's a collection to rename.
+      const created = await request(app)
+        .post('/api/collections')
+        .set(AUTH_HEADER)
+        .send({ name: 'Collection 0' })
+      expect(created.status).toBe(201)
+      const id = created.body.id
+
+      // Spend the rest of the budget on RENAMES (not creates) to prove the
+      // rename route draws from the SAME instance as create, not a fresh one.
+      for (let i = 1; i < COLLECTION_LIMIT; i++) {
+        const res = await request(app)
+          .patch(`/api/collections/${id}`)
+          .set(AUTH_HEADER)
+          .send({ name: `Collection ${i}` })
+        expect(res.status).toBe(200)
+      }
+
+      // The budget is now fully spent (1 create + (COLLECTION_LIMIT - 1)
+      // renames = COLLECTION_LIMIT total) — the next request on EITHER route
+      // 429s with the house shape.
+      const blocked = await request(app)
+        .post('/api/collections')
+        .set(AUTH_HEADER)
+        .send({ name: 'One Too Many' })
+      expect(blocked.status).toBe(429)
+      expect(blocked.body).toEqual({
+        error: 'You’re doing that too quickly — wait a moment and try again.',
+        code: 'RATE_LIMITED',
+      })
+      const blockedRename = await request(app)
+        .patch(`/api/collections/${id}`)
+        .set(AUTH_HEADER)
+        .send({ name: 'Also One Too Many' })
+      expect(blockedRename.status).toBe(429)
+      expect(blockedRename.body.code).toBe('RATE_LIMITED')
+    } finally {
+      process.env.NODE_ENV = ORIGINAL_NODE_ENV
+    }
+  }, 30000)
+})

--- a/server/__tests__/writeLimiter.wiring.test.js
+++ b/server/__tests__/writeLimiter.wiring.test.js
@@ -17,6 +17,7 @@ const {
   recipeWriteLimiter,
   reviewWriteLimiter,
   profileWriteLimiter,
+  collectionWriteLimiter,
 } = require('../middleware/writeLimiter')
 
 const recipesRouter = require('../routes/recipes')
@@ -48,6 +49,8 @@ describe('per-surface write limiters are wired onto every moderated write route'
     ['auth', authRouter, 'post', '/updatePhoto', profileWriteLimiter],
     ['auth', authRouter, 'post', '/updateDisplayName', profileWriteLimiter],
     ['auth', authRouter, 'post', '/updatePrivacy', profileWriteLimiter],
+    ['collections', collectionsRouter, 'post', '/collections', collectionWriteLimiter],
+    ['collections', collectionsRouter, 'patch', '/collections/:id', collectionWriteLimiter],
   ]
 
   it.each(cases)(
@@ -63,11 +66,26 @@ describe('per-surface write limiters are wired onto every moderated write route'
     }
   )
 
-  it('recipe / review / profile each use a DISTINCT limiter instance', () => {
+  it('recipe / review / profile / collection each use a DISTINCT limiter instance', () => {
     // Independent instances ⇒ independent buckets (the #3 fix). If two surfaces
     // ever collapsed back onto one shared limiter this would catch it.
-    const limiters = new Set([recipeWriteLimiter, reviewWriteLimiter, profileWriteLimiter])
-    expect(limiters.size).toBe(3)
+    const limiters = new Set([
+      recipeWriteLimiter,
+      reviewWriteLimiter,
+      profileWriteLimiter,
+      collectionWriteLimiter,
+    ])
+    expect(limiters.size).toBe(4)
+  })
+
+  it('collections POST /collections and PATCH /collections/:id SHARE one limiter instance', () => {
+    // Unlike the recipe/review/profile surfaces (one bucket per surface), create
+    // and rename intentionally draw from the SAME collectionWriteLimiter bucket —
+    // they're the same class of write (a user-supplied name, same validation).
+    const createHandlers = routeHandlers(collectionsRouter, 'post', '/collections')
+    const renameHandlers = routeHandlers(collectionsRouter, 'patch', '/collections/:id')
+    expect(createHandlers).toContain(collectionWriteLimiter)
+    expect(renameHandlers).toContain(collectionWriteLimiter)
   })
 
   it('ingredients POST /parse mounts a user limiter right after verifyToken', () => {

--- a/server/middleware/writeLimiter.js
+++ b/server/middleware/writeLimiter.js
@@ -65,9 +65,15 @@ const recipeWriteLimiter = makeUserLimiter({ limit: 12 })
 const reviewWriteLimiter = makeUserLimiter()
 const profileWriteLimiter = makeUserLimiter()
 
+// Collections (server/routes/collections.js) carry no per-write paid cost — no
+// Cloud Vision scan, no OpenAI moderation call — same as review/profile writes,
+// so they share the 30/min default rather than the recipe surface's tighter cap.
+const collectionWriteLimiter = makeUserLimiter()
+
 module.exports = {
   makeUserLimiter,
   recipeWriteLimiter,
   reviewWriteLimiter,
   profileWriteLimiter,
+  collectionWriteLimiter,
 }

--- a/server/routes/collections.js
+++ b/server/routes/collections.js
@@ -3,6 +3,7 @@ const crypto = require('crypto')
 const { asyncHandler } = require('../util/asyncHandler')
 const { getDB } = require('../db')
 const { verifyToken, requireActive } = require('../middleware/auth')
+const { collectionWriteLimiter } = require('../middleware/writeLimiter')
 const { recipeIdQuery, recipeIdInQuery } = require('../util/recipeIdQuery')
 const { RECIPE_VISIBLE } = require('../util/moderation')
 
@@ -99,8 +100,12 @@ router.get('/collections', verifyToken, asyncHandler(async (req, res) => {
   res.json(collections.map((c) => withStats(c, saved, imageById)))
 }))
 
-// POST /collections — create a new (empty) collection.
-router.post('/collections', verifyToken, requireActive, asyncHandler(async (req, res) => {
+// POST /collections — create a new (empty) collection. Rate-limited like the
+// sibling content-write surfaces (recipes.js addRecipe/editRecipe, reviews.js
+// addRating/newReview/editReview) — the 50-cap on collections bounds worst-case
+// damage but doesn't stop a scripted create-loop from burning cycles/DB writes
+// before it ever hits the cap.
+router.post('/collections', verifyToken, requireActive, collectionWriteLimiter, asyncHandler(async (req, res) => {
   const db = getDB()
   const name = boundedName(req.body?.name)
   if (!name) {
@@ -202,8 +207,12 @@ router.post('/collections', verifyToken, requireActive, asyncHandler(async (req,
   res.status(201).json(withStats(collection, []))
 }))
 
-// PATCH /collections/:id — rename a collection.
-router.patch('/collections/:id', verifyToken, requireActive, asyncHandler(async (req, res) => {
+// PATCH /collections/:id — rename a collection. Shares the create limiter's
+// bucket instance: like editRecipe/editReview sharing their surface's limiter
+// with the create route, a rename is the same class of write as a create (a
+// user-supplied name, same validation/bounds) so it draws from the same budget
+// rather than getting its own.
+router.patch('/collections/:id', verifyToken, requireActive, collectionWriteLimiter, asyncHandler(async (req, res) => {
   const db = getDB()
   const { id } = req.params
   const name = boundedName(req.body?.name)
@@ -260,6 +269,10 @@ router.patch('/collections/:id', verifyToken, requireActive, asyncHandler(async 
 
 // DELETE /collections/:id — remove a collection. The recipes it held stay in
 // the master saved list; only the folder and its membership tags go away.
+// Intentionally unlimited, mirroring the sibling surfaces: deleteRecipe,
+// deleteReview, and removeRating carry no makeUserLimiter either — deletes
+// shrink state rather than growing it, so they're not the abuse vector the
+// content-write limiters guard against.
 router.delete('/collections/:id', verifyToken, requireActive, asyncHandler(async (req, res) => {
   const db = getDB()
   const { id } = req.params
@@ -290,6 +303,11 @@ router.delete('/collections/:id', verifyToken, requireActive, asyncHandler(async
 // PATCH /recipes/:recipeId/collections — set which collections a saved recipe
 // belongs to, in one call (drives the add-to-collection checkbox popover).
 // Filing a not-yet-saved recipe auto-saves it to the master list first.
+// Intentionally unlimited: this is a membership toggle over an already-capped
+// set of collections (<= MAX_COLLECTIONS), the same class of write as
+// recipes.js's save/unsave (POST/DELETE /recipes/:id/save), which likewise
+// carries no makeUserLimiter — it doesn't create new named resources the way
+// POST/PATCH /collections does.
 router.patch(
   '/recipes/:recipeId/collections',
   verifyToken,


### PR DESCRIPTION
## Summary

Wave 12 · U1 — closes the filed gap: `POST /collections` had only the global per-IP backstop in `app.js`, unlike every other content-write surface (`recipes.js` `addRecipe`/`editRecipe`, `reviews.js` `addRating`/`newReview`/`editReview`, `auth.js` profile writes), which all mount a `makeUserLimiter`-based per-uid limiter (`docs/CONVENTIONS.md` §3.4). Low urgency — `MAX_COLLECTIONS = 50` bounds worst-case damage per account — but it was an asymmetry with its sibling write surfaces.

## Approach

- Added `collectionWriteLimiter = makeUserLimiter()` in `server/middleware/writeLimiter.js` (default 30/min, house `{ error, code: 'RATE_LIMITED' }` 429 shape).
- **Rate chosen**: mirrors `reviewWriteLimiter`/`profileWriteLimiter` (30/min default), *not* `recipeWriteLimiter`'s tighter 12/min — collection writes trigger no paid per-write cost (no Cloud Vision scan, no OpenAI moderation call on the name field), the same reasoning the existing 30-vs-12 split in `writeLimiter.js` already documents.
- **Middleware position**: mounted after `verifyToken` → `requireActive`, before the handler — same order as every sibling mount (`server/routes/recipes.js:507`, `server/routes/reviews.js:52`).
- **Scope decision** (per the task's step 3): `recipes.js`/`reviews.js` rate-limit both their *create* route and their *edit* route from the same per-surface bucket (`addRecipe`+`editRecipe` share `recipeWriteLimiter`; `addRating`/`newReview`/`editReview` share `reviewWriteLimiter`), while their *delete* routes (`deleteRecipe`, `deleteReview`, `removeRating`) and the save/unsave membership toggle stay unlimited. Mirroring that convention for collections' equivalent verbs:
  - `POST /collections` (create) and `PATCH /collections/:id` (rename — the "edit" equivalent, same user-supplied-name validation) now share `collectionWriteLimiter`.
  - `DELETE /collections/:id` stays unlimited (mirrors `deleteRecipe`/`deleteReview`/`removeRating` — deletes shrink state, not the abuse vector these limiters guard).
  - `PATCH /recipes/:recipeId/collections` (add/remove a saved recipe's collection membership) stays unlimited (mirrors `recipes.js`'s save/unsave toggle — a membership flip over an already-capped resource set, not a new-resource creation).
  - Each unlimited route now carries a comment explaining why, so a future reader doesn't mistake the omission for an oversight.

## Test evidence

- New `server/__tests__/collectionsLimiter.test.js`: follows the established one-file `NODE_ENV`-flip pattern (`server/__tests__/bugReportsLimiter.test.js`, `server/__tests__/writeLimiter.test.js`) — flips `NODE_ENV` to un-skip the limiter (it `skip`s under Jest by default), drives the real 30-request cap across a mix of creates and renames on one uid to prove they share a single bucket, asserts the 31st request 429s with the house `{ error, code: 'RATE_LIMITED' }` shape on *both* routes, then restores `NODE_ENV` in `finally`.
- Extended `server/__tests__/writeLimiter.wiring.test.js` (structural, no NODE_ENV flip needed): added `collectionWriteLimiter` wiring cases (ordering after `verifyToken`/`requireActive`), a 4th distinct-instance assertion, and a case pinning that create+rename intentionally share the *same* instance (unlike recipe/review/profile, which each get their own).
- Full gate: `cd server && npm test` → **40 suites / 879 tests passed** (0 failed) after these changes.

## Adjacent issues noticed (not fixed — out of scope)

- Collection names (`POST /collections`, `PATCH /collections/:id`) are never run through `moderateText`/`moderateImage`, unlike `auth.js`'s profile-write routes (`setUsername`, `updateProfile`, `updateDisplayName` all call `moderateText`). A malicious 50-char collection name currently ships unmoderated.
- `server/routes/drafts.js` (`POST /`, `PUT /:id`) mounts **no** `makeUserLimiter` at all, despite the filed backlog item's title describing "the drafts/recipes write routes, which mount `makeUserLimiter`-based limiters" — that framing doesn't match the code on disk today (only `recipes.js`'s `addRecipe`/`editRecipe` actually do). Drafts creation is capped at 25/user (`MAX_DRAFTS_PER_USER`) the same way collections was capped at 50, so it may be a sibling gap worth its own filed item.
- `docs/API_CONTRACT.md` doesn't currently document collections' 429 behavior; if the contract doc is meant to enumerate rate-limited routes, it may need a note for this — flagging rather than editing per the task's docs-freeze.

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8