### PR TITLE
fix: honest coerce-then-check guard in formatDate

### DIFF
--- a/src/test/formatDate.test.ts
+++ b/src/test/formatDate.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { formatDate } from 'src/util/formatDate'
+
+const monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
+// Mirrors formatDate's own rendering so assertions stay correct regardless of
+// the runner's local timezone, while still pinning the string contract.
+const expectedLabel = (date: Date, short: boolean): string => {
+  const month = short
+    ? monthNames[date.getMonth()].substring(0, 3)
+    : monthNames[date.getMonth()]
+  return `${month} ${date.getDate()}, ${date.getFullYear()}`
+}
+
+// formatDate's real contract is an epoch-ms string (see `createdAt` /
+// `reviewCreatedAt`, produced via `Date.now().toString()` — RecipeAPI.addRecipe,
+// server/routes/reviews.js). The guard used to be `Number.isNaN(d) ? new
+// Date(d) : new Date(Number(d))`, but `Number.isNaN` never coerces its input,
+// so `Number.isNaN(<any string>)` is always false — every string, including a
+// genuine ISO string, took the `new Date(Number(d))` branch and rendered
+// "Invalid Date" for ISO input. The fix coerces first (`Number(d)`) and
+// branches on whether *that* is NaN, falling back to `new Date(d)` only for
+// non-numeric strings.
+describe('formatDate', () => {
+  it('renders an epoch-ms string (the real contract) correctly, long form', () => {
+    const ms = 1700000000000
+    expect(formatDate(String(ms), false)).toBe(expectedLabel(new Date(ms), false))
+  })
+
+  it('renders an epoch-ms string correctly, short form', () => {
+    const ms = 1700000000000
+    expect(formatDate(String(ms), true)).toBe(expectedLabel(new Date(ms), true))
+  })
+
+  it('renders a Date.now()-style epoch-ms string (reviewCreatedAt/createdAt shape)', () => {
+    const ms = Date.now()
+    const epochMsString = ms.toString()
+    expect(formatDate(epochMsString, false)).toBe(expectedLabel(new Date(ms), false))
+    expect(formatDate(epochMsString, true)).toBe(expectedLabel(new Date(ms), true))
+  })
+
+  it('parses a genuine ISO date string instead of rendering Invalid Date (regression)', () => {
+    const iso = '2023-11-14T12:00:00.000Z'
+    const result = formatDate(iso, false)
+    // Before the fix: Number('2023-11-14T12:00:00.000Z') is NaN, but
+    // Number.isNaN(iso) (no coercion) is false, so the old guard took the
+    // `new Date(Number(iso))` branch -> new Date(NaN) -> Invalid Date ->
+    // rendered as "undefined NaN, NaN".
+    expect(result).not.toBe('undefined NaN, NaN')
+    expect(result).not.toContain('NaN')
+    expect(result).not.toContain('undefined')
+    expect(result).toBe(expectedLabel(new Date(iso), false))
+  })
+
+  it('parses a genuine ISO date string in short form', () => {
+    const iso = '2023-11-14T12:00:00.000Z'
+    expect(formatDate(iso, true)).toBe(expectedLabel(new Date(iso), true))
+  })
+})

--- a/src/util/formatDate.ts
+++ b/src/util/formatDate.ts
@@ -14,7 +14,8 @@ const monthNames = [
 ]
 
 export const formatDate = (d: string, short: boolean): string => {
-  const date = Number.isNaN(d) ? new Date(d) : new Date(Number(d))
+  const n = Number(d)
+  const date = Number.isNaN(n) ? new Date(d) : new Date(n)
   let day = date.getDate()
   let month = monthNames[date.getMonth()]
   let year = date.getFullYear()


### PR DESCRIPTION
## Summary
- `formatDate`'s ternary guard (`Number.isNaN(d) ? ... : ...`) was dead: `Number.isNaN` never coerces, so it's always `false` for a string input, meaning every call silently took the `new Date(Number(d))` branch. A genuine ISO-string input rendered "Invalid Date" (`undefined NaN, NaN` in this function's output shape).
- Fix: coerce first (`const n = Number(d)`), then branch on `Number.isNaN(n)`, falling back to `new Date(d)` for non-numeric strings — matching the documented epoch-ms-string contract (see `formatMonthYear`'s comment) while still letting a real ISO string parse instead of failing.
- Output is byte-identical for both current call sites, which each pass an epoch-ms string:
  - `src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/OwnReviewCard.tsx:52` — `formatDate(review.reviewCreatedAt, true)`
  - `src/pages/SingleRecipe/DataSections/RatingsAndReviews/Reviews/RecipeReview.tsx:25` — `formatDate(review.reviewCreatedAt, true)`
  - (`review.reviewCreatedAt` is `Date.now().toString()`, set in `server/routes/reviews.js:120/128` — confirmed epoch-ms string.)
  - Note: `src/pages/Account/UserRecipes/UserRecipeThumbnail.tsx` defines its own **local** `formatDate` helper, not the util — not a call site of this function.

## Test plan
- [x] Added `src/test/formatDate.test.ts` (no prior test file existed): pins current epoch-ms-string behavior (long + short form, including a `Date.now()`-shaped value), and adds a regression case for a genuine ISO string that reproduced "Invalid Date" (`undefined NaN, NaN`) before the fix — verified failing on the pre-fix code, passing after.
- [x] `npm test` — 91 test files, 744 passed, 2 skipped (pre-existing), 0 failed.
- [x] `npm run typecheck` (`tsc --noEmit`) — clean, 0 errors.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK