### PR TITLE
fix: guard IngredientItem edit-submit against re-entry during pending enrichment

### DIFF
--- a/src/pages/AddRecipe/Ingredients/IngredientItem.tsx
+++ b/src/pages/AddRecipe/Ingredients/IngredientItem.tsx
@@ -76,6 +76,18 @@ const IngredientItem: FC<IngredientItemProps> = ({
   // only a genuine user blur (click-away while editing) reaches
   // handleEditSubmit a second time.
   const suppressNextBlurSubmitRef = useRef(false)
+  // Guards handleEditSubmit's async path (the getIngredientData enrichment
+  // await) against re-entry. Set synchronously at the top of handleEditSubmit
+  // — before the first await — and cleared in a finally, so it's already true
+  // for the whole pending window. Without it: (a) a genuine blur-away while
+  // the row is still awaiting enrichment slips past suppressNextBlurSubmitRef
+  // (that flag only guards the submit's own trailing self-blur, not a real
+  // user blur) and fires a second, fully duplicate submit against the same
+  // stale editedVal; (b) a rapid double-Enter does the same via onEnter. Both
+  // mean a duplicate network call, a duplicate 429 toast, and doubled
+  // rate-limit consumption. A ref (not state) because it's read/written
+  // synchronously inside event handlers and never needs to trigger a render.
+  const isSubmittingRef = useRef(false)
 
   // When enrichment last 429'd, hold retryAt (epoch ms) here so the retry
   // button can disable itself instead of immediately re-429ing. Sourced from
@@ -142,64 +154,79 @@ const IngredientItem: FC<IngredientItemProps> = ({
     )
   }
   const handleEditSubmit = async () => {
-    if (!editedVal || !ingredient) {
-      setIsEditing(false)
-      return
-    }
+    // Re-entry guard: a second call (rapid double-Enter, or a genuine
+    // blur-away that races the pending enrichment await below) while a
+    // submit is already in flight is dropped. Set before any await so it's
+    // already true for the entire pending window — see isSubmittingRef above.
+    if (isSubmittingRef.current) return
+    isSubmittingRef.current = true
+    try {
+      if (!editedVal || !ingredient) {
+        setIsEditing(false)
+        return
+      }
 
-    const isLabel = 'label' in ingredient
+      const isLabel = 'label' in ingredient
 
-    if (isLabel && ingredient.label !== editedVal) {
-      editIngredient(ingredient.id, { label: editedVal, id: ingredient.id })
-    } else if (
-      !isLabel &&
-      ingredient.parsedIngredient.originalIngredientString !== editedVal
-    ) {
-      const id = ingredient.id
-      setItemStatus(id, 'loading')
-      try {
-        // Same timeout/exit guard as the add path: getIngredientData soft-fails
-        // but can't protect against a request that never settles, so race it
-        // against a wall clock.
-        const ingredientDataRes = await withTimeout(
-          RecipeAPI.getIngredientData(editedVal)
-        )
-        editIngredient(id, { ...ingredientDataRes })
-        const rowError =
-          'error' in ingredientDataRes ? ingredientDataRes.error : undefined
-        setItemStatus(id, rowError ? 'error' : null)
-        // Same honest-messaging branch as the add path: a 429 is a distinct,
-        // expected condition, not a generic miss, so it gets its own toast
-        // instead of silently landing on the row.
-        if (rowError?.code === INGREDIENT_RATE_LIMIT_CODE) {
+      if (isLabel && ingredient.label !== editedVal) {
+        editIngredient(ingredient.id, { label: editedVal, id: ingredient.id })
+      } else if (
+        !isLabel &&
+        ingredient.parsedIngredient.originalIngredientString !== editedVal
+      ) {
+        const id = ingredient.id
+        setItemStatus(id, 'loading')
+        try {
+          // Same timeout/exit guard as the add path: getIngredientData soft-fails
+          // but can't protect against a request that never settles, so race it
+          // against a wall clock.
+          const ingredientDataRes = await withTimeout(
+            RecipeAPI.getIngredientData(editedVal)
+          )
+          editIngredient(id, { ...ingredientDataRes })
+          const rowError =
+            'error' in ingredientDataRes ? ingredientDataRes.error : undefined
+          setItemStatus(id, rowError ? 'error' : null)
+          // Same honest-messaging branch as the add path: a 429 is a distinct,
+          // expected condition, not a generic miss, so it gets its own toast
+          // instead of silently landing on the row.
+          if (rowError?.code === INGREDIENT_RATE_LIMIT_CODE) {
+            toast.error(
+              `"${editedVal}" hit the ingredient lookup limit — wait a moment before retrying.`
+            )
+          }
+        } catch (err: unknown) {
+          const timedOut = err instanceof IngredientEnrichTimeoutError
+          setItemStatus(id, 'error')
           toast.error(
-            `"${editedVal}" hit the ingredient lookup limit — wait a moment before retrying.`
+            timedOut
+              ? `"${editedVal}" is taking too long to look up — kept without nutrition data. Retry or edit it.`
+              : `Couldn't fetch data for "${editedVal}" — kept without it. Retry or edit it.`
           )
         }
-      } catch (err: unknown) {
-        const timedOut = err instanceof IngredientEnrichTimeoutError
-        setItemStatus(id, 'error')
-        toast.error(
-          timedOut
-            ? `"${editedVal}" is taking too long to look up — kept without nutrition data. Retry or edit it.`
-            : `Couldn't fetch data for "${editedVal}" — kept without it. Retry or edit it.`
-        )
       }
-    }
 
-    setIsEditing(false)
-    suppressNextBlurSubmitRef.current = true
-    editInputRef?.current?.blur()
+      setIsEditing(false)
+      suppressNextBlurSubmitRef.current = true
+      editInputRef?.current?.blur()
+    } finally {
+      isSubmittingRef.current = false
+    }
   }
 
   // Wired to FormInput's onBlur. Genuine blur-away (clicking elsewhere while
   // editing) should still submit; the blur() handleEditSubmit triggers on
-  // itself should not resubmit — see suppressNextBlurSubmitRef above.
+  // itself should not resubmit — see suppressNextBlurSubmitRef above. A blur
+  // that lands while a submit is already pending (isSubmittingRef) is also
+  // dropped rather than firing a second submit; the in-flight submit's own
+  // post-await tail (setIsEditing(false), etc.) is what exits edit mode, so
+  // dropping this blur doesn't leave the row stuck open.
   const handleBlur = () => {
     if (suppressNextBlurSubmitRef.current) {
       suppressNextBlurSubmitRef.current = false
       return
     }
+    if (isSubmittingRef.current) return
     handleEditSubmit()
   }
 

--- a/src/test/IngredientItemEdit.test.tsx
+++ b/src/test/IngredientItemEdit.test.tsx
@@ -222,4 +222,75 @@ describe('IngredientItem inline edit', () => {
     expect(mockGetIngredientData).not.toHaveBeenCalled()
     expect(setItemStatus).not.toHaveBeenCalled()
   })
+
+  // In-flight re-entry guard (isSubmittingRef): the enrichment await in
+  // handleEditSubmit leaves the input visible+focused for the whole pending
+  // window (setIsEditing(false) only runs after the await settles). Without
+  // a guard, a genuine blur-away or a rapid double-Enter during that window
+  // fires a second full submit against the same stale editedVal — a real
+  // duplicate paid lookup and duplicate 429 toast. These tests hold the
+  // enrichment promise open with a deferred so they can assert the *pending*
+  // window's behavior, not just the settled outcome.
+  describe('in-flight submit re-entry guard', () => {
+    const deferred = <T,>() => {
+      let resolve!: (v: T) => void
+      const promise = new Promise<T>(res => {
+        resolve = res
+      })
+      return { promise, resolve }
+    }
+
+    it('blur-away while enrichment is still pending does not trigger a second submit', async () => {
+      const { promise, resolve } = deferred<ReturnType<typeof enriched>>()
+      mockGetIngredientData.mockReturnValue(promise)
+      const { container } = renderItem()
+      const removeBtn = container.querySelector('.ingr-remove') as HTMLButtonElement
+
+      fireEvent.click(container.querySelector('.item-btn') as HTMLElement)
+      const input = container.querySelector('input') as HTMLInputElement
+      fireEvent.change(input, { target: { value: '2 cups flour' } })
+      fireEvent.keyDown(input, { key: 'Enter' }) // starts the pending submit
+
+      await waitFor(() => expect(mockGetIngredientData).toHaveBeenCalledTimes(1))
+
+      // Real blur-away while the first submit is still awaiting enrichment —
+      // the input is still rendered+focused at this point (setIsEditing(false)
+      // hasn't run yet), so this exercises the exact race.
+      act(() => removeBtn.focus())
+
+      // Let the pending submit resolve.
+      await act(async () => {
+        resolve(enriched('2 cups flour'))
+      })
+
+      await waitFor(() => expect(mockGetIngredientData).toHaveBeenCalledTimes(1))
+      // The in-flight submit's own post-await tail is what exits edit mode —
+      // confirm the blur-away didn't leave the row wedged open.
+      expect(container.querySelector('.edit-input')).toBeNull()
+    })
+
+    it('a rapid double-Enter while enrichment is still pending only submits once', async () => {
+      const { promise, resolve } = deferred<ReturnType<typeof enriched>>()
+      mockGetIngredientData.mockReturnValue(promise)
+      const { container } = renderItem()
+
+      fireEvent.click(container.querySelector('.item-btn') as HTMLElement)
+      const input = container.querySelector('input') as HTMLInputElement
+      fireEvent.change(input, { target: { value: '2 cups flour' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      // Second Enter fires while the first submit is still awaiting.
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => expect(mockGetIngredientData).toHaveBeenCalledTimes(1))
+
+      await act(async () => {
+        resolve(enriched('2 cups flour'))
+      })
+
+      await waitFor(() =>
+        expect(container.querySelector('.edit-input')).toBeNull()
+      )
+      expect(mockGetIngredientData).toHaveBeenCalledTimes(1)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

`IngredientItem.handleEditSubmit` awaits `RecipeAPI.getIngredientData` while
the row stays visible and focused (`setIsEditing(false)` only runs after the
await settles). Without a re-entry guard across that window:

- a genuine blur-away while the submit is still pending slips past
  `suppressNextBlurSubmitRef` (which only guards the submit's own trailing
  self-`blur()`, not a real user blur) and fires a second, fully duplicate
  submit against the same stale `editedVal`
- a rapid double-Enter does the same via `onEnter`

Both produce a duplicate enrichment network call, a duplicate 429 toast, and
doubled rate-limit consumption. No data corruption — writes are id-keyed —
but a real duplicate paid lookup.

- Added `isSubmittingRef` (ref, not state — no re-render needed), set
  synchronously at the top of `handleEditSubmit` before any `await`, cleared
  in a `finally`.
- `handleEditSubmit`'s own re-entry and `handleBlur`'s submit call both
  early-return while it's set.
- The in-flight submit's own post-await tail (`setIsEditing(false)`, etc.)
  is what exits edit mode, so a dropped blur doesn't leave the row wedged
  open in edit mode.
- The existing #295 stuck-flag semantics on `suppressNextBlurSubmitRef`
  (reset on edit-entry in `handleIngrClick`) are unchanged.

`InstructionItem` was not touched — its submit path is synchronous and
unaffected by this race.

## Test plan

- [x] Two new regression tests in `src/test/IngredientItemEdit.test.tsx`
      (`in-flight submit re-entry guard` describe block), using a deferred
      promise to hold the enrichment pending and **real focus movement**
      (`otherEl.focus()` inside `act()`, not `fireEvent.blur`) per house
      convention:
      - blur-away while enrichment is pending → exactly one
        `getIngredientData` call, row exits edit mode once the pending
        submit resolves (not wedged open)
      - rapid double-Enter while enrichment is pending → exactly one
        `getIngredientData` call
- [x] All pre-existing single-submit regression tests in the same file still
      pass unmodified
- [x] `npm install && npm test -- --run` — 90 test files, 737 passed, 2
      pre-existing skips, 0 failed
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx tsc -p tsconfig.tests.json --noEmit` — clean

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK