### PR TITLE
fix(server): floor perPage/page on all paginated routes (negative values 500'd)

### DIFF
--- a/server/__tests__/admin-users.test.js
+++ b/server/__tests__/admin-users.test.js
@@ -111,6 +111,23 @@ describe('GET /api/admin/users', () => {
       .set(AUTH_HEADER)
     expect(res.body).toEqual({ users: [], totalCount: 0 })
   })
+
+  it('floors a negative perPage instead of 500ing (negative skip)', async () => {
+    admin.__setClaims({ admin: true })
+    await seedUser('u1', 'alpha')
+    await seedUser('u2', 'beta')
+    await seedUser('u3', 'gamma')
+
+    // A negative perPage floors to 1, so page=2 (skip=1) returns the 2nd
+    // alphabetically-sorted user.
+    const res = await request(app)
+      .get('/api/admin/users?page=2&perPage=-5')
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.users).toHaveLength(1)
+    expect(res.body.users[0].username).toBe('beta')
+    expect(res.body.totalCount).toBe(3)
+  })
 })
 
 describe('GET /api/admin/users/:uid', () => {

--- a/server/__tests__/audit-log.test.js
+++ b/server/__tests__/audit-log.test.js
@@ -132,6 +132,22 @@ describe('GET /api/admin/audit', () => {
     const page2 = await request(app).get('/api/admin/audit?page=2&perPage=25').set(AUTH_HEADER)
     expect(page2.body.entries).toHaveLength(5)
   })
+
+  it('floors a negative perPage instead of 500ing (negative skip)', async () => {
+    admin.__setClaims({ admin: true })
+    await seedAudit([
+      { action: 'recipe.hide', targetId: 'r1', createdAt: new Date('2026-01-01') },
+      { action: 'recipe.hide', targetId: 'r2', createdAt: new Date('2026-02-01') },
+      { action: 'recipe.hide', targetId: 'r3', createdAt: new Date('2026-03-01') },
+    ])
+
+    // A negative perPage floors to 1, so page=2 (skip=1) returns the 2nd-newest entry.
+    const res = await request(app).get('/api/admin/audit?page=2&perPage=-5').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.entries).toHaveLength(1)
+    expect(res.body.entries[0].targetId).toBe('r2')
+    expect(res.body.totalCount).toBe(3)
+  })
 })
 
 describe('admin mutations write audit entries', () => {

--- a/server/__tests__/ingredient-telemetry.test.js
+++ b/server/__tests__/ingredient-telemetry.test.js
@@ -202,4 +202,18 @@ describe('GET /api/admin/ingredients', () => {
       .set(AUTH_HEADER)
     expect(res.body.totalCount).toBe(3)
   })
+
+  it('floors a negative perPage instead of 500ing (negative skip)', async () => {
+    admin.__setClaims({ admin: true })
+    await seedTelemetry()
+    // A negative perPage floors to 1, so page=2 (skip=1) returns the
+    // 2nd-highest-count item (count desc: 9, 5, 1 → the count:5 doc).
+    const res = await request(app)
+      .get('/api/admin/ingredients?page=2&perPage=-5')
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.items).toHaveLength(1)
+    expect(res.body.items[0].count).toBe(5)
+    expect(res.body.totalCount).toBe(3)
+  })
 })

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -140,6 +140,14 @@ describe('GET /recipes', () => {
     expect(res.body.total_results).toBe(3)
   })
 
+  it('floors a negative recipesPerPage instead of 500ing (negative limit/skip)', async () => {
+    const res = await request(server).get('/api/recipes?page=1&recipesPerPage=-5')
+    expect(res.status).toBe(200)
+    // A negative recipesPerPage floors to 1, so page=1 (skip=1) returns 1 recipe.
+    expect(res.body.recipeList).toHaveLength(1)
+    expect(res.body.total_results).toBe(3)
+  })
+
   it('caps recipesPerPage at 50 even when a larger page is requested', async () => {
     const db = getDB()
     // 3 seeded in beforeEach + 52 more = 55 total, so a capped page shows exactly 50.

--- a/server/__tests__/reports.test.js
+++ b/server/__tests__/reports.test.js
@@ -434,6 +434,26 @@ describe('GET /api/reports', () => {
     expect(res.body.reports.length).toBe(1)
   })
 
+  it('floors a negative perPage instead of 500ing (negative limit/skip)', async () => {
+    admin.__setClaims({ admin: true })
+    const docs = Array.from({ length: 3 }, () => ({
+      _id: new ObjectId(),
+      targetType: 'recipe',
+      recipeId: `r-${Math.random()}`,
+      reporterUid: 'u1',
+      reason: 'spam',
+      status: 'open',
+      createdAt: new Date(),
+    }))
+    await getDB().collection('reports').insertMany(docs)
+
+    // A negative perPage floors to 1, so page=1 (skip=1) returns 1 report.
+    const res = await request(app).get('/api/reports?page=1&perPage=-5').set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body.reports.length).toBe(1)
+    expect(res.body.totalCount).toBe(3)
+  })
+
   it('caps perPage at MAX_PER_PAGE (50)', async () => {
     admin.__setClaims({ admin: true })
     // Create 60 reports

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -859,6 +859,26 @@ describe('GET /getReviews', () => {
     expect(res.body.reviews).toHaveLength(2)
   })
 
+  it('floors a negative reviewsPerPage instead of 500ing (negative limit/skip)', async () => {
+    for (let i = 0; i < 3; i++) {
+      await seedRating({
+        username: `negperpageuser${i}`,
+        recipeId: RECIPE_ID,
+        rating: 3,
+        reviewText: `Review ${i}`,
+        reviewCreatedAt: `${i}000`,
+      })
+    }
+
+    const res = await request(app).get(
+      `/api/getReviews?recipeId=${RECIPE_ID}&page=1&reviewsPerPage=-5`
+    )
+    expect(res.status).toBe(200)
+    // A negative reviewsPerPage floors to 1, so page=1 (skip=1) returns 1 review.
+    expect(res.body.reviews).toHaveLength(1)
+    expect(res.body.totalCount).toBe(3)
+  })
+
   it('caps reviewsPerPage at 50 even when a larger page is requested', async () => {
     const db = getDB()
     await db.collection('ratings').insertMany(
@@ -1212,6 +1232,27 @@ describe('GET /getSingleUserReviews', () => {
     expect(res.status).toBe(200)
     expect(res.body.totalCount).toBe(2)
     expect(res.body.reviews).toHaveLength(2)
+  })
+
+  it('floors a negative reviewsPerPage instead of 500ing (negative limit/skip)', async () => {
+    for (let i = 0; i < 3; i++) {
+      await seedRating({
+        userId: TEST_UID,
+        username: TEST_USERNAME,
+        recipeId: `negperpage-recipe-${i}`,
+        rating: 3,
+        reviewText: `Review ${i}`,
+        reviewCreatedAt: `${i}000`,
+      })
+    }
+
+    const res = await request(app).get(
+      `/api/getSingleUserReviews?username=${TEST_USERNAME}&page=1&reviewsPerPage=-5`
+    )
+    expect(res.status).toBe(200)
+    // A negative reviewsPerPage floors to 1, so page=1 (skip=1) returns 1 review.
+    expect(res.body.reviews).toHaveLength(1)
+    expect(res.body.totalCount).toBe(3)
   })
 })
 

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -110,6 +110,53 @@ describe('GET /getSavedRecipes', () => {
     expect(res.body.totalCount).toBe(3)
   })
 
+  it('treats a negative page as page 0 instead of an empty slice', async () => {
+    await seedRecipes([
+      { _id: 'r1', title: 'Recipe One' },
+      { _id: 'r2', title: 'Recipe Two' },
+      { _id: 'r3', title: 'Recipe Three' },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'r1', dateSaved: '1000' },
+        { recipeId: 'r2', dateSaved: '2000' },
+        { recipeId: 'r3', dateSaved: '3000' },
+      ],
+    })
+
+    const res = await request(app)
+      .get('/api/getSavedRecipes?page=-1')
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    expect(res.body.recipes).toHaveLength(3)
+    expect(res.body.totalCount).toBe(3)
+  })
+
+  it('floors a negative recipesPerPage instead of a degenerate slice', async () => {
+    await seedRecipes([
+      { _id: 'r1', title: 'Recipe One' },
+      { _id: 'r2', title: 'Recipe Two' },
+      { _id: 'r3', title: 'Recipe Three' },
+    ])
+    await seedUserRecipeData(TEST_UID, {
+      savedRecipes: [
+        { recipeId: 'r1', dateSaved: '1000' },
+        { recipeId: 'r2', dateSaved: '2000' },
+        { recipeId: 'r3', dateSaved: '3000' },
+      ],
+    })
+
+    // A negative recipesPerPage floors to 1, so page=1 (offset 1) returns 1 recipe.
+    const res = await request(app)
+      .get('/api/getSavedRecipes?page=1&recipesPerPage=-5')
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    expect(res.body.recipes).toHaveLength(1)
+    expect(res.body.totalCount).toBe(3)
+  })
+
   it('order=new returns the newest-saved recipe first (page=0, recipesPerPage=1)', async () => {
     await seedRecipes([
       { _id: 'r1', title: 'Old Recipe' },
@@ -269,6 +316,39 @@ describe('GET /getCreatedRecipes', () => {
 
     expect(res.status).toBe(200)
     expect(res.body.recipes).toHaveLength(2)
+    expect(res.body.totalCount).toBe(3)
+  })
+
+  it('treats a negative page as page 0 instead of 500ing (negative skip)', async () => {
+    await seedRecipes([
+      { _id: 'r1', title: 'One', userId: TEST_UID, createdAt: '1000' },
+      { _id: 'r2', title: 'Two', userId: TEST_UID, createdAt: '2000' },
+      { _id: 'r3', title: 'Three', userId: TEST_UID, createdAt: '3000' },
+    ])
+
+    const res = await request(app)
+      .get('/api/getCreatedRecipes?page=-1')
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    expect(res.body.recipes).toHaveLength(3)
+    expect(res.body.totalCount).toBe(3)
+  })
+
+  it('floors a negative recipesPerPage instead of 500ing (negative limit/skip)', async () => {
+    await seedRecipes([
+      { _id: 'r1', title: 'One', userId: TEST_UID, createdAt: '1000' },
+      { _id: 'r2', title: 'Two', userId: TEST_UID, createdAt: '2000' },
+      { _id: 'r3', title: 'Three', userId: TEST_UID, createdAt: '3000' },
+    ])
+
+    // A negative recipesPerPage floors to 1, so page=1 (skip=1) returns 1 recipe.
+    const res = await request(app)
+      .get('/api/getCreatedRecipes?page=1&recipesPerPage=-5')
+      .set(AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    expect(res.body.recipes).toHaveLength(1)
     expect(res.body.totalCount).toBe(3)
   })
 

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -174,8 +174,10 @@ router.get('/admin/users', verifyToken, requireAdmin, asyncHandler(async (req, r
   const db = getDB()
   const query = (req.query.query || '').trim()
   const page = Math.max(parseInt(req.query.page) || 1, 1)
+  // Floor at 1 so a negative ?perPage can't sneak past the Math.min cap and
+  // produce a negative .skip() downstream (MongoDB rejects that as a 500).
   const perPage = Math.min(
-    parseInt(req.query.perPage) || DEFAULT_PER_PAGE,
+    Math.max(parseInt(req.query.perPage) || DEFAULT_PER_PAGE, 1),
     MAX_PER_PAGE
   )
 
@@ -327,7 +329,9 @@ router.get('/admin/audit', verifyToken, requireAdmin, asyncHandler(async (req, r
   const db = getDB()
   const { action, targetType, actorUid } = req.query
   const page = Math.max(parseInt(req.query.page) || 1, 1)
-  const perPage = Math.min(parseInt(req.query.perPage) || DEFAULT_PER_PAGE, MAX_PER_PAGE)
+  // Floor at 1 so a negative ?perPage can't sneak past the Math.min cap and
+  // produce a negative .skip() downstream (MongoDB rejects that as a 500).
+  const perPage = Math.min(Math.max(parseInt(req.query.perPage) || DEFAULT_PER_PAGE, 1), MAX_PER_PAGE)
 
   const filter = {}
   if (typeof action === 'string' && AUDIT_ACTIONS.includes(action)) filter.action = action
@@ -476,7 +480,9 @@ router.get('/admin/ingredients', verifyToken, requireAdmin, asyncHandler(async (
   const db = getDB()
   const { type } = req.query
   const page = Math.max(parseInt(req.query.page) || 1, 1)
-  const perPage = Math.min(parseInt(req.query.perPage) || DEFAULT_PER_PAGE, MAX_PER_PAGE)
+  // Floor at 1 so a negative ?perPage can't sneak past the Math.min cap and
+  // produce a negative .skip() downstream (MongoDB rejects that as a 500).
+  const perPage = Math.min(Math.max(parseInt(req.query.perPage) || DEFAULT_PER_PAGE, 1), MAX_PER_PAGE)
 
   const filter = {}
   if (typeof type === 'string' && INGREDIENT_MISS_TYPES.includes(type)) filter.type = type

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -58,7 +58,10 @@ router.get('/recipes', asyncHandler(async (req, res) => {
   // collection. The 'simple' query parser (app.js) guarantees every value is
   // a string or string[] — never a `{$ne:…}` operator object — so the helpers
   // below only have to coerce those two shapes.
-  const limit = Math.min(parseInt(recipesPerPage) || 5, MAX_PER_PAGE)
+  // Floor at 1 so a negative ?recipesPerPage can't sneak past the Math.min
+  // cap above and make `limit` negative — that in turn made `skip` negative
+  // for page > 0 (MongoDB rejects a negative skip/limit as a 500).
+  const limit = Math.min(Math.max(parseInt(recipesPerPage) || 5, 1), MAX_PER_PAGE)
   // Floor at 0 so a negative ?page never produces a negative .skip() (which
   // MongoDB rejects, surfacing as a 500 instead of a clean first page).
   const skip = Math.max(0, parseInt(page) || 0) * limit

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -195,7 +195,11 @@ router.get('/reports', verifyToken, requireAdmin, asyncHandler(async (req, res) 
   if (status && ['open', ...RESOLUTIONS].includes(status)) filter.status = status
   if (targetType && TARGET_TYPES.includes(targetType)) filter.targetType = targetType
 
-  const limit = Math.min(parseInt(perPage) || 20, MAX_PER_PAGE)
+  // Floor at 1 so a negative ?perPage can't sneak past the Math.min cap above
+  // and make `limit` negative. The page floor below alone isn't sufficient —
+  // a negative perPage made `limit` negative, so `skip = page * limit` went
+  // negative again for page > 0 (MongoDB rejects that as a 500) (#289).
+  const limit = Math.min(Math.max(parseInt(perPage) || 20, 1), MAX_PER_PAGE)
   // Floor at 0 so a negative ?page never produces a negative .skip() (which
   // MongoDB rejects, surfacing as a 500 instead of a clean first page).
   const skip = Math.max(0, parseInt(page) || 0) * limit

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -272,7 +272,10 @@ router.get('/getReviews', optionalAuth, asyncHandler(async (req, res) => {
   const { recipeId, page = 0, reviewsPerPage = 5, filter } = req.query
   if (!recipeId || typeof recipeId !== 'string') return res.status(400).json({ error: 'recipeId is required' })
 
-  const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
+  // Floor at 1 so a negative ?reviewsPerPage can't sneak past the Math.min
+  // cap above and make `limit` negative — that in turn made `skip` negative
+  // for page > 0 (MongoDB rejects a negative skip/limit as a 500).
+  const limit = Math.min(Math.max(parseInt(reviewsPerPage) || 5, 1), MAX_PER_PAGE)
   // Floor at 0 so a negative ?page never produces a negative .skip() (which
   // MongoDB rejects, surfacing as a 500 instead of a clean first page).
   const skip = Math.max(0, parseInt(page) || 0) * limit
@@ -319,7 +322,9 @@ router.get('/getSingleUserReviews', asyncHandler(async (req, res) => {
     .findOne({ username_lower: String(username).toLowerCase() })
   if (!ownerDoc) return res.json({ reviews: [], totalCount: 0 })
 
-  const limit = Math.min(parseInt(reviewsPerPage) || 5, MAX_PER_PAGE)
+  // Floor at 1 — see getReviews: a negative reviewsPerPage defeats the page
+  // floor below by making `limit` negative, so `skip` goes negative again.
+  const limit = Math.min(Math.max(parseInt(reviewsPerPage) || 5, 1), MAX_PER_PAGE)
   // Floor at 0 — see getReviews: negative skip is a MongoDB error (500).
   const skip = Math.max(0, parseInt(page) || 0) * limit
   // Suppress admin-taken-down reviews from a user's public review list too.

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -70,8 +70,13 @@ router.get('/getCreatedRecipes', verifyToken, asyncHandler(async (req, res) => {
 
   const sort = order === 'old' ? { createdAt: 1 } : { createdAt: -1 }
 
-  const pageNum = parseInt(page) || 0
-  const perPage = Math.min(parseInt(recipesPerPage) || 6, MAX_PER_PAGE)
+  // Floor at 0 so a negative ?page never produces a negative .skip() (which
+  // MongoDB rejects, surfacing as a 500 instead of a clean first page).
+  const pageNum = Math.max(0, parseInt(page) || 0)
+  // Floor at 1 so a negative ?recipesPerPage can't sneak past the Math.min
+  // cap and produce a negative .skip() downstream (MongoDB rejects that as a
+  // 500).
+  const perPage = Math.min(Math.max(parseInt(recipesPerPage) || 6, 1), MAX_PER_PAGE)
 
   const collection = db.collection('recipes')
   // The author's own created list: exclude takedowns/de-publishes, but DO show
@@ -120,8 +125,13 @@ router.get('/getSavedRecipes', verifyToken, asyncHandler(async (req, res) => {
     )
   }
 
-  const pageNum = parseInt(page) || 0
-  const perPage = Math.min(parseInt(recipesPerPage) || 5, MAX_PER_PAGE)
+  // Floor at 0 so a negative ?page never produces a negative slice offset
+  // (getCreatedRecipes' .skip() would 500 on this; this route slices an
+  // in-memory array instead, so a negative offset would silently yield []).
+  const pageNum = Math.max(0, parseInt(page) || 0)
+  // Floor at 1 so a negative ?recipesPerPage can't sneak past the Math.min
+  // cap and produce a degenerate/negative slice window below.
+  const perPage = Math.min(Math.max(parseInt(recipesPerPage) || 5, 1), MAX_PER_PAGE)
 
   // A title search or a field sort (title/rating/cook time) both order/filter by
   // the recipe docs themselves, so materialize the whole saved set (visible


### PR DESCRIPTION
## Summary

Filed finding (P3, sweep 2026-07-11): a negative `perPage` reaches `.limit()`/`.skip()` across most paginated routes. Only `bugReports.js:110` and `publicProfile.js:157-160` already applied the house lower floor (`Math.max(1, …)`). Elsewhere, `Math.min(-5, MAX_PER_PAGE)` passes the negative value straight through, so `limit` goes negative and `skip = page * limit` goes negative for `page > 0` — MongoDB rejects that as a 500 instead of a clean response.

This PR mirrors the existing house pattern (`bugReports.js`/`publicProfile.js`) at every remaining site. Huge `perPage` (`Math.min` cap) and `NaN` (`parseInt || default`) were already handled correctly everywhere and are untouched; only the missing lower floor was added. Default page-size values are preserved exactly.

## Per-route table

| Route | File:line | Before | After |
|---|---|---|---|
| `GET /api/recipes` | `server/routes/recipes.js:61` | negative `recipesPerPage` → negative `limit`/`skip` → 500 | floored to `Math.max(…, 1)` |
| `GET /getReviews` | `server/routes/reviews.js:275` | same | floored |
| `GET /getSingleUserReviews` | `server/routes/reviews.js:322` | same | floored |
| `GET /api/reports` | `server/routes/reports.js:198` | same (also had a stale comment claiming the page floor alone prevented this) | floored; comment corrected |
| `GET /admin/users` | `server/routes/admin.js:177-179` | same | floored |
| `GET /admin/audit` | `server/routes/admin.js:330` | same | floored |
| `GET /admin/ingredients` | `server/routes/admin.js:479` | same | floored |
| `GET /getCreatedRecipes` | `server/routes/users.js:73-74` | negative `page` → negative `.skip()` → 500; negative `recipesPerPage` → same | both floored (`page` via `Math.max(0, …)`, `recipesPerPage` via `Math.max(1, …)`) |
| `GET /getSavedRecipes` | `server/routes/users.js:123-124` | negative `page`/`recipesPerPage` → silent `[]` (in-memory slice, no DB error) | both floored |

⚠️ `reviews.js` changes touch **only** the pagination lines (275, 322) — nothing near the `newReview`/`editReview` write paths (lines ~120-182) that a parked PR (#303) also edits.

## Test plan

- [x] Added a regression test per fixed route asserting negative `perPage` (and negative `page` for `users.js`) returns `200` with the floored/default size, not a `500` — failing on pre-fix code, passing after.
- [x] `cd server && npm install && npm test` — **41 suites / 894 tests, all green**.

Test files touched: `recipes.test.js`, `reviews.test.js`, `reports.test.js`, `admin-users.test.js`, `audit-log.test.js`, `ingredient-telemetry.test.js`, `users.test.js`.

## Adjacent issues noticed (not fixed here — report only)

- None beyond the filed scope — huge-perPage and NaN handling were already correct at every site touched.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK