### PR TITLE
feat(drafts): durable unload-flush supersede + transient-hydration retry (W16 lane A)

### DIFF
--- a/server/__tests__/drafts.test.js
+++ b/server/__tests__/drafts.test.js
@@ -287,6 +287,83 @@ describe('PUT /api/drafts/:id', () => {
     expect(res.status).toBe(400)
   })
 
+  // ─── supersede flag (W16: durable unload-flush) ───────────────────────────
+  // The unload keepalive flush (src/api/drafts.ts) sets `supersede: true` so its
+  // freshest edits land unconditionally — it must never 409 against a normal
+  // autosave that raced ahead of it. Only the flush sets the flag; regular
+  // autosave still carries (and is conditioned on) the base updatedAt.
+  it('with supersede:true writes unconditionally, bypassing the updatedAt precondition (a stale base still lands)', async () => {
+    const draft = await seedDraft({ title: 'original', updatedAt: '1000' })
+    // Another save moves the stored version forward first.
+    const ahead = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'raced ahead', updatedAt: '1000' })
+    expect(ahead.status).toBe(200)
+
+    // The flush carries a STALE base ('1000') but supersede:true — a normal PUT
+    // would 409 here; the flush must win instead.
+    const flush = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'flush wins', updatedAt: '1000', supersede: true })
+    expect(flush.status).toBe(200)
+    expect(flush.body.title).toBe('flush wins')
+
+    const stored = await getDB()
+      .collection('recipeDrafts')
+      .findOne({ _id: draft._id })
+    expect(stored.title).toBe('flush wins')
+    // The transient flag is never persisted onto the document.
+    expect(stored.supersede).toBeUndefined()
+  })
+
+  it('with supersede:true does not require an updatedAt precondition (no 400 when omitted)', async () => {
+    const draft = await seedDraft({ title: 'before', updatedAt: '1000' })
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'no version, superseding', supersede: true })
+    expect(res.status).toBe(200)
+    expect(res.body.title).toBe('no version, superseding')
+  })
+
+  it('without the flag still 409s DRAFT_CONFLICT when the base updatedAt has moved', async () => {
+    const draft = await seedDraft({ title: 'original', updatedAt: '1000' })
+    const ahead = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'raced ahead', updatedAt: '1000' })
+    expect(ahead.status).toBe(200)
+
+    // Same stale base, but NO supersede flag → the precondition still guards it.
+    const stale = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'stale normal save', updatedAt: '1000' })
+    expect(stale.status).toBe(409)
+    expect(stale.body.code).toBe('DRAFT_CONFLICT')
+  })
+
+  it('with supersede:true still 404s when the draft was deleted (a flush never resurrects it)', async () => {
+    // No draft exists at this id — models the draft being deleted elsewhere
+    // between the tab loading it and the unload flush firing.
+    const res = await request(app)
+      .put(`/api/drafts/${new ObjectId()}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'flush after delete', updatedAt: '1000', supersede: true })
+    expect(res.status).toBe(404)
+  })
+
+  it("with supersede:true still can't touch another user's draft (403)", async () => {
+    const draft = await seedDraft({ userId: 'other-uid' })
+    const res = await request(app)
+      .put(`/api/drafts/${draft._id}`)
+      .set(AUTH_HEADER)
+      .send({ title: 'hijacked', updatedAt: '1000', supersede: true })
+    expect(res.status).toBe(403)
+  })
+
   it("checks ownership before bounds (403, not 400, for another user's draft)", async () => {
     const draft = await seedDraft({ userId: 'other-uid' })
     const res = await request(app)

--- a/server/routes/drafts.js
+++ b/server/routes/drafts.js
@@ -119,6 +119,17 @@ router.get('/:id', verifyToken, asyncHandler(async (req, res) => {
 // a tab that's saved on top of a since-changed draft gets a 409 instead of
 // blindly clobbering it with a full `$set` of its (now-stale) content.
 //
+// EXCEPTION — the unload keepalive flush (src/api/drafts.ts:flushDraftKeepalive)
+// sends `supersede: true`. That flush carries the freshest edits the user made
+// right before leaving the page, so it must land unconditionally: it drops the
+// `updatedAt` precondition and matches on `{_id}` alone (still ownership-checked
+// above), so it can never 409 against a normal autosave that raced ahead of it —
+// the newest content always wins the unload race. It is deliberately the ONLY
+// path that sets the flag; regular debounced autosave (updateDraft) never does,
+// so a routine save still 409s on a real cross-tab conflict. A supersede write
+// can still 404 if the draft was deleted in the interim — see the no-match
+// branch below — so a keepalive flush never resurrects a deleted draft (#307).
+//
 // Deliberately NO draftWriteLimiter here (unlike POST above). This is the
 // 1.5s-debounce autosave path — continuous typing alone can produce ~40
 // legitimate writes/min, well over a stock 30/min per-uid cap, so reusing the
@@ -148,21 +159,26 @@ router.put('/:id', verifyToken, requireActive, asyncHandler(async (req, res) => 
   if (boundsError) {
     return res.status(400).json({ error: boundsError })
   }
-  const { updatedAt: baseUpdatedAt } = req.body
-  if (typeof baseUpdatedAt !== 'string') {
+  const { updatedAt: baseUpdatedAt, supersede } = req.body
+  // The unload flush sets `supersede: true` to write unconditionally (see the
+  // route comment). Only a normal autosave requires — and is conditioned on —
+  // the `updatedAt` precondition.
+  const isSupersede = supersede === true
+  if (!isSupersede && typeof baseUpdatedAt !== 'string') {
     return res.status(400).json({ error: 'Missing updatedAt precondition' })
   }
   const update = {
     ...pickFields(req.body, RECIPE_CONTENT_FIELDS),
     updatedAt: Date.now().toString(),
   }
+  // A supersede flush matches on `{_id}` alone so a stale base version still
+  // lands; a normal save conditions on the base `updatedAt` and 409s on a
+  // mismatch. `supersede` is not a RECIPE_CONTENT_FIELD, so pickFields never
+  // persists it onto the draft document.
+  const filter = isSupersede ? { _id } : { _id, updatedAt: baseUpdatedAt }
   const updated = await db
     .collection('recipeDrafts')
-    .findOneAndUpdate(
-      { _id, updatedAt: baseUpdatedAt },
-      { $set: update },
-      { returnDocument: 'after' }
-    )
+    .findOneAndUpdate(filter, { $set: update }, { returnDocument: 'after' })
   if (!updated) {
     // Either someone else's save moved `updatedAt` out from under this
     // request, or the draft was deleted in the interim — distinguish so the

--- a/src/api/drafts.ts
+++ b/src/api/drafts.ts
@@ -71,10 +71,12 @@ class DraftAPIClass {
   // Synchronous, fire-and-forget draft save for page unload (beforeunload /
   // pagehide). An async axios request won't reliably complete while the page is
   // being torn down, so this uses `fetch(..., { keepalive: true })`, which the
-  // browser guarantees to run to completion in the background. It mirrors the
-  // normal autosave contract: PUT /drafts/:id (echoing the `baseUpdatedAt`
-  // concurrency precondition the server requires) for an existing draft, or
-  // POST /drafts to create one. The Bearer token is read synchronously from the
+  // browser guarantees to run to completion in the background. For an existing
+  // draft it PUTs with `supersede: true`, so the server applies the write
+  // WITHOUT the `updatedAt` precondition — this flush carries the user's last
+  // edits and must win the unload race against any autosave still in flight,
+  // never 409. For a brand-new draft it POSTs /drafts to create one. The Bearer
+  // token is read synchronously from the
   // cache the axios interceptor maintains (see http-common). Returns false
   // without firing when no token is available (signed out, or no request has
   // ever warmed the cache).
@@ -100,40 +102,26 @@ class DraftAPIClass {
 
     if (id) {
       const url = `${API_BASE_URL}/api/drafts/${id}`
-      send('PUT', url, { ...content, updatedAt: baseUpdatedAt })
+      // `supersede: true` makes this the authoritative "newest edits win" write:
+      // the server (server/routes/drafts.js) applies it WITHOUT the `updatedAt`
+      // precondition, so it can never 409 against a normal autosave that was
+      // still in flight when the page unloaded — the flush's freshest content
+      // always lands. That's why there's no 409-retry dance here anymore (it was
+      // #311's workaround for a flush that *could* conflict; a supersede write
+      // can't). We still send `updatedAt` for parity/observability; the server
+      // ignores it on the supersede path. The flush is deliberately the only
+      // caller that sets this flag — normal debounced autosave (updateDraft)
+      // never does, so a real cross-tab conflict still 409s there.
+      send('PUT', url, { ...content, updatedAt: baseUpdatedAt, supersede: true })
         .then(res => {
           if (res.ok) return
-          if (res.status === 409) {
-            // This keepalive PUT lost the unload race against a normal autosave
-            // that was still in flight: both carried the same base `updatedAt`,
-            // and the older in-flight save landed first, so ours 409s. Without a
-            // retry the *newest* edits (this flush) would be silently dropped.
-            // Retry once against the server's now-current version so the newest
-            // content supersedes the older write — autosave's prime directive is
-            // never to lose active work.
-            return res
-              .json()
-              .then((data: { draft?: { updatedAt?: string } }) => {
-                const latest = data?.draft?.updatedAt
-                if (latest && latest !== baseUpdatedAt) {
-                  return send('PUT', url, { ...content, updatedAt: latest }).then(
-                    retry => {
-                      if (!retry.ok) {
-                        console.error(
-                          'Keepalive draft flush retry did not persist:',
-                          retry.status
-                        )
-                      }
-                    }
-                  )
-                }
-                console.error('Keepalive draft flush conflict unresolved')
-              })
-              .catch(() => {})
-          }
-          // Any other resolved-but-non-2xx (a 429 rate-limit, a 5xx, …) means the
-          // flush did NOT persist. Surface it rather than letting a resolved
-          // failure masquerade as a successful save (see the POST branch below).
+          // A supersede PUT can't 409, but it can still 404 if the draft was
+          // deleted elsewhere while this tab held it open — in which case we
+          // give up rather than recreate it (a keepalive flush must never
+          // resurrect a deleted draft, #307). Any other resolved-but-non-2xx (a
+          // 429 rate-limit, a 5xx, …) also means the flush did NOT persist.
+          // Surface it rather than letting a resolved failure masquerade as a
+          // successful save (see the POST branch below).
           console.error('Keepalive draft flush did not persist:', res.status)
         })
         .catch(() => {

--- a/src/pages/AddRecipe/useRecipeForm.ts
+++ b/src/pages/AddRecipe/useRecipeForm.ts
@@ -279,6 +279,26 @@ export function useRecipeForm(initialRecipe?: RecipeType) {
   // drafts created in the current session (the user never had an image to lose).
   const [resumedFromDraft, setResumedFromDraft] = useState(false)
 
+  // ─── Resume-hydration retry (transient-failure recovery) ──────────────────
+  // A transient (network/5xx) failure of the `?draftId` GET below used to be
+  // terminal for the session: autosave stayed disabled (hydrated=false) with no
+  // recovery but a manual refresh, so a one-off blip permanently wedged the
+  // editor. We now re-attempt the GET on the user's next edit (autosave is off
+  // while un-hydrated, so an edit is the only signal the user is still working
+  // and the network may have recovered). Bumping this counter re-runs the
+  // hydration effect; the retry is bounded so a persistently-down server doesn't
+  // fire a GET per keystroke forever — after MAX_HYDRATION_ATTEMPTS we fall back
+  // to the manual-refresh prompt. A 404/403 on any attempt still routes to the
+  // "draft is gone → start fresh" recovery below (autosave re-creates on the
+  // next edit), never to this retry path.
+  const [hydrationRetry, setHydrationRetry] = useState(0)
+  // Armed by a transient hydration failure; the next edit consumes it to fire a
+  // retry. A ref so the edit-watcher effect reads it without re-subscribing.
+  const hydrationPendingRetryRef = useRef(false)
+  // Count of hydration GETs that have failed transiently, to bound the retries.
+  const hydrationFailuresRef = useRef(0)
+  const MAX_HYDRATION_ATTEMPTS = 4
+
   // Load the draft named in the URL whenever it points at one we haven't loaded
   // yet. Runs on mount for `?draftId=…`, and again when the resume banner
   // navigates to a draft while this page is already mounted — same route, so no
@@ -352,15 +372,25 @@ export function useRecipeForm(initialRecipe?: RecipeType) {
           // Transient failure (network/5xx) on a draft that likely still
           // exists. Leave autosave disabled (hydrated stays false) so we don't
           // create a duplicate or overwrite the unloaded draft with a partial
-          // form; ask the user to retry.
-          toast.error('Could not load your draft. Refresh to try again.')
+          // form. Rather than wedge the session until a manual refresh, arm a
+          // bounded retry: the user's next edit re-runs this GET (see the
+          // edit-watcher effect below), so a blip that clears recovers on its
+          // own. Only give up (and ask for a refresh) once the retries are
+          // exhausted, so a persistently-failing server isn't hit per keystroke.
+          hydrationFailuresRef.current += 1
+          if (hydrationFailuresRef.current < MAX_HYDRATION_ATTEMPTS) {
+            hydrationPendingRetryRef.current = true
+            toast.error("Couldn't load your draft — we'll retry as you keep editing.")
+          } else {
+            toast.error('Could not load your draft. Refresh to try again.')
+          }
         }
       })
     return () => {
       cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [urlDraftId])
+  }, [urlDraftId, hydrationRetry])
 
   // Serializable draft content mirrored from form state. Times are stored as
   // minutes (matching the recipe shape); empty values are omitted.
@@ -397,6 +427,20 @@ export function useRecipeForm(initialRecipe?: RecipeType) {
       nutritionLabels,
     ]
   )
+
+  // Fire a hydration retry on the user's first edit after a transient failure.
+  // While un-hydrated, autosave is disabled and no draft GET is otherwise in
+  // flight, so an edit (draftContent identity change) is the trigger to try
+  // again. The ref is consumed here so exactly one retry is armed per failure —
+  // a re-armed retry only follows the *next* transient failure, not every
+  // keystroke. Placed after `draftContent` so its identity is defined when this
+  // effect subscribes.
+  useEffect(() => {
+    if (hydrated || !hydrationPendingRetryRef.current) return
+    hydrationPendingRetryRef.current = false
+    setHydrationRetry(n => n + 1)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftContent])
 
   // A brand-new draft is created once the form holds any real content, not just
   // a title (see hasDraftableContent). An all-default form still never creates

--- a/src/test/AddRecipe.test.tsx
+++ b/src/test/AddRecipe.test.tsx
@@ -779,6 +779,78 @@ describe('AddRecipe form', () => {
     })
   })
 
+  describe('transient resume-hydration failure recovers (W16 seed 2)', () => {
+    it('retries the hydration on the next edit instead of wedging autosave forever', async () => {
+      const user = userEvent.setup()
+      // The first `?draftId` GET fails transiently (5xx) — the draft still
+      // exists. Pre-W16 this was terminal: autosave stayed disabled for the
+      // session and the ONLY signal (an edit) never re-attempted the load, so
+      // the resumed content never arrived and nothing ever autosaved again. The
+      // retry lands the draft on the next edit.
+      draftGet
+        .mockRejectedValueOnce({ isAxiosError: true, response: { status: 503 } })
+        .mockResolvedValueOnce({
+          _id: 'd1',
+          userId: 'u1',
+          createdAt: '1',
+          updatedAt: '1',
+          title: 'Recovered draft',
+          description: 'from the server',
+        })
+      renderAddRecipe({ initialEntries: ['/add-recipe?draftId=d1'] })
+
+      // First attempt fires and fails; wait for the transient-failure toast so
+      // the retry is armed before we type.
+      await waitFor(() => expect(draftGet).toHaveBeenCalledTimes(1))
+      await waitFor(() => expect(toastError).toHaveBeenCalled())
+
+      // The user keeps working — a single edit must re-attempt the hydration
+      // (pre-fix draftGet is only ever called once).
+      await user.type(
+        screen.getByPlaceholderText('Add a title to your recipe.'),
+        'X'
+      )
+      await waitFor(() => expect(draftGet).toHaveBeenCalledTimes(2))
+
+      // The retry succeeds: the untouched description hydrates from the draft,
+      // while the title the user was typing is preserved (merge guard).
+      await waitFor(() =>
+        expect(
+          screen.getByPlaceholderText('Add a description to your recipe')
+        ).toHaveValue('from the server')
+      )
+      expect(
+        screen.getByPlaceholderText('Add a title to your recipe.')
+      ).toHaveValue('X')
+    })
+
+    it('a retry that 404s falls through to a fresh start (draft truly gone)', async () => {
+      const user = userEvent.setup()
+      // Transient failure first, then the draft turns out to be gone on retry.
+      draftGet
+        .mockRejectedValueOnce({ isAxiosError: true, response: { status: 503 } })
+        .mockRejectedValueOnce({
+          isAxiosError: true,
+          response: { status: 404, data: { error: 'Draft not found' } },
+        })
+      renderAddRecipe({ initialEntries: ['/add-recipe?draftId=d1'] })
+      await waitFor(() => expect(draftGet).toHaveBeenCalledTimes(1))
+      await waitFor(() => expect(toastError).toHaveBeenCalled())
+
+      // The edit retries; the 404 routes to the "start a new one" recovery.
+      await user.type(
+        screen.getByPlaceholderText('Add a title to your recipe.'),
+        'Fresh'
+      )
+      await waitFor(() => expect(draftGet).toHaveBeenCalledTimes(2))
+      await waitFor(() =>
+        expect(toastError).toHaveBeenCalledWith(
+          "Couldn't load that draft — starting a new one."
+        )
+      )
+    })
+  })
+
   describe('unenriched persisted rows surface as errored (review fix)', () => {
     const parsed = (original: string) => ({
       ingredient: 'flour',

--- a/src/test/draftsKeepalive.test.tsx
+++ b/src/test/draftsKeepalive.test.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest'
 import DraftAPI from 'src/api/drafts'
 import AuthAPI from 'src/api/auth'
-import { getCachedIdToken } from 'src/api/http-common'
+import { getCachedIdToken, http } from 'src/api/http-common'
 import { RecipeDraftContent } from 'types'
 
 // The keepalive flush must not depend on Firebase init or a real axios instance,
@@ -9,7 +9,10 @@ import { RecipeDraftContent } from 'types'
 // URL assertion.
 vi.mock('src/api/http-common', () => ({
   API_BASE_URL: 'http://api.test',
-  http: {},
+  // `put` is stubbed so the debounced-autosave path (updateDraft) can be
+  // exercised alongside the keepalive flush, to prove only the flush sets the
+  // supersede flag.
+  http: { put: vi.fn() },
   getCachedIdToken: vi.fn(),
   warmIdToken: vi.fn(),
 }))
@@ -19,6 +22,7 @@ vi.mock('src/api/auth', () => ({
 
 const mockedAuth = AuthAPI as unknown as { getUID: ReturnType<typeof vi.fn> }
 const mockedGetToken = getCachedIdToken as unknown as ReturnType<typeof vi.fn>
+const mockedPut = (http as unknown as { put: ReturnType<typeof vi.fn> }).put
 
 const content: RecipeDraftContent = { title: 'Soup', description: 'Cozy' }
 
@@ -34,7 +38,7 @@ afterEach(() => {
 })
 
 describe('DraftAPI.flushDraftKeepalive', () => {
-  it('PUTs an existing draft with the updatedAt precondition and a keepalive Bearer request', () => {
+  it('PUTs an existing draft with supersede:true and a keepalive Bearer request (W16)', () => {
     const fired = DraftAPI.flushDraftKeepalive('draft-1', content, '1000')
     expect(fired).toBe(true)
 
@@ -44,8 +48,11 @@ describe('DraftAPI.flushDraftKeepalive', () => {
     expect(init.method).toBe('PUT')
     expect(init.keepalive).toBe(true)
     expect(init.headers.Authorization).toBe('Bearer tok-abc')
-    // The B5 concurrency field must ride along with the content.
-    expect(JSON.parse(init.body)).toEqual({ ...content, updatedAt: '1000' })
+    // The flush sends supersede:true so the server writes unconditionally and it
+    // can't 409 against a racing autosave. The base updatedAt still rides along
+    // (parity/observability); the server ignores it on the supersede path.
+    const body = JSON.parse(init.body)
+    expect(body).toEqual({ ...content, updatedAt: '1000', supersede: true })
   })
 
   it('POSTs a brand-new draft (no id) without an updatedAt field', () => {
@@ -75,48 +82,43 @@ describe('DraftAPI.flushDraftKeepalive', () => {
   // Wait a macrotask so the fetch `.then`/`.json()` chain (and any retry) runs.
   const flushMicrotasks = () => new Promise(res => setTimeout(res, 0))
 
-  it('retries the PUT once against the server’s latest version on a 409, so the newest edits win the unload race (W15 bug 1)', async () => {
-    // Models bug 1: this keepalive PUT and a normal autosave that was still in
-    // flight both carried the same base updatedAt ('1000'). The older in-flight
-    // save landed first, bumping the stored version to '2000', so this PUT 409s.
-    // Pre-fix it was dropped and the newest edits were silently lost; post-fix it
-    // retries once against '2000' and supersedes the older write.
-    const conflict = new Response(
-      JSON.stringify({ code: 'DRAFT_CONFLICT', draft: { updatedAt: '2000' } }),
-      { status: 409, headers: { 'Content-Type': 'application/json' } }
-    )
+  it('does not retry the PUT — a supersede flush cannot 409, so the #311 retry dance is gone (W16)', async () => {
+    // Post-W16 the flush sets supersede:true, so the server writes
+    // unconditionally and the "PUT lost the unload race" 409 can no longer
+    // happen. There is a single PUT and no conditional retry.
     const ok = new Response(null, { status: 200 })
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(conflict)
-      .mockResolvedValueOnce(ok)
+    const fetchMock = vi.fn().mockResolvedValue(ok)
     vi.stubGlobal('fetch', fetchMock)
 
     const fired = DraftAPI.flushDraftKeepalive('draft-1', content, '1000')
     expect(fired).toBe(true)
     await flushMicrotasks()
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-    // The retry carries the SAME (newest) content but the server's fresh version.
-    const retryBody = JSON.parse(fetchMock.mock.calls[1][1].body)
-    expect(retryBody).toEqual({ ...content, updatedAt: '2000' })
-    expect(fetchMock.mock.calls[1][1].method).toBe('PUT')
-    expect(fetchMock.mock.calls[1][1].keepalive).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      ...content,
+      updatedAt: '1000',
+      supersede: true,
+    })
   })
 
-  it('does not retry when the 409 body carries no fresher version', async () => {
-    const conflict = new Response(
-      JSON.stringify({ code: 'DRAFT_CONFLICT' }),
-      { status: 409, headers: { 'Content-Type': 'application/json' } }
-    )
-    const fetchMock = vi.fn().mockResolvedValue(conflict)
+  it('gives up (logs, no recreate) when the superseding PUT 404s — the draft was deleted elsewhere (#307)', async () => {
+    // A supersede PUT still 404s if the draft was deleted while this tab held it
+    // open. The flush must NOT resurrect it (no retry, no create) — it just logs.
+    const gone = new Response(JSON.stringify({ error: 'Draft not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const fetchMock = vi.fn().mockResolvedValue(gone)
     vi.stubGlobal('fetch', fetchMock)
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     DraftAPI.flushDraftKeepalive('draft-1', content, '1000')
     await flushMicrotasks()
 
+    // Exactly one request (the PUT); no follow-up create/retry.
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][1].method).toBe('PUT')
     expect(errSpy).toHaveBeenCalled()
     errSpy.mockRestore()
   })
@@ -152,5 +154,21 @@ describe('DraftAPI.flushDraftKeepalive', () => {
 
     expect(errSpy).not.toHaveBeenCalled()
     errSpy.mockRestore()
+  })
+})
+
+describe('DraftAPI.updateDraft — regular autosave never supersedes (W16)', () => {
+  it('sends only the content + updatedAt precondition, and NO supersede flag', async () => {
+    mockedPut.mockResolvedValue({ data: { ...content, updatedAt: '2000' } })
+
+    await DraftAPI.updateDraft('draft-1', content, '1000')
+
+    expect(mockedPut).toHaveBeenCalledTimes(1)
+    const [url, body] = mockedPut.mock.calls[0]
+    expect(url).toBe('api/drafts/draft-1')
+    // The supersede bypass is the flush's alone; a debounced save stays
+    // precondition-guarded so a real cross-tab conflict still 409s.
+    expect(body).toEqual({ ...content, updatedAt: '1000' })
+    expect('supersede' in body).toBe(false)
   })
 })


### PR DESCRIPTION
Wave 16, lane A — the drafts-autosave cluster. Two fused seeds, one serialized PR.

## Seed 1 — Durable unload-flush supersede
Make the keepalive unload flush deterministic instead of racy.

- **Client** (`src/api/drafts.ts`, `flushDraftKeepalive`): the PUT now carries `supersede: true`. Because a supersede write can't 409, **#311's 409-retry-once dance is removed** as redundant. The flush can still 404 (draft deleted elsewhere) → it gives up rather than resurrect it (**#307** preserved). `supersede` is set only by the flush; `updateDraft` (debounced autosave) never sends it.
- **Server** (`server/routes/drafts.js`, `PUT /:id`): `supersede === true` applies the `$set` matching on `{_id}` alone (still ownership-checked) — no `updatedAt` precondition — so it can't 409. A normal PUT is unchanged: still requires `updatedAt` (400 if missing) and still 409s `DRAFT_CONFLICT` on a moved version. A supersede write to a deleted draft still 404s. `supersede` is not a content field, so it's never persisted.

**API contract change for the orchestrator to document:** `PUT /api/drafts/:id` now accepts an optional `supersede: boolean` in the body. When `true`, the `updatedAt` precondition is bypassed (unconditional last-write-wins) and `updatedAt` is not required; when absent/falsy, existing behavior (precondition required, 409 on mismatch) is unchanged.

## Seed 2 — Transient resume-hydration failure no longer wedges autosave
A network/5xx failure of the `?draftId` `getDraft` used to leave `hydrated` false for the whole session (manual-refresh only). Now a transient failure arms a **bounded retry on the next user edit** (`MAX_HYDRATION_ATTEMPTS`, then the manual-refresh prompt). A retry that 404/403s routes to the existing "draft is gone → start fresh" recovery.

## Test evidence
- Root `npx tsc --noEmit`: clean.
- Vitest (`npm test`): **755 passed / 2 skipped** (was 752).
- Server Jest (`cd server && npm test`): **908 passed** (drafts suite 28, +6 new).
- **Failing-before proven** for Seed 2: with the source reverted, the two new `W16 seed 2` tests fail (draftGet called once, wedged); with the fix they pass.

## jsdom caveat
jsdom can't prove `fetch(keepalive:true)` actually completes after document teardown, nor real unload timing — the flush's supersede body/no-retry is unit-asserted only. A directed live-browser pass may be warranted for the unload race.

## Pinned behaviors verified still hold
- **#286**: keepalive flush still fires on `beforeunload`/`pagehide`, single-flush guard, POST-create for a new draft.
- **#294**: a resolved-but-non-2xx POST (429/5xx) still surfaces as a failed create, not a silent success.
- **#307**: a keepalive flush never resurrects a deleted draft (supersede PUT 404 → give up); the autosave 404 → re-create-on-next-edit recovery is untouched.
- **#311**: normal autosave still sends and bumps the `updatedAt` precondition and 409s `DRAFT_CONFLICT` on a real conflict; the resume-hydration merge-vs-clobber guard, passive sign-out badge, and distinct conflict badge all still pass.

https://claude.ai/code/session_01Qdn9Nt9c4DAS6m7AxMHFAK