### PR TITLE
feat: V5 cutover half — numeric review timestamps (New/Top sort single-typing)

### DIFF
--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -331,9 +331,9 @@ All routes live in `server/routes/reviews.js`, mounted at `/api` (server/app.js)
   - `400 {error:'Review cannot exceed 2000 characters'}` — `DESCRIPTION_MAX_LENGTH` = 2000 (server/util/recipeLimits.js:7)
   - `422 {error: <friendly message>, code:'CONTENT_BLOCKED'}` — `moderateText(reviewText, 'review')` verdict not clean; both high and medium confidence block inline via `respondBlocked` (server/util/automod.js:99), which also fires a best-effort `content.blocked` audit row
   - `400 {error:'Username not found for this user'}` — no `usernames` doc
-- **Response:** `200` = the full updated `ratings` document (re-fetched after upsert: `_id, userId, recipeId, username, rating, ratingLastUpdated, reviewText, reviewCreatedAt, reviewLastUpdated`, timestamps as `Date.now().toString()`). Plus `401/403/429` as above.
+- **Response:** `200` = the full updated `ratings` document (re-fetched after upsert: `_id, userId, recipeId, username, rating, ratingLastUpdated, reviewText, reviewCreatedAt, reviewLastUpdated`, timestamps as **numeric epoch-ms** (`Date.now()`); `''` remains the "no review yet" sentinel on rating-only docs). Plus `401/403/429` as above.
 - **Client:** `src/api/recipes.ts:440` → `RecipeAPI.newReview(recipeId, text)` — used by `src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/AddReview.tsx:37`.
-- **Notes:** Upsert on `{userId, recipeId}`; on insert `rating: null` is defaulted so a review-before-rating doc never poisons the aggregate. No rating recompute (text doesn't affect the score).
+- **Notes:** Upsert on `{userId, recipeId}`; on insert `rating: null` is defaulted so a review-before-rating doc never poisons the aggregate. No rating recompute (text doesn't affect the score). **V5 cutover:** timestamps flipped from `Date.now().toString()` strings to numeric epoch-ms; pre-migration prod docs remain strings until the coupled `normalizeRatingTypes.js --apply` run (the two must ship together — the New/Top sorts compare BSON type first).
 
 ### GET /api/checkIfReviewed
 - **Handler:** `server/routes/reviews.js:110`
@@ -353,7 +353,7 @@ All routes live in `server/routes/reviews.js`, mounted at `/api` (server/app.js)
   - `404 {error:'Review not found'}` — update matched 0 docs (non-author can never match, since the filter is `{userId: req.uid, recipeId}`, so a miss is purely "no such doc" — not-found, not a permissions failure; normalized from `403` alongside the delete routes below, house convention per `drafts.js`)
 - **Response:** `200 {edited: true}`. Plus `401/429`.
 - **Client:** `src/api/recipes.ts:456` → `RecipeAPI.editReview(recipeId, text)` — used by `src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.tsx:59`.
-- **Notes:** Updates `reviewText` + `reviewLastUpdated` only. As of §D PR-A both create and edit accept a JSON body (`newReview`→`reviewText`, `editReview`→`text`); the field-name difference remains but the transport is now aligned.
+- **Notes:** Updates `reviewText` + `reviewLastUpdated` only (`reviewLastUpdated` is now numeric epoch-ms `Date.now()`, per the V5 cutover — see /newReview). As of §D PR-A both create and edit accept a JSON body (`newReview`→`reviewText`, `editReview`→`text`); the field-name difference remains but the transport is now aligned.
 
 ### DELETE /api/deleteReview
 - **Handler:** `server/routes/reviews.js:156`

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -271,6 +271,8 @@ describe('POST /editReview', () => {
       .collection('ratings')
       .findOne({ username: TEST_USERNAME, recipeId: RECIPE_ID })
     expect(doc.reviewText).toBe('Updated review')
+    // V5 cutover: an edit stamps a numeric epoch-ms reviewLastUpdated.
+    expect(doc.reviewLastUpdated).toEqual(expect.any(Number))
   })
 
   it('accepts the params in a JSON body (the new client transport)', async () => {
@@ -579,6 +581,9 @@ describe('POST /newReview', () => {
     expect(res.body.reviewText).toBe('Amazing dish!')
     expect(res.body.username).toBe(TEST_USERNAME)
     expect(res.body.recipeId).toBe(RECIPE_ID)
+    // V5 cutover: timestamps are numeric epoch-ms, never strings.
+    expect(res.body.reviewCreatedAt).toEqual(expect.any(Number))
+    expect(res.body.reviewLastUpdated).toEqual(expect.any(Number))
   })
 
   // Audit §4 item 4: reviewText must be bounded (mirrors DESCRIPTION_MAX_LENGTH).
@@ -626,6 +631,10 @@ describe('POST /newReview', () => {
 
     expect(res.status).toBe(200)
     expect(res.body.reviewText).toBe('Updated text')
+    // V5 cutover: the upsert overwrites the legacy string timestamps with
+    // numeric epoch-ms.
+    expect(res.body.reviewCreatedAt).toEqual(expect.any(Number))
+    expect(res.body.reviewLastUpdated).toEqual(expect.any(Number))
   })
 
   // Identity is resolved server-side from req.uid → usernames collection.

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -117,7 +117,10 @@ router.post('/newReview', verifyToken, requireActive, reviewWriteLimiter, asyncH
   if (!usernameDoc) return res.status(400).json({ error: 'Username not found for this user' })
   const { username } = usernameDoc
 
-  const now = Date.now().toString()
+  // Numeric epoch-ms (V5 cutover): the ratings collection must be single-typed
+  // for the New/Top sorts (BSON compares by type first). '' stays the
+  // "no review yet" sentinel — normalizeRatingTypes preserves it.
+  const now = Date.now()
   // Keyed by the stable uid (D1). username is denormalized for display, written
   // once on insert ($setOnInsert) alongside the defaulted rating fields. The
   // dup-retry handles a concurrent double-submit racing on the unique index.
@@ -179,7 +182,7 @@ router.post('/editReview', verifyToken, requireActive, reviewWriteLimiter, async
   // convention (drafts.js): 404 = no such doc, 403 = exists but not yours.
   const editResult = await db.collection('ratings').updateOne(
     { userId: req.uid, recipeId },
-    { $set: { reviewText: text, reviewLastUpdated: Date.now().toString() } }
+    { $set: { reviewText: text, reviewLastUpdated: Date.now() } }
   )
   if (editResult.matchedCount === 0) {
     return res.status(404).json({ error: 'Review not found' })

--- a/src/types.ts
+++ b/src/types.ts
@@ -271,8 +271,10 @@ export type OptionalReviewType = {
   // docs carry null here (the server writes numbers, never strings).
   rating: number | null
   ratingLastUpdated: string
-  reviewCreatedAt?: string
-  reviewLastUpdated?: string
+  // Transitional (V5 cutover): numeric epoch-ms on new writes, string on
+  // pre-migration docs; '' = no review yet.
+  reviewCreatedAt?: string | number
+  reviewLastUpdated?: string | number
   reviewText?: string
   recipeTitle?: string
   recipeImage?: string
@@ -286,8 +288,10 @@ export type ReviewType = {
   recipeId: string
   rating: number | null
   ratingLastUpdated: string
-  reviewCreatedAt: string
-  reviewLastUpdated: string
+  // Transitional (V5 cutover): numeric epoch-ms on new writes, string on
+  // pre-migration docs; '' = no review yet.
+  reviewCreatedAt: string | number
+  reviewLastUpdated: string | number
   reviewText: string
   photoURL: string | null
   displayName: string | null
@@ -308,8 +312,10 @@ export type OwnReviewStatus = {
   rating?: number | null
   ratingLastUpdated?: string
   reviewText?: string
-  reviewCreatedAt?: string
-  reviewLastUpdated?: string
+  // Transitional (V5 cutover): numeric epoch-ms on new writes, string on
+  // pre-migration docs; '' = no review yet.
+  reviewCreatedAt?: string | number
+  reviewLastUpdated?: string | number
 }
 
 export interface NewReviewType {

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -13,7 +13,7 @@ const monthNames = [
   'December',
 ]
 
-export const formatDate = (d: string, short: boolean): string => {
+export const formatDate = (d: string | number, short: boolean): string => {
   const date = Number.isNaN(d) ? new Date(d) : new Date(Number(d))
   let day = date.getDate()
   let month = monthNames[date.getMonth()]


### PR DESCRIPTION
## What this is

This is the **write-path half of the V5 two-part atomic cutover**. `POST /newReview` and `POST /editReview` now write `reviewCreatedAt` / `reviewLastUpdated` as **numeric epoch-ms** (`Date.now()`) instead of `Date.now().toString()` strings. The `''` "no review yet" sentinels (`$setOnInsert` in `/addRating`, the blanking in `/deleteReview`) are deliberately unchanged — `normalizeRatingTypes` preserves them.

## DO NOT MERGE

**Do not merge until the prod `node server/scripts/normalizeRatingTypes.js --apply` has run.** The two halves must ship together.

## What regresses if either half ships alone

- **This PR merged without the migration:** new reviews write numeric timestamps into a string-typed prod collection. The New/Top sorts (`{ reviewCreatedAt: -1 }` / `{ rating: -1 }` in `server/routes/reviews.js`) compare BSON *type* before value, so new reviews land in a separate type block and sort wrongly relative to every existing review.
- **Migration run without this PR:** the collection is normalized to numbers, but the very next posted/edited review re-introduces string timestamps, re-mixing the types and regressing the same sorts again.

## Changes

- `server/routes/reviews.js` — `/newReview` and `/editReview` stamp `Date.now()` (numeric); `''` sentinels untouched.
- `server/__tests__/reviews.test.js` — write-path assertions strengthened to `expect.any(Number)` (create, upsert-over-legacy-string-doc, edit).
- `src/types.ts` — transitional widening: `reviewCreatedAt` / `reviewLastUpdated` are `string | number` (`OptionalReviewType`, `ReviewType`, `OwnReviewStatus`); pre-migration docs are strings until the coupled cutover.
- `src/util/formatDate.ts` — `formatDate(d: string | number, short)`; runtime already coerced via `Number(d)`.
- `docs/API_CONTRACT.md` — `/newReview` response + notes and `/editReview` notes updated to numeric epoch-ms, with the sentinel and the pre-migration-strings caveat.

Out of scope (separate post-cutover follow-up): retiring `coerceRating` in `src/api/recipes.ts`.

## Verification

Post-merge + post-apply, this must be **0 and stay 0** after a new review is posted:

```js
db.ratings.countDocuments({ $or: [{ rating: { $type: 'string' } }, { reviewCreatedAt: { $type: 'string', $ne: '' } }] })
```

## Gates

- Server Jest: **883 passed, 41 suites**
- Client Vitest: **735 passed, 2 skipped (90 files)**
- `tsc -p tsconfig.json --noEmit` and `tsc -p tsconfig.tests.json --noEmit`: clean

## Sequencing

See **docs/RELEASE_RUNBOOK.md** (being authored tonight) for the sequenced cutover steps.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK