### PR TITLE
fix: recover drafts autosave after the open draft is deleted elsewhere (404 → re-create on next edit)

### DIFF
--- a/src/pages/AddRecipe/useDraftAutosave.ts
+++ b/src/pages/AddRecipe/useDraftAutosave.ts
@@ -82,6 +82,16 @@ function isDraftConflictError(err: unknown): boolean {
   )
 }
 
+// The server returns 404 from PUT /drafts/:id when the draft the autosave is
+// updating no longer exists — it was deleted elsewhere (another tab's Drafts
+// list, or the POST 25-cap trim evicting the oldest draft) while this tab held
+// it open. Distinct from a 409 conflict: the draft is *gone*, not merely newer,
+// so the recovery is to re-create a fresh draft on the next edit rather than to
+// reload. Only ever seen on the update (id) path; a create never 404s.
+function isDraftDeletedError(err: unknown): boolean {
+  return axios.isAxiosError(err) && err.response?.status === 404
+}
+
 type Params = {
   // Serializable draft content derived from the form state (no image).
   content: RecipeDraftContent
@@ -119,6 +129,12 @@ type Params = {
   // Autosave stops retrying for the rest of the session; the caller should
   // tell the user to reload the page to see the latest version.
   onConflict?: (message: string) => void
+  // Called when an update 404s because the draft was deleted elsewhere while
+  // open here (another tab's Drafts list, or the per-user cap trim). The caller
+  // must drop the now-dead `draftId`/`draftUpdatedAt` it owns (and any URL
+  // param) so the next edit re-creates a fresh draft instead of retrying the
+  // doomed PUT; it should also surface the message. See the 404 branch below.
+  onDeletedElsewhere?: (message: string) => void
 }
 
 type DraftAutosave = {
@@ -139,6 +155,7 @@ export function useDraftAutosave({
   onDraftCreated,
   onLimitReached,
   onConflict,
+  onDeletedElsewhere,
 }: Params): DraftAutosave {
   const [status, setStatus] = useState<DraftStatus>('idle')
 
@@ -201,9 +218,11 @@ export function useDraftAutosave({
   const onDraftCreatedRef = useRef(onDraftCreated)
   const onLimitReachedRef = useRef(onLimitReached)
   const onConflictRef = useRef(onConflict)
+  const onDeletedElsewhereRef = useRef(onDeletedElsewhere)
   onDraftCreatedRef.current = onDraftCreated
   onLimitReachedRef.current = onLimitReached
   onConflictRef.current = onConflict
+  onDeletedElsewhereRef.current = onDeletedElsewhere
 
   const saveNow = async () => {
     // `enabled` is false in edit mode (and before a resume finishes hydrating);
@@ -281,6 +300,7 @@ export function useDraftAutosave({
             (err.response?.data as { error?: string } | undefined)?.error) ||
           'You have too many saved drafts. Delete some to start a new one.'
         onLimitReachedRef.current?.(message)
+        setStatus('error')
       } else if (isDraftConflictError(err)) {
         // Another tab/session saved on top of this draft since it was loaded.
         // Stop autosaving so we don't keep clobbering (or 409ing against) it;
@@ -291,10 +311,28 @@ export function useDraftAutosave({
             (err.response?.data as { error?: string } | undefined)?.error) ||
           'This draft was updated elsewhere. Reload the page to see the latest version.'
         onConflictRef.current?.(message)
+        setStatus('error')
+      } else if (isDraftDeletedError(err)) {
+        // The draft we were updating is gone (deleted elsewhere, or evicted by
+        // the per-user cap trim). Drop the dead id + version so the flush/unmount
+        // paths (which read these refs) can't keep resurrecting the doomed PUT,
+        // and so the NEXT edit re-creates a fresh draft via the createDraft path
+        // — autosave's prime directive is never to lose active work. The caller
+        // owns the real `draftId` (prop-mirrored into draftIdRef every render),
+        // so it must null its copy too or the mirror would restore the dead id;
+        // onDeletedElsewhere hands it that job (and surfaces the message). We do
+        // NOT re-create now — that happens naturally on the next edit/debounce
+        // tick — and reset to a calm 'idle' badge rather than a stuck 'error'.
+        draftIdRef.current = null
+        updatedAtRef.current = null
+        onDeletedElsewhereRef.current?.(
+          'This draft was deleted elsewhere — your edits here will be saved as a new draft.'
+        )
+        setStatus('idle')
       } else {
         console.error('Draft autosave failed:', err)
+        setStatus('error')
       }
-      setStatus('error')
     } finally {
       inFlightRef.current = false
       // Re-run only if new edits arrived while this save was in flight. Compare

--- a/src/pages/AddRecipe/useRecipeForm.ts
+++ b/src/pages/AddRecipe/useRecipeForm.ts
@@ -394,6 +394,19 @@ export function useRecipeForm(initialRecipe?: RecipeType) {
     },
     onLimitReached: (message: string) => toast.error(message),
     onConflict: (message: string) => toast.error(message),
+    onDeletedElsewhere: (message: string) => {
+      // The draft we were autosaving into was deleted elsewhere (another tab's
+      // Drafts list, or the per-user cap trim evicting the oldest). Drop the dead
+      // id + URL param — mirroring the hydration-404 recovery above — so the next
+      // edit re-creates a fresh draft instead of retrying a doomed PUT. Current
+      // work isn't lost: it re-creates on the next change.
+      setDraftId(null)
+      setDraftUpdatedAt(null)
+      const next = new URLSearchParams(searchParams)
+      next.delete('draftId')
+      setSearchParams(next, { replace: true })
+      toast.error(message)
+    },
   })
 
   // Reflect the active draft id in the URL (replace) so a refresh resumes the

--- a/src/test/useDraftAutosave.test.tsx
+++ b/src/test/useDraftAutosave.test.tsx
@@ -366,6 +366,146 @@ describe('useDraftAutosave — updatedAt concurrency guard (B5)', () => {
   })
 })
 
+describe('useDraftAutosave — open draft deleted elsewhere (W14 404 recovery)', () => {
+  it('drops the dead id, notifies once, and re-creates a new draft on the next edit', async () => {
+    // The draft this tab is autosaving into was deleted elsewhere (another tab's
+    // Drafts list, or the POST 25-cap trim evicting the oldest). The server
+    // answers the autosave PUT with a bare 404 (no DRAFT_CONFLICT code). Pre-fix
+    // the hook fell into the generic `else`, set 'error' with draftId still set,
+    // and every keystroke retried the doomed PUT forever — the editor wedged.
+    mockedDraftAPI.updateDraft.mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 404, data: { error: 'Draft not found' } },
+    })
+    mockedDraftAPI.createDraft.mockResolvedValue({
+      ...createdDraft,
+      _id: 'recreated-draft',
+      updatedAt: '5000',
+    })
+    const onDeletedElsewhere = vi.fn()
+    const onDraftCreated = vi.fn()
+
+    const { result, rerender } = renderHook(
+      ({ content, draftId, draftUpdatedAt }) =>
+        useDraftAutosave({
+          content,
+          enabled: true,
+          isSignedIn: true,
+          canCreate: true,
+          draftId,
+          draftUpdatedAt,
+          onDraftCreated,
+          onDeletedElsewhere,
+        }),
+      {
+        initialProps: {
+          content: { title: '' } as Record<string, unknown>,
+          draftId: 'existing-draft' as string | null,
+          draftUpdatedAt: '1000' as string | null,
+        },
+      }
+    )
+
+    // Edit → the autosave PUT fires and 404s.
+    rerender({
+      content: { title: 'Soup' },
+      draftId: 'existing-draft',
+      draftUpdatedAt: '1000',
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+    expect(mockedDraftAPI.updateDraft).toHaveBeenCalledTimes(1)
+    // Notified exactly once, calm 'idle' badge (never the stuck 'error'), and
+    // NO immediate re-create — that's deferred to the next edit by design.
+    expect(onDeletedElsewhere).toHaveBeenCalledTimes(1)
+    expect(onDeletedElsewhere).toHaveBeenCalledWith(
+      'This draft was deleted elsewhere — your edits here will be saved as a new draft.'
+    )
+    expect(result.current.status).toBe('idle')
+    expect(mockedDraftAPI.createDraft).not.toHaveBeenCalled()
+
+    // The caller reacts to onDeletedElsewhere by nulling the draftId it owns
+    // (useRecipeForm does exactly this). The next edit must now POST a brand-new
+    // draft — not retry the dead PUT — and adopt the freshly created id/version.
+    rerender({
+      content: { title: 'Soup revived' },
+      draftId: null,
+      draftUpdatedAt: null,
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+    expect(mockedDraftAPI.createDraft).toHaveBeenCalledTimes(1)
+    expect(mockedDraftAPI.createDraft).toHaveBeenCalledWith({
+      title: 'Soup revived',
+    })
+    // The dead draft is never PUT to again after the 404.
+    expect(mockedDraftAPI.updateDraft).toHaveBeenCalledTimes(1)
+    expect(onDraftCreated).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: 'recreated-draft', updatedAt: '5000' })
+    )
+    expect(result.current.status).toBe('saved')
+  })
+
+  it('does not resurrect the dead draft via the unload flush after a 404', async () => {
+    mockedDraftAPI.updateDraft.mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 404, data: { error: 'Draft not found' } },
+    })
+
+    const { rerender } = renderHook(
+      ({ content, draftId, draftUpdatedAt }) =>
+        useDraftAutosave({
+          content,
+          enabled: true,
+          isSignedIn: true,
+          canCreate: true,
+          draftId,
+          draftUpdatedAt,
+          onDraftCreated: vi.fn(),
+          onDeletedElsewhere: vi.fn(),
+        }),
+      {
+        initialProps: {
+          content: { title: '' } as Record<string, unknown>,
+          draftId: 'existing-draft' as string | null,
+          draftUpdatedAt: '1000' as string | null,
+        },
+      }
+    )
+
+    rerender({
+      content: { title: 'Soup' },
+      draftId: 'existing-draft',
+      draftUpdatedAt: '1000',
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+      await Promise.resolve()
+    })
+
+    // Caller nulls the id in response to the 404; the user then edits and a hard
+    // unload fires before the debounce. The flush must POST a NEW draft (id null),
+    // never PUT the dead 'existing-draft' with a stale precondition.
+    rerender({
+      content: { title: 'Soup revived' },
+      draftId: null,
+      draftUpdatedAt: null,
+    })
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload'))
+    })
+    expect(mockedDraftAPI.flushDraftKeepalive).toHaveBeenCalledWith(
+      null,
+      { title: 'Soup revived' },
+      ''
+    )
+  })
+})
+
 describe('useDraftAutosave — unload flush (V8 item 1)', () => {
   // jsdom dispatches beforeunload/pagehide as ordinary events, so we can assert
   // the handler fires the keepalive save with the right payload. What jsdom


### PR DESCRIPTION
## The wedge

The AddRecipe drafts editor **wedged permanently** when its open draft was deleted out from under it. `useDraftAutosave` (`src/pages/AddRecipe/useDraftAutosave.ts`) only handled the two 409 codes — `DRAFT_LIMIT` and `DRAFT_CONFLICT`. The deliberate **404** the server returns from `PUT /drafts/:id` when the draft is gone (`server/routes/drafts.js:171-174`) fell straight into the generic `else` branch → `setStatus('error')` with `draftId` still set. From then on every keystroke re-fired the doomed PUT (still guarded by the id), and `saveNow` never fell back to `createDraft`. That tab could never persist again.

**Triggers:** delete the open draft in another tab's Drafts list, or the `POST /drafts` 25-cap trim evicting the oldest draft while it's open in a tab.

## Recovery semantics

On a **404** from the autosave PUT (new `isDraftDeletedError` predicate — a bare 404, distinct from the coded 409s):

1. Clear the hook's internal `draftIdRef` + `updatedAtRef` so the in-flight `finally` re-fire, the unmount flush, and the keepalive flush (all read those refs) can't resurrect the dead PUT.
2. Fire a new one-shot `onDeletedElsewhere(message)` callback. The caller (`useRecipeForm`) nulls the `draftId`/`draftUpdatedAt` **it owns** (the prop is mirrored into `draftIdRef` every render, so the hook alone can't durably clear it) and drops the `?draftId` URL param — mirroring the existing hydration-404 recovery — then toasts *"This draft was deleted elsewhere — your edits here will be saved as a new draft."*
3. The next edit/debounce tick re-creates a fresh draft via the existing `createDraft` fallback — autosave's prime directive: never lose active work. **Re-create is deferred to the next edit, not fired immediately at 404 time.**
4. Badge resets to a calm `idle` (reusing the existing status) instead of a stuck `error`.
5. The publish-flow `clearDraft` DELETE→404 path (guarded by `disabledRef`) is untouched.

The catch block was lightly refactored so each branch sets its own status (the deleted branch needs `idle`, not the shared trailing `error`); 409/limit branches still set `error` exactly as before.

## Files changed

- `src/pages/AddRecipe/useDraftAutosave.ts` — 404 predicate, `onDeletedElsewhere` prop + ref, recovery branch.
- `src/pages/AddRecipe/useRecipeForm.ts` — wire `onDeletedElsewhere` to null the owned draft id/version + URL param + toast (the toast/URL infra lives here; mirrors the hydration-404 recovery already in this file).
- `src/test/useDraftAutosave.test.tsx` — two regression tests.

## Test evidence

- New: PUT 404 → id/refs cleared, notified once, `idle` badge, no immediate re-create; next edit **POSTs a new draft** and adopts its id/version; dead draft never PUT again. Plus: unload flush after a 404 POSTs a new draft rather than PUTting the dead one.
- `npx vitest run src/test/useDraftAutosave.test.tsx` → **17 passed**.
- `npm test -- --run` → **90 files, 737 passed / 2 skipped** (existing 409/conflict, cap, publish/clearDraft, unload-flush tests all stay green).
- `npx tsc -p tsconfig.json --noEmit` and `npx tsc -p tsconfig.tests.json --noEmit` → both clean.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK