### PR TITLE
fix(server): boot-provision D1 ratings index, requireActive on parse, harden PUT-limiter pin

### DIFF
--- a/server/__tests__/ensureIndexes.test.js
+++ b/server/__tests__/ensureIndexes.test.js
@@ -1,0 +1,42 @@
+/**
+ * ensureIndexes provisioning — proves db.js builds the indexes its hot/invariant
+ * paths depend on at connect time. setup.js already calls connectDB() (→ runs
+ * ensureIndexes) before every file, so by the time these tests run the indexes
+ * exist on the in-memory Mongo; we just read them back with listIndexes().
+ *
+ * The load-bearing case here is the D1 ratings identity index: it is UNIQUE and
+ * PARTIAL, and its spec must stay byte-for-byte identical to the copy in
+ * scripts/createModerationIndexes.js (a same-name-different-options createIndex
+ * throws), so this pins the exact key + options the boot path installs.
+ */
+const { getDB } = require('../db')
+
+// Read the named index off a collection, or undefined. listIndexes() returns the
+// live server view including `unique` and `partialFilterExpression`.
+async function indexByName(collection, name) {
+  const all = await getDB().collection(collection).listIndexes().toArray()
+  return all.find((ix) => ix.name === name)
+}
+
+describe('ensureIndexes provisions the ratings indexes at boot', () => {
+  it('builds the D1 { userId, recipeId } unique+partial identity index', async () => {
+    const ix = await indexByName('ratings', 'userId_1_recipeId_1')
+    expect(ix).toBeDefined()
+    expect(ix.key).toEqual({ userId: 1, recipeId: 1 })
+    // The invariant this index enforces — one rating per (user, recipe).
+    expect(ix.unique).toBe(true)
+    // PARTIAL on an existing userId so pre-backfill legacy docs don't block the
+    // build and every read (which always predicates on userId) is still served.
+    expect(ix.partialFilterExpression).toEqual({ userId: { $exists: true } })
+  })
+
+  it('still builds the { username } index that backs the rename cascade', async () => {
+    // Kept (not dropped): the POST /setUsername rename cascade updateMany's ratings
+    // by bare `username`, so this index avoids a COLLSCAN on every handle change.
+    const ix = await indexByName('ratings', 'username_1')
+    expect(ix).toBeDefined()
+    expect(ix.key).toEqual({ username: 1 })
+    // It is a plain (non-unique) index — several rows share a username.
+    expect(ix.unique).toBeUndefined()
+  })
+})

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -516,12 +516,19 @@ describe('GET /getAccountCounts', () => {
 
   it('excludes moderation-hidden ratings from the ratings badge', async () => {
     await seedUser(TEST_UID, 'testuser')
-    await seedRecipes([{ _id: 'c1', userId: 'other' }])
+    await seedRecipes([
+      { _id: 'c1', userId: 'other' },
+      { _id: 'c2', userId: 'other' },
+    ])
+    // One visible rating (counts) plus a moderation-hidden one that must NOT count.
+    // The two ratings are on DIFFERENT recipes because a user has at most one
+    // rating per recipe — the D1 unique { userId, recipeId } index (provisioned at
+    // boot in db.js) rejects two rating docs for the same (user, recipe).
     await seedRating({ userId: TEST_UID, username: 'testuser', recipeId: 'c1', rating: 5 })
     await seedRating({
       userId: TEST_UID,
       username: 'testuser',
-      recipeId: 'c1',
+      recipeId: 'c2',
       rating: 1,
       moderationHidden: true,
     })

--- a/server/__tests__/writeLimiter.wiring.test.js
+++ b/server/__tests__/writeLimiter.wiring.test.js
@@ -39,6 +39,18 @@ const routeHandlers = (router, method, path) => {
   return layer.route.stack.map((s) => s.handle)
 }
 
+// Structurally identify ANY express-rate-limit middleware — including a limiter
+// instance a route file never exports. `rateLimit()` (used by every limiter in
+// middleware/writeLimiter.js and the per-route parseLimiter/reportLimiter) attaches
+// `getKey` and `resetKey` function properties to the returned middleware; a plain
+// route handler or auth middleware has neither. This lets the pins below assert
+// "is / is not a limiter" without needing a reference to the specific singleton, so
+// a brand-new, not-yet-exported limiter added to a route can't slip past them.
+const isRateLimiter = (handler) =>
+  typeof handler === 'function' &&
+  typeof handler.getKey === 'function' &&
+  typeof handler.resetKey === 'function'
+
 describe('per-surface write limiters are wired onto every moderated write route', () => {
   const cases = [
     ['recipes', recipesRouter, 'post', '/addRecipe', recipeWriteLimiter],
@@ -81,10 +93,14 @@ describe('per-surface write limiters are wired onto every moderated write route'
     expect(limiters.size).toBe(5)
   })
 
-  it('PUT /drafts/:id (autosave) is NOT wired to draftWriteLimiter or any other limiter', () => {
-    // The autosave path is deliberately unlimited (see the comment at that
-    // route's mount point in drafts.js) — assert none of the per-surface
-    // limiter instances appear in its handler chain.
+  it('PUT /drafts/:id (autosave) is NOT wired to draftWriteLimiter or ANY rate-limiter', () => {
+    // The autosave path is deliberately unlimited (see the comment at that route's
+    // mount point in drafts.js). Two layers of assertion:
+    //   1. none of the KNOWN per-surface limiter instances appear, and
+    //   2. structurally, NO handler in the chain is a rate-limiter at all — so a
+    //      brand-new limiter instance added to this route (which the instance
+    //      checks alone would miss, since they only know the 5 exported singletons)
+    //      still fails this pin.
     const handlers = routeHandlers(draftsRouter, 'put', '/:id')
     const allLimiters = [
       recipeWriteLimiter,
@@ -94,6 +110,7 @@ describe('per-surface write limiters are wired onto every moderated write route'
       draftWriteLimiter,
     ]
     allLimiters.forEach((limiter) => expect(handlers).not.toContain(limiter))
+    expect(handlers.some(isRateLimiter)).toBe(false)
   })
 
   it('collections POST /collections and PATCH /collections/:id SHARE one limiter instance', () => {
@@ -106,12 +123,18 @@ describe('per-surface write limiters are wired onto every moderated write route'
     expect(renameHandlers).toContain(collectionWriteLimiter)
   })
 
-  it('ingredients POST /parse mounts a user limiter right after verifyToken', () => {
+  it('ingredients POST /parse mounts requireActive + a user limiter after verifyToken', () => {
     // parseLimiter is internal to the route file (not exported), so assert
-    // structurally: verifyToken first, exactly one middleware before the handler.
+    // structurally: verifyToken → requireActive → limiter → handler. requireActive
+    // gates paid Spoonacular quota behind an active account, matching every other
+    // write surface's order.
     const handlers = routeHandlers(ingredientsRouter, 'post', '/parse')
     expect(handlers[0]).toBe(verifyToken)
-    expect(handlers).toHaveLength(3) // verifyToken, parseLimiter, handler
+    expect(handlers[1]).toBe(requireActive)
+    expect(handlers).toHaveLength(4) // verifyToken, requireActive, parseLimiter, handler
+    // The 3rd handler is the unexported per-user parseLimiter — identify it
+    // structurally rather than by reference.
+    expect(isRateLimiter(handlers[2])).toBe(true)
   })
 
   it('gamification POST /acknowledgeAchievements mounts profileWriteLimiter after verifyToken', () => {
@@ -148,6 +171,7 @@ describe('requireActive is wired onto every blocked-user write surface', () => {
     ['recipes', recipesRouter, 'post', '/recipes/:id/save'],
     ['recipes', recipesRouter, 'delete', '/recipes/:id/save'],
     ['recipes', recipesRouter, 'post', '/madeRecipe'],
+    ['ingredients', ingredientsRouter, 'post', '/parse'],
   ]
 
   it.each(cases)(

--- a/server/db.js
+++ b/server/db.js
@@ -129,12 +129,51 @@ async function ensureIndexes() {
     console.error('Failed to create title text index on recipes:', err.message)
   }
 
-  // Backs GET /api/getSingleUserReviews (a user's ratings) and the ratings count
-  // in GET /api/getAccountCounts, both of which filter ratings by username.
+  // Backs the username-rename cascade in POST /setUsername (routes/auth.js), which
+  // `updateMany({ username: prevUsername }, …)` over ratings to carry a handle
+  // change across a user's denormalized review rows. NOTE: this index's ORIGINAL
+  // consumers — GET /api/getSingleUserReviews and the ratings tally in GET
+  // /api/getAccountCounts — both migrated to the stable `userId` in D1, so it now
+  // serves ONLY that (rare) rename write; it's kept because that updateMany would
+  // otherwise COLLSCAN the whole ratings collection. If the rename cascade is ever
+  // moved off `username` (the D1 direction), this index becomes fully dead and can
+  // be dropped.
   try {
     await db.collection('ratings').createIndex({ username: 1 })
   } catch (err) {
     console.error('Failed to create index on ratings.username:', err.message)
+  }
+
+  // D1 ratings identity index — the "one rating per (user, recipe)" invariant every
+  // review upsert relies on. Provisioned at boot (in addition to the deliberate
+  // scripts/createModerationIndexes.js run) so the window between a fresh deploy's
+  // write path going live and someone running the script can't slip a duplicate
+  // past the upsert filter. Definition mirrors that script's entry EXACTLY — same
+  // key, same name, same options (unique + partialFilterExpression) — because a
+  // same-name-but-different-options createIndex throws; identical specs make the
+  // two calls a no-op for each other. UNIQUE enforces the invariant; PARTIAL on
+  // `userId: { $exists: true }` so it ignores not-yet-backfilled legacy docs (and
+  // still serves every read, which always predicates on an existing userId). Also
+  // backs the userId-prefix scans (getSingleUserReviews, account counts,
+  // exportMyData, delete-account cascade).
+  try {
+    await db.collection('ratings').createIndex(
+      { userId: 1, recipeId: 1 },
+      {
+        name: 'userId_1_recipeId_1',
+        unique: true,
+        partialFilterExpression: { userId: { $exists: true } },
+      }
+    )
+  } catch (err) {
+    // A unique index can fail to build over legacy data holding pre-backfill
+    // duplicates (cf. the username_lower guard above). Log rather than crash
+    // startup — the duplicates need manual cleanup + the backfill re-run, but the
+    // rest of the server should still come up.
+    console.error(
+      'Failed to create D1 unique index on ratings.userId_recipeId:',
+      err.message
+    )
   }
 
   // Backs GET /getReviews, the per-recipe review list on every recipe-detail page.

--- a/server/routes/ingredients.js
+++ b/server/routes/ingredients.js
@@ -1,6 +1,6 @@
 const { Router } = require('express')
 const { ingredientParser } = require('@jclind/ingredient-parser')
-const { verifyToken } = require('../middleware/auth')
+const { verifyToken, requireActive } = require('../middleware/auth')
 const { makeUserLimiter } = require('../middleware/writeLimiter')
 const { GENERIC_500_MESSAGE } = require('../util/respondServerError')
 const { asyncHandler } = require('../util/asyncHandler')
@@ -115,7 +115,10 @@ function mapIngredientData(data) {
   return out
 }
 
-router.post('/parse', verifyToken, parseLimiter, asyncHandler(async (req, res) => {
+// requireActive sits between verifyToken and the limiter (the house write-surface
+// order) so a just-suspended/banned account — whose ID token stays valid for up to
+// ~1h — can't keep burning paid Spoonacular quota through the enrichment proxy.
+router.post('/parse', verifyToken, requireActive, parseLimiter, asyncHandler(async (req, res) => {
   const { ingredientString } = req.body
   if (!ingredientString || typeof ingredientString !== 'string') {
     return res.status(400).json({ error: 'ingredientString must be a non-empty string' })

--- a/server/scripts/createModerationIndexes.js
+++ b/server/scripts/createModerationIndexes.js
@@ -46,6 +46,13 @@ const INDEXES = [
   // write AND the userId-prefix scans (getSingleUserReviews, account counts,
   // exportMyData, the delete-account cascade).
   //
+  // Also provisioned at server boot (db.js ensureIndexes) with an IDENTICAL spec —
+  // same key, name, and options — so a fresh deploy's write path never runs
+  // against an unindexed ratings collection before this script does. This copy is
+  // kept because it's idempotent and the release runbook §2e runs it against prod
+  // as an explicit gate; the two identical createIndex calls are a no-op for each
+  // other (a same-name-but-different-options call would throw, hence "identical").
+  //
   // UNIQUE — enforces the "one rating per (user, recipe)" invariant the upserts
   // rely on. Without it, a legacy doc missing `userId` (pre-backfill) or a
   // concurrent double-submit would slip a SECOND row past the upsert filter and


### PR DESCRIPTION
Wave 14 lane B — three filed findings from the 2026-07-11 server sweep, one PR. Scope: `server/db.js`, `server/routes/ingredients.js`, `server/scripts/createModerationIndexes.js` (comment), `server/__tests__/*`.

## 1. D1 ratings `{userId, recipeId}` index — now provisioned at boot (P2)
The unique+partial identity index (the "one rating per (user, recipe)" invariant every review upsert relies on) lived **only** in `scripts/createModerationIndexes.js`, leaving a window where a fresh deploy's write path could slip a duplicate past the upsert before someone ran the script. Moved into `db.js` `ensureIndexes`, mirroring the script's entry **exactly** (same key, name, options) so the two `createIndex` calls are a no-op for each other rather than a same-name/different-options throw:

```js
db.collection('ratings').createIndex(
  { userId: 1, recipeId: 1 },
  { name: 'userId_1_recipeId_1', unique: true,
    partialFilterExpression: { userId: { $exists: true } } }
)
```

The script keeps its idempotent copy (release runbook §2e runs it against prod as a gate), with a comment noting boot now also provisions it.

### ⚠️ Deviation from the brief — the stale `{ username }` index is KEPT, not dropped
The brief asked to drop the boot-created `ratings.createIndex({ username: 1 })` on the premise that "no route queries ratings by `username` anymore," and gated it on: *"confirm by grep that truly nothing filters ratings by bare `username` before dropping."*

That grep found a **live consumer**: the `POST /setUsername` **rename cascade** (`server/routes/auth.js:191-194`) does `ratings.updateMany({ username: prevUsername }, { $set: { username } })` — a filter on bare `username`. Dropping the index would turn every username change into a full `ratings` COLLSCAN. `auth.js` is out of this lane's scope rails, so the cascade can't be migrated here. Per the brief's own guard I left the index in place and instead **updated its comment** to record that its original read consumers (`getSingleUserReviews`, `getAccountCounts`) migrated to `userId` in D1 and it now serves only the rename write. No `dropIndex` was added. (Flagged for the orchestrator — see below.)

## 2. `requireActive` on `POST /api/ingredients/parse` (P3)
The route mounted `verifyToken → parseLimiter` only, letting a just-suspended/banned account burn paid Spoonacular quota for up to ~1h of token validity. Added `requireActive` between `verifyToken` and `parseLimiter` (the house write-surface order).

## 3. Hardened the PUT-drafts no-limiter pin (P3)
`writeLimiter.wiring.test.js` only checked the 5 **exported** limiter instances, so a brand-new inline limiter on `PUT /drafts/:id` would pass. Added a structural `isRateLimiter` predicate — `express-rate-limit` attaches `getKey`/`resetKey` function properties to its middleware; a plain handler has neither — and assert **no** handler in the PUT chain is a limiter. Same predicate strengthens the parse pin (now `verifyToken → requireActive → limiter → handler`, length 4).

## Tests
- Extended `writeLimiter.wiring.test.js`: new parse chain + structural pins; added `/parse` to the requireActive-surface cases.
- New `ensureIndexes.test.js`: pins the boot-provisioned D1 `userId_1_recipeId_1` (unique + partialFilterExpression) and the retained `username_1` index.
- Fixed one `users.test.js` seed that modelled an impossible two-ratings-per-`(user,recipe)` state the new unique index (correctly) rejects — split onto two recipes, intent preserved.

**`cd server && npm test` → 886/886 passing, 42 suites.** (Two earlier full runs showed unrelated `connect ETIMEDOUT` flakiness — the known CPU-contention vector documented in `globalSetup.js`; clean re-runs are green.)

## Flagged (report-only, not acted on)
- The brief's premise that nothing filters ratings by `username` is inaccurate — the rename cascade still does. A future D1 follow-up could migrate that cascade off `username` (it already carries `userId`), after which the `username` index becomes fully dead and droppable.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK