### PR TITLE
security: fix 2026-07-11 audit batch 1 (H1, M1, M2, M3, M4, L1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ npx cypress open       # Open Cypress test runner
 - `PORT` - Default 4000
 - `INGREDIENT_PARSER_PROXY_URL` - Optional. Overrides the base URL of the hosted ingredient-enrichment proxy used by `@jclind/ingredient-parser` v2 (server/routes/ingredients.js). Unset = the package's default hosted proxy. NOTE: as of `@jclind/ingredient-parser` v2 the parser is key-free on the client — the proxy holds the Spoonacular key — so `SPOONACULAR_API_KEY` is **no longer used by this server** (it was needed only by the v1 in-process library call).
 - `EDAMAM_APP_ID` / `EDAMAM_APP_KEY` - Edamam nutrition API credentials, used server-side only by the `POST /api/nutrition/details` proxy (server/routes/nutrition.js). Moved off the client (formerly `VITE_EDAMAM_APP_ID/KEY`) so the keys aren't shipped in the browser bundle.
+- `PAID_QUOTA_<SURFACE>_USER_DAILY` / `PAID_QUOTA_<SURFACE>_GLOBAL_DAILY` - Optional. Per-account and global DAILY spend ceilings on the paid third-party surfaces (audit H1), on top of the per-minute rate limiters. `<SURFACE>` is one of `NUTRITION` (Edamam), `INGREDIENTS` (Spoonacular parse), `RECIPE` (Cloud Vision + OpenAI moderation on recipe creates). Unset = the code defaults in `server/util/paidQuota.js` (nutrition 150/6000, ingredients 600/20000, recipe 50/2000). The global ceiling is what bounds a Sybil swarm's total spend regardless of account count; tune below your billing comfort line. Counters live in the `paidQuota` Mongo collection and self-reap via a TTL index. The limiter is skipped under `NODE_ENV=test`.
 
 ## Key Patterns
 

--- a/docs/SECURITY_AUDIT_2026-07-11.md
+++ b/docs/SECURITY_AUDIT_2026-07-11.md
@@ -7,6 +7,23 @@
 
 ---
 
+## Remediation log
+
+**Batch 1 (2026-07-11)** — verified-before-fixed against dev, each with a live repro + a re-run proving closure and a passing control:
+
+| Finding | Status | Fix summary |
+|---|---|---|
+| **H1** · paid-API aggregate cost ceiling | ✅ Fixed | New `server/util/paidQuota.js` — per-account + **global** daily counters (Mongo, TTL-reaped) mounted on `/ingredients/parse`, `/nutrition/details`, and recipe creates; `ingr` array length-capped. Live proof: per-account cap trips, and the global ceiling stops a **fresh** account (Sybil defeat). |
+| **M1** · review endpoints leak reviewer/admin UIDs + stamps | ✅ Fixed | Inclusion projection on `getReviews`/`getSingleUserReviews` + `publicRecipeProjection` on the `$lookup` sub-pipeline. `userId`/`moderatedBy`/`moderatedAt`/`moderationHidden` + recipe internal stamps no longer reach public callers. |
+| **M2** · ratings/reviews never load target recipe | ✅ Fixed | `addRating`/`newReview` now load the recipe: 404 on missing/hidden, 403 on self-rating. |
+| **M3** · client-controlled `authorUsername` | ✅ Fixed | Removed from `CREATABLE_RECIPE_FIELDS`; derived server-side from `req.uid`→username at create. |
+| **M4** · `servingPrice` recompute defeats its bounds check | ✅ Fixed | `servingPrice` recomputed onto the body **before** `validateRecipeBounds` on create + edit, so the persisted value is bounds-checked. |
+| **L1** · two write routes missing `requireActive` | ✅ Fixed | Added `requireActive` to `/nutrition/details` and `/acknowledgeAchievements`. |
+
+Deferred to follow-up waves: **M5/M6/M7** and the remaining **LOW/INFO** items (L2–L6, I1–I2).
+
+---
+
 ## TL;DR
 
 The **hard perimeter holds.** The scary classes came back clean: **no NoSQL injection**, **no mass-assignment privilege escalation** (you can't forge `isAdmin`/`authorId`/`points`/`rating` — the field-allowlist blocks it), admin routes are correctly gated by `requireAdmin`, and cross-user object tampering (IDOR on edit/delete) is enforced by `req.uid` ownership checks.

--- a/server/__tests__/moderation-routes.test.js
+++ b/server/__tests__/moderation-routes.test.js
@@ -81,6 +81,17 @@ beforeEach(() => {
   admin.__updateUser.mockClear()
 })
 
+// addRecipe derives authorUsername from the caller's uid→username mapping (audit
+// M3), so the create-path tests need a usernames doc for TEST_UID or they'd 400
+// before reaching the moderation tiers under test. Scoped to the two create
+// describes (the reviews/profile describes seed their own user via seedUser).
+const seedCreatorUsername = () =>
+  getDB().collection('usernames').updateOne(
+    { _id: TEST_UID },
+    { $set: { username: 'chef_test', username_lower: 'chef_test' } },
+    { upsert: true }
+  )
+
 afterEach(async () => {
   admin.__resetClaims()
   admin.__resetUsers()
@@ -97,6 +108,7 @@ afterEach(async () => {
 })
 
 describe('POST /addRecipe — moderation tiers', () => {
+  beforeEach(seedCreatorUsername)
   it('high confidence → 422 blocked, nothing persisted', async () => {
     moderateText.mockResolvedValue(HIGH)
     const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
@@ -273,6 +285,7 @@ describe('username + profile blocking', () => {
 })
 
 describe('fail-open at the route layer', () => {
+  beforeEach(seedCreatorUsername)
   it('classifier-disabled/error verdict (clean) lets the recipe save', async () => {
     moderateText.mockResolvedValue({ ...CLEAN, source: 'error' })
     const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)
@@ -284,6 +297,7 @@ describe('fail-open at the route layer', () => {
 // ── P2: image moderation, collapsed with the text verdict on the recipe path ──
 
 describe('POST /addRecipe — image moderation tiers (text clean)', () => {
+  beforeEach(seedCreatorUsername)
   it('high-confidence image → 422 blocked, nothing persisted', async () => {
     moderateImage.mockResolvedValue(IMG_HIGH)
     const res = await request(app).post('/api/addRecipe').set(AUTH).send(RECIPE_BODY)

--- a/server/__tests__/nutrition.test.js
+++ b/server/__tests__/nutrition.test.js
@@ -79,6 +79,22 @@ describe('POST /api/nutrition/details', () => {
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
+  // Audit H1 (rollup): the ingr array is length-bounded so one paid Edamam call
+  // can't be made to do the work of thousands of ingredients (the 100 kb body
+  // limit alone let far more than a real recipe's worth through). A recipe can't
+  // exceed MAX_INGREDIENTS rows, so anything larger is rejected before the fetch.
+  it('returns 400 when ingr exceeds MAX_INGREDIENTS, without calling Edamam', async () => {
+    const { MAX_INGREDIENTS } = require('../util/recipeLimits')
+    global.fetch = jest.fn()
+    const res = await request(app)
+      .post('/api/nutrition/details')
+      .set(AUTH_HEADER)
+      .send({ ingr: Array.from({ length: MAX_INGREDIENTS + 1 }, () => '1 cup flour') })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/cannot contain more than/)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
   // ── Misconfiguration ─────────────────────────────────────────────────────────
 
   it('returns 503 (not 500/200) when the Edamam keys are not configured', async () => {

--- a/server/__tests__/paidQuota.test.js
+++ b/server/__tests__/paidQuota.test.js
@@ -1,0 +1,88 @@
+/**
+ * Audit H1 — daily paid-API spend ceiling.
+ *
+ * Exercises the counter core (bumpAndCheckQuota) directly against the in-memory
+ * Mongo, rather than through a route: the middleware itself is skipped under
+ * NODE_ENV=test (like every sibling rate limiter, so the supertest suites aren't
+ * throttled), so the DB-backed decision logic is what needs coverage. `now` is
+ * injected so the UTC-day rollover is deterministic without touching the clock.
+ */
+const { getDB } = require('../db')
+const { bumpAndCheckQuota, utcDayKey } = require('../util/paidQuota')
+
+const DAY1 = new Date('2026-07-11T12:00:00Z')
+const DAY2 = new Date('2026-07-12T00:30:00Z')
+
+afterEach(async () => {
+  await getDB().collection('paidQuota').deleteMany({})
+})
+
+const bump = (opts) => bumpAndCheckQuota(getDB(), { surface: 'test', now: DAY1, ...opts })
+
+describe('bumpAndCheckQuota — per-account daily cap', () => {
+  it('allows exactly perUserDaily calls, then rejects with scope=user', async () => {
+    const opts = { uid: 'u1', perUserDaily: 3, globalDaily: 1000 }
+    expect((await bump(opts)).allowed).toBe(true) // 1
+    expect((await bump(opts)).allowed).toBe(true) // 2
+    expect((await bump(opts)).allowed).toBe(true) // 3
+    const over = await bump(opts) // 4
+    expect(over.allowed).toBe(false)
+    expect(over.scope).toBe('user')
+    expect(over.cap).toBe(3)
+  })
+
+  it('keeps each account on its own budget (isolation)', async () => {
+    const a = { uid: 'a', perUserDaily: 1, globalDaily: 1000 }
+    const b = { uid: 'b', perUserDaily: 1, globalDaily: 1000 }
+    expect((await bump(a)).allowed).toBe(true)
+    expect((await bump(a)).allowed).toBe(false) // a is capped
+    expect((await bump(b)).allowed).toBe(true) // b still has its own allowance
+  })
+})
+
+describe('bumpAndCheckQuota — global daily ceiling (Sybil defeater)', () => {
+  it('rejects a FRESH account once the aggregate ceiling is spent, even under its own cap', async () => {
+    // Per-account cap is generous (100); the global ceiling is 5.
+    const mk = (uid) => ({ uid, perUserDaily: 100, globalDaily: 5 })
+    // userA spends 3 (all allowed) → global = 3.
+    for (let i = 0; i < 3; i++) expect((await bump(mk('userA'))).allowed).toBe(true)
+    // A brand-new account gets 2 more (global 4, 5) then is stopped by the GLOBAL
+    // ceiling on its 3rd — despite being far under its own per-account cap.
+    expect((await bump(mk('sybil'))).allowed).toBe(true) // global 4
+    expect((await bump(mk('sybil'))).allowed).toBe(true) // global 5
+    const blocked = await bump(mk('sybil')) // global 6 > 5
+    expect(blocked.allowed).toBe(false)
+    expect(blocked.scope).toBe('global')
+    expect(blocked.cap).toBe(5)
+  })
+
+  it('does NOT bump the global counter when the per-account cap already rejected', async () => {
+    const opts = { uid: 'u', perUserDaily: 1, globalDaily: 100 }
+    await bump(opts) // allowed → global 1
+    await bump(opts) // rejected at per-account, global must stay 1
+    const globalDoc = await getDB()
+      .collection('paidQuota')
+      .findOne({ _id: `${utcDayKey(DAY1)}:test:g` })
+    expect(globalDoc.count).toBe(1)
+  })
+})
+
+describe('bumpAndCheckQuota — daily window', () => {
+  it('resets counters when the UTC day rolls over', async () => {
+    const opts = { uid: 'u', perUserDaily: 1, globalDaily: 1000 }
+    expect((await bump(opts)).allowed).toBe(true) // day1: 1
+    expect((await bump(opts)).allowed).toBe(false) // day1: capped
+    // Same uid/caps, next UTC day → fresh counter, allowed again.
+    const nextDay = await bumpAndCheckQuota(getDB(), { surface: 'test', now: DAY2, ...opts })
+    expect(nextDay.allowed).toBe(true)
+  })
+
+  it('stamps expireAt for TTL cleanup', async () => {
+    await bump({ uid: 'u', perUserDaily: 5, globalDaily: 5 })
+    const doc = await getDB()
+      .collection('paidQuota')
+      .findOne({ _id: `${utcDayKey(DAY1)}:test:u:u` })
+    expect(doc.expireAt instanceof Date).toBe(true)
+    expect(doc.expireAt.getTime()).toBeGreaterThan(DAY1.getTime())
+  })
+})

--- a/server/__tests__/recipes.test.js
+++ b/server/__tests__/recipes.test.js
@@ -57,6 +57,17 @@ const BASE_RECIPE = {
     'https://firebasestorage.googleapis.com/v0/b/test-bucket/o/recipeImages%2Ftuscan.jpg?alt=media&token=abc',
 }
 
+// addRecipe now derives the author handle from the caller's uid→username mapping
+// (audit M3), so the test uid needs a usernames doc or POST /addRecipe 400s
+// ("You must set a username before publishing"). Seed it before every test.
+beforeEach(async () => {
+  await getDB().collection('usernames').updateOne(
+    { _id: TEST_UID },
+    { $set: { username: 'testuser', username_lower: 'testuser' } },
+    { upsert: true }
+  )
+})
+
 afterEach(async () => {
   const db = getDB()
   await Promise.all([
@@ -64,6 +75,7 @@ afterEach(async () => {
     db.collection('userRecipeData').deleteMany({}),
     db.collection('stats').deleteMany({}),
     db.collection('ratings').deleteMany({}),
+    db.collection('usernames').deleteMany({}),
   ])
 })
 
@@ -518,6 +530,45 @@ describe('POST /addRecipe', () => {
     expect(stored.userId).toBe(TEST_UID)
   })
 
+  // Audit M3: authorUsername is derived server-side from the caller's uid→username
+  // mapping and is NOT accepted from the client, so a user can't publish a recipe
+  // attributed to someone else's handle.
+  it('derives authorUsername from the caller’s uid, ignoring a client-supplied one', async () => {
+    const res = await request(server)
+      .post('/api/addRecipe')
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Test Recipe',
+        ingredients: [{ id: 'i1', name: 'salt' }],
+        instructions: [{ content: 'Add salt', index: 1, id: 's1' }],
+        mealTypes: ['dinner'],
+        // Impersonation attempt — client claims to be a different, popular handle.
+        authorUsername: 'famous_chef',
+      })
+    expect(res.status).toBe(201)
+    const { ObjectId } = require('mongodb')
+    const stored = await getDB().collection('recipes').findOne({ _id: new ObjectId(res.body._id) })
+    // 'testuser' is the handle seeded for TEST_UID in the top-level beforeEach.
+    expect(stored.authorUsername).toBe('testuser')
+    expect(stored.authorUsername).not.toBe('famous_chef')
+  })
+
+  it('rejects a create when the caller has no username (400)', async () => {
+    // Remove the seeded handle so the caller has no uid→username mapping.
+    await getDB().collection('usernames').deleteOne({ _id: TEST_UID })
+    const res = await request(server)
+      .post('/api/addRecipe')
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Test Recipe',
+        ingredients: [{ id: 'i1', name: 'salt' }],
+        instructions: [{ content: 'Add salt', index: 1, id: 's1' }],
+        mealTypes: ['dinner'],
+      })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/set a username/i)
+  })
+
   it('ignores client-supplied status, featured, and a forged rating on create', async () => {
     const res = await request(server)
       .post('/api/addRecipe')
@@ -643,8 +694,36 @@ describe('POST /addRecipe', () => {
       await expectRejected({ servings: 0 }, /Servings must be between/)
     })
 
-    it('rejects a serving price over the cap', async () => {
-      await expectRejected({ servingPrice: 5_000_000 }, /Serving price must be between/)
+    // Audit M4: servingPrice is recomputed from the submitted ingredient prices
+    // BEFORE the bounds check, so an over-cap/negative RECOMPUTED value is what
+    // must be rejected — a client-sent servingPrice figure is ignored entirely
+    // (see the "server-recomputed servingPrice (V1)" + "audit M4" describes below).
+    // A forged ingredientData.totalPriceUSACents used to slip an out-of-bounds
+    // price past this check because the recompute ran only AFTER it.
+    it('rejects an over-cap servingPrice recomputed from a forged ingredient price', async () => {
+      await expectRejected(
+        {
+          servings: 1,
+          servingPrice: 100, // ignored — the recompute below is what's validated
+          ingredients: [
+            { id: 'i1', parsedIngredient: { originalIngredientString: '1 diamond' }, ingredientData: { totalPriceUSACents: 2_000_000 } },
+          ],
+        },
+        /Serving price must be between/
+      )
+    })
+
+    it('rejects a negative servingPrice recomputed from a forged ingredient price', async () => {
+      await expectRejected(
+        {
+          servings: 1,
+          servingPrice: 100, // ignored — the recompute below is what's validated
+          ingredients: [
+            { id: 'i1', parsedIngredient: { originalIngredientString: '1 gold' }, ingredientData: { totalPriceUSACents: -999_999 } },
+          ],
+        },
+        /Serving price must be between/
+      )
     })
 
     it('rejects an absurdly large total time', async () => {

--- a/server/__tests__/reviews.test.js
+++ b/server/__tests__/reviews.test.js
@@ -222,6 +222,75 @@ describe('POST /addRating', () => {
   })
 })
 
+// ─── Audit M2: rating/review target must exist, be visible, and not be self ─────
+// addRating + newReview previously never loaded the recipe they wrote against, so
+// they accepted ghost/hidden targets and let an author rate their OWN recipe.
+
+describe('addRating / newReview — target recipe validation (audit M2)', () => {
+  const SELF_RECIPE = 'recipe-self-001'
+  const HIDDEN_RECIPE = 'recipe-hidden-001'
+  beforeEach(async () => {
+    const db = getDB()
+    // A recipe the TEST_UID caller owns (self-rating target) and a soft-hidden one.
+    await db.collection('recipes').insertMany([
+      { _id: SELF_RECIPE, userId: TEST_UID, title: 'My Own Recipe', rating: { rateCount: 0, rateValue: 0 } },
+      { _id: HIDDEN_RECIPE, userId: OTHER_UID, status: 'hidden', title: 'Hidden Recipe', rating: { rateCount: 0, rateValue: 0 } },
+    ])
+  })
+
+  it('addRating on a NONEXISTENT recipe → 404 (no rating written)', async () => {
+    const res = await request(app)
+      .post('/api/addRating?recipeId=ghost-recipe-xyz&rating=5')
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(404)
+    expect(await getDB().collection('ratings').countDocuments({ recipeId: 'ghost-recipe-xyz' })).toBe(0)
+  })
+
+  it('addRating on a HIDDEN recipe → 404', async () => {
+    const res = await request(app)
+      .post(`/api/addRating?recipeId=${HIDDEN_RECIPE}&rating=5`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(404)
+  })
+
+  it('addRating on the caller’s OWN recipe → 403 (no self-rating)', async () => {
+    const res = await request(app)
+      .post(`/api/addRating?recipeId=${SELF_RECIPE}&rating=5`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(403)
+    expect(res.body.error).toMatch(/your own recipe/i)
+    expect(await getDB().collection('ratings').countDocuments({ recipeId: SELF_RECIPE })).toBe(0)
+  })
+
+  it('newReview on a NONEXISTENT recipe → 404 (no review written, no XP farming)', async () => {
+    const res = await request(app)
+      .post('/api/newReview')
+      .set(AUTH_HEADER)
+      .send({ recipeId: 'ghost-recipe-xyz', reviewText: 'nice' })
+    expect(res.status).toBe(404)
+    expect(await getDB().collection('ratings').countDocuments({ recipeId: 'ghost-recipe-xyz' })).toBe(0)
+  })
+
+  it('newReview on the caller’s OWN recipe → 403', async () => {
+    const res = await request(app)
+      .post('/api/newReview')
+      .set(AUTH_HEADER)
+      .send({ recipeId: SELF_RECIPE, reviewText: 'best recipe ever' })
+    expect(res.status).toBe(403)
+    expect(res.body.error).toMatch(/your own recipe/i)
+  })
+
+  it('CONTROL: a valid rating on someone else’s visible recipe still succeeds', async () => {
+    // RECIPE_ID (seeded in the shared beforeEach) has no author uid, so it isn't
+    // the caller's own recipe and is publicly visible.
+    const res = await request(app)
+      .post(`/api/addRating?recipeId=${RECIPE_ID}&rating=4`)
+      .set(AUTH_HEADER)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ rated: true })
+  })
+})
+
 // ─── POST /editReview ──────────────────────────────────────────────────────────
 
 describe('POST /editReview', () => {
@@ -818,6 +887,40 @@ describe('GET /getReviews', () => {
     expect(res.body.reviews[0].isCurrentUser).toBe(false)
   })
 
+  // Audit M1: the public review payload must NOT carry the reviewer's Firebase
+  // uid or the moderation stamps (moderatedBy/moderatedAt/moderationHidden — the
+  // admin uid + timestamp of a takedown/restore). Seed a review carrying all of
+  // them, then assert an anonymous read strips them while still rendering the
+  // display fields + the derived isCurrentUser flag.
+  it('does not leak userId or moderation stamps to a public caller', async () => {
+    await seedRating({
+      userId: OTHER_UID,
+      username: OTHER_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 4,
+      reviewText: 'A restored review',
+      reviewCreatedAt: '1000',
+      reviewLastUpdated: '1000',
+      moderationHidden: false, // restored → visible again, but stamps remain
+      moderatedBy: 'admin-uid-123',
+      moderatedAt: new Date(),
+    })
+
+    const res = await request(app).get(`/api/getReviews?recipeId=${RECIPE_ID}`)
+    expect(res.status).toBe(200)
+    const review = res.body.reviews[0]
+    // No internal identifiers.
+    expect(review).not.toHaveProperty('userId')
+    expect(review).not.toHaveProperty('moderatedBy')
+    expect(review).not.toHaveProperty('moderatedAt')
+    expect(review).not.toHaveProperty('moderationHidden')
+    // Display fields still present so the review renders.
+    expect(review.username).toBe(OTHER_USERNAME)
+    expect(review.rating).toBe(4)
+    expect(review.reviewText).toBe('A restored review')
+    expect(review.isCurrentUser).toBe(false)
+  })
+
   it('paginates results', async () => {
     for (let i = 0; i < 3; i++) {
       await seedRating({
@@ -1039,6 +1142,48 @@ describe('GET /getSingleUserReviews', () => {
     expect(res.status).toBe(200)
     expect(res.body.reviews[0].recipeData).toBeDefined()
     expect(res.body.reviews[0].recipeData._id).toBe(RECIPE_ID)
+  })
+
+  // Audit M1: the returnRecipeData join must strip BOTH the review-level reviewer
+  // uid/moderation stamps AND the recipe's internal admin stamps (featuredBy/
+  // moderatedBy/publishUpdatedBy + timestamps) — this join path used to bypass the
+  // publicRecipeProjection every other public recipe read applies.
+  it('strips reviewer uid + recipe internal admin stamps when returnRecipeData=true', async () => {
+    const db = getDB()
+    // Stamp the joined recipe with admin uids that must never reach a public read.
+    await db.collection('recipes').updateOne(
+      { _id: RECIPE_ID },
+      { $set: { featuredBy: 'admin-uid-1', featuredAt: new Date(), moderatedBy: 'admin-uid-2', publishUpdatedBy: 'admin-uid-3' } }
+    )
+    await seedRating({
+      userId: TEST_UID,
+      username: TEST_USERNAME,
+      recipeId: RECIPE_ID,
+      rating: 4,
+      reviewText: 'Great recipe!',
+      reviewCreatedAt: '1000',
+      moderatedBy: 'admin-uid-9',
+      moderatedAt: new Date(),
+    })
+
+    const res = await request(app).get(
+      `/api/getSingleUserReviews?username=${TEST_USERNAME}&returnRecipeData=true`
+    )
+    expect(res.status).toBe(200)
+    const review = res.body.reviews[0]
+    // Review-level internal fields gone.
+    expect(review).not.toHaveProperty('userId')
+    expect(review).not.toHaveProperty('moderatedBy')
+    expect(review).not.toHaveProperty('moderatedAt')
+    // Joined recipe's internal admin stamps gone.
+    const rd = review.recipeData
+    expect(rd).not.toHaveProperty('featuredBy')
+    expect(rd).not.toHaveProperty('featuredAt')
+    expect(rd).not.toHaveProperty('moderatedBy')
+    expect(rd).not.toHaveProperty('publishUpdatedBy')
+    // Still renders.
+    expect(rd.title).toBe('Review Test Recipe')
+    expect(review.recipeTitle).toBe('Review Test Recipe')
   })
 
   // The account "Ratings" list reads flat recipeImage/recipeTitle off each

--- a/server/__tests__/user-status-enforcement.test.js
+++ b/server/__tests__/user-status-enforcement.test.js
@@ -61,6 +61,29 @@ describe('requireActive blocks suspended/banned users from writes', () => {
     expect(res.status).toBe(403)
     expect(res.body.code).toBe('ACCOUNT_BANNED')
   })
+
+  // Audit L1: these two write routes previously omitted requireActive, so a
+  // banned/suspended account kept burning paid Edamam quota and mutating
+  // gamification state for the ~1h its token stayed valid.
+  it('banned → 403 ACCOUNT_BANNED on POST /nutrition/details (audit L1)', async () => {
+    await setStatus('banned')
+    const res = await request(app)
+      .post('/api/nutrition/details')
+      .set(AUTH_HEADER)
+      .send({ ingr: ['1 cup flour'], title: 'x' })
+    expect(res.status).toBe(403)
+    expect(res.body.code).toBe('ACCOUNT_BANNED')
+  })
+
+  it('banned → 403 ACCOUNT_BANNED on POST /acknowledgeAchievements (audit L1)', async () => {
+    await setStatus('banned')
+    const res = await request(app)
+      .post('/api/acknowledgeAchievements')
+      .set(AUTH_HEADER)
+      .send({ ids: ['first_recipe'] })
+    expect(res.status).toBe(403)
+    expect(res.body.code).toBe('ACCOUNT_BANNED')
+  })
 })
 
 describe('requireActive lets active / legacy users through', () => {

--- a/server/__tests__/writeLimiter.wiring.test.js
+++ b/server/__tests__/writeLimiter.wiring.test.js
@@ -123,27 +123,32 @@ describe('per-surface write limiters are wired onto every moderated write route'
     expect(renameHandlers).toContain(collectionWriteLimiter)
   })
 
-  it('ingredients POST /parse mounts requireActive + a user limiter after verifyToken', () => {
-    // parseLimiter is internal to the route file (not exported), so assert
-    // structurally: verifyToken → requireActive → limiter → handler. requireActive
-    // gates paid Spoonacular quota behind an active account, matching every other
-    // write surface's order.
+  it('ingredients POST /parse mounts requireActive + a user limiter + the daily paid-quota limiter after verifyToken', () => {
+    // parseLimiter + the paid-quota limiter are internal to the route file (not
+    // exported), so assert structurally: verifyToken → requireActive → per-minute
+    // limiter → daily paid-quota limiter → handler. requireActive gates paid
+    // Spoonacular quota behind an active account; the paidQuotaLimiter adds the
+    // per-account + global DAILY ceiling (audit H1), matching the write-surface order.
     const handlers = routeHandlers(ingredientsRouter, 'post', '/parse')
     expect(handlers[0]).toBe(verifyToken)
     expect(handlers[1]).toBe(requireActive)
-    expect(handlers).toHaveLength(4) // verifyToken, requireActive, parseLimiter, handler
+    expect(handlers).toHaveLength(5) // verifyToken, requireActive, parseLimiter, paidQuotaLimiter, handler
     // The 3rd handler is the unexported per-user parseLimiter — identify it
     // structurally rather than by reference.
     expect(isRateLimiter(handlers[2])).toBe(true)
+    // The 4th is the daily paid-quota limiter (audit H1), named for structural id.
+    expect(handlers[3].name).toBe('paidQuotaLimiter')
   })
 
-  it('gamification POST /acknowledgeAchievements mounts profileWriteLimiter after verifyToken', () => {
-    // A userProfiles write that shares the profile budget. Unlike the profile
-    // routes above it has no requireActive, so assert only verifyToken → limiter.
+  it('gamification POST /acknowledgeAchievements mounts requireActive + profileWriteLimiter after verifyToken', () => {
+    // A userProfiles write that shares the profile budget. requireActive was added
+    // (audit L1) so a suspended/banned account can't keep mutating gamification
+    // state: assert verifyToken → requireActive → limiter.
     const handlers = routeHandlers(gamificationRouter, 'post', '/acknowledgeAchievements')
-    expect(handlers).toContain(verifyToken)
+    expect(handlers[0]).toBe(verifyToken)
+    expect(handlers[1]).toBe(requireActive)
     expect(handlers).toContain(profileWriteLimiter)
-    expect(handlers.indexOf(verifyToken)).toBeLessThan(handlers.indexOf(profileWriteLimiter))
+    expect(handlers.indexOf(requireActive)).toBeLessThan(handlers.indexOf(profileWriteLimiter))
   })
 
   it('reports POST /reports mounts a breadth limiter after verifyToken + requireActive', () => {

--- a/server/db.js
+++ b/server/db.js
@@ -247,6 +247,16 @@ async function ensureIndexes() {
   } catch (err) {
     console.error('Failed to create indexes on ingredientMisses:', err.message)
   }
+
+  // Paid-API daily spend counters (audit H1). Docs are keyed by UTC-day + surface
+  // (+ uid for the per-account counter) and carry an `expireAt`; a TTL index reaps
+  // them shortly after the day rolls over so the collection never grows unbounded.
+  // expireAfterSeconds: 0 means "delete once the wall clock passes expireAt".
+  try {
+    await db.collection('paidQuota').createIndex({ expireAt: 1 }, { expireAfterSeconds: 0 })
+  } catch (err) {
+    console.error('Failed to create TTL index on paidQuota.expireAt:', err.message)
+  }
 }
 
 async function closeDB() {

--- a/server/routes/gamification.js
+++ b/server/routes/gamification.js
@@ -2,7 +2,7 @@ const express = require('express')
 const { asyncHandler } = require('../util/asyncHandler')
 const router = express.Router()
 const { getDB } = require('../db')
-const { verifyToken } = require('../middleware/auth')
+const { verifyToken, requireActive } = require('../middleware/auth')
 const { profileWriteLimiter } = require('../middleware/writeLimiter')
 const { getGamificationCountsFor } = require('../util/accountCounts')
 const { computeGamification, ACHIEVEMENTS } = require('../util/gamification')
@@ -33,8 +33,10 @@ router.get('/getGamification', verifyToken, asyncHandler(async (req, res) => {
 // profileWriteLimiter mirrors the sibling userProfiles writes (updateProfile,
 // updatePrivacy, …): cheap + idempotent, but it's still an authed per-user write,
 // so it shares the same per-uid write budget rather than relying only on the
-// coarse global per-IP backstop.
-router.post('/acknowledgeAchievements', verifyToken, profileWriteLimiter, asyncHandler(async (req, res) => {
+// coarse global per-IP backstop. requireActive gates it like every other content
+// write so a suspended/banned account can't keep mutating gamification state for
+// the ~1h token lifetime (audit L1).
+router.post('/acknowledgeAchievements', verifyToken, requireActive, profileWriteLimiter, asyncHandler(async (req, res) => {
   const { ids } = req.body || {}
   if (!Array.isArray(ids)) {
     return res.status(400).json({ error: 'ids must be an array' })

--- a/server/routes/ingredients.js
+++ b/server/routes/ingredients.js
@@ -2,6 +2,7 @@ const { Router } = require('express')
 const { ingredientParser } = require('@jclind/ingredient-parser')
 const { verifyToken, requireActive } = require('../middleware/auth')
 const { makeUserLimiter } = require('../middleware/writeLimiter')
+const { makePaidQuotaLimiter } = require('../util/paidQuota')
 const { GENERIC_500_MESSAGE } = require('../util/respondServerError')
 const { asyncHandler } = require('../util/asyncHandler')
 const { getDB } = require('../db')
@@ -82,6 +83,21 @@ const parseLimiter = makeUserLimiter({
   message: 'Too many ingredient lookups — wait a minute and try again.',
 })
 
+// Daily spend ceiling on the paid Spoonacular surface (audit H1) — a per-account
+// and a global daily cap on top of the per-minute parseLimiter, so a Sybil swarm
+// of fresh accounts (each of which resets the per-uid minute budget) can't drain
+// the enrichment budget across the day. The parse route fires once per ingredient
+// row, so the per-account daily allowance is generous — a heavy author filling
+// several max-size recipes a day stays well under 600 — while the global ceiling
+// bounds total spend regardless of account count. Overridable via
+// PAID_QUOTA_INGREDIENTS_USER_DAILY / PAID_QUOTA_INGREDIENTS_GLOBAL_DAILY.
+const parseQuota = makePaidQuotaLimiter({
+  surface: 'ingredients',
+  perUserDaily: 600,
+  globalDaily: 20000,
+  message: 'Daily ingredient-lookup limit reached — please try again tomorrow.',
+})
+
 // Spoonacular migrated CDNs: the old spoonacular.com/cdn host now 301-redirects;
 // img.spoonacular.com serves the image directly. The parser's buildImageUrl
 // still constructs the old host (node_modules/@jclind/ingredient-parser/dist/
@@ -118,7 +134,7 @@ function mapIngredientData(data) {
 // requireActive sits between verifyToken and the limiter (the house write-surface
 // order) so a just-suspended/banned account — whose ID token stays valid for up to
 // ~1h — can't keep burning paid Spoonacular quota through the enrichment proxy.
-router.post('/parse', verifyToken, requireActive, parseLimiter, asyncHandler(async (req, res) => {
+router.post('/parse', verifyToken, requireActive, parseLimiter, parseQuota, asyncHandler(async (req, res) => {
   const { ingredientString } = req.body
   if (!ingredientString || typeof ingredientString !== 'string') {
     return res.status(400).json({ error: 'ingredientString must be a non-empty string' })

--- a/server/routes/nutrition.js
+++ b/server/routes/nutrition.js
@@ -1,8 +1,10 @@
 const { Router } = require('express')
-const { verifyToken } = require('../middleware/auth')
+const { verifyToken, requireActive } = require('../middleware/auth')
 const { makeUserLimiter } = require('../middleware/writeLimiter')
+const { makePaidQuotaLimiter } = require('../util/paidQuota')
 const { GENERIC_500_MESSAGE } = require('../util/respondServerError')
 const { asyncHandler } = require('../util/asyncHandler')
+const { MAX_INGREDIENTS } = require('../util/recipeLimits')
 
 const router = Router()
 
@@ -18,7 +20,24 @@ const nutritionLimiter = makeUserLimiter({
   message: 'Too many nutrition lookups — wait a minute and try again.',
 })
 
-router.post('/details', verifyToken, nutritionLimiter, asyncHandler(async (req, res) => {
+// Daily spend ceiling on the paid Edamam surface (audit H1) — a per-account and a
+// global daily cap on top of the per-minute limiter, so a Sybil swarm of fresh
+// accounts can't drain the nutrition budget across the day. Caps are overridable
+// via PAID_QUOTA_NUTRITION_USER_DAILY / PAID_QUOTA_NUTRITION_GLOBAL_DAILY. A real
+// user hits nutrition once per recipe save, so 150/account/day is far above human
+// use while still bounding a single rogue account hard.
+const nutritionQuota = makePaidQuotaLimiter({
+  surface: 'nutrition',
+  perUserDaily: 150,
+  globalDaily: 6000,
+  message: 'Daily nutrition-lookup limit reached — please try again tomorrow.',
+})
+
+// requireActive sits between verifyToken and the limiter (the house write-surface
+// order, mirroring /api/ingredients/parse) so a just-suspended/banned account —
+// whose ID token stays valid for up to ~1h — can't keep burning paid Edamam
+// quota through this proxy (audit L1).
+router.post('/details', verifyToken, requireActive, nutritionLimiter, nutritionQuota, asyncHandler(async (req, res) => {
   const { ingr, title } = req.body
   if (
     !Array.isArray(ingr) ||
@@ -28,6 +47,15 @@ router.post('/details', verifyToken, nutritionLimiter, asyncHandler(async (req, 
     return res
       .status(400)
       .json({ error: 'ingr must be a non-empty array of strings' })
+  }
+  // Bound the array length (audit H1 rollup): a recipe can't exceed MAX_INGREDIENTS
+  // rows, so a payload larger than that is either malformed or an attempt to make
+  // one paid Edamam call do the work of many. The 100 kb body limit alone let
+  // thousands of short strings through.
+  if (ingr.length > MAX_INGREDIENTS) {
+    return res
+      .status(400)
+      .json({ error: `ingr cannot contain more than ${MAX_INGREDIENTS} items` })
   }
 
   const appId = process.env.EDAMAM_APP_ID

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -4,6 +4,7 @@ const { ObjectId } = require('mongodb')
 const { getDB, getClient } = require('../db')
 const { verifyToken, optionalAuth, requireAdmin, requireActive } = require('../middleware/auth')
 const { recipeWriteLimiter } = require('../middleware/writeLimiter')
+const { makePaidQuotaLimiter } = require('../util/paidQuota')
 const { recipeIdQuery, recipeIdInQuery } = require('../util/recipeIdQuery')
 const { MIN_SIGNAL, selectForYou, tasteScore, weightedSample } = require('../util/forYou')
 const { loadInteractions, buildSeenProfile } = require('../util/tasteContext')
@@ -506,8 +507,22 @@ router.get('/getRecipe', optionalAuth, asyncHandler(async (req, res) => {
   res.json(recipe)
 }))
 
+// Daily spend ceiling on recipe CREATES (audit H1): every create runs a paid
+// Cloud Vision image scan + OpenAI text moderation, so it's a paid surface too.
+// A per-account + global daily cap on top of the 12/min recipeWriteLimiter bounds
+// a Sybil swarm's cumulative Vision/OpenAI spend. 50 creates/account/day is far
+// above any human authoring cadence. Overridable via PAID_QUOTA_RECIPE_USER_DAILY
+// / PAID_QUOTA_RECIPE_GLOBAL_DAILY. (editRecipe re-scans the image only when it
+// actually changes, so it isn't unconditionally metered here.)
+const recipeCreateQuota = makePaidQuotaLimiter({
+  surface: 'recipe',
+  perUserDaily: 50,
+  globalDaily: 2000,
+  message: 'Daily recipe-creation limit reached — please try again tomorrow.',
+})
+
 // POST /addRecipe
-router.post('/addRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncHandler(async (req, res) => {
+router.post('/addRecipe', verifyToken, requireActive, recipeWriteLimiter, recipeCreateQuota, asyncHandler(async (req, res) => {
   const db = getDB()
   const body = req.body
   const uid = req.uid
@@ -519,9 +534,27 @@ router.post('/addRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncH
   // stored (matches the client's submit-time trim) and the length cap sees the
   // trimmed value.
   normalizeRecipeInput(body)
+  // Recompute servingPrice from the submitted ingredient prices BEFORE the bounds
+  // check (audit M4). The recompute previously ran only when building the insert
+  // doc — AFTER validateRecipeBounds had checked the client-sent figure — so a
+  // forged/negative/over-cap ingredientData.totalPriceUSACents produced an
+  // out-of-bounds persisted servingPrice the bounds check never saw. Writing it
+  // onto `body` here means validateRecipeBounds validates the value that will
+  // actually be stored (and pickFields copies this same recomputed value below).
+  body.servingPrice = calculateServingPrice(body.ingredients, body.servings)
   const boundsError = validateRecipeBounds(body)
   if (boundsError) {
     return res.status(400).json({ error: boundsError })
+  }
+
+  // Derive the author handle server-side from the caller's uid (audit M3): the
+  // client no longer supplies authorUsername (removed from CREATABLE_RECIPE_FIELDS),
+  // so a user can't publish a recipe attributed to someone else's handle. Reject
+  // before the paid moderation scans if the caller has no username — they can't be
+  // attributed and can't have completed onboarding.
+  const authorDoc = await db.collection('usernames').findOne({ _id: uid })
+  if (!authorDoc) {
+    return res.status(400).json({ error: 'You must set a username before publishing a recipe' })
   }
 
   // Automated moderation on BOTH axes — text and the recipe image — collapsed to
@@ -554,6 +587,9 @@ router.post('/addRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncH
     ...pickFields(body, CREATABLE_RECIPE_FIELDS),
     _id: newId,
     userId: uid,
+    // Server-derived (audit M3): the displayed author is the caller's real handle,
+    // never a client-supplied one.
+    authorUsername: authorDoc.username,
     // A 13-digit ms-epoch string (matches the edit path's editedAt stamp), so the
     // "Newest"/"Oldest" browse sort's lexicographic ordering stays chronological.
     createdAt: Date.now().toString(),
@@ -562,15 +598,13 @@ router.post('/addRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncH
     numTimesSaved: 0,
     numTimesMade: 0,
     views: 0,
-    // Server-recomputed from the submitted ingredients/servings, overriding
-    // whatever pickFields just copied from the client body above — the client's
-    // servingPrice is UI-preview-only now (see util/calculateServingPrice, a
-    // mirror of src/util/calculateServingPrice.ts). A stale tab, raced submit,
-    // or a direct API caller can otherwise persist a price inconsistent with
-    // the stored rows (e.g. understated when a lowball price rides along with
-    // unenriched/null ingredientData rows, which are still legitimately
-    // publishable by design).
-    servingPrice: calculateServingPrice(body.ingredients, body.servings),
+    // Server-recomputed from the submitted ingredients/servings (see the recompute
+    // + bounds-validation above, audit M4) — the client's servingPrice is
+    // UI-preview-only now (see util/calculateServingPrice, a mirror of
+    // src/util/calculateServingPrice.ts). Re-stated explicitly here so the stored
+    // value is unmistakably the validated server figure, not the client's; pickFields
+    // already copied this same recomputed body.servingPrice above.
+    servingPrice: body.servingPrice,
   }
   await db.collection('recipes').insertOne(docToInsert)
   // A new recipe can introduce a cuisine/diet/mealType the browse filter UI has
@@ -617,6 +651,13 @@ router.put('/editRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncH
   // Trim the title before bounds + persistence (see addRecipe) so an edit can't
   // reintroduce surrounding whitespace the create path already strips.
   normalizeRecipeInput(body)
+  // Recompute servingPrice from the submitted ingredient prices BEFORE the bounds
+  // check (audit M4) — see addRecipe. `servings` is optional on edit (not a
+  // required field), so fall back to the recipe's stored value when the edit
+  // omits it, dividing by what will actually be persisted rather than undefined.
+  // `ingredients` IS required, so body.ingredients is always present here.
+  const effectiveServings = 'servings' in body ? body.servings : recipe.servings
+  body.servingPrice = calculateServingPrice(body.ingredients, effectiveServings)
   const boundsError = validateRecipeBounds(body)
   if (boundsError) {
     return res.status(400).json({ error: boundsError })
@@ -645,18 +686,13 @@ router.put('/editRecipe', verifyToken, requireActive, recipeWriteLimiter, asyncH
   // ignored. The hold status is NOT set here — holdRecipeForReview owns it, so
   // the recipe is only hidden once its admin-queue report exists.
   //
-  // servingPrice is server-recomputed, not trusted from the client (see
-  // addRecipe / util/calculateServingPrice). `servings` is optional at this
-  // layer (not in REQUIRED_RECIPE_FIELDS), so an edit that doesn't touch it
-  // won't include it in `body` — fall back to the recipe's current stored
-  // servings so the recompute divides by what will actually be persisted,
-  // not `undefined`. `ingredients` IS required, so body.ingredients is always
-  // present here.
-  const effectiveServings = 'servings' in body ? body.servings : recipe.servings
+  // servingPrice was recomputed + bounds-validated above (audit M4); pickFields
+  // copies that recomputed body.servingPrice, and it's re-stated explicitly here
+  // so the stored value is unmistakably the validated server figure.
   const update = {
     ...pickFields(body, EDITABLE_RECIPE_FIELDS),
     editedAt: Date.now().toString(),
-    servingPrice: calculateServingPrice(body.ingredients, effectiveServings),
+    servingPrice: body.servingPrice,
   }
   // Medium → re-hold as 'pending_review', BUT never downgrade an admin takedown:
   // if the recipe is already 'hidden'/'unpublished', an owner edit must not lift

--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -8,6 +8,8 @@ const { REVIEW_VISIBLE, RECIPE_VISIBLE } = require('../util/moderation')
 const { DESCRIPTION_MAX_LENGTH } = require('../util/recipeLimits')
 const { recordAudit } = require('../util/auditLog')
 const { recomputeRecipeRating, hasNumericRating } = require('../util/recipeRating')
+const { publicRecipeProjection, pickFields } = require('../util/recipeFields')
+const { recipeIdQuery } = require('../util/recipeIdQuery')
 const { upsertWithDupRetry } = require('../util/upsertWithDupRetry')
 const { notifyInBackground, notifyReviewTakenDown } = require('../util/email')
 const { moderateText } = require('../util/textModeration')
@@ -17,6 +19,30 @@ const router = Router()
 
 // Hard ceiling on client-requested page sizes (audit §4.5); mirrors recipes.js.
 const MAX_PER_PAGE = 50
+
+// The review fields safe to serialize to PUBLIC (unauthenticated / non-admin)
+// callers — an inclusion allowlist, so a field added to the rating doc later
+// can't silently leak (audit M1). Deliberately EXCLUDES:
+//   • `userId` — the reviewer's Firebase uid (a username→uid oracle). It's still
+//     FETCHED on /getReviews because it's the identity join key for avatar
+//     enrichment + the isCurrentUser flag, but stripped from the response there.
+//   • `moderatedBy` / `moderatedAt` / `moderationHidden` — the admin uid +
+//     timestamp of any takedown/restore; internal moderation state no client
+//     reads. An inclusion projection drops these structurally.
+const REVIEW_PUBLIC_FIELDS = [
+  '_id',
+  'recipeId',
+  'username',
+  'rating',
+  'ratingLastUpdated',
+  'reviewCreatedAt',
+  'reviewLastUpdated',
+  'reviewText',
+]
+// Mongo inclusion projection over the allowlist, for the public review reads.
+const reviewPublicProjection = Object.fromEntries(
+  REVIEW_PUBLIC_FIELDS.map((f) => [f, 1])
+)
 
 // Resolve reviewer avatar + display name for a page of reviews (§D). photoURL and
 // displayName live on the Firebase Auth record, not the rating doc, so batch-fetch
@@ -48,6 +74,30 @@ async function resolveReviewerIdentities(reviews) {
   return byUid
 }
 
+// Load the rating/review target recipe and enforce the two integrity rules the
+// rating writes previously skipped entirely (audit M2): neither addRating nor
+// newReview loaded the recipe they were writing against, so —
+//   • a nonexistent / hidden / pending recipeId still upserted a rating (ghost
+//     targets, and XP/achievement farming off junk recipeIds), and
+//   • an author could rate + review their OWN recipe, inflating its public
+//     average and ranking signal.
+// Returns a { status, error } to send back, or null when the write may proceed.
+// Scoped through RECIPE_VISIBLE so a soft-hidden/unpublished/pending recipe is
+// "not found" for rating purposes — you can only rate what the public can see.
+// Projected to just userId (the recipe author uid), the only field the checks
+// need. Called BEFORE the (paid) text-moderation pass in newReview so a ghost or
+// self-target never spends a classifier call.
+async function checkRatableRecipe(db, recipeId, uid) {
+  const recipe = await db
+    .collection('recipes')
+    .findOne({ ...recipeIdQuery(recipeId), ...RECIPE_VISIBLE }, { projection: { userId: 1 } })
+  if (!recipe) return { status: 404, error: 'Recipe not found' }
+  if (recipe.userId === uid) {
+    return { status: 403, error: 'You cannot rate or review your own recipe' }
+  }
+  return null
+}
+
 // POST /addRating
 router.post('/addRating', verifyToken, requireActive, reviewWriteLimiter, asyncHandler(async (req, res) => {
   const { recipeId, rating } = req.query
@@ -67,6 +117,14 @@ router.post('/addRating', verifyToken, requireActive, reviewWriteLimiter, asyncH
   }
   if (parsedRating < 1 || parsedRating > 5) {
     return res.status(400).json({ error: 'Rating must be between 1 and 5' })
+  }
+
+  // Target must exist, be publicly visible, and not be the caller's own recipe
+  // (audit M2) — otherwise this endpoint upserts ratings against ghost/hidden
+  // targets and lets an author self-rate.
+  const targetError = await checkRatableRecipe(db, recipeId, userId)
+  if (targetError) {
+    return res.status(targetError.status).json({ error: targetError.error })
   }
 
   // dup-retry: the unique { userId, recipeId } index turns a concurrent
@@ -103,6 +161,14 @@ router.post('/newReview', verifyToken, requireActive, reviewWriteLimiter, asyncH
   }
   if (reviewText.length > DESCRIPTION_MAX_LENGTH) {
     return res.status(400).json({ error: `Review cannot exceed ${DESCRIPTION_MAX_LENGTH} characters` })
+  }
+
+  // Target must exist, be publicly visible, and not be the caller's own recipe
+  // (audit M2). Checked BEFORE the paid moderation pass so a ghost/self target
+  // never spends a classifier call.
+  const targetError = await checkRatableRecipe(db, recipeId, userId)
+  if (targetError) {
+    return res.status(targetError.status).json({ error: targetError.error })
   }
 
   // Reviews are short and author-only; there's no useful owner-only "pending"
@@ -287,7 +353,16 @@ router.get('/getReviews', optionalAuth, asyncHandler(async (req, res) => {
   else if (filter === 'top') sort = { rating: -1 }
 
   const [rawReviews, totalCount] = await Promise.all([
-    db.collection('ratings').find(query).sort(sort).skip(skip).limit(limit).toArray(),
+    // Project to the public allowlist PLUS userId: the uid is needed server-side
+    // (identity enrichment + isCurrentUser) but is stripped from the response
+    // below, and the projection structurally drops the moderation stamps (M1).
+    db.collection('ratings')
+      .find(query)
+      .project({ ...reviewPublicProjection, userId: 1 })
+      .sort(sort)
+      .skip(skip)
+      .limit(limit)
+      .toArray(),
     db.collection('ratings').countDocuments(query),
   ])
 
@@ -296,8 +371,10 @@ router.get('/getReviews', optionalAuth, asyncHandler(async (req, res) => {
   const identities = await resolveReviewerIdentities(rawReviews)
   const reviews = rawReviews.map((r) => {
     const identity = identities.get(r.userId)
+    // pickFields drops userId (not on the allowlist) from the serialized shape;
+    // r.userId is still read here for the enrichment + isCurrentUser flag.
     return {
-      ...r,
+      ...pickFields(r, REVIEW_PUBLIC_FIELDS),
       isCurrentUser: req.uid != null && r.userId === req.uid,
       photoURL: identity ? identity.photoURL : null,
       displayName: identity ? identity.displayName : null,
@@ -371,6 +448,12 @@ router.get('/getSingleUserReviews', asyncHandler(async (req, res) => {
                   },
                 },
               },
+              // Project the joined recipe to the public recipe shape so the
+              // internal admin stamps (moderatedBy/featuredBy/publishUpdatedBy +
+              // their timestamps) never ride out to a public caller through this
+              // join — every OTHER public recipe read strips them via
+              // publicRecipeProjection, and this join path now does too (audit M1).
+              { $project: publicRecipeProjection },
             ],
             as: 'recipe',
           },
@@ -393,9 +476,11 @@ router.get('/getSingleUserReviews', asyncHandler(async (req, res) => {
       // The account "Ratings" list reads flat `recipeImage`/`recipeTitle` off
       // each review (the rating doc itself stores neither). Denormalize them
       // from the recipe doc so the thumbnail and title actually render; keep
-      // the full `recipeData` for callers (e.g. admin) that need the rest.
+      // the (now public-projected) `recipeData` for callers that need the rest.
+      // pickFields keeps only the review allowlist, dropping the reviewer uid +
+      // moderation stamps from the review-level fields too (audit M1).
       return {
-        ...r,
+        ...pickFields(r, REVIEW_PUBLIC_FIELDS),
         recipeImage: recipeData.recipeImage,
         recipeTitle: recipeData.title,
         recipeData,
@@ -403,9 +488,11 @@ router.get('/getSingleUserReviews', asyncHandler(async (req, res) => {
     })
   } else {
     // No recipe join → every visible review is returnable, so a plain
-    // find + countDocuments over the same query keeps totalCount exact.
+    // find + countDocuments over the same query keeps totalCount exact. Project
+    // to the public allowlist so the reviewer uid + moderation stamps never
+    // reach a public caller (M1); this path needs no uid server-side.
     ;[reviews, totalCount] = await Promise.all([
-      db.collection('ratings').find(query).sort(sort).skip(skip).limit(limit).toArray(),
+      db.collection('ratings').find(query).project(reviewPublicProjection).sort(sort).skip(skip).limit(limit).toArray(),
       db.collection('ratings').countDocuments(query),
     ])
   }

--- a/server/util/paidQuota.js
+++ b/server/util/paidQuota.js
@@ -1,0 +1,120 @@
+const { getDB } = require('../db')
+
+// ─── Paid-API daily spend ceiling (audit H1) ────────────────────────────────
+//
+// The per-user-per-MINUTE limiters (writeLimiter / parseLimiter / nutrition) and
+// the global per-IP backstop bound BURST rate, but nothing bounds cumulative
+// daily spend: a fresh Firebase account resets the per-uid minute budget and IPs
+// rotate freely, so an attacker with N throwaway accounts multiplies the paid
+// Spoonacular/Edamam/Vision/OpenAI bill linearly (a Sybil quota-drain / dollar-
+// cost DoS). This adds two DAILY counters per paid surface, in Mongo:
+//   • a per-ACCOUNT daily cap  — bounds a single account's daily spend, and
+//   • a global daily ceiling   — bounds TOTAL daily spend across ALL accounts,
+//     which is the one that actually defeats Sybil (it doesn't matter how many
+//     accounts an attacker mints once the aggregate ceiling trips).
+//
+// Counters live in the `paidQuota` collection, keyed by UTC day + surface (+ uid
+// for the per-account counter), and self-reap via a TTL index on `expireAt`
+// (db.js). The per-account counter is incremented first and, if it's over cap,
+// the global counter is NOT touched — so one abusive account can't inflate the
+// global number with its own rejected overflow.
+
+// A UTC calendar-day key (YYYY-MM-DD). UTC (not local) so the daily window is
+// stable regardless of server timezone and every replica agrees on "today".
+function utcDayKey(now) {
+  return now.toISOString().slice(0, 10)
+}
+
+// Atomically increment one counter and return its post-increment value. Upserts
+// the doc on the first hit of the day, stamping `expireAt` two days out so the
+// TTL index reaps it after the window has fully passed.
+async function bumpCounter(db, id, day, now) {
+  const expireAt = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000)
+  const doc = await db.collection('paidQuota').findOneAndUpdate(
+    { _id: id },
+    {
+      $inc: { count: 1 },
+      $setOnInsert: { day, expireAt },
+    },
+    { upsert: true, returnDocument: 'after' }
+  )
+  return doc.count
+}
+
+// Increment the per-account and global daily counters for `surface` and decide
+// whether the call may proceed. A cap of N permits counts 1..N and rejects the
+// N+1'th call (count > cap). `now` is injectable for tests. Returns:
+//   { allowed: true }
+//   { allowed: false, scope: 'user' | 'global', count, cap }
+async function bumpAndCheckQuota(db, { surface, uid, perUserDaily, globalDaily, now = new Date() }) {
+  const day = utcDayKey(now)
+
+  // Per-account first — reject (and skip the global bump) if this one account has
+  // already spent its daily allowance, so its overflow never pollutes the global
+  // counter.
+  const userCount = await bumpCounter(db, `${day}:${surface}:u:${uid}`, day, now)
+  if (userCount > perUserDaily) {
+    return { allowed: false, scope: 'user', count: userCount, cap: perUserDaily }
+  }
+
+  const globalCount = await bumpCounter(db, `${day}:${surface}:g`, day, now)
+  if (globalCount > globalDaily) {
+    return { allowed: false, scope: 'global', count: globalCount, cap: globalDaily }
+  }
+
+  return { allowed: true }
+}
+
+// Read an integer cap from env, falling back to `fallback` when unset/invalid.
+function envInt(name, fallback) {
+  const raw = process.env[name]
+  const n = raw != null ? parseInt(raw, 10) : NaN
+  return Number.isInteger(n) && n > 0 ? n : fallback
+}
+
+// Build an Express middleware enforcing the daily quota for one paid `surface`.
+// Mount AFTER verifyToken (needs req.uid). Skipped under Jest like the sibling
+// rate limiters (the suite fires many requests per uid; the dedicated
+// paidQuota.test.js exercises bumpAndCheckQuota directly). Caps are read from env
+// at call time with the given defaults, so a deploy can tighten them without a
+// code change:
+//   PAID_QUOTA_<SURFACE>_USER_DAILY   / PAID_QUOTA_<SURFACE>_GLOBAL_DAILY
+// Fails OPEN on a counter-DB error: a transient Mongo hiccup must not hard-block
+// legitimate paid calls (the per-minute limiters still bound burst); the error is
+// logged so a real outage surfaces.
+function makePaidQuotaLimiter({
+  surface,
+  perUserDaily,
+  globalDaily,
+  message = 'Daily limit reached for this feature — please try again tomorrow.',
+}) {
+  const envPrefix = `PAID_QUOTA_${surface.toUpperCase()}`
+  return async function paidQuotaLimiter(req, res, next) {
+    if (process.env.NODE_ENV === 'test') return next()
+    try {
+      const result = await bumpAndCheckQuota(getDB(), {
+        surface,
+        uid: req.uid,
+        perUserDaily: envInt(`${envPrefix}_USER_DAILY`, perUserDaily),
+        globalDaily: envInt(`${envPrefix}_GLOBAL_DAILY`, globalDaily),
+      })
+      if (!result.allowed) {
+        // Log the global trip loudly — it means the aggregate spend ceiling was
+        // hit, which is either a real spike or an in-progress abuse wave worth
+        // alerting on.
+        if (result.scope === 'global') {
+          console.error(
+            `[paidQuota] GLOBAL daily ceiling hit for surface=${surface} (count=${result.count}, cap=${result.cap})`
+          )
+        }
+        return res.status(429).json({ error: message, code: 'DAILY_QUOTA_EXCEEDED' })
+      }
+      return next()
+    } catch (err) {
+      console.error(`[paidQuota] counter check failed for surface=${surface}, failing open:`, err && err.message)
+      return next()
+    }
+  }
+}
+
+module.exports = { makePaidQuotaLimiter, bumpAndCheckQuota, utcDayKey }

--- a/server/util/recipeFields.js
+++ b/server/util/recipeFields.js
@@ -30,17 +30,22 @@ const EDITABLE_RECIPE_FIELDS = [
   'totalTime',
 ]
 
-// Creating a recipe additionally accepts the author snapshot. The server stamps
-// _id/userId, the createdAt/editedAt timestamps, zeroes the social counters, and
-// seeds the rating itself — so the client can't dictate a recipe's creation time
-// (createdAt drives the "Newest"/"Oldest" browse sort, so a forged/skewed client
-// clock could otherwise pin a recipe to the top of Newest). Curation/moderation
-// flags (`status`, `featured`) and any other unlisted key the client sends are
-// ignored on create, exactly as the edit whitelist ignores them on update.
-const CREATABLE_RECIPE_FIELDS = [
-  ...EDITABLE_RECIPE_FIELDS,
-  'authorUsername',
-]
+// Creating a recipe carries no extra client-supplied fields beyond the editable
+// set. The server stamps _id/userId, the createdAt/editedAt timestamps, zeroes
+// the social counters, seeds the rating itself, and derives `authorUsername`
+// from the caller's req.uid→username mapping — so the client can't dictate a
+// recipe's creation time (createdAt drives the "Newest"/"Oldest" browse sort, so
+// a forged/skewed client clock could otherwise pin a recipe to the top of
+// Newest) NOR forge the displayed author.
+//
+// `authorUsername` USED to be here, but it was persisted verbatim and never
+// checked against the caller — letting a user publish a recipe attributed to
+// someone else's handle (audit M3, author impersonation). It's now server-
+// derived at write time (routes/recipes.js addRecipe) and is NOT client-
+// writable, so CREATABLE == EDITABLE. Curation/moderation flags (`status`,
+// `featured`) and any other unlisted key the client sends are ignored on create,
+// exactly as the edit whitelist ignores them on update.
+const CREATABLE_RECIPE_FIELDS = [...EDITABLE_RECIPE_FIELDS]
 
 // The internal moderation/curation stamps an admin action writes onto a recipe.
 // They carry admin Firebase uids + curation metadata that no client reads, so
@@ -68,6 +73,10 @@ const RECIPE_INTERNAL_STAMPS = [
 const PUBLIC_RECIPE_FIELDS = [
   '_id',
   ...CREATABLE_RECIPE_FIELDS,
+  // Server-derived author handle (stamped from req.uid at create — audit M3).
+  // Not client-writable (dropped from CREATABLE above), but public: the recipe
+  // card/detail displays it, so it must reach public responses.
+  'authorUsername',
   // Server-stamped timestamps the client renders (formerly client-supplied, now
   // authoritative on the server — see CREATABLE_RECIPE_FIELDS).
   'createdAt',

--- a/src/types.ts
+++ b/src/types.ts
@@ -279,9 +279,12 @@ export type OptionalReviewType = {
 }
 export type ReviewType = {
   _id: string
-  // Stable Firebase uid of the reviewer (D1) — identity join key, never shown.
-  // `username` is the public handle; `displayName` the optional visible name.
-  userId: string
+  // The reviewer's stable Firebase uid is used server-side as the identity join
+  // key but is NEVER serialized to callers (audit M1: it was a username→uid
+  // oracle). The public handle is `username`; `displayName` the optional visible
+  // name; `isCurrentUser` the rename-proof "this review is mine" signal. Kept
+  // optional only so legacy callers don't break — it is not present at runtime.
+  userId?: string
   username: string
   recipeId: string
   rating: number | null


### PR DESCRIPTION
Batch 1 of the [2026-07-11 security & abuse audit](../blob/development/docs/SECURITY_AUDIT_2026-07-11.md). Every finding was **reproduced live against dev first**, fixed, then re-run to prove closure with a passing legitimate control.

## Findings fixed

| | Vulnerability | Fix | Proof |
|---|---|---|---|
| **H1** | Paid third-party APIs had no aggregate/daily cost ceiling → Sybil quota-drain | `server/util/paidQuota.js`: per-account **+ global** daily counters (Mongo, TTL-reaped) on `/ingredients/parse`, `/nutrition/details`, recipe creates; `ingr` array length-capped | with caps 3/5: per-account cap trips call 4, and a **fresh** account is blocked at call 3 by the **global** ceiling (`count 6 > 5`) despite being under its own cap |
| **M1** | Review endpoints leaked reviewer + admin Firebase UIDs and internal recipe stamps to anonymous callers | inclusion projection on `getReviews`/`getSingleUserReviews` + `publicRecipeProjection` on the `$lookup` sub-pipeline | anon read no longer exposes `userId`/`moderatedBy`/`moderatedAt`/`moderationHidden`/`featuredBy`; render fields intact |
| **M2** | `addRating`/`newReview` never loaded the target recipe (self-rating, ghost/hidden targets, XP farming) | load the recipe: 404 missing/hidden, 403 self-rating | self → 403, ghost → 404; different active user still rates fine |
| **M3** | `authorUsername` client-controlled → author impersonation | removed from `CREATABLE_RECIPE_FIELDS`; derived server-side from `req.uid` at create | client-sent handle ignored; stored author = real owner |
| **M4** | `servingPrice` recomputed *after* its bounds check → forged ingredient price persisted out-of-bounds | recompute onto body **before** `validateRecipeBounds` (create + edit) | negative / over-cap → 400; legit recompute persists |
| **L1** | `/nutrition/details` + `/acknowledgeAchievements` missing `requireActive` | added `requireActive` to both | banned user → 403; control read still 200 |

## Notes
- Caps are env-overridable (`PAID_QUOTA_<SURFACE>_USER_DAILY`/`_GLOBAL_DAILY`), documented in CLAUDE.md; a loud server-log line fires when the global ceiling trips (aggregate-spend alerting hook).
- **Behavior change:** M3 now requires a username to publish a recipe (nameless caller → 400), consistent with `addRating`/`newReview` and the onboarding flow.
- Deferred to follow-up waves (as scoped): M5/M6/M7 and remaining LOW/INFO items.

## Tests
- Server: **928 pass** (44 suites, +19 tests incl. new `paidQuota.test.js`)
- Frontend: **757 pass**, `tsc` clean
- All dev test data (`SECAUDIT-` prefix) purged.

https://claude.ai/code/session_016qypUfjmhuvDCLAt4LMgV3