### PR TITLE
Add per-uid rate limiter to POST /drafts (F1)

### DIFF
--- a/server/__tests__/draftsLimiter.test.js
+++ b/server/__tests__/draftsLimiter.test.js
@@ -1,0 +1,99 @@
+/**
+ * routes/drafts.js — draftWriteLimiter's real 429 behaviour on POST /drafts,
+ * and proof that PUT /drafts/:id (autosave) is NOT limited.
+ *
+ * Mirrors collectionsLimiter.test.js: the limiter `skip`s under NODE_ENV=test
+ * (so the rest of the suite, which fires many requests per user via
+ * supertest, isn't throttled), so this file flips NODE_ENV to exercise the
+ * real behaviour, then restores it in `finally` so a failed assertion can't
+ * leak the flip into later test files run in the same --runInBand process.
+ * The global per-IP backstop in app.js (limit 1000) is also live under this
+ * flip but nowhere near the request counts driven below.
+ */
+
+const request = require('supertest')
+const { ObjectId } = require('mongodb')
+const app = require('../app')
+const { getDB } = require('../db')
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV
+const AUTH_HEADER = { Authorization: 'Bearer fake-test-token' }
+const TEST_UID = 'test-uid'
+const DRAFT_LIMIT = 30 // draftWriteLimiter's default (makeUserLimiter())
+
+afterEach(async () => {
+  await getDB().collection('recipeDrafts').deleteMany({})
+})
+
+describe('draftWriteLimiter — POST /drafts only', () => {
+  it('429s with the house { error, code: RATE_LIMITED } JSON shape once the per-user cap is hit', async () => {
+    process.env.NODE_ENV = 'development' // un-skip draftWriteLimiter
+    try {
+      // DRAFT_LIMIT (30, the rate cap) is above MAX_DRAFTS_PER_USER (25, the
+      // drafts.js resource cap from V3), so once the loop passes 25 creates
+      // the route itself starts 409ing with DRAFT_LIMIT — a *different*
+      // status/code than the 429 this test pins. Assert only that the
+      // limiter itself doesn't trip (never 429) for the first DRAFT_LIMIT
+      // requests; which of 201/409 the handler returns is drafts.js's own
+      // concern, not the limiter's.
+      for (let i = 0; i < DRAFT_LIMIT; i++) {
+        const res = await request(app)
+          .post('/api/drafts')
+          .set(AUTH_HEADER)
+          .send({ title: `Draft ${i}` })
+        expect(res.status).not.toBe(429)
+      }
+
+      // The rate budget is now fully spent (DRAFT_LIMIT requests) — the next
+      // POST 429s with the house shape regardless of drafts.js's own cap.
+      const blocked = await request(app)
+        .post('/api/drafts')
+        .set(AUTH_HEADER)
+        .send({ title: 'One Too Many' })
+      expect(blocked.status).toBe(429)
+      expect(blocked.body).toEqual({
+        error: 'You’re doing that too quickly — wait a moment and try again.',
+        code: 'RATE_LIMITED',
+      })
+    } finally {
+      process.env.NODE_ENV = ORIGINAL_NODE_ENV
+    }
+  }, 30000)
+
+  it('PUT /drafts/:id (autosave) is NOT limited — more than DRAFT_LIMIT PUTs all pass the limiter', async () => {
+    process.env.NODE_ENV = 'development' // un-skip draftWriteLimiter (if it were mounted here)
+    try {
+      // Seed a draft to autosave against directly in the DB, rather than via
+      // POST /drafts — the prior test in this file already ran DRAFT_LIMIT+1
+      // POSTs for this same uid, and draftWriteLimiter is a module-level
+      // singleton whose 60s window is shared across tests in this
+      // --runInBand process, so a POST here could itself 429.
+      const now = Date.now().toString()
+      const id = new ObjectId()
+      await getDB().collection('recipeDrafts').insertOne({
+        _id: id,
+        userId: TEST_UID,
+        title: 'WIP',
+        createdAt: now,
+        updatedAt: now,
+      })
+      let updatedAt = now
+
+      // Fire MORE than DRAFT_LIMIT PUTs (the POST cap) against the same
+      // draft. If PUT were accidentally sharing or mounting a limiter, this
+      // would 429 well before the loop finishes; since it's deliberately
+      // unmounted, every single one succeeds.
+      const attempts = DRAFT_LIMIT + 10
+      for (let i = 0; i < attempts; i++) {
+        const res = await request(app)
+          .put(`/api/drafts/${id}`)
+          .set(AUTH_HEADER)
+          .send({ title: `Autosave ${i}`, updatedAt })
+        expect(res.status).toBe(200)
+        updatedAt = res.body.updatedAt
+      }
+    } finally {
+      process.env.NODE_ENV = ORIGINAL_NODE_ENV
+    }
+  }, 30000)
+})

--- a/server/__tests__/writeLimiter.wiring.test.js
+++ b/server/__tests__/writeLimiter.wiring.test.js
@@ -18,6 +18,7 @@ const {
   reviewWriteLimiter,
   profileWriteLimiter,
   collectionWriteLimiter,
+  draftWriteLimiter,
 } = require('../middleware/writeLimiter')
 
 const recipesRouter = require('../routes/recipes')
@@ -51,6 +52,7 @@ describe('per-surface write limiters are wired onto every moderated write route'
     ['auth', authRouter, 'post', '/updatePrivacy', profileWriteLimiter],
     ['collections', collectionsRouter, 'post', '/collections', collectionWriteLimiter],
     ['collections', collectionsRouter, 'patch', '/collections/:id', collectionWriteLimiter],
+    ['drafts', draftsRouter, 'post', '/', draftWriteLimiter],
   ]
 
   it.each(cases)(
@@ -66,7 +68,7 @@ describe('per-surface write limiters are wired onto every moderated write route'
     }
   )
 
-  it('recipe / review / profile / collection each use a DISTINCT limiter instance', () => {
+  it('recipe / review / profile / collection / draft each use a DISTINCT limiter instance', () => {
     // Independent instances ⇒ independent buckets (the #3 fix). If two surfaces
     // ever collapsed back onto one shared limiter this would catch it.
     const limiters = new Set([
@@ -74,8 +76,24 @@ describe('per-surface write limiters are wired onto every moderated write route'
       reviewWriteLimiter,
       profileWriteLimiter,
       collectionWriteLimiter,
+      draftWriteLimiter,
     ])
-    expect(limiters.size).toBe(4)
+    expect(limiters.size).toBe(5)
+  })
+
+  it('PUT /drafts/:id (autosave) is NOT wired to draftWriteLimiter or any other limiter', () => {
+    // The autosave path is deliberately unlimited (see the comment at that
+    // route's mount point in drafts.js) — assert none of the per-surface
+    // limiter instances appear in its handler chain.
+    const handlers = routeHandlers(draftsRouter, 'put', '/:id')
+    const allLimiters = [
+      recipeWriteLimiter,
+      reviewWriteLimiter,
+      profileWriteLimiter,
+      collectionWriteLimiter,
+      draftWriteLimiter,
+    ]
+    allLimiters.forEach((limiter) => expect(handlers).not.toContain(limiter))
   })
 
   it('collections POST /collections and PATCH /collections/:id SHARE one limiter instance', () => {

--- a/server/middleware/writeLimiter.js
+++ b/server/middleware/writeLimiter.js
@@ -70,10 +70,18 @@ const profileWriteLimiter = makeUserLimiter()
 // so they share the 30/min default rather than the recipe surface's tighter cap.
 const collectionWriteLimiter = makeUserLimiter()
 
+// Drafts (server/routes/drafts.js) also carry no per-write paid cost — no Cloud
+// Vision scan, no moderation call — so this shares the 30/min default too. It is
+// mounted ONLY on POST /drafts (create), which is already bounded by V3's
+// 25-draft-per-user cap. PUT /drafts/:id (autosave) deliberately does NOT use
+// this limiter — see the comment at that route's mount point for why.
+const draftWriteLimiter = makeUserLimiter()
+
 module.exports = {
   makeUserLimiter,
   recipeWriteLimiter,
   reviewWriteLimiter,
   profileWriteLimiter,
   collectionWriteLimiter,
+  draftWriteLimiter,
 }

--- a/server/routes/drafts.js
+++ b/server/routes/drafts.js
@@ -3,6 +3,7 @@ const { asyncHandler } = require('../util/asyncHandler')
 const { ObjectId } = require('mongodb')
 const { getDB } = require('../db')
 const { verifyToken, requireActive } = require('../middleware/auth')
+const { draftWriteLimiter } = require('../middleware/writeLimiter')
 const { validateRecipeBounds } = require('../util/recipeLimits')
 const { RECIPE_CONTENT_FIELDS, pickFields } = require('../util/recipeFields')
 
@@ -25,7 +26,7 @@ const MAX_DRAFTS_PER_USER = 25
 
 // POST /drafts — create a new draft for the current user. Returns the new _id
 // so the client can switch to update-on-autosave from then on.
-router.post('/', verifyToken, requireActive, asyncHandler(async (req, res) => {
+router.post('/', verifyToken, requireActive, draftWriteLimiter, asyncHandler(async (req, res) => {
   const db = getDB()
   const boundsError = validateRecipeBounds(req.body)
   if (boundsError) {
@@ -117,6 +118,16 @@ router.get('/:id', verifyToken, asyncHandler(async (req, res) => {
 // the update is conditioned on the stored draft still carrying that value, so
 // a tab that's saved on top of a since-changed draft gets a 409 instead of
 // blindly clobbering it with a full `$set` of its (now-stale) content.
+//
+// Deliberately NO draftWriteLimiter here (unlike POST above). This is the
+// 1.5s-debounce autosave path — continuous typing alone can produce ~40
+// legitimate writes/min, well over a stock 30/min per-uid cap, so reusing the
+// POST limiter here would throttle normal editing, not abuse. It also must
+// never be the request that eats a 429 for #294's keepalive flush on tab
+// unload. Damage from PUT spam is bounded another way: it can only rewrite
+// the caller's OWN drafts (ownership-checked above), and the draft set itself
+// is capped at MAX_DRAFTS_PER_USER by POST's post-insert trim, so there's no
+// unbounded resource growth to protect against here.
 router.put('/:id', verifyToken, requireActive, asyncHandler(async (req, res) => {
   const db = getDB()
   if (!ObjectId.isValid(req.params.id)) {


### PR DESCRIPTION
## Summary
- Backlog item: `drafts.js` had **zero** `makeUserLimiter` references (POST or PUT) — no per-uid rate limiter at all.
- Adds `draftWriteLimiter` (`server/middleware/writeLimiter.js`) — `makeUserLimiter()` default (30/min), mirroring `collectionWriteLimiter`'s cost rationale (no paid per-write cost: no Cloud Vision, no moderation call).
- Mounts it **only** on `POST /drafts` (create), after `verifyToken, requireActive`. `PUT /drafts/:id` (autosave) is deliberately left **unlimited** — it's the 1.5s-debounce autosave path (~40 legitimate writes/min while typing), and #294's keepalive unload flush must never be the request that eats a 429. PUT damage is already bounded: ownership-checked, and the draft set is capped at 25/user (V3's post-insert trim on POST).
- DELETE and the GETs are untouched (matches how sibling routes treat non-creating operations).

## Design call (pre-made, not re-litigated in this PR)
Limit only `POST /drafts`, mirroring PR #299's philosophy of limiting resource-creating writes.

## Files changed
- `server/middleware/writeLimiter.js` — new `draftWriteLimiter` export (5th per-surface instance).
- `server/routes/drafts.js` — mount `draftWriteLimiter` on `POST /` after `verifyToken, requireActive`; add an explanatory comment on `PUT /:id` documenting why it stays unlimited.
- `server/__tests__/draftsLimiter.test.js` (new) — mirrors `collectionsLimiter.test.js`: flips `NODE_ENV` to exercise the real limiter, drives `POST /drafts` to the 30-cap and asserts the next request 429s with the house `{ error, code: 'RATE_LIMITED' }` shape; separately asserts `PUT /drafts/:id` is not limited across `DRAFT_LIMIT + 10` requests.
- `server/__tests__/writeLimiter.wiring.test.js` — adds the `POST /drafts` wiring case, bumps the distinct-instances assertion 4→5, adds a case asserting no limiter is wired onto `PUT /drafts/:id`.

## Test plan
- [x] `cd server && npm test` — 41 suites / 883 tests passing (baseline 40/879 + 1 new suite / 4 new tests).
- [x] Verified worktree discipline: all work done under `.claude/worktrees/agent-aee0bc3db49bd40b0`, never touched the main checkout.

## Note for orchestrator
`docs/API_CONTRACT.md` will need updating — `POST /api/drafts` now gains a 429 response. Left untouched per instructions (orchestrator-owned doc).

https://claude.ai/code/session_01N8AxP2hw58W6hSCp4uzSQ8