### PR TITLE
test: modernize numeric-0 servings case (F2)

### DIFF
--- a/src/test/recipeFormValidation.test.ts
+++ b/src/test/recipeFormValidation.test.ts
@@ -141,16 +141,13 @@ describe('validateRecipeForm', () => {
     )
   })
 
-  it('treats servings of 0 / "" as missing', () => {
+  it('treats an empty servings string as missing, and "0" as an invalid whole number', () => {
     expect(validateRecipeForm({ ...validForm(), servings: '' }).servings).toBe(
       'Servings amount is required'
     )
-    expect(
-      // @ts-expect-error — deliberately passes numeric 0, unreachable now that
-      // the servings contract is `string` ('0' would hit the whole-number branch
-      // instead); kept as-is to preserve the falsy-guard coverage unchanged.
-      validateRecipeForm({ ...validForm(), servings: 0 }).servings
-    ).toBe('Servings amount is required')
+    expect(validateRecipeForm({ ...validForm(), servings: '0' }).servings).toBe(
+      'Servings must be a whole number of at least 1'
+    )
   })
 
   it('rejects negative or fractional servings', () => {


### PR DESCRIPTION
## Summary
- `recipeFormValidation.test.ts`'s "servings of 0" case passed numeric `0` behind a commented `@ts-expect-error`, kept byte-identical by #300 to stay a typing-only merge. Under the post-#298 string contract, numeric `0` is unreachable from the UI and `'0'` (string) actually takes the whole-number branch, not the required-field branch.
- Rewrites the case against reachable string inputs: `''` → `'Servings amount is required'`, `'0'` → `'Servings must be a whole number of at least 1'`.
- Drops the commented `@ts-expect-error` (and its explanatory comment) — no longer needed with string inputs, and an unused suppression is itself a tsc error under `tsconfig.tests.json`.
- Touches nothing else.

## Test plan
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npx tsc --noEmit -p tsconfig.tests.json` → 0 errors
- [x] `npm test` → 90 files / 735 passed / 2 skipped (matches baseline exactly; case was rewritten in place, not split, so no count drift)

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8