### PR TITLE
refactor: dedup UserRecipeThumbnail's local formatDate onto shared util

### DIFF
--- a/src/pages/Account/UserRecipes/UserRecipeThumbnail.tsx
+++ b/src/pages/Account/UserRecipes/UserRecipeThumbnail.tsx
@@ -10,16 +10,17 @@ import { CreatedRecipeCardType } from 'types'
 import { formatRating } from 'src/util/formatRating'
 import { formatCompactCount } from 'src/util/formatCompactCount'
 import { formatPrice } from 'src/util/formatPrice'
+import { formatDate } from 'src/util/formatDate'
 
 
-const formatDate = (createdAt: string) => {
+// Delegates valid-date formatting to the shared util (byte-identical short-form
+// output for epoch-ms strings), but keeps a local null guard for falsy/garbage
+// createdAt (e.g. "0", "", non-numeric) so the date is hidden instead of
+// rendering the shared util's un-guarded "Dec 31, 1969" fallback.
+const formatCreated = (createdAt: string) => {
   const ms = Number(createdAt)
   if (!ms || Number.isNaN(ms)) return null
-  return new Date(ms).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
+  return formatDate(createdAt, true)
 }
 
 type UserRecipeThumbnailType = {
@@ -35,7 +36,7 @@ const UserRecipeThumbnail: FC<UserRecipeThumbnailType> = ({
   loading,
 }) => {
   const isLoading = loading || !recipe
-  const createdDate = recipe ? formatDate(recipe.createdAt) : null
+  const createdDate = recipe ? formatCreated(recipe.createdAt) : null
   const price =
     recipe && recipe.servingPrice != null && recipe.servingPrice > 0
       ? formatPrice(recipe.servingPrice)

--- a/src/test/UserRecipeThumbnail.test.tsx
+++ b/src/test/UserRecipeThumbnail.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * UserRecipeThumbnail's created-date formatting used to be a local hand-rolled
+ * `toLocaleDateString` call; it now delegates valid-date formatting to the
+ * shared `src/util/formatDate` util (short form) while keeping a local
+ * null/NaN guard so a missing/garbage `createdAt` hides the date instead of
+ * rendering the shared util's un-guarded epoch-zero fallback.
+ */
+
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import UserRecipeThumbnail from 'src/pages/Account/UserRecipes/UserRecipeThumbnail'
+import { CreatedRecipeCardType } from 'types'
+
+const baseRecipe: CreatedRecipeCardType = {
+  _id: 'recipe-1',
+  title: 'Test Recipe',
+  recipeImage: '',
+  totalTime: 20,
+  servingPrice: null,
+  rating: { rateValue: 0, rateCount: 0 },
+  createdAt: '',
+  views: 0,
+  numTimesSaved: 0,
+  numTimesMade: 0,
+}
+
+describe('UserRecipeThumbnail created-date formatting', () => {
+  it('renders the pinned "Mon D, YYYY" short-form date for a valid epoch-ms createdAt', () => {
+    // 2026-07-11T14:30:00 local -> shared formatDate(short=true) contract.
+    const ms = new Date(2026, 6, 11, 14, 30, 0).getTime()
+    const recipe = { ...baseRecipe, createdAt: String(ms) }
+
+    render(
+      <MemoryRouter>
+        <UserRecipeThumbnail recipe={recipe} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Jul 11, 2026')).toBeInTheDocument()
+  })
+
+  it('hides the date (null guard preserved) for a garbage/zero createdAt', () => {
+    for (const createdAt of ['0', '', 'not-a-date']) {
+      const recipe = { ...baseRecipe, createdAt }
+      const { unmount, container } = render(
+        <MemoryRouter>
+          <UserRecipeThumbnail recipe={recipe} />
+        </MemoryRouter>
+      )
+
+      expect(container.querySelector('.date')).toBeNull()
+      unmount()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- `UserRecipeThumbnail.tsx` hand-rolled its own `toLocaleDateString`-based `formatDate`; verified byte-identical short-form output against the shared `src/util/formatDate` for every month/day (single- and double-digit) across years 2020-2027 with valid epoch-ms input (0 mismatches).
- Delegated valid-date formatting to the shared util, renamed the local wrapper to `formatCreated`, and **preserved the local null/NaN guard** so a missing/garbage `createdAt` (e.g. `"0"`, `""`, non-numeric) still hides the date instead of rendering the shared util's un-guarded fallback (`Dec 31, 1969`).
- No behavior change for real inputs — `recipe.createdAt` is always a `Date.now().toString()` epoch-ms string in production.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 754 passed | 2 skipped (baseline 752 + 2 new), 92 test files
- [x] New `src/test/UserRecipeThumbnail.test.tsx` pins the rendered "Jul 11, 2026" short-form date for a valid epoch-ms `createdAt`, and asserts the date is hidden (`.date` node absent) for `"0"`, `""`, and `"not-a-date"` createdAt values (null-guard regression coverage).

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK