### PR TITLE
feat(server): prod hardening — health ping, graceful shutdown, quiet CORS 403, JSON 404, FRONTEND_URLS warning, CI release trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ name: Tests
 on:
   pull_request:
   push:
-    branches: [main, development]
+    branches: [main, development, release]
 
 concurrency:
   group: tests-${{ github.ref }}

--- a/server/__tests__/app-hardening.test.js
+++ b/server/__tests__/app-hardening.test.js
@@ -1,0 +1,70 @@
+/**
+ * Prod-hardening regression tests (Wave 14 lane E):
+ *   - GET /health does a live DB ping: 200 {status:'ok'} healthy, 503
+ *     {status:'degraded'} when the ping fails.
+ *   - A rejected CORS origin renders as a quiet JSON 403 (no Sentry capture).
+ *   - An unmatched /api route returns a JSON 404, not Express's default HTML.
+ *
+ * The signal handlers and graceful shutdown live in index.js, which the test
+ * suite never loads, so they are intentionally not exercised here.
+ */
+
+const request = require('supertest')
+const app = require('../app')
+const { getDB } = require('../db')
+
+// ─── /health live DB ping ────────────────────────────────────────────────────
+
+describe('GET /health', () => {
+  it('returns 200 { status: "ok" } when the DB ping succeeds', async () => {
+    const res = await request(app).get('/health')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ status: 'ok' })
+  })
+
+  it('returns 503 { status: "degraded" } when the DB ping fails', async () => {
+    const db = getDB()
+    const spy = jest
+      .spyOn(db, 'command')
+      .mockRejectedValue(new Error('mongo unreachable'))
+    try {
+      const res = await request(app).get('/health')
+      expect(res.status).toBe(503)
+      expect(res.body).toEqual({ status: 'degraded' })
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('uses the getDB() singleton (never opens a new client) for the ping', async () => {
+    const db = getDB()
+    const spy = jest.spyOn(db, 'command')
+    await request(app).get('/health')
+    expect(spy).toHaveBeenCalledWith({ ping: 1 })
+    spy.mockRestore()
+  })
+})
+
+// ─── CORS rejection → quiet JSON 403 ─────────────────────────────────────────
+
+describe('CORS origin rejection', () => {
+  it('renders a disallowed origin as a JSON 403, not a 500', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await request(app)
+      .get('/api/recipes')
+      .set('Origin', 'http://evil.example.com')
+    expect(res.status).toBe(403)
+    expect(res.body).toEqual({ error: 'Bad request' })
+    spy.mockRestore()
+  })
+})
+
+// ─── Unmatched /api route → JSON 404 ─────────────────────────────────────────
+
+describe('unmatched /api route', () => {
+  it('returns a JSON 404 { error: "Not found" }', async () => {
+    const res = await request(app).get('/api/no-such-endpoint-xyz')
+    expect(res.status).toBe(404)
+    expect(res.body).toEqual({ error: 'Not found' })
+  })
+})

--- a/server/app.js
+++ b/server/app.js
@@ -17,6 +17,7 @@ const adminRoutes = require('./routes/admin')
 const collectionRoutes = require('./routes/collections')
 const Sentry = require('@sentry/node')
 const { GENERIC_500_MESSAGE } = require('./util/respondServerError')
+const { getDB } = require('./db')
 
 const app = express()
 
@@ -37,6 +38,19 @@ const netlifyPreviewPattern = /^https:\/\/deploy-preview-\d+--prepify\.netlify\.
 const isProduction = process.env.NODE_ENV === 'production'
 const localhostDevPattern = /^http:\/\/(localhost|127\.0\.0\.1):30(0\d|10)$/
 
+// Loud startup warning: in production with FRONTEND_URLS unset/empty, the CORS
+// allow-list silently falls back to 'http://localhost:3000' — which no real
+// browser client sends — so every production origin (except Netlify deploy
+// previews) is blocked and the frontend can't reach the API. This only warns;
+// the fallback behaviour is intentionally left unchanged.
+if (isProduction && !(process.env.FRONTEND_URLS || '').trim()) {
+  console.warn(
+    'WARNING: FRONTEND_URLS is unset in production. CORS will fall back to ' +
+      "'http://localhost:3000' and block all real production origins. Set " +
+      'FRONTEND_URLS to your production frontend origin(s) (comma-separated).'
+  )
+}
+
 app.use(cors({
   origin: (origin, callback) => {
     if (
@@ -47,7 +61,12 @@ app.use(cors({
     ) {
       callback(null, true)
     } else {
-      callback(new Error('Not allowed by CORS'))
+      // A rejected origin is an expected client condition, not a server fault:
+      // tag it 403 so the error backstop renders it as a quiet JSON 403 and
+      // does NOT Sentry-capture it (the backstop only captures status >= 500).
+      const err = new Error('Not allowed by CORS')
+      err.status = 403
+      callback(err)
     }
   },
   credentials: true,
@@ -63,7 +82,29 @@ if (isProduction) app.set('trust proxy', 1)
 
 // /health stays above the limiter so platform health checks and uptime
 // monitors can never be throttled into a false "down".
-app.get('/health', (req, res) => res.json({ status: 'ok' }))
+//
+// A live DB round-trip (not a static 200): a wedged instance whose Mongo
+// connection has dropped must report unhealthy so Railway restarts it instead
+// of leaving the deploy green on a broken pod. The ping is raced against a 2s
+// timeout so a hung/unreachable Mongo can't stall the healthcheck past the
+// driver's serverSelectionTimeoutMS. It reuses the getDB() singleton (never a
+// new client) and can never throw: a not-yet-connected getDB(), a failed ping,
+// or the timeout all collapse to a 503 { status: 'degraded' }.
+app.get('/health', async (req, res) => {
+  let timer
+  try {
+    const db = getDB() // throws if connectDB() hasn't completed yet
+    const timeout = new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error('health ping timeout')), 2000)
+    })
+    await Promise.race([db.command({ ping: 1 }), timeout])
+    res.json({ status: 'ok' })
+  } catch (err) {
+    res.status(503).json({ status: 'degraded' })
+  } finally {
+    clearTimeout(timer)
+  }
+})
 
 // Generous global per-IP backstop — normal browsing is tens of requests a
 // minute, so only scripted abuse approaches this. The tight per-user limit on
@@ -94,6 +135,15 @@ app.use('/api', reportRoutes)
 app.use('/api', bugReportRoutes)
 app.use('/api', adminRoutes)
 app.use('/api', collectionRoutes)
+
+// JSON 404 for unmatched API routes. Without this, an unknown /api/* path falls
+// through to Express's default handler, which returns an HTML "Cannot GET …"
+// page — a JSON API should answer with JSON. Scoped to /api and mounted AFTER
+// every router (so real routes still match) but BEFORE the error backstop.
+// Non-API surfaces (/health, anything outside /api) are unaffected.
+app.use('/api', (req, res) => {
+  res.status(404).json({ error: 'Not found' })
+})
 
 // Central error backstop. Route handlers catch their own errors (via
 // respondServerError), but errors thrown *outside* a route's try/catch — a

--- a/server/index.js
+++ b/server/index.js
@@ -1,17 +1,63 @@
 // Must load first so Sentry instruments express before it's required below.
 require('./instrument')
+const Sentry = require('@sentry/node')
 const app = require('./app')
-const { connectDB } = require('./db')
+const { connectDB, closeDB } = require('./db')
 
 const PORT = process.env.PORT || 4000
 
 connectDB()
   .then(() => {
-    app.listen(PORT, '0.0.0.0', () => {
+    const server = app.listen(PORT, '0.0.0.0', () => {
       console.log(`Server running on port ${PORT}`)
     })
+
+    // Graceful shutdown. Railway sends SIGTERM on every deploy/rollout (and
+    // SIGINT on a local Ctrl-C): stop accepting new connections, drain the
+    // in-flight ones, close the Mongo client, then exit 0. A ~10s force-exit
+    // timer guarantees the process still dies if a connection or the client
+    // hangs, so a rollout can never wedge on a stuck instance.
+    let shuttingDown = false
+    const shutdown = signal => {
+      if (shuttingDown) return
+      shuttingDown = true
+      console.log(`Received ${signal}, shutting down gracefully`)
+      const force = setTimeout(() => {
+        console.error('Graceful shutdown timed out after 10s, forcing exit')
+        process.exit(1)
+      }, 10000)
+      server.close(async () => {
+        try {
+          await closeDB()
+        } catch (err) {
+          console.error('Error closing Mongo during shutdown:', err.message)
+        }
+        clearTimeout(force)
+        process.exit(0)
+      })
+    }
+    process.on('SIGTERM', () => shutdown('SIGTERM'))
+    process.on('SIGINT', () => shutdown('SIGINT'))
   })
-  .catch((err) => {
+  .catch(err => {
     console.error('Failed to connect to MongoDB:', err.message)
     process.exit(1)
   })
+
+// Crash-and-restart on a truly unexpected fault: an unhandled rejection or an
+// uncaught exception leaves the process in an undefined state, so the correct
+// response on Railway (which restarts a crashed process) is to log it, surface
+// it to Sentry, flush the queued event, and exit non-zero. Sentry.* are safe
+// no-ops when SENTRY_DSN is unset (dev/CI), so no init guard is needed; the
+// captureException is still wrapped so a Sentry failure can't block the exit.
+const handleFatal = (err, origin) => {
+  console.error(`Fatal ${origin}:`, err)
+  try {
+    Sentry.captureException(err)
+    Sentry.flush(2000).finally(() => process.exit(1))
+  } catch {
+    process.exit(1)
+  }
+}
+process.on('unhandledRejection', reason => handleFatal(reason, 'unhandledRejection'))
+process.on('uncaughtException', err => handleFatal(err, 'uncaughtException'))


### PR DESCRIPTION
Wave 14 lane E — server prod hardening. Six filed P3s from the 2026-07-11 prod-readiness sweep. Scoped to `server/app.js`, `server/index.js`, `.github/workflows/test.yml`, and a new server test file. No route files / limiters / db.js touched.

## Per-item notes

**1. `/health` was a static 200 (`app.js`)** — a runtime Mongo drop left Railway green on a wedged pod. Now runs `db.command({ ping: 1 })` raced against a 2s timeout (`Promise.race`), returns `200 {status:'ok'}` on success and `503 {status:'degraded'}` on failure. Reuses the `getDB()` singleton (never a new client); a not-yet-connected `getDB()` throw, a failed ping, and the timeout all collapse to 503. Never throws; clears its timer in `finally` so no lingering handle. Stays above the rate limiter as before.

**2. No process handlers / graceful shutdown (`index.js`)** — added `SIGTERM`/`SIGINT` → `server.close` (drain in-flight) → `closeDB()` → `exit 0`, with a 10s force-exit timer and a re-entrancy guard. `unhandledRejection`/`uncaughtException` → `console.error` + `Sentry.captureException` + `Sentry.flush(2000)` → `exit 1` (crash-and-restart is correct on Railway). Sentry reused from the existing `./instrument` init; `Sentry.*` no-op safely without `SENTRY_DSN`, and the capture is wrapped so a Sentry failure can't block the exit. Handlers live in `index.js`, which the Jest suite never loads — so no handlers are registered during tests (verified: suite exits cleanly, no open-handle hang).

**3. Rejected CORS origins threw → 500 + Sentry noise (`app.js`)** — the thrown error is now tagged `.status = 403`. The error backstop already preserves a thrower-set 4xx and only `Sentry.captureException`s for `status >= 500`, so a rejected origin now renders as a quiet JSON `403 { error: 'Bad request' }` (the house 4xx body) with no Sentry capture. Verified via test.

**4. Unmatched `/api/*` returned Express default HTML** — added `app.use('/api', (req,res) => res.status(404).json({ error: 'Not found' }))`, mounted after all routers and before the error middleware, scoped to `/api`. `/health` and non-API surfaces unchanged.

**5. `FRONTEND_URLS` unset in production = silent CORS outage (`app.js`)** — at startup, when `NODE_ENV === 'production'` and `FRONTEND_URLS` is unset/empty, a loud `console.warn` explains the fallback to `http://localhost:3000` will block all real prod origins. Warning only — fallback behaviour unchanged.

**6. CI didn't run on direct pushes to `release` (`test.yml`)** — added `release` to the push `branches` list. Nothing else in the workflow touched.

## Test evidence

New `server/__tests__/app-hardening.test.js` (5 tests): health 200 healthy, 503 on mocked ping reject, ping uses the `getDB()` singleton with `{ ping: 1 }`, CORS-reject → JSON 403, unmatched `/api` → JSON 404.

Full server suite green: **42 suites / 888 tests passing**, ~38s, no open-handle hang.

## Adjacent issues noticed (report only, not fixed)
- The E2E workflow's `wait-on .../health` gate now depends on a live Mongo ping succeeding at boot; the e2e job already provides a `mongo:7` service the server connects to, so this stays green — but a future health check that fails the boot ping would now block the e2e wait-on where the old static 200 wouldn't.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK