### PR TITLE
Typecheck the Vitest suite via tsconfig.tests.json + fix surfaced type drift (Wave 12 U2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,12 @@ jobs:
       # (per-file esbuild/rolldown transpile) does NOT check.
       - name: Typecheck (tsc --noEmit)
         run: npm run typecheck
+      # The Vitest suite lives in src/test/**, which the base tsconfig excludes
+      # (the Cypress config files would otherwise poison the program with
+      # Cypress's global Chai `expect`). tsconfig.tests.json re-includes it so
+      # test files can't silently drift from the real types.
+      - name: Typecheck tests (tsc --noEmit -p tsconfig.tests.json)
+        run: npx tsc --noEmit -p tsconfig.tests.json
       # Verify the production bundle actually builds (Netlify parity).
       - name: Production build (vite build)
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/jest": "^30.0.0",
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^6.0.1",
         "cypress": "^15.14.2",
@@ -1837,85 +1836,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@jest/diff-sequences": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
-      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/expect-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
-      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/get-type": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
-      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/pattern": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.4.0",
-        "@jest/schemas": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3012,13 +2932,6 @@
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3262,73 +3175,6 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
-    "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jest": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
-      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^30.0.0",
-        "pretty-format": "^30.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
@@ -3436,13 +3282,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/tmp": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
@@ -3468,23 +3307,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/yargs": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5000,24 +4822,6 @@
       "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -6454,190 +6258,6 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jest-diff": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
-      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/diff-sequences": "30.4.0",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-diff/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
-      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "jest-diff": "30.4.1",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.4.1",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "jest-util": "30.4.1",
-        "picomatch": "^4.0.3",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-mock": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-regex-util": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/joi": {
@@ -8313,22 +7933,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-is-18": {
-      "name": "react-is",
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-is-19": {
-      "name": "react-is",
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -9084,16 +8688,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/slice-ansi": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
@@ -9188,29 +8782,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stack-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stack-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/stackback": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/jest": "^30.0.0",
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "cypress": "^15.14.2",

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -11,6 +11,7 @@ import { calculateServingPrice } from 'src/util/calculateServingPrice'
 import {
   AccountTabCounts,
   IngredientsType,
+  LabelType,
   NewReviewType,
   NutritionDataType,
   CreatedRecipeCardType,
@@ -602,7 +603,12 @@ class RecipeAPIClass {
   }
 
   // Ingredients
-  async getIngredientData(val: string): Promise<IngredientsType> {
+  // Return type excludes LabelType: this always produces a parsed-ingredient
+  // shape (enriched or error-degraded), never a group label — so callers can
+  // read `ingredientData`/`error` without first narrowing away the label arm.
+  async getIngredientData(
+    val: string
+  ): Promise<Exclude<IngredientsType, LabelType>> {
     const parsedIngredient = parseIngredientString(val)
     // Phase A: enrichment is soft-fail. A thrown network error (server down, timeout,
     // 5xx surfaced as axios rejection) must not bubble up — callers stick on the

--- a/src/test/AccountSections.loading.test.tsx
+++ b/src/test/AccountSections.loading.test.tsx
@@ -107,7 +107,7 @@ const makeReview = (
   _id: 'review-1',
   username: 'chef',
   recipeId: 'recipe-1',
-  rating: '5',
+  rating: 5,
   ratingLastUpdated: '1000',
   reviewText: 'Loved it',
   recipeTitle: 'Test Recipe',

--- a/src/test/AddRecipeSummaryBar.test.tsx
+++ b/src/test/AddRecipeSummaryBar.test.tsx
@@ -18,6 +18,10 @@ const parsed = (id: string) => ({
     ingredient: 'flour',
     quantity: 1,
     unit: 'cup',
+    unitPlural: null,
+    symbol: null,
+    minQty: null,
+    maxQty: null,
     comment: null,
     originalIngredientString: '1 cup flour',
   },
@@ -26,7 +30,8 @@ const parsed = (id: string) => ({
 const label = (id: string) => ({ id, label: 'Section' })
 
 const baseProps = {
-  servings: 4 as number | '',
+  // Raw servings field string, matching AddRecipeSummaryBarProps.servings.
+  servings: '4',
   prepTime: { hours: 1, minutes: 30 },
   cookTime: { hours: 0, minutes: 15 },
   ingredients: [parsed('1'), parsed('2')],

--- a/src/test/RecipesApi.test.ts
+++ b/src/test/RecipesApi.test.ts
@@ -662,7 +662,9 @@ describe('RecipeAPI.uploadRecipeImage — uid-keyed Storage path (I2)', () => {
       /^recipeImages\/test-uid\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
     )
     expect(objectPath).not.toContain('photo.jpg')
-    expect(uploadBytes).toHaveBeenCalledOnce()
+    // toHaveBeenCalledTimes(1) over toHaveBeenCalledOnce: semantically identical,
+    // but the latter doesn't resolve on `expect(fn)`'s type under tsc 6.0.3.
+    expect(uploadBytes).toHaveBeenCalledTimes(1)
   })
 
   it('fails closed (throws, no upload) when there is no authenticated uid', async () => {

--- a/src/test/recipeFormValidation.test.ts
+++ b/src/test/recipeFormValidation.test.ts
@@ -18,6 +18,10 @@ const ingredient = (id: string): IngredientsType => ({
     ingredient: 'Flour',
     quantity: 1,
     unit: 'cup',
+    unitPlural: null,
+    symbol: null,
+    minQty: null,
+    maxQty: null,
     comment: null,
     originalIngredientString: '1 cup Flour',
   },
@@ -36,7 +40,7 @@ const validForm = (): ValidatableRecipeForm => ({
   recipeImage: new File([''], 'photo.jpg', { type: 'image/jpeg' }),
   existingImageUrl: undefined,
   description: 'A delicious recipe',
-  servings: 4,
+  servings: '4',
   prepTime: { hours: 0, minutes: 30 },
   ingredients: [ingredient('i1')],
   instructions: [instruction('s1', 1)],
@@ -141,9 +145,12 @@ describe('validateRecipeForm', () => {
     expect(validateRecipeForm({ ...validForm(), servings: '' }).servings).toBe(
       'Servings amount is required'
     )
-    expect(validateRecipeForm({ ...validForm(), servings: 0 }).servings).toBe(
-      'Servings amount is required'
-    )
+    expect(
+      // @ts-expect-error — deliberately passes numeric 0, unreachable now that
+      // the servings contract is `string` ('0' would hit the whole-number branch
+      // instead); kept as-is to preserve the falsy-guard coverage unchanged.
+      validateRecipeForm({ ...validForm(), servings: 0 }).servings
+    ).toBe('Servings amount is required')
   })
 
   it('rejects negative or fractional servings', () => {
@@ -151,13 +158,13 @@ describe('validateRecipeForm', () => {
     // and fractional servings (e.g. -2, 1.5) through as "valid". Contract:
     // servings must be a positive integer (>= 1).
     expect(
-      validateRecipeForm({ ...validForm(), servings: -2 }).servings
+      validateRecipeForm({ ...validForm(), servings: '-2' }).servings
     ).toBe('Servings must be a whole number of at least 1')
     expect(
-      validateRecipeForm({ ...validForm(), servings: 1.5 }).servings
+      validateRecipeForm({ ...validForm(), servings: '1.5' }).servings
     ).toBe('Servings must be a whole number of at least 1')
     expect(
-      validateRecipeForm({ ...validForm(), servings: 1 }).servings
+      validateRecipeForm({ ...validForm(), servings: '1' }).servings
     ).toBeUndefined()
   })
 

--- a/src/test/test-globals.d.ts
+++ b/src/test/test-globals.d.ts
@@ -1,0 +1,10 @@
+// Ambient types for the Vitest suite, typechecked via tsconfig.tests.json.
+// Vitest runs with `globals: true` (vite.config.ts), so `describe`/`it`/
+// `expect`/`vi` are globals in test files — the reference below pulls in their
+// declarations. The jest-dom import loads the matcher augmentations
+// (`toBeInTheDocument`, `toHaveClass`, ...) onto Vitest's `expect`, mirroring
+// the runtime setup in src/test/setup.ts. (The vestigial `@types/jest`
+// devDependency used to provide ambient test globals; it typed the suite
+// against Jest's matchers instead of Vitest's and has been removed.)
+/// <reference types="vitest/globals" />
+import '@testing-library/jest-dom/vitest'

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,22 @@
+{
+  // Typecheck config for the Vitest suite. `src/test/**` is excluded from the
+  // base tsconfig.json (its `exclude`), so `npm run typecheck` never sees test
+  // files — type drift in tests (and their fixtures) goes unnoticed. This config
+  // adds them to a dedicated `tsc --noEmit -p tsconfig.tests.json` pass (wired
+  // into CI's Static job) without disturbing the app build.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // The suite runs on Node 24 / modern jsdom, so ES2022 runtime APIs like
+    // Array.prototype.at() are available. The base app targets ES2020 for the
+    // browser bundle; widen the lib here (typecheck-only, no emit) so test code
+    // using those APIs typechecks. DOM libs must be listed explicitly because
+    // setting `lib` replaces (not extends) the target's defaults.
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  // Drop src/test from the base exclude so tests are typechecked. Keep excluding
+  // the Cypress config files: importing 'cypress' pulls Cypress's global Chai
+  // `expect` into the program, which shadows Vitest's global `expect` and breaks
+  // every matcher assertion in the suite.
+  "exclude": ["node_modules", "cypress", "cypress.config.ts", "cypress.visual.config.ts"]
+}


### PR DESCRIPTION
## What

`src/test/**` was excluded from `tsconfig.json`, so the Vitest suite was never typechecked — type errors in tests were invisible to the `tsc --noEmit` gate and tests drifted from the real types silently (the U2 backlog item). This PR adds a dedicated `tsconfig.tests.json` typecheck for the suite, wires it into CI's Static job, and fixes everything it surfaced.

## Why a tests-tsconfig instead of including src/test in the base config

A naive main-include explodes with **1292 errors** — not real drift. The base program (no `include`) compiles root-level `cypress.config.ts` + `cypress.visual.config.ts`, whose `import 'cypress'` injects **Cypress's global Chai `expect`**, shadowing Vitest's global `expect`. Every matcher assertion (`toBeInTheDocument`, `toHaveClass`, even native `toBeGreaterThan`) then fails to resolve: **1274 false errors**. Verified those two files are the only non-`src` sources of a global `expect`.

`tsconfig.tests.json` extends the base, re-includes `src/test`, excludes only those two Cypress config files, and bumps `lib` to ES2022 (typecheck-only — the suite runs on Node 24; the app's ES2020 build target is untouched). CI's Static job runs it as a second step after the base typecheck.

**Count story: 1292 → 17 → 12.** 1292 naive include; 17 real errors once the Cypress poisoning is excluded; 12 after the ES2022 `lib` bump clears 5 `Array.prototype.at()` gaps.

## Also in this PR (declared)

- **Removed the vestigial `@types/jest` devDependency** (pre-Vitest leftover from "build: add typescript support"). Its ambient globals meant the suite was typed against *Jest's* matcher surface instead of Vitest's — the same class of type-lie this lane exists to fix. `src/test/test-globals.d.ts` now provides `vitest/globals` + `@testing-library/jest-dom/vitest`, matching the runtime setup in `src/test/setup.ts`.
- **One non-test type-level change** (orchestrator-authorized): `RecipeAPI.getIngredientData` in `src/api/recipes.ts` is now typed `Promise<Exclude<IngredientsType, LabelType>>` — it never returns a group label, and the over-wide type was the actual cause of one test error. Return-type narrowing only; zero runtime effect; no call-site fallout (base typecheck stays 0).
- **One deliberate assertion-call swap**: `expect(uploadBytes).toHaveBeenCalledOnce()` → `toHaveBeenCalledTimes(1)` (RecipesApi.test.ts). Semantically identical; `toHaveBeenCalledOnce` doesn't resolve on `expect(fn)`'s type under tsc 6.0.3.

## The 12 surfaced errors, per item

| File | Errors | Category | Fix |
|---|---|---|---|
| recipeFormValidation.test.ts | 1 | `ParsedIngredient` fixture missing `unitPlural`/`symbol`/`minQty`/`maxQty` | completed fixture (null fields) |
| recipeFormValidation.test.ts | 4 | stale numeric `servings` literals after the number→string contract flip | `4`/`-2`/`1.5`/`1` → string equivalents (`Number()` coercion in the validator makes results identical) |
| recipeFormValidation.test.ts | 1 | `servings: 0` asserts falsy-guard behavior unreachable under the string contract (`'0'` would hit the whole-number branch) | `@ts-expect-error` with explanatory comment — assertion untouched; follow-up to modernize this test to be filed by the orchestrator |
| AddRecipeSummaryBar.test.tsx | 3 | `baseProps.servings: number \| ''` vs the component's `string`; incomplete `parsed()` fixture | `servings: '4'` + completed fixture |
| AccountSections.loading.test.tsx | 1 | `rating: '5'` but `OptionalReviewType.rating` is `number \| null` ("server writes numbers, never strings") | `'5'` → `5` |
| RecipesApi.test.ts | 1 | `result.ingredientData` blocked by `getIngredientData`'s over-wide return type | the authorized src narrowing above |
| RecipesApi.test.ts | 1 | `toHaveBeenCalledOnce` type-resolution gap | the declared swap above |

(The 5 `Array.at()` errors in Recipes/RecipesApi/TimeInput tests are resolved by the tests-config `lib` bump — no test edits.)

## Gates

- `npm run typecheck` (base): **0 errors** (unchanged, incl. after the return-type narrowing)
- `npx tsc --noEmit -p tsconfig.tests.json`: **0 errors**
- `npm test`: **90 files, 735 passed / 2 skipped** — identical totals before and after
- `npm run build`: green
- CI Static job steps run locally in order (typecheck → tests typecheck → build): all green

No runtime behavior changes beyond the declared `toHaveBeenCalledTimes(1)` swap.

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8